### PR TITLE
Implement /prices API

### DIFF
--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -48,6 +48,7 @@ var debtors        = require('../controllers/finance/debtors');
 var cashboxes      = require('../controllers/finance/cashboxes');
 var exchange       = require('../controllers/finance/exchange');
 var cashflow       = require('../controllers/cashflow');
+var priceList      = require('../controllers/finance/priceList');
 
 var patientInvoice = require('../controllers/finance/patientInvoice');
 
@@ -343,6 +344,7 @@ exports.configure = function (app) {
   app.put('/users/:id', users.update);
   app.put('/users/:id/password', users.password);
   app.delete('/users/:id', users.delete);
+  // @deprecated
   app.get('/editsession/authenticate/:pin', users.authenticatePin);
 
   // budget controller
@@ -367,6 +369,13 @@ exports.configure = function (app) {
   app.get('/cashboxes/:id/currencies/:currencyId', cashboxes.currencies.details);
   app.post('/cashboxes/:id/currencies', cashboxes.currencies.create);
   app.put('/cashboxes/:id/currencies/:currencyId', cashboxes.currencies.update);
+
+  // price lists
+  app.get('/prices', priceList.list);
+  app.get('/prices/:uuid', priceList.details);
+  app.post('/prices', priceList.create);
+  app.put('/prices/:uuid', priceList.update);
+  app.delete('/prices/:uuid', priceList.delete);
 
   // @todo - classify these
   app.get('/cashflow/report/', cashflow.getReport);

--- a/server/controllers/finance/cashboxes.js
+++ b/server/controllers/finance/cashboxes.js
@@ -12,8 +12,6 @@ var db = require('../../lib/db');
 * in life.
 */
 
-// FIXME -- For some reason, is_bank can be null.
-
 /**
 * GET /cashboxes
 * Lists available cashboxes, defaulting to all in the database.  Pass in the

--- a/server/controllers/finance/priceList.js
+++ b/server/controllers/finance/priceList.js
@@ -231,7 +231,7 @@ exports.update = function update(req, res, next) {
   var items;
   var data = req.body.list;
   var priceListSql =
-    'UPDATE price_list SET ?;';
+    'UPDATE price_list SET ? WHERE id = ?;';
 
   var priceListDeleteItemSql =
     'DELETE FROM price_list_item WHERE price_list_uuid = ?';
@@ -258,7 +258,7 @@ exports.update = function update(req, res, next) {
     // if we get here, it means the price list exists and we can perform an
     // update query on it. Since we are doing multiple operations at once,
     // wrap the queries in a DB transaction.
-    trans.addQuery(priceListSql, data);
+    trans.addQuery(priceListSql, [ data, req.params.uuid ]);
 
     // only trigger price list item updates if the items have been sent back to
     // the server

--- a/server/models/test/data.sql
+++ b/server/models/test/data.sql
@@ -1,6 +1,6 @@
 -- bhima test database
 
-INSERT INTO `unit` VALUES 
+INSERT INTO `unit` VALUES
 (0,'Root','TREE.ROOT','The unseen root node',NULL,'/partials/index.html','/root'),
 (1,'Admin','TREE.ADMIN','The Administration Super-Category',0,'/partials/admin/index.html','/admin'),
 -- (2,'Enterprise','TREE.ENTERPRISE','Manage the registered enterprises from here',1,'/partials/enterprise/','/enterprise'),
@@ -134,7 +134,7 @@ INSERT INTO `village` VALUES ('03a329b2-03fe-4f73-b40f-56a2870cc7e6','MUBUABUA',
 
 INSERT INTO `enterprise` VALUES (1,'Test Enterprise','TE','243 81 504 0540','enterprise@test.org','a0a8998d-af22-4a73-9071-bd43a23f77e3',NULL,2,'103');
 INSERT INTO `project` VALUES (1,'Test Project A','TPA',1,759), (2,'Test Project B','TPB',1,759);
-INSERT INTO `account` VALUES 
+INSERT INTO `account` VALUES
 (3626,3,1,1000,'Test Capital Account',0,0,NULL,NULL,'2015-11-04 14:25:12',1,NULL,1,NULL,NULL,0,NULL),
 (3627,2,1,1100,'Test Capital One',3626,0,NULL,NULL,'2015-11-04 14:26:13',1,1,1,NULL,0,0,NULL),
 (3628,2,1,1200,'Test Capital Two',3626,0,NULL,NULL,'2015-11-04 14:27:13',1,1,1,NULL,0,0,NULL),
@@ -144,9 +144,9 @@ INSERT INTO `account` VALUES
 (3635,3,1,41000,'Test Debtor Accounts',3629,0,NULL,NULL,'2015-11-04 14:32:22',4,NULL,0,NULL,NULL,0,NULL),
 (3636,3,1,4600, 'Test Inventory Accounts', 3629, 0, NULL, NULL, '2015-11-04 14:32:22',4,NULL,0,NULL,NULL,0,NULL),
 (3637,2,1,46001,'Test Item Account',3636,0,NULL,NULL,'2015-11-04 14:32:22',4,NULL,1,NULL,NULL,0,NULL);
- 
+
 -- testing financial transactions
-INSERT INTO `fiscal_year` VALUES 
+INSERT INTO `fiscal_year` VALUES
 (1, 1, 12, 'Test fiscal year', NULL, NULL, NULL, 1, 2016, NULL, 0);
 
 INSERT INTO `period` VALUES
@@ -183,17 +183,18 @@ INSERT INTO `cash_box_account_currency` VALUES (1,1,1,3626,3626,3626,3626),(2,2,
 INSERT INTO `transaction_type` VALUES
 (1, 'sale');
 
-INSERT INTO `inventory_group` VALUES 
+INSERT INTO `inventory_group` VALUES
   ('1410dfe0-b478-11e5-b297-023919d3d5b0', 'Test inventory group', 'INVGRP', 3636, NULL, NULL, NULL);
 
 INSERT INTO `inventory_type` (`id`, `text`) VALUES (1,'Article'),(2,'Assembly'),(3,'Service');
 INSERT INTO `inventory_unit` (`id`, `text`) VALUES (1,'Act'),(2,'Pallet'),(3,'Pill'),(4,'Box'),(5,'Lot'),(6,'amp'),(7,'bags'),(8,'btl'),(9,'cap'),(10,'flc'),(11,'jar'),(12,'ltr'),(13,'pce'),(14,'sch'),(15,'tab'),(16,'tub'),(17,'vial');
 
-INSERT INTO `inventory` VALUES 
+INSERT INTO `inventory` VALUES
   (1, 'cf05da13-b477-11e5-b297-023919d3d5b0', 'INV0', 'Test inventory item', 25.0, 10, '1410dfe0-b478-11e5-b297-023919d3d5b0', NULL, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP),
-  (1, '289cc0a1-b90f-11e5-8c73-159fdc73ab02', 'INV1', 'Second Test inventory item', 10.0, 10, '1410dfe0-b478-11e5-b297-023919d3d5b0', NULL, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP); 
+  (1, '289cc0a1-b90f-11e5-8c73-159fdc73ab02', 'INV1', 'Second Test inventory item', 10.0, 10, '1410dfe0-b478-11e5-b297-023919d3d5b0', NULL, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP),
+  (1, 'c48a3c4b-c07d-4899-95af-411f7708e296', 'INV2', 'Third Test Inventory Item', 105.0, 10, '1410dfe0-b478-11e5-b297-023919d3d5b0', NULL, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP);
 
-INSERT INTO `debitor_group` VALUES 
+INSERT INTO `debitor_group` VALUES
   (1, '4de0fe47-177f-4d30-b95f-cff8166400b4', 'Test Debtor Group', 3631, '03a329b2-03fe-4f73-b40f-56a2870cc7e6', NULL, NULL, NULL, 0, 0, 0, NULL),
   (1, '66f03607-bfbc-4b23-aa92-9321ca0ff586', 'Second Test Debtor Group', 3631, '03a329b2-03fe-4f73-b40f-56a2870cc7e6', NULL, NULL, NULL, 0, 0, 0, NULL);
 
@@ -205,7 +206,7 @@ INSERT INTO `debitor` VALUES
   ('a11e6b7f-fbbb-432e-ac2a-5312a66dccf4', '4de0fe47-177f-4d30-b95f-cff8166400b4','Patient/1/Patient'),
   ('3be232f9-a4b9-4af6-984c-5d3f87d5c107', '4de0fe47-177f-4d30-b95f-cff8166400b4','Patient/2/Patient');
 
-INSERT INTO `patient` VALUES 
+INSERT INTO `patient` VALUES
   ('81af634f-321a-40de-bc6f-ceb1167a9f65',1,1,'a11e6b7f-fbbb-432e-ac2a-5312a66dccf4',NULL,'Test','1','1990-06-01',NULL,NULL,NULL,NULL,NULL,NULL,NULL,'M',NULL,NULL,NULL,NULL,NULL,NULL,0,'bda70b4b-8143-47cf-a683-e4ea7ddd4cff','bda70b4b-8143-47cf-a683-e4ea7ddd4cff','2015-11-14 07:04:49',NULL,NULL,'Patient','100'),
   ('274c51ae-efcc-4238-98c6-f402bfb39866',1,2,'3be232f9-a4b9-4af6-984c-5d3f87d5c107',NULL,'Test','2','1990-06-01',NULL,NULL,NULL,NULL,NULL,NULL,NULL,'M',NULL,NULL,NULL,NULL,NULL,NULL,0,'bda70b4b-8143-47cf-a683-e4ea7ddd4cff','bda70b4b-8143-47cf-a683-e4ea7ddd4cff','2015-11-14 07:04:49',NULL,NULL,'Patient','110');
 

--- a/server/models/updates/synt.sql
+++ b/server/models/updates/synt.sql
@@ -6,10 +6,60 @@ INSERT INTO unit (`id`, `name`, `key`, `description`, `parent`, `url`, `path`) V
 (138, 'Employee State Pdf', 'TREE.EMPLOYEE_STATE', 'Situation Financiere employee' , 128, 'partials/reports_proposed/employee_state/', '/reports/employee_state/');
 
 
--- Deleting 
+-- Deleting
 -- By Chris LOMAME
 -- Date : 2015-12-16
 -- No way to view this report because it is necessary to have a store in parameter
 -- /reports/stock_store/:depotId
 
 delete from unit where id = 134;
+
+--
+-- BEGIN PRICE LIST UPDATES
+--
+
+-- This should eventually be in a schema migration script, but it is fine for the moment.
+-- jniles
+
+-- DANGER
+set foreign_key_checks = 0;
+
+-- make sure all FK links have been removed
+UPDATE debitor_group SET price_list_uuid = NULL;
+UPDATE patient_group SET price_list_uuid = NULL;
+
+DROP TABLE IF EXISTS price_list_item;
+DROP TABLE IF EXISTS price_list;
+
+CREATE TABLE price_list (
+  `enterprise_id`       SMALLINT(5) UNSIGNED NOT NULL,
+  `uuid`                CHAR(36) NOT NULL,
+  `label`               VARCHAR(250) NOT NULL,
+  `description`         TEXT,
+  `created_at`          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`          TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`uuid`),
+  KEY `enterprise_id` (`enterprise_id`),
+  FOREIGN KEY (`enterprise_id`) REFERENCES `enterprise` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE price_list_item (
+  `uuid`                CHAR(36) NOT NULL,
+  `inventory_uuid`      CHAR(36) NOT NULL,
+  `price_list_uuid`     CHAR(36) NOT NULL,
+  `label`               VARCHAR(250) NOT NULL,
+  `value`               INTEGER NOT NULL,
+  `is_percentage`       BOOLEAN NOT NULL DEFAULT 0,
+  `created_at`          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`uuid`),
+  KEY `price_list_uuid` (`price_list_uuid`),
+  KEY `inventory_uuid` (`inventory_uuid`),
+  FOREIGN KEY (`price_list_uuid`) REFERENCES `price_list` (`uuid`) ON DELETE CASCADE,
+  FOREIGN KEY (`inventory_uuid`) REFERENCES `inventory` (`uuid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+set foreign_key_checks = 1;
+
+--
+-- END PRICE LIST UPDATES
+--

--- a/server/test/api/priceList.js
+++ b/server/test/api/priceList.js
@@ -1,14 +1,8 @@
-/* global describe, it, beforeEach, process */
+/*global describe, it, beforeEach, process*/
 
 var chai = require('chai');
 var chaiHttp = require('chai-http');
 var expect = chai.expect;
-
-var q = require('q');
-
-var url = 'https://localhost:8080';
-var user = { username : 'superuser', password : 'superuser', project: 1 };
-
 chai.use(chaiHttp);
 
 // workaround for low node versions
@@ -20,11 +14,26 @@ if (!global.Promise) {
 // environment variables - disable certificate errors
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
 
+// base URL
+var url = 'https://localhost:8080';
+var user = { username : 'superuser', password : 'superuser', project: 1};
+
 /**
  * The /prices API endpoint
  */
 describe('(/prices ) The price list API', function () {
   var agent = chai.request.agent(url);
+
+  // temp error handler
+  function handler(err) { throw err; }
+
+  // login before each request
+  beforeEach(function () {
+    return agent
+      .post('/login')
+      .send(user);
+  });
+
 
   // constants
   var PRICE_LIST_EMPTY = {
@@ -38,4 +47,118 @@ describe('(/prices ) The price list API', function () {
     description : 'A price list with two items attached.',
     items : [] // TODO
   };
+  var ITEMS = [{
+    uuid : '9eded093-699b-4765-9659-eced7db1d487',
+    inventory_uuid : 'd76ee730-704e-4144-b7ef-33695ff1c03a',
+    label : 'Test $10 reduction on an item',
+    is_percentage : false,
+    value : 10
+  }, {
+    uuid : '6051c32a-a9f0-427c-884a-c2cad3da14d5',
+    inventory_uuid : 'c48a3c4b-c07d-4899-95af-411f7708e296',
+    label : 'Test 12% reduction on an item',
+    is_percentage : true,
+    value :12
+  }];
+
+
+  it('GET /prices returns an empty list of price lists', function () {
+    return agent.get('/prices')
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.json;
+        expect(res.body).to.be.empty;
+      })
+      .catch(handler);
+  });
+
+  it('GET /prices/unknownId returns a 404 error', function () {
+    return agent.get('/prices/unknownId')
+      .then(function (res) {
+        expect(res).to.have.status(404);
+        expect(res.body).to.have.all.keys('code', 'httpStatus', 'reason');
+      })
+      .catch(handler);
+  });
+
+
+  it('POST /prices should create a price list (without price list items)', function () {
+    return agent.post('/prices')
+      .send({ list : PRICE_LIST_EMPTY })
+      .then(function (res) {
+        expect(res).to.have.status(201);
+        expect(res.body).to.be.json;
+        expect(res.body).to.have.all.keys('uuid');
+
+        // attach the returned id
+        PRICE_LIST_EMPTY.uuid =  res.body.uuid;
+        return agent.get('/prices/' + PRICE_LIST_EMPTY.uuid);
+      })
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.all.keys('uuid', 'label', 'description', 'enterprise_id');
+      })
+      .catch(handler);
+  });
+
+  it('PUT /prices should update the (empty) price list\'s label', function () {
+    var newLabel = 'Test Empty Price List (updated)' ;
+    return agent.put('/prices/' + PRICE_LIST_EMPTY.uuid)
+      .send({ list : { label : newLabel }})
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.json;
+        expect(res.body).to.have.all.keys('uuid', 'label', 'description', 'enterprise_id');
+        expect(res.body.label).to.equal(newLabel);
+        expect(res.body.items).to.be.empty;
+      })
+      .catch(handler);
+  });
+
+  it('PUT /prices should update the (empty) price list with price list items', function () {
+    return agent.put('/prices/' + PRICE_LIST_EMPTY.uuid)
+      .send({ list : { items : ITEMS }})
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.json;
+        expect(res.body).to.have.all.keys('uuid', 'label', 'description', 'enterprise_id');
+        expect(res.body).to.deep.equal(PRICE_LIST_EMPTY);
+      })
+      .catch(handler);
+  });
+
+  it('GET /prices should return a list of one item', function () {
+    return agent.get('/prices')
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.json;
+        expect(res.body).to.have.length(1);
+      })
+      .catch(handler);
+  });
+
+  it('DELETE /prices/unknownid should return a 404 error.', function () {
+    return agent.delete('/prices/unknownid')
+      .then(function (res) {
+        expect(res).to.have.status(404);
+        expect(res).to.be.json;
+        expect(res.body).to.have.all.keys('code', 'httpStatus', 'reason');
+      })
+      .catch(handler);
+  });
+
+  it('DELETE /prices/:uuid should delete an existing price list', function () {
+    return agent.delete('/prices/' + PRICE_LIST_EMPTY.uuid)
+      .then(function (res) {
+        expect(res).to.have.status(201);
+        return agent.get('/prices/' + PRICE_LIST_EMPTY.uuid);
+      })
+      .then(function (res) {
+        expect(res).to.have.status(404);
+        expect(res).to.be.json;
+        expect(res).to.have.all.keys('code', 'httpStatus', 'reason');
+      })
+      .catch(handler);
+  });
+
 });

--- a/server/test/api/priceList.js
+++ b/server/test/api/priceList.js
@@ -1,0 +1,41 @@
+/* global describe, it, beforeEach, process */
+
+var chai = require('chai');
+var chaiHttp = require('chai-http');
+var expect = chai.expect;
+
+var q = require('q');
+
+var url = 'https://localhost:8080';
+var user = { username : 'superuser', password : 'superuser', project: 1 };
+
+chai.use(chaiHttp);
+
+// workaround for low node versions
+if (!global.Promise) {
+  var q = require('q');
+  chai.request.addPromises(q.Promise);
+}
+
+// environment variables - disable certificate errors
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+
+/**
+ * The /prices API endpoint
+ */
+describe('(/prices ) The price list API', function () {
+  var agent = chai.request.agent(url);
+
+  // constants
+  var PRICE_LIST_EMPTY = {
+    uuid : 'da4be62a-4310-4088-97a4-57c14cab49c8',
+    label : 'Test Empty Price List',
+    description : 'A price list without items attached yet.'
+  };
+  var PRICE_LIST_TWO_ITEMS = {
+    uuid : 'bc9f6833-850f-4ac1-8f04-a60b7b2b38dc8',
+    label : 'Test Price List w/ Two Items',
+    description : 'A price list with two items attached.',
+    items : [] // TODO
+  };
+});

--- a/sh/install.sh
+++ b/sh/install.sh
@@ -15,6 +15,11 @@ usage () {
 
 REBUILD=0;
 DEPENDENCIES=0;
+
+DB_NAME='bhima';
+DB_USER='bhima';
+DB_PASS='HISCongo2013';
+
 while getopts ":hrd" opt; do
   case $opt in
     h)
@@ -51,22 +56,23 @@ build_depends () {
 # build the database
 build_db () {
   echo "Building the bhima database ... "
-  user="bhima"
-  pass="HISCongo2013"
 
   # force database rebuild from command line option
   if [ $REBUILD -eq 1 ]
     then
       echo "Executing DROP SCHEMA command, since install was called with -r (rebuild)."
-      mysql -u $user -p$pass -e "DROP SCHEMA IF EXISTS bhima;"
+      mysql -u $DB_USER -p$DB_PASS -e "DROP SCHEMA IF EXISTS $DB_NAME;"
   fi
-  mysql -u $user -p$pass -e "CREATE SCHEMA IF NOT EXISTS bhima;"
+  mysql -u $DB_USER -p$DB_PASS -e "CREATE SCHEMA IF NOT EXISTS $DB_NAME;"
 
   echo "Building schema ..."
-  mysql -u $user -p$pass bhima < server/models/schema.sql
+  mysql -u $DB_USER -p$DB_PASS bhima < server/models/schema.sql
 
   echo "Importing data ..."
-  mysql -u $user -p$pass bhima < server/models/test/data.sql
+  mysql -u $DB_USER -p$DB_PASS bhima < server/models/test/data.sql
+
+  echo "Running db upgrades ..."
+  #mysql -u $DB_USER -p$DB_PASS bhima < server/models/updates/synt.sql
 }
 
 # compile the server using gulp

--- a/sh/integration-tests.sh
+++ b/sh/integration-tests.sh
@@ -12,6 +12,7 @@ mysql -u $user -p$pw -e "CREATE DATABASE bhima_test;"
 #mysql -u $user -p$pw -e "GRANT ALL ON bhima_test.* TO 'bhima'@'localhost' IDENTIFIED BY 'HISCongo2013';"
 mysql -u $user -p$pw bhima_test < server/models/schema.sql
 mysql -u $user -p$pw bhima_test < server/models/test/data.sql
+mysql -u $user -p$pw bhima_test < server/models/updates/synt.sql
 
 echo "Building server ...."
 


### PR DESCRIPTION
This PR implements the price list api under the `/prices` endpoint.  More specifically,
- `GET /prices` returns a list of price lists
- `GET /prices/:uuid` returns the details of a single price list + items
- `POST /prices` creates a new price list (and optionally, price list items)
- `PUT /prices/:uuid` updates an existing price list + items
- `DELETE /prices/:uuid` will delete a price list + items.

Included in this PR are tests for all routes.  Some corner cases tested:
1. Creating a price list with price list items
2. Creating a price list without price list items
3. Deleting a price list with price list items
4. If a price list item is invalid, the request fails gracefully and cleans up the created price list.

I recommend the #10 be merged before this PR is merged.  The tools found there will help clean up these integration tests immensely.
