### PR TITLE
chore(tests): clean up all end-to-end tests with FormUtils

### DIFF
--- a/client/src/js/directives/bhLocationSelect.js
+++ b/client/src/js/directives/bhLocationSelect.js
@@ -8,7 +8,6 @@ angular.module('bhima.directives')
   templateUrl : 'partials/templates/bhLocationSelect.tmpl.html',
   controller : LocationSelectController,
   bindings: {
-    id:                '@',
     locationUuid:      '=', // two-way binding
     disable:           '<', // one-way binding
     validationTrigger: '<', // one-way binding
@@ -58,9 +57,6 @@ function LocationSelectController(Locations, $scope) {
 
   /** loading indicator */
   vm.loading = false;
-
-  /** default id */
-  vm.id = vm.id || 'bh-location-select-component';
 
   /** methods */
   vm.loadVillages = loadVillages;

--- a/client/src/partials/cash/cash.html
+++ b/client/src/partials/cash/cash.html
@@ -182,7 +182,7 @@
                 </bh-currency-input>
 
                 <div class="form-group">
-                  <button type="submit" class="btn btn-primary" data-action="submit">
+                  <button type="submit" class="btn btn-primary" data-method="submit">
                     <span class="glyphicon glyphicon-refresh" ng-show="CashCtrl.loadingState"></span>
                     {{ (CashCtrl.loadingState ? "UTIL.LOADING" : "FORM.SUBMIT") | translate }}
                   </button>

--- a/client/src/partials/cash/cashboxes/cashboxes.html
+++ b/client/src/partials/cash/cashboxes/cashboxes.html
@@ -1,11 +1,11 @@
 <div class="flex-header">
   <div class="bhima-title">
-      
+
     <ol class="headercrumb">
       <li class="static">{{ "TREE.ADMIN" | translate }}</li>
       <li class="title">{{ "CASH.CASHBOX.TITLE" | translate }}</li>
     </ol>
-    
+
   </div>
 </div>
 
@@ -22,7 +22,7 @@
     <div class="row">
 
       <div class="col-md-6">
-        <table class="table table-striped table-borded table-condensed" style="max-height:600px; overflow:auto;">
+        <table class="table table-striped table-bordered table-condensed" style="max-height:600px; overflow:auto;">
           <thead>
             <tr>
               <th colspan="2">{{ "COLUMNS.NAME" | translate }}</th>
@@ -53,12 +53,17 @@
           <form class="panel-body" name="CreateForm" ng-submit="CashCtrl.submit(CreateForm.$invalid)" novalidate>
 
             <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.text.$invalid }">
-              <label class="control-label">{{ "COLUMNS.NAME" | translate }}</label>
-              <input class="form-control" name="CreateForm.text" ng-model="CashCtrl.box.text" required>
+              <label class="control-label">
+                {{ "COLUMNS.NAME" | translate }}
+              </label>
+              <input class="form-control" name="text" ng-model="CashCtrl.box.text" required>
+              <div class="help-block" ng-messages="CreateForm.text.$error" ng-show="CreateForm.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.type.$invalid }">
-              <label>{{ "COLUMNS.TYPE" | translate }}</label>
+              <label class="control-label">{{ "COLUMNS.TYPE" | translate }}</label>
               <div class="radio">
                 <label>
                   <input type="radio" name="type" ng-model="CashCtrl.box.type" value="primary" required>
@@ -72,13 +77,21 @@
                   {{ "CASH.CASHBOX.AUXILIARY" | translate }}
                 </label>
               </div>
+              <div class="help-block" ng-messages="CreateForm.type.$error" ng-show="CreateForm.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.project.$invalid }">
-              <label class="control-label">{{ "CASH.CASHBOX.PROJECT" | translate }}</label>
+              <label class="control-label">
+                {{ "CASH.CASHBOX.PROJECT" | translate }}
+              </label>
               <select class="form-control" name="project" ng-model="CashCtrl.box.project_id" ng-options="project.id as project.name for project in CashCtrl.projects" required>
                 <option value="" disabled>{{ "SELECT.PROJECT" | translate }}</option>
               </select>
+              <div class="help-block" ng-messages="CreateForm.project.$error" ng-show="CreateForm.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <div class="form-group">
@@ -100,12 +113,17 @@
             <div class="panel-body">
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.text.$invalid }">
-                <label class="control-label">{{ "COLUMNS.NAME" | translate }}</label>
-                <input class="form-control" name="UpdateForm.text" ng-model="CashCtrl.box.text" required>
+                <label class="control-label">
+                  {{ "COLUMNS.NAME" | translate }}
+                </label>
+                <input class="form-control" name="text" ng-model="CashCtrl.box.text" required>
+                <div class="help-block" ng-messages="UpdateForm.text.$error" ng-show="UpdateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.type.$invalid }">
-                <label>{{ "COLUMNS.TYPE" | translate }}</label>
+                <label class="control-label">{{ "COLUMNS.TYPE" | translate }}</label>
                 <div class="radio">
                   <label>
                     <input type="radio" name="type" ng-model="CashCtrl.box.type" value="primary" required>
@@ -119,6 +137,9 @@
                     {{ "CASH.CASHBOX.AUXILIARY" | translate }}
                   </label>
                 </div>
+                <div class="help-block" ng-messages="UpdateForm.type.$error" ng-show="UpdateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
               </div>
 
               <div class="form-group">
@@ -126,7 +147,7 @@
                 <div ng-repeat="currency in CashCtrl.currencies | orderBy:currency.name track by currency.id">
                   <p ng-class="{ 'text-danger' : !currency.configured }">
                     <i class="glyphicon glyphicon-alert" ng-if="!currency.configured"></i> {{ currency.name }} ({{ currency.symbol}})
-                    <a class="btn btn-xs btn-default" href="" ng-click="CashCtrl.configureCurrency(currency)">
+                    <a class="btn btn-xs btn-default" href="" ng-click="CashCtrl.configureCurrency(currency)" data-currency-id="{{ currency.id }}">
                       <i class="glyphicon glyphicon-pencil"></i> {{ "FORM.CONFIGURE" | translate }}
                     </a>
                   </p>
@@ -137,10 +158,20 @@
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.project.$invalid }">
-                <label class="control-label">{{ "CASH.CASHBOX.PROJECT" | translate }}</label>
-                <select class="form-control" name="project" ng-model="CashCtrl.box.project_id" ng-options="project.id as project.name for project in CashCtrl.projects" required>
+                <label class="control-label">
+                  {{ "CASH.CASHBOX.PROJECT" | translate }}
+                </label>
+                <select
+                  class="form-control"
+                  name="project"
+                  ng-model="CashCtrl.box.project_id"
+                  ng-options="project.id as project.name for project in CashCtrl.projects track by project.id"
+                  required>
                   <option value="" disabled>{{ "SELECT.PROJECT" | translate }}</option>
                 </select>
+                <div class="help-block" ng-messages="UpdateForm.project.$error" ng-show="UpdateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
               </div>
             </div>
 

--- a/client/src/partials/permissions/permissions.html
+++ b/client/src/partials/permissions/permissions.html
@@ -1,21 +1,24 @@
 <div class="flex-header">
   <div class="bhima-title">
-      
     <ol class="headercrumb">
       <li class="static">{{ "TREE.ADMIN" | translate }}</li>
       <li class="title">{{ "PERMISSIONS.TITLE" | translate }}</li>
     </ol>
-    
   </div>
 </div>
 
 <!-- flex-util not recommended - pending new top right menu design -->
 <div class="flex-util">
-    <button id="initCreate" class="btn btn-default btn-sm" ng-click="PermissionsCtrl.setState('create')" ng-class="{ 'active' : PermissionsCtrl.state === 'create' }">
-      <i class="glyphicon glyphicon-plus-sign"></i> {{ "PERMISSIONS.ADD_NEW_USER" | translate }}
-    </button>
+  <button
+    type="button"
+    class="btn btn-default btn-sm"
+    ng-click="PermissionsCtrl.setState('create')"
+    ng-class="{ 'active' : PermissionsCtrl.state === 'create' }"
+    data-method="create">
+    <span class="glyphicon glyphicon-plus-sign"></span> {{ "PERMISSIONS.ADD_NEW_USER" | translate }}
+  </button>
 </div>
-  
+
 <div class="flex-content">
 <div class="container-fluid">
   <div class="row">
@@ -43,42 +46,48 @@
             <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.firstname.$invalid }">
               <label class="control-label">{{ "COLUMNS.FIRST_NAME" | translate }}</label>
               <input name="firstname" ng-model="PermissionsCtrl.user.first" class="form-control" required>
-              <p class="help-block" ng-if="CreateForm.$submitted && CreateForm.firstname.$invalid">
-                {{ "FORM.REQUIRED_FIELD" | translate }}
-              </p>
+              <div class="help-block" ng-messages="CreateForm.firstname.$error" ng-show="CreateForm.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.lastname.$invalid }">
               <label class="control-label">{{ "COLUMNS.LAST_NAME" | translate }}</label>
               <input name="lastname" ng-model="PermissionsCtrl.user.last" class="form-control" required>
-              <p class="help-block" ng-if="CreateForm.$submitted && CreateForm.lastname.$invalid">
-                {{ "FORM.REQUIRED_FIELD" | translate }}
-              </p>
+              <div class="help-block" ng-messages="CreateForm.lastname.$error" ng-show="CreateForm.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <div class="form-group"  ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.username.$invalid }">
               <label class="control-label">{{ "COLUMNS.USER_NAME" | translate }}</label>
               <input name="username" ng-model="PermissionsCtrl.user.username" class="form-control" required>
-              <p class="help-block" ng-if="CreateForm.$submitted && CreateForm.username.$invalid">
-                {{ "FORM.REQUIRED_FIELD" | translate }}
-              </p>
+              <div class="help-block" ng-messages="CreateForm.username.$error" ng-show="CreateForm.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.email.$invalid }">
               <label class="control-label">{{ "COLUMNS.EMAIL" | translate }}</label>
               <input name="email" ng-model="PermissionsCtrl.user.email" class="form-control" type="email" required>
-              <p class="help-block" ng-if="CreateForm.$submitted && CreateForm.email.$invalid">
-                {{ "FORM.REQUIRED_EMAIL" | translate }}
-              </p>
+              <div class="help-block" ng-messages="CreateForm.email.$error" ng-show="CreateForm.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.projects.$invalid }">
               <label class="control-label">{{ "COLUMNS.PROJECTS" | translate }}</label>
-              <select name="projects" ng-model="PermissionsCtrl.user.projects" class="form-control" ng-options="project.id as project.name for project in PermissionsCtrl.projects" required multiple>
+              <select
+                name="projects"
+                ng-model="PermissionsCtrl.user.projects"
+                class="form-control"
+                ng-options="project.id as project.name for project in PermissionsCtrl.projects"
+                required
+                multiple>
               </select>
-              <p class="help-block" ng-if="CreateForm.$submitted && CreateForm.projects.$invalid">
-                {{ "FORM.REQUIRED_OPTION" | translate }}
-              </p>
+              <div class="help-block" ng-messages="CreateForm.projects.$error" ng-show="CreateForm.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <div class="form-group has-feedback" ng-class="{ 'has-error' : CreateForm.$submitted && !PermissionsCtrl.validPassword() }">
@@ -99,7 +108,7 @@
             </div>
 
             <div class="form-group">
-              <button id="submitCreate" type="submit" class="btn btn-success">
+              <button type="submit" class="btn btn-success" data-method="submit">
                 <i class="glyphicon glyphicon-ok"></i> {{ 'FORM.SUBMIT' | translate }}
               </button>
               <button type="button" class="btn btn-default" ng-click="PermissionsCtrl.setState('default')">
@@ -118,31 +127,32 @@
         <div class="panel-heading">
           {{ "PERMISSIONS.UPDATE_USER_FORM" | translate }}
         </div>
+
         <form class="panel-body" name="UpdateForm" ng-submit="PermissionsCtrl.submit(UpdateForm.$invalid)" novalidate>
           <fieldset>
 
             <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.firstname.$invalid }">
               <label class="control-label">{{ "COLUMNS.FIRST_NAME" | translate }}</label>
               <input name="firstname" ng-model="PermissionsCtrl.user.first" class="form-control" required>
-              <p class="help-block" ng-if="UpdateForm.$submitted && UpdateForm.firstname.$invalid">
-                {{ "FORM.REQUIRED_FIELD" | translate }}
-              </p>
+              <div class="help-block" ng-messages="UpdateForm.firstname.$error" ng-show="UpdateForm.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.lastname.$invalid }">
               <label class="control-label">{{ "COLUMNS.LAST_NAME" | translate }}</label>
               <input name="lastname" ng-model="PermissionsCtrl.user.last" class="form-control" required>
-              <p class="help-block" ng-if="UpdateForm.$submitted && UpdateForm.lastname.$invalid">
-                {{ "FORM.REQUIRED_FIELD" | translate }}
-              </p>
+              <div class="help-block" ng-messages="UpdateForm.lastname.$error" ng-show="UpdateForm.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <div class="form-group"  ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.username.$invalid }">
               <label class="control-label">{{ "COLUMNS.USER_NAME" | translate }}</label>
               <input name="username" ng-model="PermissionsCtrl.user.username" class="form-control" required>
-              <p class="help-block" ng-if="UpdateForm.$submitted && UpdateForm.username.$invalid">
-                {{ "FORM.REQUIRED_FIELD" | translate }}
-              </p>
+              <div class="help-block" ng-messages="UpdateForm.username.$error" ng-show="UpdateForm.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.email.$invalid }">
@@ -155,11 +165,17 @@
 
             <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.projects.$invalid }">
               <label class="control-label">{{ "COLUMNS.PROJECTS" | translate }}</label>
-              <select name="projects" ng-model="PermissionsCtrl.user.projects" class="form-control" ng-options="project.id as project.name for project in PermissionsCtrl.projects" required multiple>
+              <select
+                name="projects"
+                ng-model="PermissionsCtrl.user.projects"
+                class="form-control"
+                ng-options="project.id as project.name for project in PermissionsCtrl.projects"
+                required
+                multiple>
               </select>
-              <p class="help-block" ng-if="UpdateForm.$submitted && UpdateForm.projects.$invalid">
-                {{ "FORM.REQUIRED_OPTION" | translate }}
-              </p>
+              <div class="help-block" ng-messages="UpdateForm.projects.$error" ng-show="UpdateForm.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <div class="form-group">
@@ -216,7 +232,6 @@
           </ul>
         </div>
       </div>
-
     </div>
   </div>
 </div>

--- a/client/src/partials/projects/projects.html
+++ b/client/src/partials/projects/projects.html
@@ -33,13 +33,19 @@
               </tr>
             </thead>
             <tbody>
-              <tr ng-repeat="project in ProjectCtrl.projects | orderBy:'name' track by project.id" ng-class="{'btn-primary' : editProject.id==project.id }">
+              <tr ng-repeat="project in ProjectCtrl.projects | orderBy:'name' track by project.id" ng-class="{ 'btn-primary' : editProject.id == project.id }">
                 <td>{{ project.id }}</td>
                 <td>{{ project.name }}</td>
                 <td>{{ project.abbr }}</td>
                 <td>{{ project.enterprise_id }}</td>
-                <td><a class="btn btn-xs btn-default" ng-click="ProjectCtrl.update(project)" id="project-upd-{{ $index + 1}}"><span class="glyphicon glyphicon-pencil"></span></a></td>
-                <td><a class="btn btn-xs btn-default" ng-click="ProjectCtrl.del(project)" id="project-del-{{ $index + 1 }}" class="danger"><span class="glyphicon glyphicon-trash"></span></a></td>
+                <td>
+                  <a class="btn btn-xs btn-default" ng-click="ProjectCtrl.update(project)" id="project-upd-{{ $index + 1}}"><span class="glyphicon glyphicon-pencil"></span></a>
+                </td>
+                <td>
+                  <a class="btn btn-xs btn-default" ng-click="ProjectCtrl.del(project)" id="project-del-{{ $index + 1 }}" class="danger">
+                    <span class="glyphicon glyphicon-trash"></span>
+                  </a>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -126,8 +132,8 @@
                     <label>
                       <input type="checkbox" id="locked" ng-true-value="1" ng-false-value="0" name="bhima-project-locked" ng-model="ProjectCtrl.project.locked"> {{ 'COLUMNS.LOCKED' | translate }}
                     </label>
-                  </div>             
-                </div> 
+                  </div>
+                </div>
               </div>
 
               <div class="form-group">
@@ -139,7 +145,7 @@
                   </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
 
         <div class="panel panel-primary" ng-switch-when="update">
@@ -162,10 +168,16 @@
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.enterprise_id.$invalid }">
-                <label class="col-md-3 control-label">{{ "COLUMNS.ENTERPRISE" | translate }}</label>
+                <label class="col-md-3 control-label">
+                  {{ "COLUMNS.ENTERPRISE" | translate }}
+                </label>
                 <div class="col-md-9">
-                  <select class="form-control" name="enterprise_id" ng-model="ProjectCtrl.project.enterprise_id" id="bhima-project-enterprise_id" ng-options="e.id as e.name for e in ProjectCtrl.enterprises | orderBy:'name'" required>
-                    <option value="" disabled> -- {{ 'SELECT.ENTERPRISE' | translate }} -- </option>
+                  <select
+                    class="form-control"
+                    name="enterprise_id"
+                    ng-model="ProjectCtrl.project.enterprise_id"
+                    ng-options="e.id as e.name for e in ProjectCtrl.enterprises | orderBy:'name'" required>
+                    <option value="" disabled> {{ 'SELECT.ENTERPRISE' | translate }} </option>
                   </select>
                 </div>
               </div>
@@ -179,6 +191,7 @@
                   </select>
                 </div>
               </div>
+
               <!-- end zone de sante for snis -->
               <div class="form-group">
                 <div class="col-sm-offset-3 col-sm-9">
@@ -186,8 +199,8 @@
                     <label>
                       <input type="checkbox" ng-true-value="1" ng-false-value="0" id="bhima-project-locked"  name="locked" ng-model="ProjectCtrl.project.locked"> {{ 'COLUMNS.LOCKED' | translate }}
                     </label>
-                  </div>             
-                </div>                
+                  </div>
+                </div>
               </div>
 
               <div class="form-group">
@@ -199,9 +212,9 @@
                   </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/templates/bhLocationSelect.tmpl.html
+++ b/client/src/partials/templates/bhLocationSelect.tmpl.html
@@ -3,7 +3,7 @@
   a child form is added for validation purposes, and to make the HTML easier
   to read.
 -->
-<fieldset ng-disabled="$ctrl.disable" ng-form="LocationSelectForm" id="{{ $ctrl.id }}" data-bh-location-select>
+<fieldset ng-disabled="$ctrl.disable" ng-form="LocationSelectForm" data-bh-location-select>
 
   <!-- allows a user to select a country -->
   <div class="form-group"

--- a/client/test/e2e/cash/cash.spec.js
+++ b/client/test/e2e/cash/cash.spec.js
@@ -2,14 +2,15 @@
 
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
-
-// import ui-grid testing utiliites
-var gridUtils = require('../shared/gridTestUtils.spec.js');
-var components = require('../shared/components');
-var EC = protractor.ExpectedConditions;
-
-chai.use(chaiAsPromised);
 var expect = chai.expect;
+chai.use(chaiAsPromised);
+
+// import testing utiliites
+var components = require('../shared/components');
+var GU = require('../shared/gridTestUtils.spec.js');
+var EC = protractor.ExpectedConditions;
+var FU = require('../shared/FormUtils');
+
 
 describe('Cash Payments Module', function () {
 
@@ -191,18 +192,17 @@ describe('Cash Payments Module', function () {
       cautionOption.click();
 
       // select the FC currency from the currency
-      var currencyOption = element(by.css('[data-currency-option="1"]'));
-      currencyOption.click();
+      var FC = element(by.css('[data-currency-option="1"]'));
+      FC.click();
 
       // enter the amount to pay for a caution
       components.currencyInput.set(mockCautionPayment.amount);
 
       // click the submit button
-      var submit = element(by.css('[data-action="submit"]'));
-      submit.click();
+      FU.buttons.submit();
 
       // expect the receipt modal to appear
-      expect(element(by.css('[data-cash-receipt-modal]')).isPresent()).to.eventually.equal(true);
+      FU.exists(by.css('[data-cash-receipt-modal]'), true);
     });
 
     it('should make a payment against previous invoices', function () {
@@ -219,33 +219,38 @@ describe('Cash Payments Module', function () {
       cautionOption.click();
 
       // open the invoices modal to select various invoices
-      var modalButton = element(by.css('[data-open-invoices-btn]'));
-      expect(modalButton.isPresent()).to.eventually.equal(true);
-      modalButton.click();
+      FU.exists(by.css('[data-open-invoices-btn]'), true);
+      element(by.css('[data-open-invoices-btn]')).click();
 
       // be sure that the modal opened
-      expect(element(by.css('[data-debtor-invoices-modal]')).isPresent()).to.eventually.equal(true);
+      FU.exists(by.css('[data-debtor-invoices-modal]'), true);
 
       // inside the modal, we want to select the first row to pay against
-      var row = gridUtils.selectRow(gridId, 0);
+      var row = GU.selectRow(gridId, 0);
 
       // submit the modal
       var modalSubmit =  element(by.css('[data-debtor-invoices-modal-submit]'));
       modalSubmit.click();
 
       // select the USD currency from the currency radio buttons
-      var currencyOption = element(by.css('[data-currency-option="2"]'));
-      currencyOption.click();
+      var USD = element(by.css('[data-currency-option="2"]'));
+      USD.click();
 
       // enter the amount to pay for an invoice
       components.currencyInput.set(mockInvoicesPayment.amount);
 
       // click the submit button
-      var submit = element(by.css('[data-action="submit"]'));
-      submit.click();
+      FU.buttons.submit();
 
       // expect the receipt modal to appear
-      expect(element(by.css('[data-cash-receipt-modal]')).isPresent()).to.eventually.equal(true);
+      FU.exists(by.css('[data-cash-receipt-modal]'), true);
+    });
+
+    it('should perform validation', function () {
+
+      // click the submit button
+      FU.buttons.submit();
+
     });
   });
 });

--- a/client/test/e2e/cashboxes/cashboxes.spec.js
+++ b/client/test/e2e/cashboxes/cashboxes.spec.js
@@ -1,20 +1,19 @@
-/*global describe, it, element, by, beforeEach, inject, browser */
+/*global element, by, beforeEach, browser */
 
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
-chai.use(chaiAsPromised);
 var expect = chai.expect;
+chai.use(chaiAsPromised);
 
-var FormUtils = require('../shared/FormUtils');
+var FU = require('../shared/FormUtils');
 
-describe('The Cashbox Module', function () {
+describe('Cashbox Module', function () {
 
-  // shared methods
   var path = '#/cashboxes';
-  var CASHBOX = {
-    name : 'Test Principal Cashbox',
-    type : 1,  // this is the position in the radio button "principal"
-    project : 1
+  var cashbox = {
+    name:    'Test Principal Cashbox',
+    type:    1,
+    project: 1
   };
 
   function update(n) {
@@ -30,29 +29,29 @@ describe('The Cashbox Module', function () {
 
   it('successfully creates a new cashbox', function () {
 
-    // submit the page to the server
-    FormUtils.buttons.create();
+    // switch to the create form
+    FU.buttons.create();
 
-    FormUtils.input('CashCtrl.box.text', CASHBOX.name);
-    FormUtils.radio('CashCtrl.box.type', CASHBOX.type);
+    FU.input('CashCtrl.box.text', cashbox.name);
+    FU.radio('CashCtrl.box.type', cashbox.type);
 
-    // select a random, non-disabled option
-    FormUtils.select('CashCtrl.box.project_id')
+    // select the first non-disabled option
+    FU.select('CashCtrl.box.project_id')
       .enabled()
       .first()
       .click();
 
     // submit the page to the server
-    FormUtils.buttons.submit();
+    FU.buttons.submit();
 
     // make sure the success message shows
-    FormUtils.exists(FormUtils.feedback.success(), true);
+    FU.exists(FU.feedback.success(), true);
 
     // click the cancel button
-    FormUtils.buttons.cancel();
+    FU.buttons.cancel();
 
     // make sure the message is cleared
-    FormUtils.exists(FormUtils.feedback.success(), false);
+    FU.exists(FU.feedback.success(), false);
   });
 
   it('successfully edits a cashbox', function () {
@@ -60,16 +59,16 @@ describe('The Cashbox Module', function () {
     // navigate to the update form for the second item
     update(2);
 
-    FormUtils.input('CashCtrl.box.text', 'New Cashbox Name');
-    FormUtils.radio('CashCtrl.box.type', CASHBOX.type);
+    FU.input('CashCtrl.box.text', 'New Cashbox Name');
+    FU.radio('CashCtrl.box.type', cashbox.type);
 
     // make sure no messages are displayed
-    FormUtils.exists(FormUtils.feedback.success(), false);
+    FU.exists(FU.feedback.success(), false);
 
-    FormUtils.buttons.submit();
+    FU.buttons.submit();
 
     // success message!
-    FormUtils.exists(FormUtils.feedback.success(), true);
+    FU.exists(FU.feedback.success(), true);
   });
 
   it('allows the user to change currency accounts', function () {
@@ -77,46 +76,43 @@ describe('The Cashbox Module', function () {
     // navigate to the update form for the second item
     update(2);
 
-    // get a locator for the currencies
-    var fc =
-      element.all(by.repeater('currency in CashCtrl.currencies | orderBy:currency.name track by currency.id')).get(0);
-
-    // click the first currency button
-    fc.$$('a').click();
+    // get the "FC" (congolese francs) currency
+    var FC = element(by.css('[data-currency-id="1"]'));
+    FC.click();
 
     // confirm that the modal appears
-    FormUtils.exists(by.css('[uib-modal-window]'), true);
-    FormUtils.exists(by.name('CashboxModalForm'), true);
+    FU.exists(by.css('[uib-modal-window]'), true);
+    FU.exists(by.name('CashboxModalForm'), true);
 
     // choose a random cash account
-    FormUtils.select('CashboxModalCtrl.data.account_id')
+    FU.select('CashboxModalCtrl.data.account_id')
       .enabled()
       .last()
       .click();
 
     // choose a random loss on exchange account
-    FormUtils.select('CashboxModalCtrl.data.loss_exchange_account_id')
+    FU.select('CashboxModalCtrl.data.loss_exchange_account_id')
       .enabled()
       .last()
       .click();
 
     // choose a random gain on exchange account
-    FormUtils.select('CashboxModalCtrl.data.gain_exchange_account_id')
+    FU.select('CashboxModalCtrl.data.gain_exchange_account_id')
       .enabled()
       .last()
       .click();
 
     // choose a random transfer account
-    FormUtils.select('CashboxModalCtrl.data.virement_account_id')
+    FU.select('CashboxModalCtrl.data.virement_account_id')
       .enabled()
       .last()
       .click();
 
     // submit the modal
-    FormUtils.modal.submit();
+    FU.modal.submit();
 
     // confirm that the success feedback message was displaced
-    FormUtils.exists(FormUtils.feedback.success(), true);
+    FU.exists(FU.feedback.success(), true);
   });
 
   // forget to change the gain exchange account id
@@ -126,54 +122,59 @@ describe('The Cashbox Module', function () {
     update(2);
 
     // get a locator for the currencies
-    var fc =
-      element.all(by.repeater('currency in CashCtrl.currencies | orderBy:currency.name track by currency.id')).get(1);
-
-    // click the first currency button
-    fc.$$('a').click();
+    var USD = element(by.css('[data-currency-id="2"]'));
+    USD.click();
 
     // confirm that the modal appears
-    FormUtils.exists(by.css('[uib-modal-window]'), true);
+    FU.exists(by.css('[uib-modal-window]'), true);
 
     // NOTE -- we are forgetting to change the gain account id!
 
     // choose a random cash account
-    FormUtils.select('CashboxModalCtrl.data.account_id')
+    FU.select('CashboxModalCtrl.data.account_id')
       .enabled()
       .first()
       .click();
 
     // choose a random loss on exchange account
-    FormUtils.select('CashboxModalCtrl.data.loss_exchange_account_id')
+    FU.select('CashboxModalCtrl.data.loss_exchange_account_id')
       .enabled()
       .first()
       .click();
 
     // choose a random transfer account
-    FormUtils.select('CashboxModalCtrl.data.virement_account_id')
+    FU.select('CashboxModalCtrl.data.virement_account_id')
       .enabled()
       .first()
       .click();
 
     // submit the modal
-    FormUtils.modal.submit();
+    FU.modal.submit();
 
     // confirm that the modal did not disappear
-    FormUtils.exists(by.css('[uib-modal-window]'), true);
-    FormUtils.exists(FormUtils.feedback.error(), true);
+    FU.exists(by.css('[uib-modal-window]'), true);
+    FU.exists(FU.feedback.error(), true);
+
+    // these inputs should not have error states
+    FU.validation.ok('CashboxModalCtrl.data.account_id');
+    FU.validation.ok('CashboxModalCtrl.data.loss_exchange_account_id');
+    FU.validation.ok('CashboxModalCtrl.data.virement_account_id');
+
+    // this input should show an error state to the user
+    FU.validation.error('CashboxModalCtrl.data.gain_exchange_account_id');
 
     // select a valid currency account
-    FormUtils.select('CashboxModalCtrl.data.gain_exchange_account_id')
+    FU.select('CashboxModalCtrl.data.gain_exchange_account_id')
       .enabled()
       .first()
       .click();
 
     // submit the modal
-    FormUtils.modal.submit();
+    FU.modal.submit();
 
     // confirm that the modal did not disappear
-    FormUtils.exists(by.css('[uib-modal-window]'), false);
-    FormUtils.exists(FormUtils.feedback.error(), false);
+    FU.exists(by.css('[uib-modal-window]'), false);
+    FU.exists(FU.feedback.error(), false);
   });
 
   it('allows you to delete a cashbox', function () {
@@ -182,13 +183,26 @@ describe('The Cashbox Module', function () {
     update(2);
 
     // click the "delete" button
-    FormUtils.buttons.delete();
+    FU.buttons.delete();
 
     // confirm the deletion
     browser.switchTo().alert().accept();
 
     // check to see if we are in the default state
-    FormUtils.exists(by.css('.alert.alert-info'), true);
+    FU.exists(by.css('.alert.alert-info'), true);
   });
 
+  it('performs form validation', function () {
+
+    // switch to the create form
+    FU.buttons.create();
+
+    // try to submit to the server.
+    FU.buttons.submit();
+
+    // everything should have error highlights
+    FU.validation.error('CashCtrl.box.project_id');
+    FU.validation.error('CashCtrl.box.text');
+    FU.validation.error('CashCtrl.box.type');
+  });
 });

--- a/client/test/e2e/exchange/exchange.spec.js
+++ b/client/test/e2e/exchange/exchange.spec.js
@@ -1,14 +1,16 @@
-/*global describe, it, element, by, beforeEach, inject, browser */
+/* jshint expr:true */
+/* global element, by, beforeEach, inject, browser */
 
 var chai = require('chai');
-var chaiAsPromised = require('chai-as-promised');
-chai.use(chaiAsPromised);
 var expect = chai.expect;
 
-var FormUtils = require('../shared/FormUtils');
+var helpers = require('../shared/helpers');
+var FU = require('../shared/FormUtils');
 
-describe('The Exchange Rate  Module', function () {
-  // shared methods
+helpers.configure(chai);
+
+describe('Exchange Rate Module', function () {
+
   var path = '#/exchange';
   var EXCHANGE = {
     date : '06/30/2015',
@@ -23,82 +25,98 @@ describe('The Exchange Rate  Module', function () {
   var EXCHANGE_UPDATE ={
     rate : '930'
   };
-  //To obtain the rank of a random element to the exchange rate list
-  function aleatoire(N) { 
-    return (Math.floor((N)*Math.random()+1)); 
-  }
 
   var DELETE_RATE = 1;
   var DEFAULT_EXCHANGE = 1;
-  var CURRENCY_RANK = aleatoire(DEFAULT_EXCHANGE);
+  var CURRENCY_RANK = helpers.random(DEFAULT_EXCHANGE);
   var DELETE_SUCCESS = 4;
   var DELETE_ERROR = 1;
   var RATE = 2;
-  var RATE_RANK = aleatoire(RATE);
-
+  var RATE_RANK = helpers.random(RATE);
 
   beforeEach(function () {
     browser.get(path);
   });
 
-  it('Successfully delete an Exchange Rate ', function () {
-    element(by.id('rate-' + DELETE_RATE )).click();    
+  it('successfully delete an exchange rate ', function () {
+    element(by.id('rate-' + DELETE_RATE )).click();
+
     // submit the page to the server
-    element(by.id('delete')).click();    
+    element(by.id('delete')).click();
 
     browser.switchTo().alert().accept();
-    expect(element(by.id('delete_success')).isPresent()).to.eventually.be.true;
+
+    // make sure the success message is present
+    FU.exists(by.id('delete_success'), true);
   });
 
-  it('Successfully Set a new Exchange Rate', function () {
-    FormUtils.buttons.create();
+  it('successfully set a new exchange rate', function () {
+
+    // switch to teh creation form
+    FU.buttons.create();
 
     element(by.id('previous')).click();
-    FormUtils.input('ExchangeCtrl.form.date', EXCHANGE_NEW.date);
-    element(by.id('current-' + CURRENCY_RANK )).click();
-    FormUtils.input('ModalCtrl.data.rate',EXCHANGE_NEW.rate);
-    FormUtils.buttons.submit();
 
-    expect(element(by.id('create_success')).isPresent()).to.eventually.be.true;
+    FU.input('ExchangeCtrl.form.date', EXCHANGE_NEW.date);
+    element(by.id('current-' + CURRENCY_RANK )).click();
+    FU.input('ModalCtrl.data.rate',EXCHANGE_NEW.rate);
+
+    // submit the form
+    FU.buttons.submit();
+
+    // check that the success banner is shown
+    FU.exists(by.id('create_success'), true);
   });
 
-  it('Add exchange rates for a date for an Old Date ', function () {
-    FormUtils.buttons.create();
+  it('adds exchange rates previous dates', function () {
+
+    // switch to the create form
+    FU.buttons.create();
 
     element(by.id('previous')).click();
-    FormUtils.input('ExchangeCtrl.form.date', EXCHANGE.date);
+    FU.input('ExchangeCtrl.form.date', EXCHANGE.date);
     element(by.id('current-' + CURRENCY_RANK )).click();
-    FormUtils.input('ModalCtrl.data.rate',EXCHANGE.rate);
+    FU.input('ModalCtrl.data.rate',EXCHANGE.rate);
+
     // submit the page to the server
-    FormUtils.buttons.submit();
+    FU.buttons.submit();
 
-    expect(element(by.id('create_success')).isPresent()).to.eventually.be.true;
+    // check that the success banner is shown
+    FU.exists(by.id('create_success'), true);
   });
 
   it('Updated currency exchange rates from the already recorded rate', function () {
     element(by.id('rate-' + RATE_RANK )).click();
-    
-    // submit the page to the server
-    element(by.id('submit')).click();    
-    FormUtils.input('ModalCtrl.data.rate',EXCHANGE_UPDATE.rate);
-    FormUtils.buttons.submit();
 
-    expect(element(by.id('update_success')).isPresent()).to.eventually.be.true;
+    // submit the page to the server
+    element(by.id('submit')).click();
+    FU.input('ModalCtrl.data.rate',EXCHANGE_UPDATE.rate);
+
+    // submit the form
+    FU.buttons.submit();
+
+    // check that the success banner is shown
+    FU.exists(by.id('update_success'), true);
   });
 
   it('correctly blocks invalid form submission with relevent error classes', function () {
-    FormUtils.buttons.create();
+
+    // move to the submit form
+    FU.buttons.create();
+
     element(by.id('previous')).click();
-    FormUtils.input('ExchangeCtrl.form.date', EXCHANGE_NEW.date);
+
+    FU.input('ExchangeCtrl.form.date', EXCHANGE_NEW.date);
+
     element(by.id('current-' + CURRENCY_RANK )).click();
 
     // Verify form has not been successfully submitted
     expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + path);
 
-    FormUtils.buttons.submit(); 
+    // attempt to submit the form
+    FU.buttons.submit();
 
     // The following fields should be required
-    expect(element(by.model('ModalCtrl.data.rate')).getAttribute('class')).to.eventually.contain('ng-invalid');
-  });  
-
+    FU.validation.error('ModalCtrl.data.rate');
+  });
 });

--- a/client/test/e2e/patient/registration.spec.js
+++ b/client/test/e2e/patient/registration.spec.js
@@ -1,4 +1,4 @@
-/* jshint expr : true */
+/* jshint expr:true */
 /* global element, by, inject, browser */
 
 var chai = require('chai');

--- a/client/test/e2e/permissions/permissions.spec.js
+++ b/client/test/e2e/permissions/permissions.spec.js
@@ -1,18 +1,19 @@
 /* global inject, browser, element, by */
 
 var chai = require('chai');
-var chaiAsPromised = require('chai-as-promised');
+var expect = chai.expect;
 
 // import ui-grid testing utiliites
 var gridUtils = require('../shared/gridObjectTestUtils.spec.js');
+var FU = require('../shared/FormUtils');
+var helpers = require('../shared/helpers');
 
-chai.use(chaiAsPromised);
-var expect = chai.expect;
+helpers.configure(chai);
 
-describe('The Permissions Module', function () {
+describe('Permissions Module', function () {
 
-  var PATH = '#/permissions';
-  var MOCK_USER = {
+  var path = '#/permissions';
+  var mockUser = {
     first:    'Mock',
     last:     'User',
     username: 'mockuser',
@@ -22,34 +23,52 @@ describe('The Permissions Module', function () {
 
   // pre-load premissions page
   beforeEach(function () {
-    browser.get(PATH);
+    browser.get(path);
   });
 
   // new user creation
-  it('creates a new user', function (done) {
+  it('creates a new user', function () {
 
     // activate the creation page
-    element(by.id('initCreate')).click();
+    FU.buttons.create();
 
     // fill in user data
-    element(by.model('PermissionsCtrl.user.first')).sendKeys(MOCK_USER.first);
-    element(by.model('PermissionsCtrl.user.last')).sendKeys(MOCK_USER.last);
-    element(by.model('PermissionsCtrl.user.username')).sendKeys(MOCK_USER.username);
-    element(by.model('PermissionsCtrl.user.email')).sendKeys(MOCK_USER.email);
+    FU.input('PermissionsCtrl.user.first', mockUser.first);
+    FU.input('PermissionsCtrl.user.last', mockUser.last);
+    FU.input('PermissionsCtrl.user.username', mockUser.username);
+    FU.input('PermissionsCtrl.user.email', mockUser.email);
 
     // select the first project
     element.all(by.options('project.id as project.name for project in PermissionsCtrl.projects')).first().click();
 
     // set password
-    element(by.model('PermissionsCtrl.user.password')).sendKeys(MOCK_USER.password);
-    element(by.model('PermissionsCtrl.user.passwordVerify')).sendKeys(MOCK_USER.password);
+    FU.input('PermissionsCtrl.user.password', mockUser.password);
+    FU.input('PermissionsCtrl.user.passwordVerify', mockUser.password);
 
-    // submit the user
-    element(by.id('submitCreate')).click();
+    // submit the user form
+    FU.buttons.submit();
 
     // check for a success message
-    expect(element(by.css('.bh-form-message.bh-form-message-success')).isPresent()).to.eventually.equal(true)
-    .then(function () { done(); });
+    FU.exists(by.css('.bh-form-message.bh-form-message-success'), true);
+  });
+
+  // tests the form validation on the create page
+  it('has form validation on creation', function () {
+
+    // activate the creation page
+    FU.buttons.create();
+
+    // submit the form without doing anything
+    FU.buttons.submit();
+
+    // check the validation messages
+    FU.validation.error('PermissionsCtrl.user.first');
+    FU.validation.error('PermissionsCtrl.user.last');
+    FU.validation.error('PermissionsCtrl.user.username');
+    FU.validation.error('PermissionsCtrl.user.email');
+    FU.validation.error('PermissionsCtrl.user.projects');
+    FU.validation.error('PermissionsCtrl.user.password');
+    FU.validation.error('PermissionsCtrl.user.passwordVerify');
   });
 
   /*
@@ -59,17 +78,17 @@ describe('The Permissions Module', function () {
     gridUtils.
 
     // fill in user data
-    element(by.model('PermissionsCtrl.user.first')).sendKeys(MOCK_USER.first);
-    element(by.model('PermissionsCtrl.user.last')).sendKeys(MOCK_USER.last);
-    element(by.model('PermissionsCtrl.user.username')).sendKeys(MOCK_USER.username);
-    element(by.model('PermissionsCtrl.user.email')).sendKeys(MOCK_USER.email);
+    element(by.model('PermissionsCtrl.user.first')).sendKeys(mockUser.first);
+    element(by.model('PermissionsCtrl.user.last')).sendKeys(mockUser.last);
+    element(by.model('PermissionsCtrl.user.username')).sendKeys(mockUser.username);
+    element(by.model('PermissionsCtrl.user.email')).sendKeys(mockUser.email);
 
     // select the first project
     element.all(by.options('project.id as project.name for project in PermissionsCtrl.projects')).first().click();
 
     // set password
-    element(by.model('PermissionsCtrl.user.password')).sendKeys(MOCK_USER.password);
-    element(by.model('PermissionsCtrl.user.passwordVerify')).sendKeys(MOCK_USER.password);
+    element(by.model('PermissionsCtrl.user.password')).sendKeys(mockUser.password);
+    element(by.model('PermissionsCtrl.user.passwordVerify')).sendKeys(mockUser.password);
 
     // submit the user
     element(by.id('submitCreate')).click();

--- a/client/test/e2e/shared/FormUtils.js
+++ b/client/test/e2e/shared/FormUtils.js
@@ -93,7 +93,7 @@ var validation = {
 
   // no error state present
   ok : function success(model) {
-    expect(element(by.model(model)).getAttribute('class')).to.eventually.not.contain('ng-invalid');
+    expect(element(by.model(model)).getAttribute('class')).to.eventually.contain('ng-valid');
   }
 };
 

--- a/client/test/e2e/shared/helpers.js
+++ b/client/test/e2e/shared/helpers.js
@@ -1,0 +1,22 @@
+/* jshint expr:true */
+/* global element, by, beforeEach, inject, browser */
+
+/**
+ * Test helpers
+ * 
+ * This module contains utilities that are useful in tests, but not specifically
+ * tied to forms or modules.
+ */
+
+/** gets a random number within the range(0, n) */
+exports.random = function random(n) {
+  'use strict';
+  return Math.floor((n) * Math.random() + 1); 
+};
+
+exports.configure = function configure(chai) {
+  'use strict';
+
+  // enable promise chaining for chai assertions
+  chai.use(require('chai-as-promised'));
+};


### PR DESCRIPTION
This pull request standardizes the best practices for end to end tests.  It updates the old end to end tests with the `FormUtils` library and introduces the `helpers` shared library that groups useful tools for generating tests.

Most affected modules had their HTML cleaned up by removing unused ids, adding `data-` attributes expected by the `FormUtils` library and adding in generic messages using `ng-messages`.
