### PR TITLE
CHORE(lib): deprecate guid for node-uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "fast-csv": "1.0.0",
     "morgan": "^1.6.1",
     "mysql": "^2.9.0",
+    "node-uuid": "^1.4.7",
     "numeral": "^1.5.3",
     "q": "~1.4.1",
     "session-file-store": "0.0.24",

--- a/server/lib/guid.js
+++ b/server/lib/guid.js
@@ -1,11 +1,14 @@
-// Generate guids in javascript
-// src: http://byronsalau.com/blog/how-to-create-a-guid-uuid-in-javascript/
 
+var uuid = require('node-uuid');
+var util = require('util');
 
-module.exports = function guid() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-    var r = Math.random() * 16 | 0,
-    v = c === 'x' ? r : (r & 0x3 | 0x8);
-    return v.toString(16);
-  });
-};
+/**
+ * generates version 4 UUIds
+ * @deprecated Use node-uuid directly instead
+ */
+function generate() {
+  return uuid.v4();
+}
+
+module.exports =
+  util.deprecate(generate, 'uuid() is deprecated. Please require(\'node-uuid\') and use it directly.');


### PR DESCRIPTION
This commit deprecates the previous uuid() function, favoring the
node-uuid module instead.  Developers should require node-uuid directly
in their code rather than depending on the uuid library (will be removed
during the bhima-2.X rewrite).

Closes #62.
