### PR TITLE
Implement the /sales API

### DIFF
--- a/client/src/partials/sales/sales.js
+++ b/client/src/partials/sales/sales.js
@@ -282,7 +282,7 @@ angular.module('bhima.controllers')
       var invoiceRequest = packageInvoiceRequest();
 
       if (!validSaleProperties(invoiceRequest)) { return; }
-      $http.post('sale/', invoiceRequest).then(handleSaleResponse); // FIXME: refactor to using connect
+      $http.post('/sales', invoiceRequest).then(handleSaleResponse); // FIXME: refactor to using connect
     }
 
     function packageInvoiceRequest() {
@@ -344,7 +344,7 @@ angular.module('bhima.controllers')
 
         requestContainer.saleItems.push(formatDiscountItem);
       });
-
+  
       requestContainer.caution = (invoice.debitorCaution)? invoice.debitorCaution : 0;
 
       return requestContainer;

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -49,6 +49,7 @@ var cashboxes      = require('../controllers/finance/cashboxes');
 var exchange       = require('../controllers/finance/exchange');
 var cashflow       = require('../controllers/cashflow');
 
+var patientInvoice = require('../controllers/finance/patientInvoice');
 
 var financeServices      = require('../controllers/categorised/financeServices');
 var depreciatedInventory = require('../controllers/categorised/inventory_depreciate');
@@ -285,7 +286,7 @@ exports.configure = function (app) {
   // Patient invoice API 
   
   // TODO Decide if the route should be named patient invoice
-  // app.get('/sales', patientInvoice.list);
+  app.get('/sales', patientInvoice.list);
   // app.post('/sales', patientInvoice.create);
   // app.get('/sales/:uuid', patientInvoice.details);
 

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -282,6 +282,13 @@ exports.configure = function (app) {
   app.get('/availableAccounts/:id_enterprise/', accounts.listEnterpriseAccounts);
   app.get('/availableAccounts_profit/:id_enterprise/', accounts.listEnterpriseProfitAccounts);
 
+  // Patient invoice API 
+  
+  // TODO Decide if the route should be named patient invoice
+  // app.get('/sales', patientInvoice.list);
+  // app.post('/sales', patientInvoice.create);
+  // app.get('/sales/:uuid', patientInvoice.details);
+
   // Patients API
   app.get('/patients', patient.list);
   app.post('/patients', patient.create);

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -288,7 +288,7 @@ exports.configure = function (app) {
   // TODO Decide if the route should be named patient invoice
   app.get('/sales', patientInvoice.list);
   app.post('/sales', patientInvoice.create);
-  // app.get('/sales/:uuid', patientInvoice.details);
+  app.get('/sales/:uuid', patientInvoice.details);
 
   // Patients API
   app.get('/patients', patient.list);

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -99,7 +99,7 @@ exports.configure = function (app) {
   app.get('/report/serve/:target', reports.serve);
 
   app.post('/purchase', createPurchase.execute);
-  app.post('/sale/', createSale.execute);
+  // app.post('/sale/', createSale.execute);
   app.post('/consumption_loss/', consumptionLoss.execute);
 
   // trial balance routes
@@ -287,7 +287,7 @@ exports.configure = function (app) {
   
   // TODO Decide if the route should be named patient invoice
   app.get('/sales', patientInvoice.list);
-  // app.post('/sales', patientInvoice.create);
+  app.post('/sales', patientInvoice.create);
   // app.get('/sales/:uuid', patientInvoice.details);
 
   // Patients API

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -71,8 +71,6 @@ function details(req, res, next) {
   // structure than alternative blocking methods
   db.exec(saleDetailQuery, [uuid])
     .then(function (detailsResult) { 
-      var saleDetail;
-  
       sale = detailsResult;
       return db.exec(saleItemsQuery, [uuid]);
     })

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -1,26 +1,24 @@
-/** 
- * @description Provides API endpoint for requesting information about patient invoices, provides
- * a simplified list of all patient invoices as well as detailed information for a specific invoice
- * GET /sales - retrieve all patient invoices (accepts ?q delimiter) 
- * GET /sales/:uuid - retrieve specific patient invoice 
- * GET /sales/patient/:uuid - retrieve all patient invoices for a specific patient
- * POST /sales - write a new sale 
- *
- * @returns Map exposing all methods used by the /sales API route
- *
+/**
+ * Patient Invoice API Controller 
+ *.@module controllers/finance/patientInvoice
+ * 
+ * @todo GET /sales/patient/:uuid - retrieve all patient invoices for a specific patient
  * @todo Factor in subsidies, this depends on price lists and billing services infrastructre 
  * @todo Credit note logic pending on clear design 
  */
 var db = require('../../lib/db');
 var uuid = require('../../lib/guid');
 
+/** Retrieves a list of all patient invoices (accepts ?q delimiter). */
 exports.list = list;
+
+/** Retrieves details for a specific patient invoice. */
 exports.details = details;
+
+/** Write a new patient invoice record and attempt to post it to the journal. */
 exports.create = create;
 
 function list(req, res, next) { 
-
-  // Retrieve all patient invoices 
   var saleListQuery;
 
   saleListQuery = 
@@ -53,18 +51,66 @@ function create(req, res, next) {
    
   // Verify request validity 
   var saleLineBody = req.body.sale;
+  var saleItems = req.body.saleItems;
+  
+  // Reject invalid parameters
+  if (!saleLineBody || !saleItems) { 
+    res.status(400).json({
+      code : 'ERROR.ERR_MISSING_INFO', 
+      reason : 'A valid sale details and sale items must be provided under the attributes `sale` and `saleItems`'
+    });
+    return;
+  }
+  
+  // Provide UUID if the client has not specified 
+  saleLineBody.uuid = saleLineBody.uuid || uuid();
+  
+  // Implicitly provide seller information based on user session 
+  saleLineBody.seller_id = req.session.user.id;
 
   insertSaleLineQuery = 
     'INSERT INTO sale SET ?';
+  
+  insertSaleItemQuery = 
+    'INSERT INTO sale_item (inventory_uuid, quantity, inventory_price, ' + 
+        'transaction_price, credit, debit, uuid,  sale_uuid) VALUES ?';
 
   transaction = db.transaction();
-    
+
   // Insert sale line 
   transaction
-    .addQuery(insertSaleLineQuery, [saleLineBody]);
-
+    .addQuery(insertSaleLineQuery, [saleLineBody])
+  
   // Insert sale item lines
+    .addQuery(insertSaleItemQuery, [linkSaleItems(saleItems, saleLineBody.uuid)]);
 
-  console.log('recieved sale object', req.body);
-  res.status(500).send('Not implemented');
+  transaction.execute() 
+    .then(function (results) { 
+      var confirmation = { 
+        uuid : saleLineBody.uuid,
+        results : results
+      };
+      res.status(201).json(confirmation);
+    })
+    .catch(next)
+    .done();
+}
+
+/** 
+ * Utility method to ensure patient invoice lines reference sale.
+ * @param {Object} saleItems - An Array of all sale items to be written 
+ * @param {string} saleUuid - UUID of referenced patient invoice
+ * @returns {Object} An Array of all sale items with guaranteed UUIDs and Patient Invoice references
+ */
+function linkSaleItems(saleItems, saleUuid) { 
+  return saleItems.map(function (saleItem) { 
+     
+    saleItem.uuid = saleItem.uuid || uuid();
+    saleItem.sale_uuid = saleUuid;
+   
+    // Collapse sale item into Array to be inserted into database
+    return Object.keys(saleItem).map(function (key) { 
+      return saleItem[key];
+    });
+  });
 }

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -6,8 +6,11 @@
  * @todo Factor in subsidies, this depends on price lists and billing services infrastructre 
  * @todo Credit note logic pending on clear design 
  */
-var db = require('../../lib/db');
-var uuid = require('../../lib/guid');
+var q       = require('q');
+var db      = require('../../lib/db');
+var uuid    = require('../../lib/guid');
+
+var journal = require('./journal');
 
 /** Retrieves a list of all patient invoices (accepts ?q delimiter). */
 exports.list = list;
@@ -18,15 +21,15 @@ exports.details = details;
 /** Write a new patient invoice record and attempt to post it to the journal. */
 exports.create = create;
 
+/** Undo the financial effects of a sale generating an equal and opposite credit note. */
+// exports.reverse = reverse;
+
 function list(req, res, next) { 
   var saleListQuery;
 
   saleListQuery = 
     'SELECT sale.project_id, sale.reference, sale.uuid, cost, sale.debitor_uuid, ' +
       'seller_id, invoice_date, is_distributable ' + 
-      // '(SELECT COUNT(uuid) ' + 
-      // 'FROM sale_item ' + 
-      // 'WHERE sale_item.uuid = sale.uuid) as itemCount ' + 
     'FROM sale ' + 
     'LEFT JOIN patient ON sale.debitor_uuid = patient.debitor_uuid';
 
@@ -40,9 +43,59 @@ function list(req, res, next) {
     .done();
 }
 
+/** 
+ * @todo Read the balance remaining on the debtors account given the sale as an auxillary step 
+ */
 function details(req, res, next) { 
+  var saleDetailQuery, saleItemsQuery;
+  var sale, saleItems;
+  var uuid = req.params.uuid;
+
+  saleDetailQuery = 
+    'SELECT sale.uuid, sale.project_id, sale.reference, sale.cost, sale.currency_id, ' +
+      'sale.debitor_uuid, CONCAT(patient.first_name, " ", patient.last_name) as debitor_name, ' +
+      'seller_id, discount, invoice_date, sale.note, sale.posted, sale.is_distributable ' +
+    'FROM sale ' +
+    'LEFT JOIN patient ON patient.debitor_uuid = sale.debitor_uuid ' + 
+    'WHERE sale.uuid = ?';
+
+  saleItemsQuery = 
+    'SELECT sale_item.uuid, sale_item.quantity, sale_item.inventory_price, ' + 
+      'sale_item.transaction_price, inventory.code, inventory.text, inventory.consumable ' + 
+    'FROM sale_item ' + 
+    'LEFT JOIN inventory ON sale_item.inventory_uuid = inventory.uuid ' + 
+    'WHERE sale_uuid = ?';
   
-  // Retrieve specific patient invoice
+  // This process accepts a very small performance hit querrying the sale items 
+  // even if the sale hasn't been found - however it uses a less obscure branching 
+  // structure than alternative blocking methods
+  db.exec(saleDetailQuery, [uuid])
+    .then(function (detailsResult) { 
+      var saleDetail;
+  
+      sale = detailsResult;
+      return db.exec(saleItemsQuery, [uuid]);
+    })
+    .then(function (itemsResult) { 
+      saleItems = itemsResult;
+
+      if (isEmpty(sale)) { 
+        res.status(404).json({
+          code : 'ERR_NOT_FOUND', 
+          reason : 'No sale found under the id ' + uuid
+        });
+      } else { 
+        
+        // Found sale resource - unpack and return to client
+        sale = sale[0];
+        res.status(200).json({
+          sale : sale, 
+          saleItems : saleItems
+        });
+      }
+    })
+    .catch(next)
+    .done();
 }
 
 function create(req, res, next) { 
@@ -86,6 +139,11 @@ function create(req, res, next) {
 
   transaction.execute() 
     .then(function (results) { 
+     
+      // TODO Update to use latest journal interface
+      return postSaleRecord(saleLineBody.uuid, req.body.caution, req.session.user.id);
+    })
+    .then(function (results) { 
       var confirmation = { 
         uuid : saleLineBody.uuid,
         results : results
@@ -94,6 +152,24 @@ function create(req, res, next) {
     })
     .catch(next)
     .done();
+}
+
+/** 
+ * [TO DEPRECATE] Wrapper method to allow the module to use the current journal 
+ * interface. This will be replaced with the new server journal interface 
+ * implementation.
+ * @returns {Object} Promise object to be fulfilled on journal posting
+ */
+function postSaleRecord(saleUuid, caution, userId) { 
+  var deferred = q.defer();
+  
+  journal.request('sale', saleUuid, userId, function (error, result) {
+    if (error) {
+      return deferred.reject(error);
+    }
+    return deferred.resolve(result);
+  }, caution);
+  return deferred.promise;
 }
 
 /** 
@@ -113,4 +189,13 @@ function linkSaleItems(saleItems, saleUuid) {
       return saleItem[key];
     });
   });
+}
+
+/**
+ * Utility method - determine if an array has no elements 
+ * @param {Object} array - Array to be tested 
+ * @returns {Boolean} Value reflecting if the array is empty or not (true or false respectively)
+ */
+function isEmpty(array) {
+  return array.length === 0;
 }

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -7,8 +7,12 @@
  * POST /sales - write a new sale 
  *
  * @returns Map exposing all methods used by the /sales API route
+ *
+ * @todo Factor in subsidies, this depends on price lists and billing services infrastructre 
+ * @todo Credit note logic pending on clear design 
  */
 var db = require('../../lib/db');
+var uuid = require('../../lib/guid');
 
 exports.list = list;
 exports.details = details;
@@ -17,12 +21,50 @@ exports.create = create;
 function list(req, res, next) { 
 
   // Retrieve all patient invoices 
+  var saleListQuery;
+
+  saleListQuery = 
+    'SELECT sale.project_id, sale.reference, sale.uuid, cost, sale.debitor_uuid, ' +
+      'seller_id, invoice_date, is_distributable ' + 
+      // '(SELECT COUNT(uuid) ' + 
+      // 'FROM sale_item ' + 
+      // 'WHERE sale_item.uuid = sale.uuid) as itemCount ' + 
+    'FROM sale ' + 
+    'LEFT JOIN patient ON sale.debitor_uuid = patient.debitor_uuid';
+
+  db.exec(saleListQuery)
+    .then(function (result) { 
+      var sales = result;
+
+      res.status(200).json(sales);  
+    })
+    .catch(next)
+    .done();
 }
 
 function details(req, res, next) { 
+  
   // Retrieve specific patient invoice
 }
 
 function create(req, res, next) { 
-  // write a new sale
+  var insertSaleLineQuery, insertSaleItemQuery;
+  var transaction;
+   
+  // Verify request validity 
+  var saleLineBody = req.body.sale;
+
+  insertSaleLineQuery = 
+    'INSERT INTO sale SET ?';
+
+  transaction = db.transaction();
+    
+  // Insert sale line 
+  transaction
+    .addQuery(insertSaleLineQuery, [saleLineBody]);
+
+  // Insert sale item lines
+
+  console.log('recieved sale object', req.body);
+  res.status(500).send('Not implemented');
 }

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -1,0 +1,27 @@
+/** 
+ * @description Provides API endpoint for requesting information about patient invoices, provides
+ * a simplified list of all patient invoices as well as detailed information for a specific invoice
+ * GET /sales - retrieve all patient invoices (accepts ?q delimiter) 
+ * GET /sales/:uuid - retrieve specific patient invoice 
+ * GET /sales/patient/:uuid - retrieve all patient invoices for a specific patient
+ * POST /sales - write a new sale 
+ *
+ * @returns Map exposing all methods used by the /sales API route
+ */
+var db = require('../../lib/db');
+
+exports.list = list;
+exports.details = details;
+exports.create = create;
+
+function list(req, res, next) { 
+  // Retrieve all patient invoices 
+}
+
+function details(req, res, next) { 
+  // Retrieve specific patient invoice
+}
+
+function create(req, res, next) { 
+  // write a new sale
+}

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -15,6 +15,7 @@ exports.details = details;
 exports.create = create;
 
 function list(req, res, next) { 
+
   // Retrieve all patient invoices 
 }
 

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -100,6 +100,7 @@ function details(req, res, next) {
 
 function create(req, res, next) { 
   var insertSaleLineQuery, insertSaleItemQuery;
+  var saleResults;
   var transaction;
    
   // Verify request validity 
@@ -139,14 +140,15 @@ function create(req, res, next) {
 
   transaction.execute() 
     .then(function (results) { 
-     
+      saleResults = results;
+      
       // TODO Update to use latest journal interface
       return postSaleRecord(saleLineBody.uuid, req.body.caution, req.session.user.id);
     })
     .then(function (results) { 
       var confirmation = { 
         uuid : saleLineBody.uuid,
-        results : results
+        results : saleResults
       };
       res.status(201).json(confirmation);
     })
@@ -155,7 +157,8 @@ function create(req, res, next) {
 }
 
 /** 
- * [TO DEPRECATE] Wrapper method to allow the module to use the current journal 
+ * @deprecated since version 2.X
+ * Wrapper method to allow the module to use the current journal 
  * interface. This will be replaced with the new server journal interface 
  * implementation.
  * @returns {Object} Promise object to be fulfilled on journal posting

--- a/server/controllers/finance/sale.js
+++ b/server/controllers/finance/sale.js
@@ -1,3 +1,6 @@
+// DEPRECIATED - TO BE REMOVED 
+// -used to facilitate sale creation and posting before using an API-centric system 
+
 var q = require('q');
 var db = require('./../../lib/db');
 var parser = require('./../../lib/parser');

--- a/server/controllers/medical/patient.js
+++ b/server/controllers/medical/patient.js
@@ -265,7 +265,7 @@ function list(req, res, next) {
   .then(function (result) {
     var patients = result;
 
-    res.status(200).json(result);
+    res.status(200).json(patients);
   })
   .catch(next)
   .done();

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1199,7 +1199,7 @@ CREATE TABLE `patient` (
   FOREIGN KEY (`origin_location_id`) REFERENCES `village` (`uuid`) ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TRIGGER calculate_reference BEFORE INSERT ON patient 
+CREATE TRIGGER patient_reference BEFORE INSERT ON patient 
 FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM patient WHERE patient.project_id = new.project_id);
 
 DROP TABLE IF EXISTS `patient_group`;
@@ -1629,7 +1629,7 @@ CREATE TABLE `sale` (
   FOREIGN KEY (`service_id`) REFERENCES `service` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TRIGGER calculate_reference BEFORE INSERT ON sale 
+CREATE TRIGGER sale_reference BEFORE INSERT ON sale 
 FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM sale WHERE sale.project_id = new.project_id);
 
 DROP TABLE IF EXISTS `sale_item`;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1630,7 +1630,7 @@ CREATE TABLE `sale` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TRIGGER calculate_reference BEFORE INSERT ON sale 
-FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM patient WHERE patient.project_id = new.project_id);
+FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM sale WHERE sale.project_id = new.project_id);
 
 DROP TABLE IF EXISTS `sale_item`;
 

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1629,6 +1629,9 @@ CREATE TABLE `sale` (
   FOREIGN KEY (`service_id`) REFERENCES `service` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+CREATE TRIGGER calculate_reference BEFORE INSERT ON sale 
+FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM patient WHERE patient.project_id = new.project_id);
+
 DROP TABLE IF EXISTS `sale_item`;
 
 CREATE TABLE `sale_item` (

--- a/server/models/test/data.sql
+++ b/server/models/test/data.sql
@@ -190,7 +190,8 @@ INSERT INTO `inventory_type` (`id`, `text`) VALUES (1,'Article'),(2,'Assembly'),
 INSERT INTO `inventory_unit` (`id`, `text`) VALUES (1,'Act'),(2,'Pallet'),(3,'Pill'),(4,'Box'),(5,'Lot'),(6,'amp'),(7,'bags'),(8,'btl'),(9,'cap'),(10,'flc'),(11,'jar'),(12,'ltr'),(13,'pce'),(14,'sch'),(15,'tab'),(16,'tub'),(17,'vial');
 
 INSERT INTO `inventory` VALUES 
-  (1, 'cf05da12-b477-11e5-b297-023919d3d5b0', 'INV0', 'Test inventory item', 25.0, 10, '1410dfe0-b478-11e5-b297-023919d3d5b0', NULL, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP); 
+  (1, 'cf05da13-b477-11e5-b297-023919d3d5b0', 'INV0', 'Test inventory item', 25.0, 10, '1410dfe0-b478-11e5-b297-023919d3d5b0', NULL, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP),
+  (1, '289cc0a1-b90f-11e5-8c73-159fdc73ab02', 'INV1', 'Second Test inventory item', 10.0, 10, '1410dfe0-b478-11e5-b297-023919d3d5b0', NULL, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP); 
 
 INSERT INTO `debitor_group` VALUES 
   (1, '4de0fe47-177f-4d30-b95f-cff8166400b4', 'Test Debtor Group', 3631, '03a329b2-03fe-4f73-b40f-56a2870cc7e6', NULL, NULL, NULL, 0, 0, 0, NULL),

--- a/server/models/test/data.sql
+++ b/server/models/test/data.sql
@@ -134,7 +134,34 @@ INSERT INTO `village` VALUES ('03a329b2-03fe-4f73-b40f-56a2870cc7e6','MUBUABUA',
 
 INSERT INTO `enterprise` VALUES (1,'Test Enterprise','TE','243 81 504 0540','enterprise@test.org','a0a8998d-af22-4a73-9071-bd43a23f77e3',NULL,2,'103');
 INSERT INTO `project` VALUES (1,'Test Project A','TPA',1,759), (2,'Test Project B','TPB',1,759);
-INSERT INTO `account` VALUES (3626,3,1,1000,'Test Capital Account',0,0,NULL,NULL,'2015-11-04 14:25:12',1,NULL,1,NULL,NULL,0,NULL),(3627,2,1,1100,'Test Capital One',3626,0,NULL,NULL,'2015-11-04 14:26:13',1,1,1,NULL,0,0,NULL),(3628,2,1,1200,'Test Capital Two',3626,0,NULL,NULL,'2015-11-04 14:27:13',1,1,1,NULL,0,0,NULL),(3629,3,1,40000,'Test Debtor-Creditor Accounts',0,0,NULL,NULL,'2015-11-04 14:29:11',4,NULL,1,NULL,NULL,0,NULL),(3630,2,1,4100,'Test Debtor Accounts',3629,0,NULL,NULL,'2015-11-04 14:30:46',4,NULL,1,NULL,NULL,0,NULL),(3631,3,1,41000,'Test Debtor Accounts',3629,0,NULL,NULL,'2015-11-04 14:32:22',4,NULL,1,NULL,NULL,0,NULL),(3635,3,1,41000,'Test Debtor Accounts',3629,0,NULL,NULL,'2015-11-04 14:32:22',4,NULL,0,NULL,NULL,0,NULL);
+INSERT INTO `account` VALUES 
+(3626,3,1,1000,'Test Capital Account',0,0,NULL,NULL,'2015-11-04 14:25:12',1,NULL,1,NULL,NULL,0,NULL),
+(3627,2,1,1100,'Test Capital One',3626,0,NULL,NULL,'2015-11-04 14:26:13',1,1,1,NULL,0,0,NULL),
+(3628,2,1,1200,'Test Capital Two',3626,0,NULL,NULL,'2015-11-04 14:27:13',1,1,1,NULL,0,0,NULL),
+(3629,3,1,40000,'Test Balance Accounts',0,0,NULL,NULL,'2015-11-04 14:29:11',4,NULL,1,NULL,NULL,0,NULL),
+(3630,2,1,4100,'Test Debtor Accounts',3629,0,NULL,NULL,'2015-11-04 14:30:46',4,NULL,1,NULL,NULL,0,NULL),
+(3631,3,1,41000,'Test Debtor Accounts',3629,0,NULL,NULL,'2015-11-04 14:32:22',4,NULL,0,NULL,NULL,0,NULL),
+(3635,3,1,41000,'Test Debtor Accounts',3629,0,NULL,NULL,'2015-11-04 14:32:22',4,NULL,0,NULL,NULL,0,NULL),
+(3636,3,1,4600, 'Test Inventory Accounts', 3629, 0, NULL, NULL, '2015-11-04 14:32:22',4,NULL,0,NULL,NULL,0,NULL),
+(3637,2,1,46001,'Test Item Account',3636,0,NULL,NULL,'2015-11-04 14:32:22',4,NULL,1,NULL,NULL,0,NULL);
+ 
+-- testing financial transactions
+INSERT INTO `fiscal_year` VALUES 
+(1, 1, 12, 'Test fiscal year', NULL, NULL, NULL, 1, 2016, NULL, 0);
+
+INSERT INTO `period` VALUES
+( 1 , 1 ,1,'2016-01-01', '2016-01-31', 0 ),
+( 2 , 1 ,2,'2016-02-01', '2016-02-29', 0 ),
+( 3 , 1 ,3,'2016-03-01', '2016-03-31', 0 ),
+( 4 , 1 ,4,'2016-04-01', '2016-04-30', 0 ),
+( 5 , 1 ,5,'2016-05-01', '2016-05-31', 0 ),
+( 6 , 1 ,6,'2016-06-01', '2016-06-30', 0 ),
+( 7 , 1 ,7,'2016-07-01', '2016-07-31', 0 ),
+( 8 , 1 ,8,'2016-08-01', '2016-08-31', 0 ),
+( 9 , 1 ,9,'2016-09-01', '2016-09-30', 0 ),
+( 0 , 1 ,0,'2016-10-01', '2016-10-31', 0 ),
+( 11, 1 ,1,'2016-11-01', '2016-11-30', 0 ),
+( 12 ,1 ,2,'2016-12-01', '2016-12-31', 0 );
 
 -- create test users
 INSERT INTO user (id, username, password, first, last, email) VALUES
@@ -153,10 +180,19 @@ INSERT INTO project_permission (project_id, user_id) VALUES (1, 1), (2, 1);
 INSERT INTO `cash_box` VALUES (1,'Test Primary Cashbox A ',1,0,0), (2,'Test Aux Cashbox B', 1,1, 1);
 INSERT INTO `cash_box_account_currency` VALUES (1,1,1,3626,3626,3626,3626),(2,2,1,3627,3627,3627,3627),(3,1,2,3627,3627,3627,3627),(4,2,2,3627,3627,3627,3627);
 
+INSERT INTO `transaction_type` VALUES
+(1, 'sale');
+
+INSERT INTO `inventory_group` VALUES 
+  ('1410dfe0-b478-11e5-b297-023919d3d5b0', 'Test inventory group', 'INVGRP', 3636, NULL, NULL, NULL);
+
 INSERT INTO `inventory_type` (`id`, `text`) VALUES (1,'Article'),(2,'Assembly'),(3,'Service');
 INSERT INTO `inventory_unit` (`id`, `text`) VALUES (1,'Act'),(2,'Pallet'),(3,'Pill'),(4,'Box'),(5,'Lot'),(6,'amp'),(7,'bags'),(8,'btl'),(9,'cap'),(10,'flc'),(11,'jar'),(12,'ltr'),(13,'pce'),(14,'sch'),(15,'tab'),(16,'tub'),(17,'vial');
 
-INSERT INTO `debitor_group` VALUES
+INSERT INTO `inventory` VALUES 
+  (1, 'cf05da12-b477-11e5-b297-023919d3d5b0', 'INV0', 'Test inventory item', 25.0, 10, '1410dfe0-b478-11e5-b297-023919d3d5b0', NULL, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP); 
+
+INSERT INTO `debitor_group` VALUES 
   (1, '4de0fe47-177f-4d30-b95f-cff8166400b4', 'Test Debtor Group', 3631, '03a329b2-03fe-4f73-b40f-56a2870cc7e6', NULL, NULL, NULL, 0, 0, 0, NULL),
   (1, '66f03607-bfbc-4b23-aa92-9321ca0ff586', 'Second Test Debtor Group', 3631, '03a329b2-03fe-4f73-b40f-56a2870cc7e6', NULL, NULL, NULL, 0, 0, 0, NULL);
 
@@ -168,10 +204,18 @@ INSERT INTO `debitor` VALUES
   ('a11e6b7f-fbbb-432e-ac2a-5312a66dccf4', '4de0fe47-177f-4d30-b95f-cff8166400b4','Patient/1/Patient'),
   ('3be232f9-a4b9-4af6-984c-5d3f87d5c107', '4de0fe47-177f-4d30-b95f-cff8166400b4','Patient/2/Patient');
 
-
-INSERT INTO `patient` VALUES
-  ('81af634f-321a-40de-bc6f-ceb1167a9f65',1,NULL,'a11e6b7f-fbbb-432e-ac2a-5312a66dccf4',NULL,'Test','1','1990-06-01',NULL,NULL,NULL,NULL,NULL,NULL,NULL,'M',NULL,NULL,NULL,NULL,NULL,NULL,0,'bda70b4b-8143-47cf-a683-e4ea7ddd4cff','bda70b4b-8143-47cf-a683-e4ea7ddd4cff','2015-11-14 07:04:49',NULL,NULL,'Patient','100'),
-  ('274c51ae-efcc-4238-98c6-f402bfb39866',1,NULL,'3be232f9-a4b9-4af6-984c-5d3f87d5c107',NULL,'Test','2','1990-06-01',NULL,NULL,NULL,NULL,NULL,NULL,NULL,'M',NULL,NULL,NULL,NULL,NULL,NULL,0,'bda70b4b-8143-47cf-a683-e4ea7ddd4cff','bda70b4b-8143-47cf-a683-e4ea7ddd4cff','2015-11-14 07:04:49',NULL,NULL,'Patient','110');
+INSERT INTO `patient` VALUES 
+  ('81af634f-321a-40de-bc6f-ceb1167a9f65',1,1,'a11e6b7f-fbbb-432e-ac2a-5312a66dccf4',NULL,'Test','1','1990-06-01',NULL,NULL,NULL,NULL,NULL,NULL,NULL,'M',NULL,NULL,NULL,NULL,NULL,NULL,0,'bda70b4b-8143-47cf-a683-e4ea7ddd4cff','bda70b4b-8143-47cf-a683-e4ea7ddd4cff','2015-11-14 07:04:49',NULL,NULL,'Patient','100'),
+  ('274c51ae-efcc-4238-98c6-f402bfb39866',1,2,'3be232f9-a4b9-4af6-984c-5d3f87d5c107',NULL,'Test','2','1990-06-01',NULL,NULL,NULL,NULL,NULL,NULL,NULL,'M',NULL,NULL,NULL,NULL,NULL,NULL,0,'bda70b4b-8143-47cf-a683-e4ea7ddd4cff','bda70b4b-8143-47cf-a683-e4ea7ddd4cff','2015-11-14 07:04:49',NULL,NULL,'Patient','110');
 
 INSERT INTO `assignation_patient` VALUES
   (UUID(), '112a9fb5-847d-4c6a-9b20-710fa8b4da24', '81af634f-321a-40de-bc6f-ceb1167a9f65');
+
+INSERT INTO `cost_center` VALUES
+  (1, 1, 'Test cost center', 'Example note for a test cost center', 1);
+
+INSERT INTO `profit_center` VALUES
+  (1, 1, 'Test profit center', 'Example note for a test profit center');
+
+INSERT INTO `service` VALUES
+  (1, 1, 'Test service', 1, 1);

--- a/server/test/api/patientInvoice.js
+++ b/server/test/api/patientInvoice.js
@@ -1,0 +1,37 @@
+var chai = require('chai');
+var chaiHttp = require('chai-http');
+var expect = chai.expect;
+
+var q = require('q');
+
+var url = 'https://localhost:8080';
+var user = { 
+  username : 'superuser', 
+  password : 'superuser', 
+  project: 1
+};
+
+chai.use(chaiHttp);
+
+// workaround for low node versions
+if (!global.Promise) {
+  var q = require('q');
+  chai.request.addPromises(q.Promise);
+}
+
+// Environment variables - disable certificate errors
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+
+describe('The /sales API', function () { 
+  var agent = chai.request.agent(url);
+  
+  beforeEach(function () {
+    return agent
+      .post('/login')
+      .send(user);
+  });
+  
+  // it('GET /sales returns a list of patient invoice', function () { });
+  // it('GET /sales/:uuid returns a valid patient invoice', function () { });
+  // it('GET /sales/:uuid returns 404 for an invalid patient invoice', function () { });
+});

--- a/server/test/api/patientInvoice.js
+++ b/server/test/api/patientInvoice.js
@@ -31,7 +31,21 @@ describe('The /sales API', function () {
       .send(user);
   });
   
-  // it('GET /sales returns a list of patient invoice', function () { });
+  it('GET /sales returns a list of patient invoice', function () {
+    var INITIAL_PATIENT_INVOICES = 1;
+
+    return agent.get('/sales')
+      .then(function (res) { 
+        expect(res).to.have.status(200);
+        expect(res.body).to.not.be.empty;
+        expect(res.body).to.have.length(INITIAL_PATIENT_INVOICES);
+      })
+      .catch(handle);
+  });
   // it('GET /sales/:uuid returns a valid patient invoice', function () { });
   // it('GET /sales/:uuid returns 404 for an invalid patient invoice', function () { });
+  
+  function handle(error) {
+    throw error;
+  }
 });

--- a/server/test/api/patientInvoice.js
+++ b/server/test/api/patientInvoice.js
@@ -51,6 +51,8 @@ describe('The /sales API', function () {
   // it('GET /sales/:uuid returns a valid patient invoice', function () { });
   // it('GET /sales/:uuid returns 404 for an invalid patient invoice', function () { });
   
+  // it('POST /sales/ returns 500 for an invalid patient invoice request object', function () { });
+  // it('GET /sales/:invalid_request_uuid returns 404 ensuring invalid request was not written', function () { });
   function handle(error) {
     throw error;
   }

--- a/server/test/api/patientInvoice.js
+++ b/server/test/api/patientInvoice.js
@@ -1,3 +1,6 @@
+/**
+ * @todo Replace generic boilerplate code (environment variables etc.) with import
+ */
 var chai = require('chai');
 var chaiHttp = require('chai-http');
 var expect = chai.expect;
@@ -23,7 +26,41 @@ if (!global.Promise) {
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
 
 describe('The /sales API', function () { 
+  var mockSaleUuid; 
   var agent = chai.request.agent(url);
+
+  var mockSale = {
+    sale : { 
+      project_id: 1,
+      cost: 35,
+      currency_id: 2,
+      debitor_uuid: '3be232f9-a4b9-4af6-984c-5d3f87d5c107',
+      invoice_date: '2016-01-13',
+      note: 'TPA_VENTE/Wed Jan 13 2016 10:33:34 GMT+0100 (WAT)/Test 2 Patient',
+      service_id: 1,
+      is_distributable: true 
+    },
+    saleItems : [{ 
+      inventory_uuid: '289cc0a1-b90f-11e5-8c73-159fdc73ab02',
+      quantity: 1,
+      inventory_price: 10,
+      transaction_price: 10,
+      credit: 10,
+      debit: 0
+    },{ 
+      inventory_uuid: 'cf05da13-b477-11e5-b297-023919d3d5b0',
+      quantity: 1,
+      inventory_price: 25,
+      transaction_price: 25,
+      credit: 25,
+      debit: 0 
+    }]
+  };
+
+  var invalidRequestSale = { 
+    badSale : {},
+    invalidParams : {}
+  };
   
   beforeEach(function () {
     return agent
@@ -31,8 +68,20 @@ describe('The /sales API', function () {
       .send(user);
   });
   
-  it('POST /sales will record a valid patient invoice and return success from the posting journal'), function () { 
+  it('POST /sales will record a valid patient invoice and return success from the posting journal', function () { 
+    var UUID_LENGTH = 36;
+    
+    return agent.post('/sales')
+      .send(mockSale)
+      .then(function (confirmation) { 
+        expect(confirmation).to.have.status(201);
+        expect(confirmation.body).to.contain.keys('uuid', 'results');
+        expect(confirmation.body.uuid.length).to.be.equal(UUID_LENGTH);
 
+        // If test has passed record UUID to use in further tests
+        mockSaleUuid = confirmation.body.uuid; 
+      })
+      .catch(handle);
   });
 
   it('GET /sales returns a list of patient invoices', function () {
@@ -48,11 +97,46 @@ describe('The /sales API', function () {
       })
       .catch(handle);
   });
-  // it('GET /sales/:uuid returns a valid patient invoice', function () { });
-  // it('GET /sales/:uuid returns 404 for an invalid patient invoice', function () { });
+
+  it('GET /sales/:uuid returns a valid patient invoice', function () {
+    return agent.get('/sales/' + mockSaleUuid)
+      .then(function (res) { 
+        var sale, saleItems, initialItem;
+        expect(res).to.have.status(200);
+        expect(res.body).to.contain.keys('sale', 'saleItems');
+
+        sale = res.body.sale;
+        saleItems = res.body.saleItems;
+        initialItem = saleItems[0];
   
-  // it('POST /sales/ returns 500 for an invalid patient invoice request object', function () { });
-  // it('GET /sales/:invalid_request_uuid returns 404 ensuring invalid request was not written', function () { });
+        expect(sale).to.not.be.empty;
+        expect(saleItems).to.not.be.empty;
+        expect(sale).to.contain.keys('uuid', 'cost', 'invoice_date');
+        expect(initialItem).to.contain.keys('uuid', 'code', 'quantity');
+      })
+      .catch(handle);
+  });
+  
+  it('GET /sales/:uuid returns 404 for an invalid patient invoice', function () {
+    
+    return agent.get('/sales/unkown')
+      .then(function (result) { 
+        expect(result).to.have.status(404);
+        expect(result.body).to.not.be.empty;
+      })
+      .catch(handle);
+  });
+  
+  it('POST /sales returns 400 for an invalid patient invoice request object', function () {
+    
+    return agent.post('/sales')
+      .send(invalidRequestSale)
+      .then(function (res) { 
+        expect(res).to.have.status(400);
+        expect(res.body).to.not.be.empty;
+      });
+  });
+  
   function handle(error) {
     throw error;
   }

--- a/server/test/api/patientInvoice.js
+++ b/server/test/api/patientInvoice.js
@@ -31,7 +31,13 @@ describe('The /sales API', function () {
       .send(user);
   });
   
-  it('GET /sales returns a list of patient invoice', function () {
+  it('POST /sales will record a valid patient invoice and return success from the posting journal'), function () { 
+
+  });
+
+  it('GET /sales returns a list of patient invoices', function () {
+
+    // This value depends on the success of the previous test
     var INITIAL_PATIENT_INVOICES = 1;
 
     return agent.get('/sales')


### PR DESCRIPTION
Implements /sales API, providing data that will be required when implementing the updated finance/patient invoice modules. 

Overview 
- `GET /sales` return a list of all sales
- `GET /sales/:uuid` return details for a specific sale
- `POST /sales` submit a new sale to be written, note this also implicitly posts the record to the posting journal
- (Proposed) `GET /sales/patient/:uuid` return a list of all sales for a specified patient

DELETE (reverse) route implementation is pending financial transactions reversal design, this model (DB implications, HTTP verb, etc.) will then be applied to any relevant financial transactions.
