### PR TITLE
CHORE(test): use test helpers in integration tests

### DIFF
--- a/server/test/api/account.js
+++ b/server/test/api/account.js
@@ -1,4 +1,4 @@
-/*global describe, it, beforeEach, process*/
+/* global describe, it, beforeEach */
 
 var chai = require('chai');
 var chaiHttp = require('chai-http');
@@ -8,13 +8,9 @@ chai.use(chaiHttp);
 var helpers = require('./helpers');
 helpers.configure(chai);
 
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
-
-var url = 'https://localhost:8080';
-var user = { username : 'superuser', password : 'superuser', project: 1};
-
 describe('The account API, PATH : /accounts', function () {
   var agent = chai.request.agent(helpers.baseUrl);
+
   var newAccount = {
     account_type_id : 1,
     enterprise_id : 1,
@@ -35,7 +31,7 @@ describe('The account API, PATH : /accounts', function () {
 
   var DELETABLE_ACCOUNT_ID = 3636;
   var FETCHABLE_ACCOUNT_ID = 3626;
-  
+
     // login before each request
   beforeEach(helpers.login(agent));
 
@@ -82,7 +78,7 @@ describe('The account API, PATH : /accounts', function () {
         .to.have.all.keys('id', 'enterprise_id', 'locked', 'cc_id', 'pc_id', 'created', 'classe', 'is_asset',
                           'reference_id', 'is_brut_link', 'is_used_budget', 'is_charge', 'account_number',
                           'account_txt', 'parent', 'account_type_id', 'is_title', 'type');
-       
+
        expect(res.body.id).to.be.equal(FETCHABLE_ACCOUNT_ID);
       })
       .catch(helpers.handler);
@@ -119,11 +115,11 @@ describe('The account API, PATH : /accounts', function () {
 
       })
      .catch(helpers.handler);
-  }); 
+  });
 
   it('METHOD : PUT, PATH : /accounts/:id, It updates the newly added account', function () {
     var updateInfo = { account_txt : 'updated value for testing account'};
-  
+
     return agent.put('/accounts/'+ newAccount.id)
       .send(updateInfo)
       .then(function (res) {
@@ -142,7 +138,7 @@ describe('The account API, PATH : /accounts', function () {
 
  it('METHOD : PUT, PATH : /accounts/:unknown, It refuses to update the unknow entity', function () {
     var updateInfo = { account_txt : 'updated value for testing account unknwon'};
-  
+
     return agent.put('/accounts/undefined')
       .send(updateInfo)
       .then(function (res) {
@@ -150,5 +146,5 @@ describe('The account API, PATH : /accounts', function () {
         expect(res).to.be.json;
       })
       .catch(helpers.handler);
-  });    
+  });
 });

--- a/server/test/api/accountType.js
+++ b/server/test/api/accountType.js
@@ -1,4 +1,4 @@
-/*global describe, it, beforeEach, process*/
+/* global describe, it, beforeEach */
 
 var chai = require('chai');
 var chaiHttp = require('chai-http');
@@ -7,11 +7,6 @@ chai.use(chaiHttp);
 
 var helpers = require('./helpers');
 helpers.configure(chai);
-
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
-
-var url = 'https://localhost:8080';
-var user = { username : 'superuser', password : 'superuser', project: 1};
 
 describe('The account types API, PATH : /account_types', function () {
   var agent = chai.request.agent(helpers.baseUrl);
@@ -43,7 +38,7 @@ describe('The account types API, PATH : /account_types', function () {
         expect(res).to.be.json;
         expect(res.body).to.not.be.empty;
         expect(res.body.id).to.be.equal(FETCHABLE_ACCOUNT_TYPE_ID);
-        expect(res.body).to.have.all.keys('id', 'type');        
+        expect(res.body).to.have.all.keys('id', 'type');
       })
      .catch(helpers.handler);
   });
@@ -57,14 +52,14 @@ describe('The account types API, PATH : /account_types', function () {
         expect(res.body).to.not.be.empty;
         expect(res.body.id).to.be.defined;
         newAccountType.id = res.body.id;
-        return agent.get('/account_types/' + newAccountType.id);      
+        return agent.get('/account_types/' + newAccountType.id);
       })
       .then(function (res) {
           expect(res).to.have.status(200);
           expect(res.body).to.have.all.keys('id', 'type');
       })
       .catch(helpers.handler);
-  }); 
+  });
 
   it('METHOD : PUT, PATH : /account_types/:id, It updates the newly added account_type', function () {
     var updateInfo = {type : 'updated value' };
@@ -87,8 +82,8 @@ describe('The account types API, PATH : /account_types', function () {
         return agent.get('/account_types/' + DELETABLE_ACCOUNT_TYPE_ID);
       })
       .then(function (res) {
-        expect(res).to.have.status(404);        
+        expect(res).to.have.status(404);
       })
      .catch(helpers.handler);
-  });  
+  });
 });

--- a/server/test/api/cash.js
+++ b/server/test/api/cash.js
@@ -5,7 +5,7 @@ var chaiHttp = require('chai-http');
 var expect = chai.expect;
 chai.use(chaiHttp);
 
-// import test helpers
+/** import test helpers */
 var helpers = require('./helpers');
 helpers.configure(chai);
 
@@ -28,8 +28,7 @@ describe('(/cash) Cash Payments Interface ::', function () {
     { invoice_uuid : 'c44619e0-3a88-4754-a750-a414fc9567bf', amount : 25.0 }
   ];
 
-
-  // login before each request
+  /** login before each request */
   beforeEach(helpers.login(agent));
 
   // no cash payments have been made yet
@@ -53,7 +52,6 @@ describe('(/cash) Cash Payments Interface ::', function () {
   });
 
   // Tests for the Caution Payment Interface
-  //
   describe('Caution Payments ::', function () {
 
     var CAUTION_PAYMENT = {

--- a/server/test/api/cashboxes.js
+++ b/server/test/api/cashboxes.js
@@ -1,28 +1,21 @@
-/*global describe, it, beforeEach, process*/
+/* global describe, it, beforeEach, process */
 
 var chai = require('chai');
 var chaiHttp = require('chai-http');
 var expect = chai.expect;
 chai.use(chaiHttp);
 
-// workaround for low node versions
-if (!global.Promise) {
-  var q = require('q');
-  chai.request.addPromises(q.Promise);
-}
-
-// environment variables - disable certificate errors
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
-
-// base URL
-var url = 'https://localhost:8080';
-var user = { username : 'superuser', password : 'superuser', project: 1};
+/** import test helpers */
+var helpers = require('./helpers');
+helpers.configure(chai);
 
 /**
 * The /cashboxes API endpoint
 */
 describe('The /cashboxes API endpoint', function () {
-  var agent = chai.request.agent(url);
+  'use strict';
+
+  var agent = chai.request.agent(helpers.baseUrl);
 
   // constants
   var NUMBER_OF_CASHBOXES = 2;
@@ -47,15 +40,9 @@ describe('The /cashboxes API endpoint', function () {
     loss_exchange_account_id: 3631
   };
 
-  // throw errors
-  function handler(err) { throw err; }
 
-  // login before each request
-  beforeEach(function () {
-    return agent
-      .post('/login')
-      .send(user);
-  });
+  /** login before each request */
+  beforeEach(helpers.login(agent));
 
   it('GET /cashboxes returns a list of cashboxes', function () {
     return agent.get('/cashboxes')
@@ -65,7 +52,7 @@ describe('The /cashboxes API endpoint', function () {
         expect(res.body[0]).to.contain.keys('id', 'text');
         expect(res.body).to.have.length(NUMBER_OF_CASHBOXES);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('GET /cashboxes?is_auxillary=1 returns only auxillary cashboxes', function () {
@@ -75,7 +62,7 @@ describe('The /cashboxes API endpoint', function () {
         expect(res.body).to.not.be.empty;
         expect(res.body).to.have.length(NUMBER_OF_AUX_CASHBOXES);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('GET /cashboxes/:id should return a single cashbox with currencies', function () {
@@ -87,7 +74,7 @@ describe('The /cashboxes API endpoint', function () {
         expect(res.body).to.contain.keys('currencies', 'id', 'text');
         expect(res.body.currencies).to.have.length(NUMBER_OF_CASHBOX_CURRENCIES);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('GET /cashboxes/:id should return a 404 for invalid cashbox', function () {
@@ -95,7 +82,7 @@ describe('The /cashboxes API endpoint', function () {
       .then(function (res) {
         expect(res).to.have.status(404);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('POST /cashboxes should create a new cashbox', function () {
@@ -116,7 +103,7 @@ describe('The /cashboxes API endpoint', function () {
         expect(res.body.text).to.equal(BOX.text);
         expect(res.body.is_auxillary).to.equal(BOX.is_auxillary);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('PUT /cashboxes/:id should update the cashbox', function () {
@@ -128,7 +115,7 @@ describe('The /cashboxes API endpoint', function () {
         expect(res.body.text).to.equal(BOX.text);
         expect(res.body.is_auxillary).to.equal(0);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('GET /cashboxes/:id/currencies should return an empty list of cashbox currencies', function () {
@@ -147,7 +134,7 @@ describe('The /cashboxes API endpoint', function () {
         expect(res).to.be.json;
         expect(res.body).to.contain.keys('id');
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('GET /cashboxes/:id/currencies/:currencyId should return a single cashbox currency reference', function () {
@@ -181,7 +168,7 @@ describe('The /cashboxes API endpoint', function () {
         expect(res.body.gain_exchange_account_id).not.to.equal(BOX_CURRENCY.gain_exchange_account_id);
         expect(res.body.loss_exchange_account_id).to.equal(BOX_CURRENCY.gain_exchange_account_id);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('PUT /cashboxes/:id/currencies/undefined should successfully return nothing', function () {
@@ -192,7 +179,7 @@ describe('The /cashboxes API endpoint', function () {
         expect(res).to.be.json;
         expect(res.body).to.be.empty;
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('DELETE /cashboxes/:id should delete the cashbox and associated currencies', function () {
@@ -204,7 +191,6 @@ describe('The /cashboxes API endpoint', function () {
     .then(function (res) {
       expect(res).to.have.status(404);
     })
-    .catch(handler);
+    .catch(helpers.handler);
   });
-
 });

--- a/server/test/api/costCenter.js
+++ b/server/test/api/costCenter.js
@@ -1,4 +1,4 @@
-/*global describe, it, beforeEach, process*/
+/* global describe, it, beforeEach */
 
 var chai = require('chai');
 var chaiHttp = require('chai-http');
@@ -8,13 +8,9 @@ chai.use(chaiHttp);
 var helpers = require('./helpers');
 helpers.configure(chai);
 
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
-
-var url = 'https://localhost:8080';
-var user = { username : 'superuser', password : 'superuser', project: 1};
-
 describe('The cost center API, PATH : /cost_centers', function () {
  var agent = chai.request.agent(helpers.baseUrl);
+
  var newCostCenter = {
     project_id : 1,
     text : 'tested cost',
@@ -57,7 +53,7 @@ describe('The cost center API, PATH : /cost_centers', function () {
         expect(res).to.be.json;
         expect(res.body).to.not.be.empty;
         expect(res.body.id).to.be.equal(FETCHABLE_COST_CENTER_ID);
-        expect(res.body).to.have.all.keys('project_id', 'id', 'text', 'note', 'is_principal');        
+        expect(res.body).to.have.all.keys('project_id', 'id', 'text', 'note', 'is_principal');
       })
       .catch(helpers.handler);
  });
@@ -72,14 +68,14 @@ describe('The cost center API, PATH : /cost_centers', function () {
         expect(res.body.id).to.be.defined;
         newCostCenter.id = res.body.id;
 
-        return agent.get('/cost_centers/' + newCostCenter.id);  
+        return agent.get('/cost_centers/' + newCostCenter.id);
       })
-      .then(function (res){ 
+      .then(function (res){
         expect(res).to.have.status(200);
         expect(res.body).to.have.all.keys('project_id', 'id', 'text', 'note', 'is_principal');
       })
-      .catch(helpers.handler); 
-  }); 
+      .catch(helpers.handler);
+  });
 
   it('METHOD : PUT, PATH : /cost_centers/:id, It updates the newly added cost center', function () {
     var updateInfo = {note : 'update value for note'};
@@ -104,8 +100,8 @@ describe('The cost center API, PATH : /cost_centers', function () {
         return agent.get('/cost_centers/' + DELETABLE_COST_CENTER_ID);
       })
       .then(function (res) {
-        expect(res).to.have.status(404);        
+        expect(res).to.have.status(404);
       })
       .catch(helpers.handler);
-  });  
+  });
 });

--- a/server/test/api/debtors.js
+++ b/server/test/api/debtors.js
@@ -8,7 +8,7 @@ chai.use(chaiHttp);
 var helpers = require('./helpers');
 helpers.configure(chai);
 
-describe('The /debtors API', function () { 
+describe('The /debtors API', function () {
   var agent = chai.request.agent(helpers.baseUrl);
 
   var inspectDebtorGroup;
@@ -16,27 +16,27 @@ describe('The /debtors API', function () {
   // Logs in before each test
   beforeEach(helpers.login(agent));
 
-  it('GET /debtors/groups returns a list of debtor groups', function () { 
+  it('GET /debtors/groups returns a list of debtor groups', function () {
     var INITIAL_TEST_DEBTORS = 2;
 
     return agent.get('/debtors/groups')
-      .then(function (result) { 
+      .then(function (result) {
         expect(result).to.have.status(200);
         expect(result.body).to.not.be.empty;
         expect(result.body).to.have.length(INITIAL_TEST_DEBTORS);
-        
+
         inspectDebtorGroup = result.body[0].uuid;
       })
       .catch(helpers.handler);
   });
 
-  it('GET /debtors/groups/:id returns all details for a valid debtor group', function () { 
+  it('GET /debtors/groups/:id returns all details for a valid debtor group', function () {
     return agent.get('/debtors/groups/' + inspectDebtorGroup)
-      .then(function (result) { 
+      .then(function (result) {
         var debtorGroup;
         var expectedKeySubset = ['uuid', 'account_id', 'name', 'location_id'];
 
-        expect(result).to.have.status(200); 
+        expect(result).to.have.status(200);
 
         debtorGroup = result.body;
         expect(debtorGroup).to.contain.keys(expectedKeySubset);
@@ -44,10 +44,10 @@ describe('The /debtors API', function () {
       .catch(helpers.handler);
   });
 
-  it('GET /debtors/groups/:id returns not found for invalid id', function () { 
+  it('GET /debtors/groups/:id returns not found for invalid id', function () {
     return agent.get('/debtors/groups/invalid')
-      .then(function (result) { 
-        
+      .then(function (result) {
+
         expect(result).to.have.status(404);
         expect(result.body).to.not.be.empty;
       })

--- a/server/test/api/employee.js
+++ b/server/test/api/employee.js
@@ -1,25 +1,15 @@
-/*global describe, it, beforeEach, process*/
+/* global describe, it, beforeEach, process */
 
-// import testing framework
 var chai = require('chai');
 var chaiHttp = require('chai-http');
 var expect = chai.expect;
 chai.use(chaiHttp);
 
-// workaround for low node versions
-if (!global.Promise) {
-  var q = require('q');
-  chai.request.addPromises(q.Promise);
-}
 
-// do not throw self-signed certificate errors
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+/** import test helpers */
+var helpers = require('./helpers');
+helpers.configure(chai);
 
-// base URL
-var url = 'https://localhost:8080';
-
-// throw errors
-function handler(err) { throw err; }
 
 /**
 * The /projects API endpoint
@@ -27,7 +17,12 @@ function handler(err) { throw err; }
 * This test suite implements full CRUD on the /projects HTTP API endpoint.
 */
 describe('The /employees API endpoint :: ', function () {
-  var agent = chai.request.agent(url);
+  'use strict';
+
+  var agent = chai.request.agent(helpers.baseUrl);
+
+  /** login before each request */
+  beforeEach(helpers.login(agent));
 
   // Custom dates
   var embaucheDate  = '2016-01-01',
@@ -77,14 +72,6 @@ describe('The /employees API endpoint :: ', function () {
       location_id : 'ffe563ef-781c-4551-a080-7cec135351ff'
   };
 
-  // login before each request
-  beforeEach(function () {
-    var user = { username : 'superuser', password : 'superuser', project: 1};
-    return agent
-      .post('/login')
-      .send(user);
-  });
-
   it('POST /employee should create a new employee', function () {
     return agent.post('/employees')
       .send(employee)
@@ -94,7 +81,7 @@ describe('The /employees API endpoint :: ', function () {
         expect(res.body.id).to.exist;
         employee.id = res.body.id;
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('POST /employee with fake employee data', function () {
@@ -104,7 +91,7 @@ describe('The /employees API endpoint :: ', function () {
         expect(res).to.have.status(400);
         expect(res).to.be.json;
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('GET /employees returns a list of all employees', function () {
@@ -113,7 +100,7 @@ describe('The /employees API endpoint :: ', function () {
         expect(res).to.have.status(200);
         expect(res.body).to.not.be.empty;
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('GET /employees/:id should return a specific employee ', function () {
@@ -127,7 +114,7 @@ describe('The /employees API endpoint :: ', function () {
         emp.code = emp.code_employee;
         expect(emp).to.contain.all.keys(employee);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('PUT /employee/:id should update an existing employee ', function () {
@@ -140,7 +127,7 @@ describe('The /employees API endpoint :: ', function () {
         expect(emp).to.be.a('object');
         checkValidUpdate(emp, updateEmployee);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('PUT /employee/:id should not update an existing employee with a fake Id ', function () {
@@ -149,7 +136,7 @@ describe('The /employees API endpoint :: ', function () {
       .then(function (res) {
         expect(res).to.have.status(404);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('PUT /employee/:idb should not update an existing employee with fake fields ', function () {
@@ -170,7 +157,7 @@ describe('The /employees API endpoint :: ', function () {
         expect(emp).to.be.a('object');
         checkValidUpdate(emp, updateEmployee);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   /**

--- a/server/test/api/login.js
+++ b/server/test/api/login.js
@@ -1,4 +1,4 @@
-/*global describe, it, beforeEach, process*/
+/* global describe, it, beforeEach */
 
 // import testing framework
 var chai = require('chai');
@@ -6,27 +6,19 @@ var chaiHttp = require('chai-http');
 var expect = chai.expect;
 chai.use(chaiHttp);
 
-// workaround for low node versions
-if (!global.Promise) {
-  var q = require('q');
-  chai.request.addPromises(q.Promise);
-}
-
-// do not throw self-signed certificate errors
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
-
-// base URL
-var url = 'https://localhost:8080';
+/** import test helpers */
+var helpers = require('./helpers');
+helpers.configure(chai);
 
 // begin login tests
 describe('The /login API endpoint', function () {
+  'use strict';
+
+  var url = helpers.baseUrl;
 
   // set up valid user
   var validUser = { username : 'superuser', password : 'superuser', project: 1};
   var invalidUser = { username: 'unauthorized', password : 'unauthorized' };
-
-  // throw errors
-  function handler(err) { throw err; }
 
   it('rejects access to non-existant routes', function () {
     return chai.request(url)
@@ -39,7 +31,7 @@ describe('The /login API endpoint', function () {
           reason : 'You have not yet authenticated with the API to access the endpoint.  Send a POST to /login with proper credentials to sign in.'
         });
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('rejects access to non-public routes', function () {
@@ -49,7 +41,7 @@ describe('The /login API endpoint', function () {
         expect(res).to.have.status(401);
         expect(res.body.code).to.equal('ERR_NOT_AUTHENTICATED');
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('allows access to public routes', function () {
@@ -58,7 +50,7 @@ describe('The /login API endpoint', function () {
       .then(function (res) {
         expect(res).to.have.status(200);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('rejects an unrecognized user', function () {
@@ -69,7 +61,7 @@ describe('The /login API endpoint', function () {
         expect(res).to.have.status(401);
         expect(res.body.code).to.equal('ERR_BAD_CREDENTIALS');
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
 
@@ -81,7 +73,7 @@ describe('The /login API endpoint', function () {
         expect(res).to.have.status(401);
         expect(res.body.code).to.equal('ERR_BAD_CREDENTIALS');
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('rejects a recognized user without a password', function () {
@@ -92,7 +84,7 @@ describe('The /login API endpoint', function () {
         expect(res).to.have.status(401);
         expect(res.body.code).to.equal('ERR_BAD_CREDENTIALS');
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('allows a recognized user with username, password, and project', function () {
@@ -102,7 +94,7 @@ describe('The /login API endpoint', function () {
       .then(function (res) {
         expect(res).to.have.status(200);
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 
   it('sets a user\'s session properties', function () {
@@ -116,6 +108,6 @@ describe('The /login API endpoint', function () {
         expect(res.body.enterprise).to.contain.all.keys('id', 'currency_id', 'currencySymbol');
         expect(res.body.project).to.contain.all.keys('id', 'name', 'abbr', 'enterprise_id');
       })
-      .catch(handler);
+      .catch(helpers.handler);
   });
 });

--- a/server/test/api/patientInvoice.js
+++ b/server/test/api/patientInvoice.js
@@ -1,36 +1,23 @@
-/**
- * @todo Replace generic boilerplate code (environment variables etc.) with import
- */
+/* global describe, it, beforeEach */
+
 var chai = require('chai');
 var chaiHttp = require('chai-http');
 var expect = chai.expect;
-
-var q = require('q');
-
-var url = 'https://localhost:8080';
-var user = { 
-  username : 'superuser', 
-  password : 'superuser', 
-  project: 1
-};
-
 chai.use(chaiHttp);
 
-// workaround for low node versions
-if (!global.Promise) {
-  var q = require('q');
-  chai.request.addPromises(q.Promise);
-}
+/** import test helpers */
+var helpers = require('./helpers');
+helpers.configure(chai);
 
-// Environment variables - disable certificate errors
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
-
-describe('The /sales API', function () { 
-  var mockSaleUuid; 
-  var agent = chai.request.agent(url);
+/**
+ * The /sales API endpoint
+ */
+describe('The /sales API', function () {
+  var mockSaleUuid;
+  var agent = chai.request.agent(helpers.baseUrl);
 
   var mockSale = {
-    sale : { 
+    sale : {
       project_id: 1,
       cost: 35,
       currency_id: 2,
@@ -38,52 +25,49 @@ describe('The /sales API', function () {
       invoice_date: '2016-01-13',
       note: 'TPA_VENTE/Wed Jan 13 2016 10:33:34 GMT+0100 (WAT)/Test 2 Patient',
       service_id: 1,
-      is_distributable: true 
+      is_distributable: true
     },
-    saleItems : [{ 
+    saleItems : [{
       inventory_uuid: '289cc0a1-b90f-11e5-8c73-159fdc73ab02',
       quantity: 1,
       inventory_price: 10,
       transaction_price: 10,
       credit: 10,
       debit: 0
-    },{ 
+    },{
       inventory_uuid: 'cf05da13-b477-11e5-b297-023919d3d5b0',
       quantity: 1,
       inventory_price: 25,
       transaction_price: 25,
       credit: 25,
-      debit: 0 
+      debit: 0
     }]
   };
 
-  var invalidRequestSale = { 
+  var invalidRequestSale = {
     badSale : {},
     invalidParams : {}
   };
-  
-  beforeEach(function () {
-    return agent
-      .post('/login')
-      .send(user);
-  });
+
+  /** login before each request */
+  beforeEach(helpers.login(agent));
 
   // NOTE : Temporary skips while we are sorting the posting journal routes out
-  
-  it.skip('POST /sales will record a valid patient invoice and return success from the posting journal', function () { 
+
+  it.skip('POST /sales will record a valid patient invoice and return success from the posting journal', function () {
     var UUID_LENGTH = 36;
-    
+
     return agent.post('/sales')
       .send(mockSale)
-      .then(function (confirmation) { 
+      .then(function (confirmation) {
         expect(confirmation).to.have.status(201);
         expect(confirmation.body).to.contain.keys('uuid', 'results');
         expect(confirmation.body.uuid.length).to.be.equal(UUID_LENGTH);
 
         // If test has passed record UUID to use in further tests
-        mockSaleUuid = confirmation.body.uuid; 
+        mockSaleUuid = confirmation.body.uuid;
       })
-      .catch(handle);
+      .catch(helpers.handler);
   });
 
   it.skip('GET /sales returns a list of patient invoices', function () {
@@ -92,17 +76,17 @@ describe('The /sales API', function () {
     var INITIAL_PATIENT_INVOICES = 3;
 
     return agent.get('/sales')
-      .then(function (res) { 
+      .then(function (res) {
         expect(res).to.have.status(200);
         expect(res.body).to.not.be.empty;
         expect(res.body).to.have.length(INITIAL_PATIENT_INVOICES);
       })
-      .catch(handle);
+      .catch(helpers.handler);
   });
 
   it.skip('GET /sales/:uuid returns a valid patient invoice', function () {
     return agent.get('/sales/' + mockSaleUuid)
-      .then(function (res) { 
+      .then(function (res) {
         var sale, saleItems, initialItem;
         expect(res).to.have.status(200);
         expect(res.body).to.contain.keys('sale', 'saleItems');
@@ -110,36 +94,32 @@ describe('The /sales API', function () {
         sale = res.body.sale;
         saleItems = res.body.saleItems;
         initialItem = saleItems[0];
-  
+
         expect(sale).to.not.be.empty;
         expect(saleItems).to.not.be.empty;
         expect(sale).to.contain.keys('uuid', 'cost', 'invoice_date');
         expect(initialItem).to.contain.keys('uuid', 'code', 'quantity');
       })
-      .catch(handle);
+      .catch(helpers.handler);
   });
-  
+
   it('GET /sales/:uuid returns 404 for an invalid patient invoice', function () {
-    
+
     return agent.get('/sales/unkown')
-      .then(function (result) { 
+      .then(function (result) {
         expect(result).to.have.status(404);
         expect(result.body).to.not.be.empty;
       })
-      .catch(handle);
+      .catch(helpers.handler);
   });
-  
+
   it('POST /sales returns 400 for an invalid patient invoice request object', function () {
-    
+
     return agent.post('/sales')
       .send(invalidRequestSale)
-      .then(function (res) { 
+      .then(function (res) {
         expect(res).to.have.status(400);
         expect(res.body).to.not.be.empty;
       });
   });
-  
-  function handle(error) {
-    throw error;
-  }
 });

--- a/server/test/api/patients.js
+++ b/server/test/api/patients.js
@@ -109,7 +109,7 @@ describe('The /patients API', function () {
           expect(res).to.have.status(400);
           expect(res.body.code).to.be.equals('ERR_PARAMETERS_REQUIRED');
         })
-        .catch(handle);
+        .catch(helpers.handler);
     });
 
     it('GET /patients/search with `reference` parameter', function () {
@@ -119,7 +119,7 @@ describe('The /patients API', function () {
           expect(res).to.have.status(200);
           expect(res.body).to.not.be.empty;
         })
-        .catch(handle);
+        .catch(helpers.handler);
     });
 
     it('GET /patients/search with `name` parameter', function () {
@@ -129,12 +129,12 @@ describe('The /patients API', function () {
           expect(res).to.have.status(200);
           expect(res.body).to.not.be.empty;
         })
-        .catch(handle);
+        .catch(helpers.handler);
     });
 
     it('GET /patients/search with a set of parameters (fields) as an object', function () {
       var fields = {
-        sex: "M",
+        sex: 'M',
         last_name: 2
       };
       return agent.get('/patients/search/?fields='+JSON.stringify(fields))
@@ -142,7 +142,7 @@ describe('The /patients API', function () {
           expect(res).to.have.status(200);
           expect(res.body).to.not.be.empty;
         })
-        .catch(handle);
+        .catch(helpers.handler);
     });
 
     it('GET /patients/search with `name` and `reference` parameters for the priority of reference', function () {
@@ -155,7 +155,7 @@ describe('The /patients API', function () {
           expect(res.body[0].reference).to.exist;
           expect(res.body[0].reference).to.be.equals('TPA1');
         })
-        .catch(handle);
+        .catch(helpers.handler);
     });
 
     it('GET /patients/search with `detail` and `limit` parameters', function () {
@@ -180,7 +180,7 @@ describe('The /patients API', function () {
           expect(res.body).to.not.be.empty;
           expect(res.body).to.have.length(1);
         })
-        .catch(handle);
+        .catch(helpers.handler);
     });
 
   });
@@ -194,7 +194,7 @@ describe('The /patients API', function () {
         expect(res.body).to.not.be.empty;
         expect(res.body).to.have.length(INITIAL_TEST_PATIENTS);
       })
-      .catch(handle);
+      .catch(helpers.handler);
   });
 
   it('POST /patients will register a valid patient', function () {
@@ -208,7 +208,7 @@ describe('The /patients API', function () {
         expect(confirmation.body.uuid.length).to.equal(UUID_LENGTH);
 
       })
-      .catch(handle);
+      .catch(helpers.handler);
   });
 
   it('GET /patients/:id finds and retrieves the details of the registered patient', function () {
@@ -243,7 +243,7 @@ describe('The /patients API', function () {
       .then(function (result) {
         expect(result).to.have.status(400);
       })
-      .catch(handle);
+      .catch(helpers.handler);
   });
 
   it('POST /patients will reject a patient with an incorrectly formatted request object', function () {
@@ -254,7 +254,7 @@ describe('The /patients API', function () {
         expect(result.body).to.have.keys('code', 'reason');
         expect(result.body.code).to.be.equal('ERROR.ERR_MISSING_INFO');
       })
-      .catch(handle);
+      .catch(helpers.handler);
 
   });
 
@@ -268,7 +268,7 @@ describe('The /patients API', function () {
         expect(result.body).to.not.be.empty;
         expect(result.body).to.have.length(SUBSCRIBED_PATIENT_GROUPS);
       })
-      .catch(handle);
+      .catch(helpers.handler);
   });
 
   it('GET /patients/:id/groups will return 404 not found for invalid request', function () {
@@ -279,7 +279,7 @@ describe('The /patients API', function () {
         expect(result).to.be.json;
         expect(result.body).to.not.be.empty;
       })
-      .catch(handle);
+      .catch(helpers.handler);
   });
 
   it('GET /patients/groups will return a list of all patient groups', function () {
@@ -291,8 +291,8 @@ describe('The /patients API', function () {
         expect(result.body).to.not.be.empty;
         expect(result.body).to.have.length(TOTAL_PATIENT_GROUPS);
       })
-      .catch(handle);
-  });
+      .catch(helpers.handler);
+  }); 
 
   it('Simultaneous patient registration requests respect reference lock', function () {
 
@@ -348,7 +348,7 @@ describe('The /patients API', function () {
           references.push(patientReference);
         });
       })
-      .catch(handle);
+      .catch(helpers.handler);
   });
 
  describe('Updating patient group assignment', function () {
@@ -373,7 +373,7 @@ describe('The /patients API', function () {
 
         expect(assignResult.affectedRows).to.equal(groupAssignment.assignments.length);
       })
-      .catch(handle);
+      .catch(helpers.handler);
    });
 
    /*
@@ -432,9 +432,5 @@ describe('The /patients API', function () {
     timeout);
 
     return deferred.promise;
-  }
-
-  function handle(error) {
-    throw error;
   }
 });


### PR DESCRIPTION
This commit updates all legacy tests to using the test helpers
introduced by #10.  These helpers allow global changes to error
handling, logging, and process configuration to be made in a single
location rather than in each individual test API file.
