### PR TITLE
feat(sales): interfaces for locating sales

### DIFF
--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -357,6 +357,7 @@ exports.configure = function (app) {
   app.post('/sales', patientInvoice.create);
   app.get('/sales/search', patientInvoice.search);
   app.get('/sales/:uuid', patientInvoice.details);
+  app.get('/sales/references/:reference', patientInvoice.reference);
 
   // Patients API
   app.get('/patients', patient.list);

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -355,6 +355,7 @@ exports.configure = function (app) {
   // TODO Decide if the route should be named patient invoice
   app.get('/sales', patientInvoice.list);
   app.post('/sales', patientInvoice.create);
+  app.get('/sales/search', patientInvoice.search);
   app.get('/sales/:uuid', patientInvoice.details);
 
   // Patients API

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -1,14 +1,15 @@
 /**
- * Patient Invoice API Controller 
+ * Patient Invoice API Controller
  *.@module controllers/finance/patientInvoice
- * 
+ *
  * @todo GET /sales/patient/:uuid - retrieve all patient invoices for a specific patient
- * @todo Factor in subsidies, this depends on price lists and billing services infrastructre 
- * @todo Credit note logic pending on clear design 
+ * @todo Factor in subsidies, this depends on price lists and billing services infrastructre
+ * @todo Credit note logic pending on clear design
  */
-var q       = require('q');
-var db      = require('../../lib/db');
-var uuid    = require('../../lib/guid');
+var q    = require('q');
+var db   = require('../../lib/db');
+var uuid = require('../../lib/guid');
+var _    = require('lodash');
 
 var journal = require('./journal');
 
@@ -21,73 +22,76 @@ exports.details = details;
 /** Write a new patient invoice record and attempt to post it to the journal. */
 exports.create = create;
 
+/** Filter the patient table by any column via query strings */
+exports.search = search;
+
 /** Undo the financial effects of a sale generating an equal and opposite credit note. */
 // exports.reverse = reverse;
 
-function list(req, res, next) { 
+function list(req, res, next) {
   var saleListQuery;
 
-  saleListQuery = 
+  saleListQuery =
     'SELECT sale.project_id, sale.reference, sale.uuid, cost, sale.debitor_uuid, ' +
-      'seller_id, invoice_date, is_distributable ' + 
-    'FROM sale ' + 
+      'seller_id, invoice_date, is_distributable ' +
+    'FROM sale ' +
     'LEFT JOIN patient ON sale.debitor_uuid = patient.debitor_uuid';
 
   db.exec(saleListQuery)
-    .then(function (result) { 
+    .then(function (result) {
       var sales = result;
 
-      res.status(200).json(sales);  
+      res.status(200).json(sales);
     })
     .catch(next)
     .done();
 }
 
-/** 
- * @todo Read the balance remaining on the debtors account given the sale as an auxillary step 
+/**
+ * @todo Read the balance remaining on the debtors account given the sale as an auxillary step
  */
-function details(req, res, next) { 
+function details(req, res, next) {
   var saleDetailQuery, saleItemsQuery;
   var sale, saleItems;
   var uuid = req.params.uuid;
 
-  saleDetailQuery = 
+  saleDetailQuery =
     'SELECT sale.uuid, sale.project_id, sale.reference, sale.cost, sale.currency_id, ' +
       'sale.debitor_uuid, CONCAT(patient.first_name, " ", patient.last_name) as debitor_name, ' +
       'seller_id, discount, invoice_date, sale.note, sale.posted, sale.is_distributable ' +
     'FROM sale ' +
-    'LEFT JOIN patient ON patient.debitor_uuid = sale.debitor_uuid ' + 
+    'LEFT JOIN patient ON patient.debitor_uuid = sale.debitor_uuid ' +
     'WHERE sale.uuid = ?';
 
-  saleItemsQuery = 
-    'SELECT sale_item.uuid, sale_item.quantity, sale_item.inventory_price, ' + 
-      'sale_item.transaction_price, inventory.code, inventory.text, inventory.consumable ' + 
-    'FROM sale_item ' + 
-    'LEFT JOIN inventory ON sale_item.inventory_uuid = inventory.uuid ' + 
+  saleItemsQuery =
+    'SELECT sale_item.uuid, sale_item.quantity, sale_item.inventory_price, ' +
+      'sale_item.transaction_price, inventory.code, inventory.text, inventory.consumable ' +
+    'FROM sale_item ' +
+    'LEFT JOIN inventory ON sale_item.inventory_uuid = inventory.uuid ' +
     'WHERE sale_uuid = ?';
-  
-  // This process accepts a very small performance hit querrying the sale items 
-  // even if the sale hasn't been found - however it uses a less obscure branching 
+
+  // This process accepts a very small performance hit querrying the sale items
+  // even if the sale hasn't been found - however it uses a less obscure branching
   // structure than alternative blocking methods
   db.exec(saleDetailQuery, [uuid])
-    .then(function (detailsResult) { 
+    .then(function (detailsResult) {
       sale = detailsResult;
       return db.exec(saleItemsQuery, [uuid]);
     })
-    .then(function (itemsResult) { 
+    .then(function (itemsResult) {
       saleItems = itemsResult;
 
-      if (isEmpty(sale)) { 
+      if (_.isEmpty(sale)) {
         res.status(404).json({
-          code : 'ERR_NOT_FOUND', 
+          code : 'ERR_NOT_FOUND',
           reason : 'No sale found under the id ' + uuid
         });
-      } else { 
-        
+      } else {
+
         // Found sale resource - unpack and return to client
         sale = sale[0];
         res.status(200).json({
-          sale : sale, 
+          sale : sale,
           saleItems : saleItems
         });
       }
@@ -96,55 +100,55 @@ function details(req, res, next) {
     .done();
 }
 
-function create(req, res, next) { 
+function create(req, res, next) {
   var insertSaleLineQuery, insertSaleItemQuery;
   var saleResults;
   var transaction;
-   
-  // Verify request validity 
+
+  // Verify request validity
   var saleLineBody = req.body.sale;
   var saleItems = req.body.saleItems;
-  
+
   // Reject invalid parameters
-  if (!saleLineBody || !saleItems) { 
+  if (!saleLineBody || !saleItems) {
     res.status(400).json({
-      code : 'ERROR.ERR_MISSING_INFO', 
+      code : 'ERROR.ERR_MISSING_INFO',
       reason : 'A valid sale details and sale items must be provided under the attributes `sale` and `saleItems`'
     });
     return;
   }
-  
-  // Provide UUID if the client has not specified 
+
+  // Provide UUID if the client has not specified
   saleLineBody.uuid = saleLineBody.uuid || uuid();
-  
-  // Implicitly provide seller information based on user session 
+
+  // Implicitly provide seller information based on user session
   saleLineBody.seller_id = req.session.user.id;
 
-  insertSaleLineQuery = 
+  insertSaleLineQuery =
     'INSERT INTO sale SET ?';
-  
-  insertSaleItemQuery = 
-    'INSERT INTO sale_item (inventory_uuid, quantity, inventory_price, ' + 
+
+  insertSaleItemQuery =
+    'INSERT INTO sale_item (inventory_uuid, quantity, inventory_price, ' +
         'transaction_price, credit, debit, uuid,  sale_uuid) VALUES ?';
 
   transaction = db.transaction();
 
-  // Insert sale line 
+  // Insert sale line
   transaction
     .addQuery(insertSaleLineQuery, [saleLineBody])
-  
+
   // Insert sale item lines
     .addQuery(insertSaleItemQuery, [linkSaleItems(saleItems, saleLineBody.uuid)]);
 
-  transaction.execute() 
-    .then(function (results) { 
+  transaction.execute()
+    .then(function (results) {
       saleResults = results;
-      
+
       // TODO Update to use latest journal interface
       return postSaleRecord(saleLineBody.uuid, req.body.caution, req.session.user.id);
     })
-    .then(function (results) { 
-      var confirmation = { 
+    .then(function (results) {
+      var confirmation = {
         uuid : saleLineBody.uuid,
         results : saleResults
       };
@@ -154,16 +158,16 @@ function create(req, res, next) {
     .done();
 }
 
-/** 
+/**
  * @deprecated since version 2.X
- * Wrapper method to allow the module to use the current journal 
- * interface. This will be replaced with the new server journal interface 
+ * Wrapper method to allow the module to use the current journal
+ * interface. This will be replaced with the new server journal interface
  * implementation.
  * @returns {Object} Promise object to be fulfilled on journal posting
  */
-function postSaleRecord(saleUuid, caution, userId) { 
+function postSaleRecord(saleUuid, caution, userId) {
   var deferred = q.defer();
-  
+
   journal.request('sale', saleUuid, userId, function (error, result) {
     if (error) {
       return deferred.reject(error);
@@ -173,30 +177,63 @@ function postSaleRecord(saleUuid, caution, userId) {
   return deferred.promise;
 }
 
-/** 
+/**
  * Utility method to ensure patient invoice lines reference sale.
- * @param {Object} saleItems - An Array of all sale items to be written 
+ * @param {Object} saleItems - An Array of all sale items to be written
  * @param {string} saleUuid - UUID of referenced patient invoice
  * @returns {Object} An Array of all sale items with guaranteed UUIDs and Patient Invoice references
  */
-function linkSaleItems(saleItems, saleUuid) { 
-  return saleItems.map(function (saleItem) { 
-     
+function linkSaleItems(saleItems, saleUuid) {
+  return saleItems.map(function (saleItem) {
+
     saleItem.uuid = saleItem.uuid || uuid();
     saleItem.sale_uuid = saleUuid;
-   
+
     // Collapse sale item into Array to be inserted into database
-    return Object.keys(saleItem).map(function (key) { 
+    return Object.keys(saleItem).map(function (key) {
       return saleItem[key];
     });
   });
 }
 
 /**
- * Utility method - determine if an array has no elements 
- * @param {Object} array - Array to be tested 
- * @returns {Boolean} Value reflecting if the array is empty or not (true or false respectively)
+ * Searches for a sale by query parameters provided.
  */
-function isEmpty(array) {
-  return array.length === 0;
+function search(req, res, next) {
+  'use strict';
+
+  var sql =
+    'SELECT sale.uuid, sale.project_id, CONCAT(project.abbr, sale.reference) AS reference, ' +
+      'sale.cost, sale.currency_id, sale.debitor_uuid, sale.seller_id, sale.discount, ' +
+      'sale.invoice_date, sale.note, sale.posted, sale.is_distributable ' +
+    'FROM sale JOIN project ON project.id = sale.project_id ' +
+    'WHERE ';
+
+  var conditions = [];
+
+  // look through the query string and template their key/values to the SQL query
+  var tmpl = Object.keys(req.query).map(function (key) {
+
+    // add the key + value to the conditions array
+    conditions = conditions.concat(key, req.query[key]);
+
+    // return the template string
+    return '?? = ?';
+  });
+
+  // if the client didn't send any data, simply search 'WHERE 1' to return all
+  // results in the database.
+  if (_.isEmpty(req.query)) {
+    sql += '1';
+  }
+
+  // add in the WHERE conditions to the sql tempalte
+  sql += tmpl.join(' AND ') + ';';
+
+  db.exec(sql, conditions)
+  .then(function (rows) {
+    res.status(200).json(rows);
+  })
+  .catch(next)
+  .done();
 }

--- a/server/controllers/medical/patient.js
+++ b/server/controllers/medical/patient.js
@@ -187,7 +187,6 @@ function update(req, res, next) {
 }
 
 function handleFetchPatient(uuid, codes) {
-  'use strict';
 
   var patientDetailQuery =
     'SELECT p.uuid, p.project_id, p.debitor_uuid, p.first_name, p.last_name, p.middle_name, p.hospital_no, ' +
@@ -478,7 +477,7 @@ function isEmpty(array) {
 * @desc This function is responsible to find a patient with detailled informations or not
 * and with a limited rows or not
 */
-function search (req, res, next) {
+function search(req, res, next) {
 
   var sql,
       data       = [],
@@ -578,6 +577,3 @@ function search (req, res, next) {
   .catch(next)
   .done();
 }
-
-
-

--- a/server/test/api/patientInvoice.js
+++ b/server/test/api/patientInvoice.js
@@ -51,6 +51,9 @@ describe('The /sales API', function () {
 
   /** @const total number of sales in the database */
   var NUM_SALES = 2;
+  
+  /** @const a reference for one of the sales in the database */
+  var REFERENCE = 'TPA1';
 
   /** login before each request */
   beforeEach(helpers.login(agent));
@@ -198,6 +201,26 @@ describe('The /sales API', function () {
         })
         .catch(helpers.handler);
     });
+  });
 
+  describe('(/sales/references) reference interface for the sales table', function () {
+
+    it('GET /sales/reference/:reference should return a uuid for a valid sale reference', function () {
+      return agent.get('/sales/references/'.concat(REFERENCE))
+        .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.have.property('uuid');
+        })
+        .catch(helpers.handler);
+    });
+
+    it('GET /sales/references/:reference should fail for an invalid sale reference', function () {
+      return agent.get('/sales/references/unknown')
+        .then(function (res) {
+          helpers.api.errored(res, 404);
+        })
+        .catch(helpers.handler);
+    });
   });
 });

--- a/server/test/api/patientInvoice.js
+++ b/server/test/api/patientInvoice.js
@@ -1,7 +1,9 @@
+/* jshint expr:true */
 /* global describe, it, beforeEach */
 
 var chai = require('chai');
 var expect = chai.expect;
+var uuid = require('node-uuid');
 
 /** import test helpers */
 var helpers = require('./helpers');
@@ -46,6 +48,9 @@ describe('The /sales API', function () {
     badSale : {},
     invalidParams : {}
   };
+
+  /** @const total number of sales in the database */
+  var NUM_SALES = 2;
 
   /** login before each request */
   beforeEach(helpers.login(agent));
@@ -102,22 +107,97 @@ describe('The /sales API', function () {
   });
 
   it('GET /sales/:uuid returns 404 for an invalid patient invoice', function () {
-
-    return agent.get('/sales/unkown')
-      .then(function (result) {
-        expect(result).to.have.status(404);
-        expect(result.body).to.not.be.empty;
+    return agent.get('/sales/unknown')
+      .then(function (res) {
+        helpers.api.errored(res, 404);
       })
       .catch(helpers.handler);
   });
 
   it('POST /sales returns 400 for an invalid patient invoice request object', function () {
-
     return agent.post('/sales')
       .send(invalidRequestSale)
       .then(function (res) {
-        expect(res).to.have.status(400);
-        expect(res.body).to.not.be.empty;
-      });
+        helpers.api.errored(res, 400);
+      })
+      .catch(helpers.handler);
+  });
+
+  describe('(/sales/search) Search interface for the sales table', function () {
+
+    // no params provided
+    it('GET /sales/search should return all sales if no query string provided', function () {
+      return agent.get('/sales/search')
+        .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.have.length(NUM_SALES);
+        })
+        .catch(helpers.handler);
+    });
+
+    // valid filter, all results
+    it('GET /sales/search?debitor_uuid=3be232f9-a4b9-4af6-984c-5d3f87d5c107 should return two sales', function () {
+      return agent.get('/sales/search?debitor_uuid=3be232f9-a4b9-4af6-984c-5d3f87d5c107')
+        .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.have.length(2);
+        })
+        .catch(helpers.handler);
+    });
+
+    // valid filter, but no results expected
+    it('GET /sales/search?cost=0 should return no sales', function () {
+      return agent.get('/sales/search?cost=0')
+        .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.have.length(0);
+        })
+        .catch(helpers.handler);
+    });
+
+    // invalid filter should fail with database error
+    it('GET /sales/search?invalidKey=invalidValue should error w/ 400 status', function () {
+      return agent.get('/sales/search?invalidKey=invalidValue')
+        .then(function (res) {
+          helpers.api.errored(res, 400);
+        })
+        .catch(helpers.handler);
+    });
+
+    // filter should find exactly one result
+    it('GET /sales/search?cost=75 should return a single sale', function () {
+      return agent.get('/sales/search?cost=75')
+        .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.have.length(1);
+        })
+        .catch(helpers.handler);
+    });
+
+    // filter should combine to find the same result as above
+    it('GET /sales/search?cost=75&currency_id=2 should return a single sale (combined filter)', function () {
+      return agent.get('/sales/search?cost=75&currency_id=2')
+        .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.have.length(1);
+        })
+        .catch(helpers.handler);
+    });
+
+    it('GET /sales/search?cost=75&currency_id=1 should not return any results', function () {
+      return agent.get('/sales/search?cost=75&currency_id=1')
+        .then(function (res) {
+          expect(res).to.have.status(200);
+          expect(res).to.be.json;
+          expect(res.body).to.have.length(0);
+        })
+        .catch(helpers.handler);
+    });
+
   });
 });


### PR DESCRIPTION
This PR adds in two new interfaces for locating previous sales in the database, as well as integration tests to support them.   These interfaces are
1. `GET /sales/search?columnA=valueA,columnB=valueB` - a generic search interface for the sales table.  This API endpoints templates in query strings (with escaping) to filter columns in the sale table.
2. `GET /sales/references/:reference` - returns a uuid of the sale record given the reference.
