### PR TITLE
FEAT(logger): use winston for logging

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,8 +15,8 @@ SESS_SAVE_UNINITIALIZED=0
 SESS_REAP_INTERVAL=-1
 SESS_UNSET='destroy'
 
-# morgan logger configuration
-LOG_LEVEL='combined'
+# logger configuration
+LOG_LEVEL='debug'
 LOG_FILE='access.log'
 
 # uploads

--- a/.env.travis
+++ b/.env.travis
@@ -15,8 +15,8 @@ SESS_SAVE_UNINITIALIZED=0
 SESS_REAP_INTERVAL=-1
 SESS_UNSET='destroy'
 
-# morgan logger configuraion params
-LOG_LEVEL='combined'
+# logger configuraion params
+LOG_LEVEL='debug'
 LOG_FILE='access.log'
 
 # uploads

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "numeral": "^1.5.3",
     "q": "~1.4.1",
     "session-file-store": "0.0.24",
+    "winston": "^2.1.1",
     "wkhtmltopdf": "^0.1.5"
   },
   "devDependencies": {

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -11,6 +11,8 @@
 * identicale modules - they should all be encapsulated as one
 * module. For Example finance.createSale, finance.createPurchase
 */
+var winston = require('winston');
+
 var auth            = require('../controllers/auth');
 var data            = require('../controllers/data');
 var users           = require('../controllers/users');
@@ -73,7 +75,7 @@ var transfers           = require('../controllers/finance/transfers');
 var multipart       = require('connect-multiparty');
 
 exports.configure = function (app) {
-  console.log('[config/routes] Configure routes');
+  winston.log('debug', 'Configuring routes');
 
   // exposed to the outside without authentication
   app.get('/languages', users.getLanguages);
@@ -473,5 +475,4 @@ exports.configure = function (app) {
   app.post('/discounts', discounts.create);
   app.put('/discounts/:id', discounts.update);
   app.delete('/discounts/:id', discounts.delete);
-
 };

--- a/server/controllers/finance/journal.js
+++ b/server/controllers/finance/journal.js
@@ -69,8 +69,6 @@ tableRouter = {
 // This should be a promise.
 function request (table, id, user_id, done, debCaution, details) {
 
-  console.log('Call for TABLE:', table);
-
   // handles all requests coming from the client
   if (debCaution >= 0) {
     tableRouter[table](id, user_id, done, debCaution);

--- a/server/controllers/finance/journal/primarycash.js
+++ b/server/controllers/finance/journal/primarycash.js
@@ -152,7 +152,6 @@ function transfer(id, userId, cb) {
     // FIXME/TODO -- why are we deleting from the primary cash??
     // We should be deleting and bad transfers from the posting journal!
     // Oh my.
-    console.log('[JOURNAL] Primary Cash:', error);
     sql = 'DELETE FROM primary_cash_item WHERE primary_cash_uuid = ?;';
 
     db.exec(sql, [id])
@@ -175,7 +174,6 @@ function transfer(id, userId, cb) {
  * This is used when you need to pay someone back for a previous (paid) bill.
  */
 function refund(id, userId, cb) {
-  console.log('[JOURNAL] REFUND ', id);
   var sql, data, params, reference, cfg = {}, queries = {};
 
   // TODO : Formalize this

--- a/server/controllers/reports/reports.js
+++ b/server/controllers/reports/reports.js
@@ -1,6 +1,7 @@
-var path                               = require('path');
-var fs                                 = require('fs');
-var q                                  = require('q');
+var path    = require('path');
+var fs      = require('fs');
+var q       = require('q');
+var winston = require('winston');
 
 // Import and compile template files
 var dots                               = require('dot').process({path : path.join(__dirname, 'templates')});
@@ -70,12 +71,13 @@ exports.serve = function (req, res, next) {
 
   var target = req.params.target;
   var options = {root : writePath};
+  var NAMESPACE = 'REPORTS';
 
   res.sendFile(target.concat('.pdf'), options, function (err, res) {
     if (err) {
       next(err);
     } else {
-      console.log('report generated succefully');
+      winston.log('info', '[%s] Generated %s', NAMESPACE, target.concat('.pdf'));
 
       // Delete (unlink) served file
       /*fs.unlink(path.join(__dirname, 'out/').concat(target, '.pdf'), function (err) {
@@ -147,8 +149,7 @@ function initialise() {
     if (!exists) {
       fs.mkdir(writePath, function (err) {
         if (err) { throw err; }
-
-        console.log('[controllers/report] output folder written :', writePath);
+        winston.log('debug', '[REPORT] Output folder written to %s', writePath);
       });
     }
   });


### PR DESCRIPTION
This commit allows the developers to customize log levels via
environmental variables.  The supported log levels can be found on the
winston page (https://github.com/winstonjs/winston).

The following changes have been made:
1. Remove all console.logs() from the server.
2. By default, only log exceptions and warnings.
3. (LOG_LEVEL >= info) log HTTP requests using morgan.
4. (LOG_LEVEL >= debug) Log SQL requests to the console.

The default transport is to the console, but by specifying a LOG_FILE,
you can direct output to a file as well.

You will need to set your own LOG_LEVEL in your `.env.development` and `.env.production` files.

Closes #31.
