### PR TITLE
PATH(win): Strip whitespaces from env variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "app": "gulp build && cd bin && NODE_ENV=production node server/app.js",
     "dev": "gulp build && cd bin && NODE_ENV=development node server/app.js",
     "start": "gulp build && cd bin && NODE_ENV=production node server/app.js",
-    "dev_windows": "gulp build && cd bin && set NODE_ENV=development && node server/app.js",
-    "travis": "gulp build && cd bin && NODE_ENV=travis node server/app.js"
+    "travis": "gulp build && cd bin && NODE_ENV=travis node server/app.js",
+    "dev_windows": "gulp build && cd bin && set NODE_ENV=development&& node server/app.js"
   },
   "repository": {
     "type": "git",

--- a/server/app.js
+++ b/server/app.js
@@ -17,7 +17,7 @@ var fPath = 'server/.env.{env}'.replace('{env}', env);
 // load the environmnetal variables into process using the dotenv module
 try {
   console.log('[app] Loading configuration from file: %s', fPath);
-  require('dotenv').config({ path : fPath });
+  require('dotenv').config({ path : fPath.toString().trim() });
 } catch (e) {
   console.error(
     '[ERROR] Configuration file could not be found in path: %s.',


### PR DESCRIPTION
This commit removes whitespaces from the NODE_ENV variable to ensure
correct environmental variable loading on windows.
