### PR TITLE
CHORE(lib): deprecate util, validate, sanitize

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "express": "^4.13.3",
     "express-session": "^1.11.3",
     "fast-csv": "1.0.0",
+    "lodash": "^4.2.1",
     "morgan": "^1.6.1",
     "mysql": "^2.9.0",
     "node-uuid": "^1.4.7",

--- a/server/controllers/categorised/employees.js
+++ b/server/controllers/categorised/employees.js
@@ -7,8 +7,6 @@
 * employees table through the `/employees` endpoint.
 *
 * @requires lib/db
-* @requires lib/util
-* @requires config/codes
 *
 * NOTE: This api does not handle the deletion of employees because
 * that subject is not in the actuality.
@@ -17,7 +15,6 @@
 'use strict';
 
 var db = require('./../../lib/db');
-var util = require('./../../lib/util');
 
 /**
 * Returns an array of each employee in the database

--- a/server/controllers/data.js
+++ b/server/controllers/data.js
@@ -7,8 +7,9 @@
 var url = require('url'),
     qs = require('querystring'),
     db = require('../lib/db'),
-    util = require('../lib/util'),
     parser = require('../lib/parser');
+
+var _ = require('lodash/lang');
 
 /*
  * HTTP Controllers
@@ -20,7 +21,7 @@ exports.create = function create(req, res, next) {
   //   This checks if data is an array and stuffs it
   //   into an array if it is not.  This should be done on the
   //   client (by connect).
-  data = util.isArray(req.body.data) ? req.body.data : [req.body.data];
+  data = _.isArray(req.body.data) ? req.body.data : [req.body.data];
   sql = parser.insert(req.body.table, data);
 
   db.exec(sql)

--- a/server/controllers/finance/fiscal.js
+++ b/server/controllers/finance/fiscal.js
@@ -1,6 +1,6 @@
-var db = require('./../../lib/db'),
-    util = require('./../../lib/util'),
-    journal = require('./journal');
+var db      = require('./../../lib/db');
+var journal = require('./journal');
+var _       = require('lodash/lang');
 
 exports.createFiscalYear = createFiscalYear;
 exports.fiscalYearResultat = fiscalYearResultat;
@@ -31,7 +31,7 @@ function createFiscalYear(req, res, next) {
   var hasBalances, data, fiscalYearId;
 
   // check if we need to create opening balances or not.
-  hasBalances = util.isDefined(req.body.balances);
+  hasBalances = !_.isUndefined(req.body.balances);
 
   // parse dates from client into date objects
   data = req.body;
@@ -128,7 +128,7 @@ function createOpeningBalances(data) {
 
     var details = {
       balances  : totals,
-      dateStart : util.toMysqlDate(data.start)
+      dateStart : data.start
     };
 
     return journal.request('create_fiscal_year', periodId, data.user_id, function (error, result) {

--- a/server/controllers/finance/journal/employee.js
+++ b/server/controllers/finance/journal/employee.js
@@ -2,7 +2,6 @@ var q        = require('q'),
     db       = require('../../../lib/db'),
     uuid     = require('../../../lib/guid'),
     validate = require('../../../lib/validate')(),
-    util     = require('../../../lib/util'),
     core     = require('./core');
 
 exports.invoice = invoice;

--- a/server/controllers/finance/journal/fiscal.js
+++ b/server/controllers/finance/journal/fiscal.js
@@ -2,9 +2,7 @@ var q         = require('q'),
     core      = require('./core'),
     uuid      = require('../../../lib/guid'),
     sanitize  = require('../../../lib/sanitize'),
-    validate  = require('../../../lib/validate')(),
-    db        = require('../../../lib/db'),
-    util      = require('../../../lib/util');
+    db        = require('../../../lib/db');
 
 exports.close = close;
 exports.create = create;
@@ -41,15 +39,15 @@ function close(id, user_id, data, cb) {
       // Locking simply a fiscal year without creation
       // Transaction date (in journal) must be the last date of the concerned
       // fiscal year
-      transactionDate = util.toMysqlDate(data.fiscalYearLastDate);
-      cfg.descrip = 'Closing Fiscal Year/' + String(transactionDate);
+      transactionDate = data.fiscalYearLastDate;
+      cfg.descrip = 'Closing Fiscal Year/' + transactionDate;
 
     } else if (data.flag === 'CREATE_WITH_LOCKING') {
       // Create a new fiscal year with closing previous
       // Transaction date of creation (in journal) must be the last date of
       // the closed fiscal year
-      transactionDate = util.toMysqlDate(data.closedFYLastDate);
-      cfg.descrip = 'New Fiscal Year/Closing Previous/' + String(transactionDate);
+      transactionDate = data.closedFYLastDate;
+      cfg.descrip = 'New Fiscal Year/Closing Previous/' + transactionDate;
     }
   } catch (err) {
     return cb(err);

--- a/server/controllers/medical/snis.js
+++ b/server/controllers/medical/snis.js
@@ -4,7 +4,6 @@ var url = require('url');
 
 var db = require('./../../lib/db');
 var sanitize = require('./../../lib/sanitize');
-var util = require('./../../lib/util');
 
 var _REPORT_ID;
 

--- a/server/controllers/reports/report_legacy.js
+++ b/server/controllers/reports/report_legacy.js
@@ -11,7 +11,6 @@ var url = require('url');
 
 var db = require('./../../lib/db');
 var sanitize = require('./../../lib/sanitize');
-var util = require('./../../lib/util');
 
 /*
  * HTTP Controllers
@@ -309,8 +308,8 @@ function patientRecords(params) {
   var p = querystring.parse(params),
       deferred = q.defer();
 
-  var _start = sanitize.escape(util.toMysqlDate(new Date(p.start))),
-      _end =  sanitize.escape(util.toMysqlDate(new Date(p.end).setDate(new Date(p.end).getDate() + 1))),
+  var _start = sanitize.escape(new Date(p.start)),
+      _end =  sanitize.escape(new Date(p.end).setDate(new Date(p.end).getDate() + 1)),
       _id;
 
   if (p.id.indexOf(',')) {
@@ -336,8 +335,8 @@ function patientNewVisit(params) {
   var p = querystring.parse(params),
       deferred = q.defer();
 
-  var _start = sanitize.escape(util.toMysqlDate(new Date(p.start))),
-      _end =  sanitize.escape(util.toMysqlDate(new Date(p.end).setDate(new Date(p.end).getDate() + 1))),
+  var _start = sanitize.escape(new Date(p.start)),
+      _end =  sanitize.escape(new Date(p.end).setDate(new Date(p.end).getDate() + 1)),
       _id;
 
   if (p.id.indexOf(',')) {
@@ -364,8 +363,8 @@ function patientOldVisit(params) {
   var p = querystring.parse(params),
       deferred = q.defer();
 
-  var _start = sanitize.escape(util.toMysqlDate(new Date(p.start))),
-      _end =  sanitize.escape(util.toMysqlDate(new Date(p.end).setDate(new Date(p.end).getDate() + 1))),
+  var _start = sanitize.escape(new Date(p.start)),
+      _end =  sanitize.escape(new Date(p.end).setDate(new Date(p.end).getDate() + 1)),
       _id;
 
   if (p.id.indexOf(',')) {
@@ -391,8 +390,8 @@ function patientOldVisit(params) {
 function paymentRecords(params) {
   var p = querystring.parse(params);
 
-  var _start = sanitize.escape(util.toMysqlDate(new Date(p.start))),
-      _end =  sanitize.escape(util.toMysqlDate(new Date(p.end))),
+  var _start = sanitize.escape(new Date(p.start)),
+      _end =  sanitize.escape(new Date(p.end)),
       _id = p.id;
 
   var sql =
@@ -911,8 +910,8 @@ function purchase_order() {
 function purchaseOrdeRecords(params) {
   var p = querystring.parse(params);
 
-  var _start = sanitize.escape(util.toMysqlDate(new Date(p.start))),
-      _end =  sanitize.escape(util.toMysqlDate(new Date(p.end))),
+  var _start = sanitize.escape(new Date(p.start)),
+      _end =  sanitize.escape(new Date(p.end)),
       _id = p.id,
       _transaction = sanitize.escape(p.transaction);
 
@@ -939,8 +938,8 @@ function purchaseOrdeRecords(params) {
 function donation_confirmationRecords(params) {
   var p = querystring.parse(params);
 
-  var _start = sanitize.escape(util.toMysqlDate(new Date(p.start))),
-      _end =  sanitize.escape(util.toMysqlDate(new Date(p.end)));
+  var _start = sanitize.escape(new Date(p.start)),
+      _end =  sanitize.escape(new Date(p.end));
 
   var sql =
     'SELECT DISTINCT `donations`.`uuid`, `donations`.`date`, `user`.`first`, `user`.`last`, `employee`.`prenom`, ' +
@@ -961,8 +960,8 @@ function donation_confirmationRecords(params) {
 function integration_stock(params) {
   var p = querystring.parse(params);
 
-  var _start = sanitize.escape(util.toMysqlDate(new Date(p.start))),
-      _end =  sanitize.escape(util.toMysqlDate(new Date(p.end))),
+  var _start = sanitize.escape(new Date(p.start)),
+      _end =  sanitize.escape(new Date(p.end)),
       _depot = sanitize.escape(p.depot);
 
   var sql =

--- a/server/lib/parser.js
+++ b/server/lib/parser.js
@@ -1,5 +1,5 @@
-var sanitize = require('./db').sanitize,
-    util = require('./util');
+var sanitize = require('./db').sanitize;
+var _ = require('lodash/lang');
 
 // TODO should this go here?
 // all mysql reserved words
@@ -490,7 +490,7 @@ function escapeWhereCondition(condition) {
   // We allow nested where conditions, in the form of nested
   // arrays.  If 'conditon' is an array, we recursively call the
   // parseWhere function on it!
-  if (util.isArray(condition)) { return '(' + parseWhereStatement(condition) + ')';  }
+  if (_.isArray(condition)) { return '(' + parseWhereStatement(condition) + ')';  }
 
   operator = getOperator(condition);
 

--- a/server/lib/sanitize.js
+++ b/server/lib/sanitize.js
@@ -1,33 +1,6 @@
-// lib/util/sanitize.js
+var db = require('./db');
+var util = require('util');
 
-// FIXME
-//    These are mostly duplicates of util.js.  Remove them from here and
-//    inject util.js into the application where it is needed.
 module.exports = {
-
-  // this is not incredibly secure
-  escapeid : function (id) { return ['`', id, '`'].join(''); },
-  
-  escape: function (str) { return '"' + String(str).replace(/"/g, '\\"') + '"'; },
-
-  isInt : function (n) { return (Math.floor(n) === Number(n)); },
-
-  isIn : function (s) {  return String(s).indexOf('(') > -1; },
-
-  isFloat : function (f) { return parseFloat(f) !== undefined && f.toString().indexOf('.') > -1; },
-
-  // this also works for hexadecimal ('0x12')
-  isNumber: function (n) { return !Number.isNaN(Number(n)); },
-
-  isArray: function (arr) { return Object.prototype.toString.call(arr) === '[object Array]'; },
-
-  isString: function (str) { return typeof str === 'string'; },
-
-  isObject: function (obj) { return Object.prototype.toString.call(obj) === '[object Object]'; },
-
-  // is there a better way to do this?
-  isUndefined : function (u) { return u === undefined; },
-  
-  isDefined : function (u) { return !this.isUndefined(u); }
-
+  escape: util.deprecate(db.escape, 'sanitize.escape() is deprecated.  Please use db.escape instead.')
 };

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -1,61 +1,6 @@
-/**
- * A variety of utilities to use in the server.  This should be replaced with a
- * tested npm module in the future.
- *
- * @module lib/util
- * @todo remove deprecated functions
- */
-
-// import Node's native util
 var util = require('util');
 
-/** check if an arry or object is empty */
-exports.empty = function empty(object) {
-  'use strict';
-  if (Array.isArray(object)) {
-    return object.length === 0;
-  } else {
-    return Object.keys(object).length === 0;
-  }
-};
-
-
-/**
- * check if a value is an array.  Will be removed at the release of bhima-2.X.
- * @deprecated since bhima-2.X
- */
-exports.isArray =
-  util.deprecate(Array.isArray, 'Use the native Array.isArray() instead.');
-
-
-/** check if a value is an integer */
-exports.isInt = function isInt(value) {
-  return (Math.floor(value) === Number(value));
-};
-
-/** check if a value is a number. This also works for hexadecimal ('0x12') */
-function isNumber(value) {
-  return !Number.isNaN(Number(value));
-}
-
-exports.isNumber = isNumber;
-
-/** check if a value is a string */
-exports.isString = function isString(value) {
-  return (typeof value === 'string');
-};
-
-/** check if a value is an object */
-exports.isObject = function isObject(value) {
-  return (typeof value === 'object');
-};
-
-/**
- * converts a date or date string to a mysql-friendly date
- * @deprecated since bhima-2.X
- */
-function toMysqlDate(dateString) {
-
+function toMysqlDate (dateString) {
   // This style of convert to MySQL date avoids changing
   // the prototype of the global Date object
   if (!dateString) { return new Date().toISOString().slice(0, 10); }
@@ -69,24 +14,9 @@ function toMysqlDate(dateString) {
   day = day.length < 2 ? '0' + day : day;
 
   return [year, month, day].join('-');
+
 }
 
-exports.toMysqlDate =
-  util.deprecate(toMysqlDate, 'Use node-mysql\'s automatic date escaping.');
-
-/** check if a value is a postive number */
-function isPositive(value) {
-  return isNumber(value) && Number(value) >= 0;
-}
-
-exports.isPositive = isPositive;
-
-/** check if a value is a negative number */
-exports.isNegative = function (value) {
-  return isNumber(value) && !isPositive(value);
-};
-
-/** check if a value is defined */
-exports.isDefined = function isDefined(value) {
-  return value !== undefined;
+module.exports = {
+  toMysqlDate : util.deprecate(toMysqlDate, 'util.toMysqlDate() is deprecated and will be removed soon.  Please use db.js\'s native date parsing.')
 };

--- a/server/lib/validate.js
+++ b/server/lib/validate.js
@@ -7,7 +7,6 @@ module.exports = function () {
   'use strict';
 
   return {
-    isValidDate : function (date) { return !Number.isNaN(date.parse(date)); },
     isValidNumber : function (number) {
       var cast = Number(number);
       return Number.isFinite(cast) && !Number.isNaN(cast);
@@ -17,10 +16,6 @@ module.exports = function () {
     },
     isNegative : function (number) { return !this.isPositive(number); },
     isEqual : function (a, b) { return a === b; },
-    isDefined : function (a) { return a !== undefined; },
-    isUndefined : function (a) { return !this.isDefined(a); },
-    isNull : function (a) { return a === null; },
-    exists : function (a) { return this.isDefined(a) && !this.isNull(a); }
   };
 
 };


### PR DESCRIPTION
This commit deprecates and deletes the vast majority of code in the
following files:
- lib/util.js
- lib/validate.js
- lib/sanitize.js

Any remaining methods have been wrapped in NodeJS's `util.deprecate()`
method to indicate that they should not be used.  These methods will be
completely removed in the coming month.

Additionally, `lodash` has been added as a dependency.  This serves to
fill some of the needs left by the deletion and deprecation of our lib
functions.

Closes #32.
