### PR TITLE
FEAT(travis): make TravisCI run API tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ node_js:
 before_script:
   - npm install -g gulp bower mocha
   - bower install
-  - mysql -u root -e "CREATE DATABASE bhima;"
-  - mysql -u root -e "CREATE USER 'bhima'@'localhost' IDENTIFIED BY 'HISCongo2013';"
+  - mysql -u root -e "CREATE DATABASE bhima_test;"
+  - mysql -u root -e "CREATE USER 'bhima_test'@'%' IDENTIFIED BY 'HISCongo2013';"
   - mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'bhima'@'localhost' WITH GRANT OPTION;"
-  - mysql -u root bhima < server/models/schema.sql
 
 cache:
   directories:
@@ -29,3 +28,6 @@ git:
 # make sure we aren't caching verbose output from NPM
 before_cache:
   - rm -f npm-debug.log
+
+services:
+  - mysql

--- a/sh/travis.sh
+++ b/sh/travis.sh
@@ -3,14 +3,42 @@
 # This file runs some lint checks using Travis CI
 
 # lint the client
-echo "Linting the client ..."
+echo "[LOG] Linting the client ..."
 gulp lint
 
 # build the application
-echo "Building the application ..."
+echo "[LOG] Building the application ..."
 gulp build
 
 # lint the server
-echo "Linting the server ..."
+echo "[LOG] Linting the server ..."
 jshint server/{controllers,lib,config}/*.js
 jshint server/controllers/{categorised,medical,reports,stock,finance}/*.js
+
+# Instructions for Travis to build the MySQL database
+# NOTE - the bhima user is already defined in the .travis.yml
+
+echo "[LOG] Building the database ..."
+
+user="bhima"
+pw="HISCongo2013"
+
+# build the test database
+mysql -u $user -p$pw -e "DROP DATABASE IF EXISTS bhima_test;"
+mysql -u $user -p$pw -e "CREATE DATABASE bhima_test CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
+mysql -u $user -p$pw bhima_test < server/models/schema.sql
+mysql -u $user -p$pw bhima_test < server/models/test/data.sql
+mysql -u $user -p$pw bhima_test < server/models/updates/synt.sql
+
+echo "[LOG] Building and running server in development mode ..."
+
+# build and start the server
+npm run dev &
+
+# make sure we have enough time for the server to start
+sleep 10
+
+echo "[LOG] Running integration tests."
+
+# run the tests
+mocha server/test/api/


### PR DESCRIPTION
This commit attempts to coerce TavisCI into running our integration
tests for API endpoints.  It uses the .travis.yml file to set up the
test bhima user.  Next, we use travis.sh (as for linting) to create a
test database and run integration tests.
