### PR TITLE
chore(docs): dependency flags from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ BHIMA
 [![Build Status](https://travis-ci.org/IMA-WorldHealth/bhima-2.X.svg)](https://travis-ci.org/IMA-WorldHealth/bhima-2.X)
 [![Dependency Status](https://david-dm.org/IMA-WorldHealth/bhima-2.X.svg)](https://david-dm.org/IMA-WorldHealth/bhima-2.X)
 [![devDependency Status](https://david-dm.org/IMA-WorldHealth/bhima-2.X/dev-status.svg)](https://david-dm.org/IMA-WorldHealth/bhima-2.X/#info=devDependencies)
-[![bitHound Overall Score](https://www.bithound.io/github/IMA-WorldHealth/bhima-2.X/badges/score.svg)](https://www.bithound.io/github/IMA-WorldHealth/bhima-2.X)
-[![bitHound Code](https://www.bithound.io/github/IMA-WorldHealth/bhima-2.X/badges/code.svg)](https://www.bithound.io/github/IMA-WorldHealth/bhima-2.X)
 
 _Bhima is alpha version software. Please do not use this in a commerical context._
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@ BHIMA
 =================
 
 [![Build Status](https://travis-ci.org/IMA-WorldHealth/bhima-2.X.svg)](https://travis-ci.org/IMA-WorldHealth/bhima-2.X)
-[![Dependency Status](https://david-dm.org/IMA-WorldHealth/bhima-2.X.svg)](https://david-dm.org/IMA-WorldHealth/bhima-2.X)
-[![devDependency Status](https://david-dm.org/IMA-WorldHealth/bhima-2.X/dev-status.svg)](https://david-dm.org/IMA-WorldHealth/bhima-2.X/#info=devDependencies)
 
 _Bhima is alpha version software. Please do not use this in a commerical context._
 


### PR DESCRIPTION
BitHound served its purpose and may serve us again, but at the moment we
do not have a good use case for it. This PR removes the flags for
bithound's code quality metrics, and flags for david-dm's dependency status.
