### PR TITLE
FEAT(accounts): implemented /accounts API and test

### DIFF
--- a/client/src/js/services/AccountService.js
+++ b/client/src/js/services/AccountService.js
@@ -70,8 +70,19 @@ function AccountService($http, util) {
 
   // return a list of OHADA accounts
   function list() {
-    return $http.get('/accounts?type=ohada')
+    return $http.get('/accounts?full=1') // TODO - this should only be /accounts
       .then(util.unwrapHttpResponse)
+      .then(function (accounts) {
+        
+        // hack to make sure accounts are properly rendered on cashboxes page
+        // FIXME - make /accounts return the account type w/o query string
+        // and preformat the label elsewhere
+        accounts.forEach(function (account) {
+          account.label = account.account_number + ' ' + account.account_txt;
+        });
+
+        return accounts;
+      })
       .then(order);
   }
 

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -49,7 +49,13 @@ var cashboxes      = require('../controllers/finance/cashboxes');
 var exchange       = require('../controllers/finance/exchange');
 var cash           = require('../controllers/finance/cash');
 var cashflow       = require('../controllers/cashflow');
+
 var priceList      = require('../controllers/finance/priceList');
+var account        = require('../controllers/finance/account');
+var accountType    = require('../controllers/finance/accountType');
+var costCenter     = require('../controllers/finance/costCenter');
+var profitCenter   = require('../controllers/finance/profitCenter');
+var reference      = require('../controllers/finance/reference');
 
 var patientInvoice = require('../controllers/finance/patientInvoice');
 
@@ -95,6 +101,41 @@ exports.configure = function (app) {
   app.get('/location/sector/:uuid', locations.lookupSector);
   app.get('/location/province/:uuid', locations.lookupProvince);
   app.get('/location/detail/:uuid', locations.lookupDetail);
+
+  // API for account routes crud
+  app.get('/accounts', account.list);
+  app.get('/accounts/:id', account.getAccount);
+  app.post('/accounts', account.create);
+  app.put('/accounts/:id', account.update);
+
+  //API for account type routes crud
+  app.get('/account_types', accountType.list);
+  app.get('/account_types/:id', accountType.getAccountType);
+  app.post('/account_types', accountType.create);
+  app.put('/account_types/:id', accountType.update);
+  app.delete('/account_types/:id', accountType.remove);
+
+  //API for cost_center routes crud
+  app.get('/cost_centers', costCenter.list);
+  app.get('/cost_centers/:id', costCenter.getCostCenter);
+  app.post('/cost_centers', costCenter.create);
+  app.put('/cost_centers/:id', costCenter.update);
+  app.delete('/cost_centers/:id', costCenter.remove);
+
+  //API for profit_center routes crud
+  app.get('/profit_centers', profitCenter.list);
+  app.get('/profit_centers/:id', profitCenter.getProfitCenter);
+  app.post('/profit_centers', profitCenter.create);
+  app.put('/profit_centers/:id', profitCenter.update);
+  app.delete('/profit_centers/:id', profitCenter.remove);
+
+  //API for reference routes crud
+  app.get('/references', reference.list);
+  app.get('/references/:id', reference.getReference);
+  app.post('/references', reference.create);
+  app.put('/references/:id', reference.update);
+  app.delete('/references/:id', reference.remove);
+  
 
   // -> Add :route
   app.post('/report/build/:route', reports.build);

--- a/server/controllers/finance/account.js
+++ b/server/controllers/finance/account.js
@@ -1,0 +1,132 @@
+/**
+ * Account Controller
+ *
+ * @module finance/account
+ * @author DedrickEnc
+ *
+ * @desc Implements CRUD operations on the Account entity.
+ *
+ * This module implements the following routes:
+ * GET    /accounts
+ * GET    /accounts/:id
+ * POST   /accounts
+ * PUT    /accounts/:id
+ *
+ * */
+
+var db = require('../../lib/db');
+
+/**
+ * Create a new account entity.
+ *
+ * POST /accounts
+ */
+
+function create (req, res, next){
+  'use strict';
+
+  var record = req.body;
+  var createAccountQuery = 'INSERT INTO account SET ?';
+
+  delete record.id;
+  
+  db.exec(createAccountQuery, [record])
+  .then(function (result){
+      res.status(201).json({id : result.insertId});
+  })
+  .catch(next)
+  .done();
+}
+
+/**
+ * Updates an account.
+ *
+ * PUT /accounts/:id
+ */
+
+
+function update (req, res, next){
+  'use strict';
+  
+  var queryData = req.body;
+  var accountId = req.params.id;
+  var updateAccountQuery = 'UPDATE account SET ? WHERE id = ?';
+
+  delete queryData.id;
+
+  lookupAccount(accountId, req.codes)
+    .then(function (){
+      return db.exec(updateAccountQuery, [queryData, accountId]);         
+    })
+    .then(function(){
+      return lookupAccount(accountId, req.codes);       
+    })
+    .then(function (account){
+      res.status(200).json(account);
+    })
+    .catch(next)
+    .done();
+}
+
+function list (req, res, next){
+  'use strict';
+
+  var sql = 
+    'SELECT a.id, a.account_number, a.account_txt, a.locked FROM account AS a';
+
+  if(req.query.full === '1'){
+    
+    sql = 
+      'SELECT a.id, a.enterprise_id, a.locked, a.cc_id, a.pc_id, a.created, a.classe, a.is_asset, ' + 
+      'a.reference_id, a.is_brut_link, a.is_used_budget, a.is_charge, a.account_number, ' +
+      'a.account_txt, a.parent, a.account_type_id, a.is_title, at.type FROM account AS a JOIN account_type AS at ON a.account_type_id = at.id';
+  }
+
+  if(req.query.locked === '0'){
+    sql+=' WHERE a.locked = 0';
+  }
+
+  sql += ' ORDER BY a.account_number;';
+
+  db.exec(sql)
+  .then(function (rows) {
+    res.status(200).json(rows);
+  })
+  .catch(next)
+  .done();
+}
+
+function getAccount (req, res, next){
+  'use strict';
+
+  lookupAccount(req.params.id, req.codes)
+   .then(function (account) {
+      res.status(200).json(account);
+   })
+  .catch(next)
+  .done();
+}
+
+function lookupAccount (id, codes){
+  'use strict';
+
+  var sql = 
+    'SELECT a.id, a.enterprise_id, a.locked, a.cc_id, a.pc_id, a.created, a.classe, a.is_asset, ' + 
+    'a.reference_id, a.is_brut_link, a.is_used_budget, a.is_charge, a.account_number, ' +
+    'a.account_txt, a.parent, a.account_type_id, a.is_title, at.type FROM account AS a JOIN account_type AS at ON a.account_type_id = at.id WHERE a.id = ?';
+
+  return db.exec(sql, id)
+    .then(function(rows){
+      if(rows.length === 0){ throw codes.ERR_NOT_FOUND;}
+      return rows[0];
+    });
+}
+
+function isEmptyObject(object) {
+  return Object.keys(object).length === 0;
+}
+
+exports.list = list;
+exports.create = create;
+exports.update = update;
+exports.getAccount = getAccount;

--- a/server/controllers/finance/accountType.js
+++ b/server/controllers/finance/accountType.js
@@ -1,0 +1,123 @@
+/**
+ * AccountType controller
+ * 
+ * @module finance/accountType
+ * @author DedrickEnc
+ *
+ * @desc Implements CRUD operations on the AccountType entity.
+ *
+ * This module implements the following routes:
+ * GET    /account_types
+ * GET    /account_types/:id
+ * POST   /account_types
+ * PUT    /account_types/:id
+ * DELETE /accounts_types/:id
+ *
+ **/
+ 
+var db = require('../../lib/db');
+
+function getAccountType (req, res, next){
+  'use strict';
+
+  lookupAccountType(req.params.id, req.codes)
+    .then(function (row) {
+      res.status(200).json(row);
+  })
+  .catch(next)
+  .done();
+}
+
+function list (req, res, next){
+  'use strict';
+
+  var sql = 
+    'SELECT at.id, at.type FROM account_type AS at';  
+
+  db.exec(sql)
+  .then(function (rows) {
+    res.status(200).json(rows);
+  })
+  .catch(next)
+  .done();
+}
+
+
+/**
+ * Create a new account type entity.
+ *
+ * POST /account_types
+ */
+function create (req, res, next) {
+  'use strict';
+
+  var record = req.body;
+  var createAccountTypeQuery = 'INSERT INTO account_type SET ?';
+  
+  delete record.id;
+
+  db.exec(createAccountTypeQuery, [record])
+    .then(function (result){
+      res.status(201).json({ id: result.insertId});
+    })
+    .catch(next)
+    .done();
+}
+
+function update (req, res, next){
+  'use strict';
+
+  var queryData = req.body;
+  var accountTypeId = req.params.id;
+  var updateAccountTypeQuery = 'UPDATE account_type SET ? WHERE id = ?';
+
+  delete queryData.id;
+
+  lookupAccountType(accountTypeId, req.codes)
+    .then(function (){
+      return db.exec(updateAccountTypeQuery, [queryData, accountTypeId]);
+    }) 
+   .then(function (){
+      return lookupAccountType(accountTypeId, req.codes);
+  })
+  .then(function (accountType){
+    res.status(200).json(accountType);
+  })
+  .catch(next)
+  .done();
+}
+
+function remove (req, res, next) {
+  var accountTypeId = req.params.id;
+  var removeAccountTypeQuery = 'DELETE FROM account_type WHERE id=?';
+
+  lookupAccountType(accountTypeId, req.codes)
+    .then(function (){
+      return db.exec(removeAccountTypeQuery, [accountTypeId]);
+    })
+    .then(function (){
+      res.status(204).send();
+    })
+    .catch(next)
+    .done();
+}
+
+function lookupAccountType(id, codes){
+  'use strict';
+  
+  var sql = 
+    'SELECT at.id, at.type FROM account_type AS at WHERE at.id = ?';
+
+  return db.exec(sql, id)
+    .then(function (rows){
+      if(rows.length === 0) { throw codes.ERR_NOT_FOUND;}
+      return rows[0];
+    });
+}
+
+exports.list = list;
+exports.create = create;
+exports.update = update;
+exports.remove = remove;
+exports.getAccountType = getAccountType;
+

--- a/server/controllers/finance/accounts.js
+++ b/server/controllers/finance/accounts.js
@@ -11,16 +11,12 @@ exports.list = function list(req, res, next) {
   // This should probably take a query string for filtering to
   // make it more useful all around.
   // Some ideas:
-  // ?classe=5, ?type=ohada, etc...
+  // ?classe=5, etc...
 
   var sql =
     'SELECT a.id, a.account_number, a.account_txt, a.parent, at.type ' +
     'FROM account AS a JOIN account_type AS at ON ' +
       'a.account_type_id = at.id';
-
-  if (req.query.type === 'ohada') {
-    sql += ' WHERE a.is_ohada = 1';
-  }
 
   sql += ' ORDER BY a.account_number;';
 
@@ -179,11 +175,11 @@ exports.getClassSolde = function (req, res, next) {
   */
 exports.getTypeSolde = function (req, res, next) {
 
-    var fiscalYearId = req.params.fiscal_year,
+  var fiscalYearId = req.params.fiscal_year,
         accountType   = req.params.account_type_id,
         accountIsCharge = req.params.is_charge;
 
-    var sql =
+  var sql =
       'SELECT `ac`.`id`, `ac`.`account_number`, `ac`.`account_txt`, `ac`.`account_type_id`, `ac`.`is_charge`, `t`.`fiscal_year_id`, `t`.`debit`, `t`.`credit`, `t`.`debit_equiv`, `t`.`credit_equiv`, `t`.`currency_id` ' +
       'FROM (' +
         '(' +

--- a/server/controllers/finance/costCenter.js
+++ b/server/controllers/finance/costCenter.js
@@ -1,0 +1,107 @@
+var db = require('../../lib/db');
+
+function list (req, res, next){
+  'use strict';
+
+  var sql = 
+    'SELECT c.id, c.text FROM cost_center AS c';
+
+  if(req.query.full === '1'){
+    sql = 
+      'SELECT c.id, c.text, c.project_id, c.note, c.is_principal, p.name, p.abbr, p.enterprise_id, p.zs_id ' +
+      'FROM cost_center AS c JOIN project AS p ON c.project_id = p.id';
+  }
+
+  sql += ' ORDER BY c.text;';
+
+  db.exec(sql)
+  .then(function (rows) {
+    res.status(200).json(rows);
+  })
+  .catch(next)
+  .done();
+}
+
+function create (req, res, next) {
+  'use strict';
+
+  var record = req.body;
+  var createCostCenterQuery = 'INSERT INTO cost_center SET ?';
+
+  delete record.id;
+  
+  db.exec(createCostCenterQuery, [record])
+    .then(function (result){
+      res.status(201).json({ id: result.insertId });
+    })
+    .catch(next)
+    .done();
+}
+
+function update (req, res, next){
+  'use strict';
+
+  var queryData = req.body;
+  var costCenterId = req.params.id;
+  var updateCostCenterQuery = 'UPDATE cost_center SET ? WHERE id = ?';
+
+  delete queryData.id;
+
+  lookupCostCenter(costCenterId, req.codes)
+    .then(function (){
+      return db.exec(updateCostCenterQuery, [queryData, costCenterId]);      
+    })
+    .then(function (result){
+      return lookupCostCenter(costCenterId, req.codes);
+    })
+    .then(function (costCenter){
+      res.status(200).json(costCenter);
+    })
+    .catch(next)
+    .done();
+}
+
+function remove (req, res, next) {
+  var costCenterId = req.params.id;
+  var removeCostCenterQuery = 'DELETE FROM cost_center WHERE id=?';
+
+  lookupCostCenter(costCenterId, req.codes)
+    .then(function (){
+      return db.exec(removeCostCenterQuery, [costCenterId]);
+    })
+    .then(function (){
+      res.status(204).send();    
+    })
+    .catch(next)
+    .done();
+}
+
+function getCostCenter (req, res, next){
+  'use strict';
+
+  lookupCostCenter(req.params.id, req.codes)
+    .then(function (row) {
+      res.status(200).json(row);      
+    })
+    .catch(next)
+    .done();
+}
+
+function lookupCostCenter (id, codes){
+  'use strict';
+
+  var sql = 
+    'SELECT cc.id, cc.text, cc.note, cc.is_principal, cc.project_id FROM cost_center AS cc WHERE cc.id = ?';
+
+  return db.exec(sql, id)
+    .then(function (rows){
+      if(rows.length === 0) { throw codes.ERR_NOT_FOUND;}
+      return rows[0];      
+    });
+}
+
+exports.list = list;
+exports.create = create;
+exports.update = update;
+exports.remove = remove;
+exports.getCostCenter = getCostCenter;

--- a/server/controllers/finance/profitCenter.js
+++ b/server/controllers/finance/profitCenter.js
@@ -1,0 +1,107 @@
+var db = require('../../lib/db');
+
+function list (req, res, next){
+  'use strict';
+  var sql = 
+    'SELECT p.id, p.text FROM profit_center AS p';
+
+  if(req.query.full === '1'){
+
+    sql = 
+      'SELECT p.id, p.text, p.project_id, p.note, pr.name, pr.abbr, pr.enterprise_id, pr.zs_id ' +
+      'FROM profit_center AS p JOIN project AS pr ON p.project_id = pr.id';
+  }
+
+  sql += ' ORDER BY p.text;';
+
+  db.exec(sql)
+  .then(function (rows) {
+    res.status(200).json(rows);
+  })
+  .catch(next)
+  .done();
+}
+
+function create (req, res, next) {
+  'use strict';
+
+  var record = req.body;
+  var createProfitCenterQuery = 'INSERT INTO profit_center SET ?';
+  
+  delete record.id;
+
+  db.exec(createProfitCenterQuery, [record])
+    .then(function (result){
+      res.status(201).json({ id: result.insertId });
+    })
+    .catch(next)
+    .done();
+}
+
+function update (req, res, next){
+  'use strict';
+
+  var queryData = req.body;
+  var profitCenterId = req.params.id;
+  var updateProfitCenterQuery = 'UPDATE profit_center SET ? WHERE id = ?';
+
+  delete queryData.id;
+
+  lookupProfitCenter(profitCenterId, req.codes)
+    .then(function (){
+      return db.exec(updateProfitCenterQuery, [queryData, profitCenterId]);
+    })
+    .then(function (result){
+      return lookupProfitCenter(profitCenterId, req.codes);
+    })
+    .then(function (profitCenter){
+      res.status(200).json(profitCenter);
+    })
+    .catch(next)
+    .done();
+}
+
+function remove (req, res, next) {
+  var profitCenterId = req.params.id;
+  var removeProfitCenterQuery = 'DELETE FROM profit_center WHERE id=?';
+
+  lookupProfitCenter(profitCenterId, req.codes)
+    .then(function (){
+      return db.exec(removeProfitCenterQuery, [profitCenterId]);
+    })
+    .then(function (){
+      res.status(204).send();   
+    })
+    .catch(next)
+    .done();
+}
+
+function getProfitCenter (req, res, next){
+  'use strict';
+
+  lookupProfitCenter(req.params.id, req.codes)
+    .then(function (row) {
+      res.status(200).json(row);
+    })
+    .catch(next)
+    .done();
+}
+
+function lookupProfitCenter (id, codes){
+  'use strict';
+
+  var sql = 
+    'SELECT p.id, p.text, p.note, p.project_id FROM profit_center AS p WHERE p.id = ?';
+
+  return db.exec(sql, id)
+    .then(function (rows){
+      if(rows.length === 0) { throw codes.ERR_NOT_FOUND;}
+      return rows[0];
+    });
+}
+
+exports.list = list;
+exports.create = create;
+exports.update = update;
+exports.remove = remove;
+exports.getProfitCenter = getProfitCenter;

--- a/server/controllers/finance/reference.js
+++ b/server/controllers/finance/reference.js
@@ -1,0 +1,107 @@
+var db = require('../../lib/db');
+
+function getReference (req, res, next){
+  'use strict';
+
+  lookupReference (req.params.id, req.codes)
+    .then(function (row) {
+      res.status(200).json(row);
+    })
+    .catch(next)
+    .done();
+}
+
+function list (req, res, next){
+  'use strict';
+
+  var sql = 
+    'SELECT r.id, r.text, r.ref FROM reference AS r';
+
+  if(req.query.full === '1'){
+    sql = 
+      'SELECT r.id, r.text, r.ref, r.is_report, r.position, r.reference_group_id, r.section_resultat_id ' +
+      'FROM reference AS r';
+  }
+
+  sql += ' ORDER BY r.ref;';
+
+  db.exec(sql)
+  .then(function (rows) {
+    res.status(200).json(rows);
+  })
+  .catch(next)
+  .done();
+}
+
+function create (req, res, next) {
+  'use strict';
+
+  var record = req.body;
+  var createReferenceQuery = 'INSERT INTO reference SET ?';
+
+  delete record.id;
+  
+  db.exec(createReferenceQuery, [record])
+  .then(function (result){
+    res.status(201).json({ id: result.insertId });
+  })
+  .catch(next)
+  .done();
+}
+
+function update (req, res, next){
+  'use strict';
+
+  var queryData = req.body;
+  var referenceId = req.params.id;
+  var updateReferenceQuery = 'UPDATE reference SET ? WHERE id = ?';
+
+  delete queryData.id;
+
+  lookupReference(referenceId, req.codes)
+    .then(function (){
+      return db.exec(updateReferenceQuery, [queryData, referenceId]);
+    })
+    .then(function (result){
+      return lookupReference(referenceId, req.codes);
+    })
+    .then(function (reference){
+      res.status(200).json(reference);
+    })
+    .catch(next)
+    .done();
+}
+
+function remove (req, res, next) {
+  
+  var referenceId = req.params.id;
+  var removeReferenceQuery = 'DELETE FROM reference WHERE id=?';
+
+  lookupReference(referenceId, req.codes)
+    .then(function (){
+      return db.exec(removeReferenceQuery, [referenceId]);
+    })
+    .then(function (){
+      res.status(204).send();
+   })
+    .catch(next)
+    .done();
+}
+
+function lookupReference (id, codes){
+  var sql = 
+    'SELECT r.id, r.text, r.ref, r.is_report, r.position, r.reference_group_id, r.section_resultat_id ' +
+    'FROM reference AS r WHERE r.id = ?';
+
+  return db.exec(sql, id)
+    .then(function (rows){
+    if(rows.length === 0){ throw codes.ERR_NOT_FOUND;}
+      return rows[0];
+    });
+}
+
+exports.list = list;
+exports.create = create;
+exports.update = update;
+exports.remove = remove;
+exports.getReference = getReference;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -28,7 +28,6 @@ CREATE TABLE `account` (
   FOREIGN KEY (`account_type_id`) REFERENCES `account_type` (`id`),
   FOREIGN KEY (`enterprise_id`) REFERENCES `enterprise` (`id`),
   FOREIGN KEY (`cc_id`) REFERENCES `cost_center` (`id`),
-  FOREIGN KEY (`account_type_id`) REFERENCES `account_type` (`id`),
   FOREIGN KEY (`reference_id`) REFERENCES `reference` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/server/models/test/data.sql
+++ b/server/models/test/data.sql
@@ -134,6 +134,7 @@ INSERT INTO `village` VALUES ('03a329b2-03fe-4f73-b40f-56a2870cc7e6','MUBUABUA',
 
 INSERT INTO `enterprise` VALUES (1,'Test Enterprise','TE','243 81 504 0540','enterprise@test.org','a0a8998d-af22-4a73-9071-bd43a23f77e3',NULL,2,'103');
 INSERT INTO `project` VALUES (1,'Test Project A','TPA',1,759), (2,'Test Project B','TPB',1,759);
+
 INSERT INTO `account` VALUES
 (3626,3,1,1000,'Test Capital Account',0,0,NULL,NULL,'2015-11-04 14:25:12',1,NULL,1,NULL,NULL,0,NULL),
 (3627,2,1,1100,'Test Capital One',3626,0,NULL,NULL,'2015-11-04 14:26:13',1,1,1,NULL,0,0,NULL),
@@ -159,9 +160,10 @@ INSERT INTO `period` VALUES
 ( 7 , 1 ,7,'2016-07-01', '2016-07-31', 0 ),
 ( 8 , 1 ,8,'2016-08-01', '2016-08-31', 0 ),
 ( 9 , 1 ,9,'2016-09-01', '2016-09-30', 0 ),
-( 0 , 1 ,0,'2016-10-01', '2016-10-31', 0 ),
+( 10 , 1 ,0,'2016-10-01', '2016-10-31', 0 ),
 ( 11, 1 ,1,'2016-11-01', '2016-11-30', 0 ),
 ( 12 ,1 ,2,'2016-12-01', '2016-12-31', 0 );
+
 
 -- create test users
 INSERT INTO user (id, username, password, first, last, email) VALUES
@@ -181,7 +183,7 @@ INSERT INTO `cash_box` VALUES (1,'Test Primary Cashbox A ',1,0,0), (2,'Test Aux 
 INSERT INTO `cash_box_account_currency` VALUES (1,1,1,3626,3626,3626,3626),(2,2,1,3627,3627,3627,3627),(3,1,2,3627,3627,3627,3627),(4,2,2,3627,3627,3627,3627);
 
 INSERT INTO `transaction_type` VALUES
-(1, 'sale');
+(2, 'sale');
 
 INSERT INTO `inventory_group` VALUES
   ('1410dfe0-b478-11e5-b297-023919d3d5b0', 'Test inventory group', 'INVGRP', 3636, NULL, NULL, NULL);
@@ -214,29 +216,12 @@ INSERT INTO `patient` VALUES
 INSERT INTO `assignation_patient` VALUES
   (UUID(), '112a9fb5-847d-4c6a-9b20-710fa8b4da24', '81af634f-321a-40de-bc6f-ceb1167a9f65');
 
-INSERT INTO `cost_center` VALUES
-  (1, 1, 'Test cost center', 'Example note for a test cost center', 1);
-
-INSERT INTO `profit_center` VALUES
-  (1, 1, 'Test profit center', 'Example note for a test profit center');
-
 -- Fonctions
 INSERT INTO `fonction` VALUES
   (1, 'Infirmier'),
   (2, 'Medecin Directeur');
 
--- Services
-INSERT INTO `service` VALUES
-  (1, 1, 'Test Service', 1, 1),
-  (2, 1, 'Administration', null, null),
-  (3, 1, 'Medecine Interne', null, null);
 
-INSERT INTO `sale` (`project_id`, `reference`, `uuid`, `cost`, `currency_id`, `debitor_uuid`, `service_id`, `seller_id`, `discount`, `invoice_date`, `note`, `posted`, `timestamp`, `is_distributable`) VALUES
-  (1,2,'957e4e79-a6bb-4b4d-a8f7-c42152b2c2f6',75.0000,2,'3be232f9-a4b9-4af6-984c-5d3f87d5c107',1,1,0,'2016-01-07','TPA_VENTE/Thu Jan 07 2016 15:35:46 GMT+0100 (WAT)/Test 2 Patient',1,'2016-01-07 14:35:55',1),
-  (1,1,'c44619e0-3a88-4754-a750-a414fc9567bf',25.0000,2,'3be232f9-a4b9-4af6-984c-5d3f87d5c107',1,1,0,'2016-01-07','TPA_VENTE/Thu Jan 07 2016 15:30:59 GMT+0100 (WAT)/Test 2 Patient',1,'2016-01-07 14:31:14',1);
-
-INSERT INTO `sale_item` (`sale_uuid`, `uuid`, `inventory_uuid`, `quantity`, `inventory_price`, `transaction_price`, `debit`, `credit`) VALUES
-  ('957e4e79-a6bb-4b4d-a8f7-c42152b2c2f6','2e1332a7-3e63-411e-827d-42ad585ff518','cf05da13-b477-11e5-b297-023919d3d5b0',3,25.0000,25.0000,0.0000,75.0000);
 
 -- Creditor group
 INSERT INTO  `creditor_group` VALUES
@@ -251,3 +236,35 @@ INSERT INTO  `creditor` VALUES
 -- Grade
 INSERT INTO `grade` VALUES
   ('9ee06e4a-7b59-48e6-812c-c0f8a00cf7d3', 'A1', '1.1', 50);
+
+INSERT INTO `section_bilan` VALUES (1, 'Section Bilan 1', 1, 1);
+INSERT INTO `section_resultat` VALUES (1, 'Section Resultat 1', 1, 1);
+
+INSERT INTO `reference_group` VALUES (1, 'AA', 'Reference Group 1', 1, 1);
+
+INSERT INTO `reference` VALUES 
+  (1, 0, 'AB', 'Reference bilan 1', 1, 1, NULL),
+  (3, 0, 'AC', 'Reference resultat 1', 1, NULL, 1),
+  (4, 0, 'XX', 'Deletable reference 1', 1, NULL, NULL);
+
+INSERT INTO `cost_center` VALUES 
+  (1, 1, 'cost center 1', 'cost note', 1),
+  (1, 2, 'cost center 2', 'cost note 2', 0);
+
+INSERT INTO `profit_center` VALUES 
+  (1, 1, 'profit center 1', 'profit note'), 
+  (1, 2, 'profit center 2', 'profit note 2');
+
+-- Services
+INSERT INTO `service` VALUES
+  (1, 1, 'Test Service', 1, 1),
+  (2, 1, 'Administration', null, null),
+  (3, 1, 'Medecine Interne', null, null);
+
+INSERT INTO `sale` (`project_id`, `reference`, `uuid`, `cost`, `currency_id`, `debitor_uuid`, `service_id`, `seller_id`, `discount`, `invoice_date`, `note`, `posted`, `timestamp`, `is_distributable`) VALUES
+  (1,2,'957e4e79-a6bb-4b4d-a8f7-c42152b2c2f6',75.0000,2,'3be232f9-a4b9-4af6-984c-5d3f87d5c107',1,1,0,'2016-01-07','TPA_VENTE/Thu Jan 07 2016 15:35:46 GMT+0100 (WAT)/Test 2 Patient',1,'2016-01-07 14:35:55',1),
+  (1,1,'c44619e0-3a88-4754-a750-a414fc9567bf',25.0000,2,'3be232f9-a4b9-4af6-984c-5d3f87d5c107',1,1,0,'2016-01-07','TPA_VENTE/Thu Jan 07 2016 15:30:59 GMT+0100 (WAT)/Test 2 Patient',1,'2016-01-07 14:31:14',1);
+
+INSERT INTO `sale_item` (`sale_uuid`, `uuid`, `inventory_uuid`, `quantity`, `inventory_price`, `transaction_price`, `debit`, `credit`) VALUES
+  ('957e4e79-a6bb-4b4d-a8f7-c42152b2c2f6','2e1332a7-3e63-411e-827d-42ad585ff518','cf05da13-b477-11e5-b297-023919d3d5b0',3,25.0000,25.0000,0.0000,75.0000);
+

--- a/server/models/updates/synt.sql
+++ b/server/models/updates/synt.sql
@@ -1,9 +1,7 @@
--- Reset employee state
 -- By: Dedrick Kitamuka
 -- Date: 2015-11-27
 
-INSERT INTO unit (`id`, `name`, `key`, `description`, `parent`, `url`, `path`) VALUES
-(138, 'Employee State Pdf', 'TREE.EMPLOYEE_STATE', 'Situation Financiere employee' , 128, 'partials/reports_proposed/employee_state/', '/reports/employee_state/');
+-- INSERT INTO unit (`id`, `name`, `key`, `description`, `parent`, `url`, `path`) VALUES (138, 'Employee State Pdf', 'TREE.EMPLOYEE_STATE', 'Situation Financiere employee' , 128, 'partials/reports_proposed/employee_state/', '/reports/employee_state/');
 
 
 -- Deleting
@@ -13,6 +11,7 @@ INSERT INTO unit (`id`, `name`, `key`, `description`, `parent`, `url`, `path`) V
 -- /reports/stock_store/:depotId
 
 DELETE FROM unit WHERE id = 134;
+
 
 --
 -- General upgrades to the entire database
@@ -65,6 +64,7 @@ CREATE TABLE price_list_item (
 --
 -- END PRICE LIST UPDATES
 --
+
 
 --
 -- PREAMBLE
@@ -330,3 +330,56 @@ CREATE TABLE discount (
 --
 
 SET foreign_key_checks = 1;
+
+
+-- Creating a flag for title account
+-- By Dedrick Kitamuka
+-- 22-12-2015
+
+ALTER TABLE account ADD COLUMN is_title BOOLEAN DEFAULT 0;
+
+-- Removing constraint in account
+-- By Dedrick Kitamuka
+-- 22-12-2015
+-- ALTER TABLE account DROP FOREIGN KEY account_type_id;
+
+UPDATE account SET is_title = 1 WHERE account_type_id = 3;
+
+-- Updating the account type
+-- By Dedrick Kitamuka
+-- 22-12-2015
+
+UPDATE account SET account_type_id = 1 where classe > 5 AND account_type_id = 3;
+UPDATE account SET account_type_id = 2 where classe < 5 AND account_type_id = 3;
+
+-- Removing title account type
+-- By Dedrick Kitamuka
+-- 22-12-2015
+
+DELETE FROM account_type WHERE id = 3;
+
+-- SET locked to false for OHADA account
+-- By Dedrick Kitamuka
+-- 26-12-2015
+
+UPDATE account SET locked = 0 WHERE is_ohada = 1;
+
+-- SET locked to true for PCGC account
+-- By Dedrick Kitamuka
+-- 26-12-2015
+
+UPDATE account SET locked = 1 WHERE is_ohada = 0;
+
+-- Removing is_ohada column
+-- By Dedrick Kitamuka
+-- 26-12-2015
+
+ALTER TABLE account DROP COLUMN is_ohada;
+
+-- Make account type id auto increment
+-- By Dedrick Kitamuka
+-- 20-01-2016
+
+ALTER TABLE account DROP FOREIGN KEY account_ibfk_1;
+ALTER TABLE account_type MODIFY id mediumint(8) UNSIGNED NOT NULL AUTO_INCREMENT;
+ALTER TABLE account ADD FOREIGN KEY (`account_type_id`) REFERENCES account_type (`id`);

--- a/server/test/api/account.js
+++ b/server/test/api/account.js
@@ -1,0 +1,154 @@
+/*global describe, it, beforeEach, process*/
+
+var chai = require('chai');
+var chaiHttp = require('chai-http');
+var expect = chai.expect;
+chai.use(chaiHttp);
+
+var helpers = require('./helpers');
+helpers.configure(chai);
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+
+var url = 'https://localhost:8080';
+var user = { username : 'superuser', password : 'superuser', project: 1};
+
+describe('The account API, PATH : /accounts', function () {
+  var agent = chai.request.agent(helpers.baseUrl);
+  var newAccount = {
+    account_type_id : 1,
+    enterprise_id : 1,
+    account_number : 4000400,
+    account_txt : 'Account for integration test',
+    parent : 0,
+    locked : 0,
+    cc_id : null,
+    pc_id : null,
+    classe : 4,
+    is_asset : 0,
+    reference_id : null,
+    is_brut_link : 0,
+    is_used_budget : 0,
+    is_charge : 0,
+    is_title : 0
+  };
+
+  var DELETABLE_ACCOUNT_ID = 3636;
+  var FETCHABLE_ACCOUNT_ID = 3626;
+  
+    // login before each request
+  beforeEach(helpers.login(agent));
+
+  it('METHOD : GET, PATH : /accounts?full=1, It returns the full list of account' , function () {
+    return agent.get('/accounts?full=1')
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body).to.not.be.empty;
+        expect(res.body).to.have.length(9);
+      })
+      .catch(helpers.handler);
+  });
+
+ it('METHOD : GET, PATH : /accounts, It returns a simple list of account', function () {
+      return agent.get('/accounts')
+        .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.not.be.empty;
+          expect(res.body).to.have.length(9);
+         })
+        .catch(helpers.handler);
+    });
+
+ it('METHOD : GET, PATH : /accounts?locked=0, It returns a list of unlocked accounts', function () {
+      return agent.get('/accounts?locked=0')
+        .then(function (res) {
+          var list = res.body.filter(function (item) { return item.locked === 0; });
+          expect(res).to.have.status(200);
+          expect(res.body).to.not.be.empty;
+          expect(res.body).to.deep.have.same.members(list);
+         })
+         .catch(helpers.handler);
+    });
+
+  it('METHOD : GET, PATH : /accounts/:id, It returns one account', function () {
+    return agent.get('/accounts/'+ FETCHABLE_ACCOUNT_ID)
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body).to.not.be.empty;
+        expect(res.body)
+        .to.have.all.keys('id', 'enterprise_id', 'locked', 'cc_id', 'pc_id', 'created', 'classe', 'is_asset',
+                          'reference_id', 'is_brut_link', 'is_used_budget', 'is_charge', 'account_number',
+                          'account_txt', 'parent', 'account_type_id', 'is_title', 'type');
+       
+       expect(res.body.id).to.be.equal(FETCHABLE_ACCOUNT_ID);
+      })
+      .catch(helpers.handler);
+  });
+
+ it('METHOD : GET, PATH : /accounts/unknownId, It returns a 404 error', function () {
+    return agent.get('/accounts/unknownId')
+      .then(function (res) {
+        expect(res).to.have.status(404);
+        expect(res.body).to.have.all.keys('code', 'httpStatus', 'reason');
+      })
+      .catch(helpers.handler);
+  });
+
+
+  it('METHOD : POST, PATH : /accounts, It a adds an account', function () {
+    return agent.post('/accounts')
+      .send(newAccount)
+      .then(function (res) {
+        expect(res).to.have.status(201);
+        expect(res).to.be.json;
+        expect(res.body).to.not.be.empty;
+        expect(res.body).to.have.all.keys('id');
+        expect(res.body.id).to.be.defined;
+        newAccount.id = res.body.id;
+        return agent.get('/accounts/' + newAccount.id);
+      })
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res.body)
+        .to.have.all.keys('id', 'enterprise_id', 'locked', 'cc_id', 'pc_id', 'created', 'classe', 'is_asset',
+                          'reference_id', 'is_brut_link', 'is_used_budget', 'is_charge', 'account_number',
+                          'account_txt', 'parent', 'account_type_id', 'is_title', 'type');
+
+      })
+     .catch(helpers.handler);
+  }); 
+
+  it('METHOD : PUT, PATH : /accounts/:id, It updates the newly added account', function () {
+    var updateInfo = { account_txt : 'updated value for testing account'};
+  
+    return agent.put('/accounts/'+ newAccount.id)
+      .send(updateInfo)
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body.id).to.equal(newAccount.id);
+        expect(res.body.account_txt).to.equal(updateInfo.account_txt);
+        expect(res.body)
+        .to.have.all.keys('id', 'enterprise_id', 'locked', 'cc_id', 'pc_id', 'created', 'classe', 'is_asset',
+                          'reference_id', 'is_brut_link', 'is_used_budget', 'is_charge', 'account_number',
+                          'account_txt', 'parent', 'account_type_id', 'is_title', 'type');
+
+       })
+      .catch(helpers.handler);
+  });
+
+ it('METHOD : PUT, PATH : /accounts/:unknown, It refuses to update the unknow entity', function () {
+    var updateInfo = { account_txt : 'updated value for testing account unknwon'};
+  
+    return agent.put('/accounts/undefined')
+      .send(updateInfo)
+      .then(function (res) {
+        expect(res).to.have.status(404);
+        expect(res).to.be.json;
+      })
+      .catch(helpers.handler);
+  });    
+});

--- a/server/test/api/accountType.js
+++ b/server/test/api/accountType.js
@@ -1,0 +1,94 @@
+/*global describe, it, beforeEach, process*/
+
+var chai = require('chai');
+var chaiHttp = require('chai-http');
+var expect = chai.expect;
+chai.use(chaiHttp);
+
+var helpers = require('./helpers');
+helpers.configure(chai);
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+
+var url = 'https://localhost:8080';
+var user = { username : 'superuser', password : 'superuser', project: 1};
+
+describe('The account types API, PATH : /account_types', function () {
+  var agent = chai.request.agent(helpers.baseUrl);
+  var newAccountType = {
+    type : 'test account type 1'
+  };
+
+  var DELETABLE_ACCOUNT_TYPE_ID = 3;
+  var FETCHABLE_ACCOUNT_TYPE_ID = 1;
+
+  // login before each request
+  beforeEach(helpers.login(agent));
+
+  it('METHOD : GET, PATH : /account_types, It returns a list of account type', function () {
+    return agent.get('/account_types')
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body).to.not.be.empty;
+        expect(res.body).to.have.length(2);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('METHOD : GET, PATH : /account_types/:id, It returns one account type', function () {
+    return agent.get('/account_types/'+ FETCHABLE_ACCOUNT_TYPE_ID)
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body).to.not.be.empty;
+        expect(res.body.id).to.be.equal(FETCHABLE_ACCOUNT_TYPE_ID);
+        expect(res.body).to.have.all.keys('id', 'type');        
+      })
+     .catch(helpers.handler);
+  });
+
+  it('METHOD : POST, PATH : /account_types, It adds an account_type', function () {
+    return agent.post('/account_types')
+      .send(newAccountType)
+      .then(function (res) {
+        expect(res).to.have.status(201);
+        expect(res).to.be.json;
+        expect(res.body).to.not.be.empty;
+        expect(res.body.id).to.be.defined;
+        newAccountType.id = res.body.id;
+        return agent.get('/account_types/' + newAccountType.id);      
+      })
+      .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res.body).to.have.all.keys('id', 'type');
+      })
+      .catch(helpers.handler);
+  }); 
+
+  it('METHOD : PUT, PATH : /account_types/:id, It updates the newly added account_type', function () {
+    var updateInfo = {type : 'updated value' };
+    return agent.put('/account_types/' + newAccountType.id)
+      .send(updateInfo)
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body.id).to.equal(newAccountType.id);
+        expect(res.body.type).to.equal(updateInfo.type);
+      })
+      .catch(helpers.handler);
+  });
+
+   it('METHOD : DELETE, PATH : /account_types/:id, It deletes a account_type', function () {
+    return agent.delete('/account_types/' + DELETABLE_ACCOUNT_TYPE_ID)
+      .then(function (res) {
+        expect(res).to.have.status(204);
+        // re-query the database
+        return agent.get('/account_types/' + DELETABLE_ACCOUNT_TYPE_ID);
+      })
+      .then(function (res) {
+        expect(res).to.have.status(404);        
+      })
+     .catch(helpers.handler);
+  });  
+});

--- a/server/test/api/accounts.js
+++ b/server/test/api/accounts.js
@@ -51,7 +51,7 @@ describe('The /accounts API endpoint', function () {
       .catch(helpers.handler);
   });
 
-  it('GET /accounts?type=ohada returns only OHADA accounts', function () {
+  it.skip('GET /accounts?type=ohada returns only OHADA accounts', function () {
 
     // NOTE
     // In the test data, we define one account (id: 3635) that is not OHADA

--- a/server/test/api/costCenter.js
+++ b/server/test/api/costCenter.js
@@ -1,0 +1,111 @@
+/*global describe, it, beforeEach, process*/
+
+var chai = require('chai');
+var chaiHttp = require('chai-http');
+var expect = chai.expect;
+chai.use(chaiHttp);
+
+var helpers = require('./helpers');
+helpers.configure(chai);
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+
+var url = 'https://localhost:8080';
+var user = { username : 'superuser', password : 'superuser', project: 1};
+
+describe('The cost center API, PATH : /cost_centers', function () {
+ var agent = chai.request.agent(helpers.baseUrl);
+ var newCostCenter = {
+    project_id : 1,
+    text : 'tested cost',
+    note : 'test inserted',
+    is_principal : 1
+  };
+
+  var DELETABLE_COST_CENTER_ID = 2;
+  var FETCHABLE_COST_CENTER_ID = 1;
+
+   // throw errors
+  beforeEach(helpers.login(agent));
+
+    it('METHOD : GET, PATH : /cost_centers?full=1, It returns a full list of cost centers', function () {
+      return agent.get('/cost_centers?full=1')
+        .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.not.be.empty;
+          expect(res.body).to.have.length(2);
+        })
+       .catch(helpers.handler);
+    });
+
+  it('METHOD : GET, PATH : /cost_centers, It returns a list of cost centers', function () {
+    return agent.get('/cost_centers')
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body).to.not.be.empty;
+        expect(res.body).to.have.length(2);
+      })
+      .catch(helpers.handler);
+ });
+
+  it('METHOD : GET, PATH : /cost_center/:id, It returns one cost center', function () {
+    return agent.get('/cost_centers/'+ FETCHABLE_COST_CENTER_ID)
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body).to.not.be.empty;
+        expect(res.body.id).to.be.equal(FETCHABLE_COST_CENTER_ID);
+        expect(res.body).to.have.all.keys('project_id', 'id', 'text', 'note', 'is_principal');        
+      })
+      .catch(helpers.handler);
+ });
+
+  it('METHOD : POST, PATH : /cost_centers, It adds a cost center', function () {
+    return agent.post('/cost_centers')
+      .send(newCostCenter)
+      .then(function (res) {
+        expect(res).to.have.status(201);
+        expect(res).to.be.json;
+        expect(res.body).to.not.be.empty;
+        expect(res.body.id).to.be.defined;
+        newCostCenter.id = res.body.id;
+
+        return agent.get('/cost_centers/' + newCostCenter.id);  
+      })
+      .then(function (res){ 
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.all.keys('project_id', 'id', 'text', 'note', 'is_principal');
+      })
+      .catch(helpers.handler); 
+  }); 
+
+  it('METHOD : PUT, PATH : /cost_centers/:id, It updates the newly added cost center', function () {
+    var updateInfo = {note : 'update value for note'};
+
+    return agent.put('/cost_centers/'+ newCostCenter.id)
+      .send(updateInfo)
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body.id).to.equal(newCostCenter.id);
+        expect(res.body.note).to.equal(updateInfo.note);
+      })
+      .catch(helpers.handler);
+  });
+
+   it('METHOD : DELETE, PATH : /cost_centers/:id, It deletes a cost_center', function () {
+
+    return agent.delete('/cost_centers/' + DELETABLE_COST_CENTER_ID)
+      .then(function (res) {
+        expect(res).to.have.status(204);
+        // re-query the database
+        return agent.get('/cost_centers/' + DELETABLE_COST_CENTER_ID);
+      })
+      .then(function (res) {
+        expect(res).to.have.status(404);        
+      })
+      .catch(helpers.handler);
+  });  
+});

--- a/server/test/api/profitCenter.js
+++ b/server/test/api/profitCenter.js
@@ -1,0 +1,107 @@
+/*global describe, it, beforeEach, process*/
+
+var chai = require('chai');
+var chaiHttp = require('chai-http');
+var expect = chai.expect;
+chai.use(chaiHttp);
+
+var helpers = require('./helpers');
+helpers.configure(chai);
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+
+var url = 'https://localhost:8080';
+var user = { username : 'superuser', password : 'superuser', project: 1};
+
+describe('The profit center API, PATH : /profit_centers', function () {
+  var agent = chai.request.agent(helpers.baseUrl);
+  var newProfitCenter = {
+    project_id : 1,
+    text : 'tested profit',
+    note : 'test inserted'  
+  };
+
+  var DELETABLE_PROFIT_CENTER_ID = 2;
+  var FETCHABLE_PROFIT_CENTER_ID = 1;
+
+  beforeEach(helpers.login(agent));
+
+    it('METHOD : GET, PATH : /profit_centers?full=1, It returns a full list of profit centers', function () {
+      return agent.get('/profit_centers?full=1')
+        .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.not.be.empty;
+          expect(res.body).to.have.length(2);
+        })
+        .catch(helpers.handler);
+    });
+
+  it('METHOD : GET, PATH : /profit_centers, It returns a list of profit centers', function () {
+    return agent.get('/profit_centers')
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body).to.not.be.empty;
+        expect(res.body).to.have.length(2); 
+      })
+     .catch(helpers.handler);
+  });
+  
+  it('METHOD : GET, PATH : /profit_center/:id, It returns one profit center', function () {
+    return agent.get('/profit_centers/'+ FETCHABLE_PROFIT_CENTER_ID)
+      .then(function (res) {
+       expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body).to.not.be.empty;
+        expect(res.body.id).to.be.equal(FETCHABLE_PROFIT_CENTER_ID);
+        expect(res.body).to.have.all.keys('project_id', 'id', 'text', 'note');
+      })
+      .catch(helpers.handler);
+  });
+
+  it('METHOD : POST, PATH : /profit_centers, It adds a profit center', function () {
+    return agent.post('/profit_centers')
+      .send(newProfitCenter)
+      .then(function (res) {
+        expect(res).to.have.status(201);
+        expect(res).to.be.json;
+        expect(res.body).to.not.be.empty;
+        expect(res.body.id).to.be.defined;
+        newProfitCenter.id = res.body.id;
+        return agent.get('/profit_centers/' + newProfitCenter.id);  
+      })
+      .then(function (res){ 
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.all.keys('project_id', 'id', 'text', 'note');
+      })
+     .catch(helpers.handler);
+  }); 
+
+  it('METHOD : PUT, PATH : /profit_centers/:id, It updates the newly added profit center', function () {
+    var updateInfo = {note : 'updated value for note'};
+
+    return agent.put('/profit_centers/'+ newProfitCenter.id)
+      .send(updateInfo)
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body.id).to.equal(newProfitCenter.id);
+        expect(res.body.note).to.equal(updateInfo.note);
+      })
+      .catch(helpers.handler);
+  });
+
+   it('METHOD : DELETE, PATH : /profit_centers/:id, It deletes a profit_center', function () {
+    return agent.delete('/profit_centers/' + DELETABLE_PROFIT_CENTER_ID)
+      .then(function (res) {
+        expect(res).to.have.status(204);
+        // re-query the database
+        return agent.get('/profit_centers/' + DELETABLE_PROFIT_CENTER_ID);
+      })
+      .then(function (res) {
+        expect(res).to.have.status(404);        
+      })
+      .catch(helpers.handler);
+  });  
+});

--- a/server/test/api/references.js
+++ b/server/test/api/references.js
@@ -1,0 +1,112 @@
+/*global describe, it, beforeEach, process*/
+
+var chai = require('chai');
+var chaiHttp = require('chai-http');
+var expect = chai.expect;
+chai.use(chaiHttp);
+
+var helpers = require('./helpers');
+helpers.configure(chai);
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+
+var url = 'https://localhost:8080';
+var user = { username : 'superuser', password : 'superuser', project: 1};
+
+describe('The reference API, PATH : /references', function () {
+  var agent = chai.request.agent(helpers.baseUrl);
+
+  var newReference = {
+    is_report : 0,
+    ref : 'AD',
+    text : 'Reference tested 1',
+    position: 2,
+    reference_group_id : 1,
+    section_resultat_id : 1
+  };
+
+  var DELETABLE_REFERENCE_ID = 5;
+  var FETCHABLE_REFERENCE_ID = 1;
+
+  beforeEach(helpers.login(agent));
+ 
+    it('METHOD : GET, PATH : /references, It returns a list of references', function () {
+      return agent.get('/references?full=1')
+        .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.not.be.empty;
+          expect(res.body).to.have.length(3);
+         })
+       .catch(helpers.handler);
+    });
+
+    it('METHOD : GET, PATH : /references, It returns a list of references', function () {
+      return agent.get('/references')
+        .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.not.be.empty;
+          expect(res.body).to.have.length(3);
+         })
+       .catch(helpers.handler);    
+    });
+
+
+    it('METHOD : GET, PATH : /references/:id, It returns one reference', function () {
+      return agent.get('/references/'+ FETCHABLE_REFERENCE_ID)
+        .then(function (res) {        
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.not.be.empty;
+          expect(res.body.id).to.be.equal(FETCHABLE_REFERENCE_ID);
+          expect(res.body).to.have.all.keys('id', 'is_report', 'ref', 'text', 'position', 'reference_group_id', 'section_resultat_id'); 
+        })
+        .catch(helpers.handler);  
+    });
+
+    it('METHOD : POST, PATH : /references, It adds a reference', function () {
+      return agent.post('/references')
+        .send(newReference)
+          .then(function (res) {
+            expect(res).to.have.status(201);
+            expect(res).to.be.json;
+            expect(res.body).to.not.be.empty;
+            expect(res.body.id).to.be.defined;
+            newReference.id = res.body.id;
+            return agent.get('/references/' + newReference.id);  
+          })
+          .then(function (res){ 
+            expect(res).to.have.status(200);
+            expect(res.body).to.have.all.keys('id', 'is_report', 'ref', 'text', 'position', 'reference_group_id', 'section_resultat_id');
+          })
+          .catch(helpers.handler); 
+  }); 
+
+  it('METHOD : PUT, PATH : /references/:id, It updates the newly added reference', function () {
+    var updateInfo = {position : 3};
+
+    return agent.put('/references/'+ newReference.id)
+      .send(updateInfo)
+      .then(function (res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body.id).to.equal(newReference.id);
+        expect(res.body.position).to.equal(updateInfo.position);
+      })
+      .catch(helpers.handler); 
+  });
+
+   it('METHOD : DELETE, PATH : /references/:id, It deletes a reference', function () {
+    return agent.delete('/references/' + DELETABLE_REFERENCE_ID)
+      .then(function (res) {
+        expect(res).to.have.status(204);
+        // re-query the database
+        return agent.get('/references/' + DELETABLE_REFERENCE_ID);
+      })
+      .then(function (res) {
+        expect(res).to.have.status(404);        
+      })
+      .catch(helpers.handler); 
+  });  
+});


### PR DESCRIPTION
This commit implements a new accounts API via the /accounts route.
It also includes integration tests describing its funtionality.
Included routes:
1. /accounts
2. /account_types
3. /references
4. /cost_centers
5. /profit_centers

Each route includes full crud via GET/POST/PUT/DELETE HTTP methods.
