### PR TITLE
CHORE(badges): updated badges to reflect repository rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 BHIMA
 =================
 
-[![Build Status](https://travis-ci.org/IMA-WorldHealth/bhima.svg?branch=development)](https://travis-ci.org/IMA-WorldHealth/bhima)
-[![Dependency Status](https://david-dm.org/IMA-WorldHealth/bhima/development.svg)](https://david-dm.org/IMA-WorldHealth/bhima/development)
-[![devDependency Status](https://david-dm.org/IMA-WorldHealth/bhima/development/dev-status.svg)](https://david-dm.org/IMA-WorldHealth/bhima/development#info=devDependencies)
-[![bitHound Overall Score](https://www.bithound.io/github/IMA-WorldHealth/bhima/badges/score.svg)](https://www.bithound.io/github/IMA-WorldHealth/bhima)
-[![bitHound Code](https://www.bithound.io/github/IMA-WorldHealth/bhima/badges/code.svg)](https://www.bithound.io/github/IMA-WorldHealth/bhima)
+[![Build Status](https://travis-ci.org/IMA-WorldHealth/bhima-2.X.svg?branch=development)](https://travis-ci.org/IMA-WorldHealth/bhima-2.X)
+[![Dependency Status](https://david-dm.org/IMA-WorldHealth/bhima-2.X/development.svg)](https://david-dm.org/IMA-WorldHealth/bhima-2.X/development)
+[![devDependency Status](https://david-dm.org/IMA-WorldHealth/bhima-2.X/development/dev-status.svg)](https://david-dm.org/IMA-WorldHealth/bhima-2.X/development#info=devDependencies)
+[![bitHound Overall Score](https://www.bithound.io/github/IMA-WorldHealth/bhima-2.X/badges/score.svg)](https://www.bithound.io/github/IMA-WorldHealth/bhima-2.X)
+[![bitHound Code](https://www.bithound.io/github/IMA-WorldHealth/bhima-2.X/badges/code.svg)](https://www.bithound.io/github/IMA-WorldHealth/bhima-2.X)
 
 _Bhima is alpha version software. Please do not use this in a commerical context._
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bhima",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "description": "A rural hospital information management system.",
   "main": "server/app.js",
   "scripts": {


### PR DESCRIPTION
This commit changes the badges to point at proper builds and dependencies following the 1.X/2.X split.
