### PR TITLE
feat(reference): modal for looking up references

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -1154,7 +1154,7 @@
    "REGISTER_SUCCESS"   : "Register successfully",
    "SEARCH_BY_CODE"     : "Tap the code",
    "SEARCH_BY_NAME"     : "Tap the empoyee name",
-   "SERVICE"            : "Service",   
+   "SERVICE"            : "Service",
    "SEX"                : "Sex",
    "SUBMIT_EDIT"        : "Submit Details",
    "SUBMIT_NEW"         : "Submit Registration",
@@ -1807,6 +1807,15 @@
    "VILLAGE"               : "Village",
    "MODAL"               : "Add a new Location"
    },
+"MODALS" : {
+  "REFERENCES" : {
+    "TITLE" : "Receipt Lookup Modal",
+    "TYPE" : "Receipt Type",
+    "REFERENCE_LOOKUP" : "Reference Lookup",
+    "NO_RECEIPT" : "No receipt matches that reference.",
+    "SUCCESS" : "Successfully found a receipt!"
+  }
+},
 "NO_EXCHANGE": {
    "CURRENT_DATE" : "Current Date",
    "EXPLANATION"  : "This module requires an exchange rate.  There is no exchange rate set for today.",
@@ -2701,6 +2710,7 @@
    "REFERENCE"             : "Select a Reference",
    "REFERENCE_GROUP"       : "Select a Reference Group",
    "RESULT_ACCOUNT_SCT"    : "Select a Result Account section",
+   "RECEIPT"               : "Select a Receipt",
    "SECTOR"                : "Select a Sector",
    "SERVICE"               : "Select a Service",
    "SOURCE"                : "Select a source",

--- a/client/src/js/services/CashService.js
+++ b/client/src/js/services/CashService.js
@@ -18,12 +18,13 @@ CashService.$inject = [ '$http', 'util', 'ExchangeRateService' ];
  */
 function CashService($http, util, Exchange) {
   var service = this;
-  var baseUrl = '/cash';
+  var baseUrl = '/cash/';
 
   service.read = read;
   service.create = create;
   service.update = update;
   service.delete = remove;
+  service.reference = reference;
 
   /**
    * Fetchs cash payments from the server.  If an uuid is specified, will read a
@@ -31,13 +32,12 @@ function CashService($http, util, Exchange) {
    * database.
    *
    * @method read
-   * @param {string} uuid A cash payment UUID
+   * @param {string} uuid (optional) - a cash payment UUID
+   * @param {object} options - parameters to be passed as HTTP query strings
    * @returns {object|array} payments One or more cash payments.
    */
   function read(uuid, options) {
-    var target = (uuid) ?
-      baseUrl + '/' + uuid :
-      baseUrl;
+    var target = baseUrl.concat(uuid || '');
 
     return $http.get(target, options)
       .then(util.unwrapHttpResponse);
@@ -121,7 +121,7 @@ function CashService($http, util, Exchange) {
    * @returns {object} payments A promise containing the entire cash payment record
    */
   function update(uuid, data) {
-    var target = baseUrl + '/' + uuid;
+    var target = baseUrl.concat(uuid);
     return $http.put(target, data)
       .then(util.unwrapHttpResponse);
   }
@@ -131,15 +131,30 @@ function CashService($http, util, Exchange) {
    *
    * @method delete
    * @param {string} uuid A cash payment UUID
-   * @returns Promise A resolved or rejected empty promise
+   * @returns {promise} promise - a resolved or rejected empty promise
    */
   function remove(uuid) {
-    var target = baseUrl + '/' + uuid;
+    var target = baseUrl.concat(uuid);
 
     // Technically, we are not returning any body, so unwrappHttpResponse does
     // not do anything.  However, to keep uniformity with the API, I've included
     // it.
     return $http.delete(target)
+      .then(util.unwrapHttpResponse);
+  }
+
+  /**
+   * Searches for a cash payment by its reference.
+   *
+   * @method reference
+   * @param {string} reference
+   * @returns {promise} promise - a resolved or rejected promise with the
+   * result sent from the server.
+   */
+  function reference(ref) {
+    var target = baseUrl + 'references/' + ref;
+
+    return $http.get(target)
       .then(util.unwrapHttpResponse);
   }
 }

--- a/client/src/js/services/JournalVoucherService.js
+++ b/client/src/js/services/JournalVoucherService.js
@@ -1,0 +1,53 @@
+angular.module('bhima.services')
+  .service('JournalVoucherService', JournalVoucherService);
+
+JournalVoucherService.$inject = [ '$http', 'util' ];
+
+/**
+ * Journal Voucher Service
+ *
+ * The service queries the journal vouchers backend tables to retrieve generic
+ * vouchers.  Currently only supports the reference() method.
+ *
+ * @todo - implement full CRUD in this service.
+ */
+function JournalVoucherService($http, util) {
+  var service = this;
+  var baseUrl = '/vouchers/';
+
+  /** @method read */
+  service.read = read;
+
+  /** @method reference */
+  service.reference = reference;
+
+  /**
+   * Retrieves a particular journal voucher by UUID or lists all vouchers if
+   * no UUID is specified.
+   *
+   * @param {string} uuid (optional) - the uuid of the journal voucher to look
+   * up in the database.
+   * @param {object} options (optional) - options to be passed as query string
+   * parameters to the HTTP request
+   * @returns {promise} promise - the result of the HTTP request
+   */
+  function read(uuid, options) {
+    var target = baseUrl.concat(uuid || '');
+    return $http.get(target)
+      .then(util.unwrapHttpResponse);
+  }
+
+  /**
+   * Searches for a particular journal voucher by its human readable reference
+   *
+   * @param {string} ref - the reference to search for
+   * @returns {promise} promise - a resolved or rejected result from the server
+   */
+  function reference(ref) {
+    var target = baseUrl + 'references/' + ref;
+    return $http.get(target)
+      .then(util.unwrapHttpResponse);
+  }
+
+  return service;
+}

--- a/client/src/js/services/PatientInvoiceService.js
+++ b/client/src/js/services/PatientInvoiceService.js
@@ -1,0 +1,53 @@
+
+angular.module('bhima.services')
+  .service('PatientInvoiceService', PatientInvoiceService);
+
+PatientInvoiceService.$inject = [ '$http', 'util' ];
+
+/**
+ * Patient Invoice Service
+ *
+ * Allows direct querying of the /sales API.  Normally this should be done
+ * through the PatientService, but for queries not tied to particular patients,
+ * this service is particularly useful.
+ */
+function PatientInvoiceService($http, util) {
+  var service = this;
+  var baseUrl = '/sales/';
+
+  /** @method read */
+  service.read = read;
+
+  /** @method reference */
+  service.reference = reference;
+
+  /**
+   * Retrieves a particular sale by UUID or a list of all sales if no UUID is
+   * specified.
+   *
+   * @param {string} uuid (optional) - the uuid of the patient invoice to look
+   * up in the database.
+   * @param {object} options (optional) - options to be passed as query string
+   * parameters to the http request
+   * @returns {promise} promise - the result of the HTTP request
+   */
+  function read(uuid, options) {
+    var target = baseUrl.concat(uuid || '');
+    return $http.get(target)
+      .then(util.unwrapHttpResponse);
+  }
+
+  /**
+   * Searches for a particular patient invoice by its reference
+   *
+   * @param {string} ref - the reference to search for
+   * @returns {promise} promise - a resolved or rejected result from the server
+   */
+  function reference(ref) {
+    var target = baseUrl + 'references/' + ref;
+    return $http.get(target)
+      .then(util.unwrapHttpResponse);
+  }
+
+  return service;
+}

--- a/client/src/js/services/PurchaseOrderService.js
+++ b/client/src/js/services/PurchaseOrderService.js
@@ -1,0 +1,54 @@
+angular.module('bhima.services')
+  .service('PurchaseOrderService', PurchaseOrderService);
+
+PurchaseOrderService.$inject = [ '$http', 'util' ];
+
+/**
+ * Purchase Order Service
+ *
+ * Connects client controllers with the purchase order backend.
+ *
+ * @todo -- there is currently no backend for purchase orders to search by
+ * reference.
+ */
+function PurchaseOrderService($http, util) {
+  var service = this;
+  var baseUrl = '/purchases/';
+
+  /** @method read */
+  service.read = read;
+
+  /** @method reference */
+  service.reference = reference;
+
+
+  /**
+   * Retrieves a purchase order by UUID or lists all purchases if no UUID is
+   * specified.
+   *
+   * @param {string} uuid (optional) - the uuid of the purchase order to look
+   * up in the database.
+   * @param {object} options (optional) - options to be passed as query string
+   * parameters to the HTTP request
+   * @returns {promise} promise - the result of the HTTP request
+   */
+  function read(uuid, options) {
+    var target = baseUrl.concat(uuid || '');
+    return $http.get(target, options)
+      .then(util.unwrapHttpResponse);
+  }
+
+  /**
+   * Searches for a particular purchase order by its reference
+   *
+   * @param {string} ref - the reference to search for
+   * @returns {promise} promise - a resolved or rejected result from the server
+   */
+  function reference(ref) {
+    var target = baseUrl + 'references/' + ref;
+    return $http.get(target)
+      .then(util.unwrapHttpResponse);
+  }
+
+  return service;
+}

--- a/client/src/partials/journal/modals/references.modal.html
+++ b/client/src/partials/journal/modals/references.modal.html
@@ -12,8 +12,8 @@
       <select
         class="form-control"
         name="type"
-        ng-model="ReferenceLookupModalCtrl.path"
-        ng-options="tgt.path as (tgt.key | translate) for tgt in ::ReferenceLookupModalCtrl.targets track by tgt.path"
+        ng-model="ReferenceLookupModalCtrl.target"
+        ng-options="tgt as (tgt.key | translate) for tgt in ::ReferenceLookupModalCtrl.targets track by tgt.path"
         required
         >
         <option value="" disabled>Select a Receipt Type</option>
@@ -21,7 +21,9 @@
     </div>
 
     <!-- input to find the correct receipt by reference -->
-    <div class="form-group has-feedback" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.reference.$error }">
+    <div class="form-group has-feedback" ng-class="{
+      'has-error' : ModalForm.reference.$dirty && ModalForm.reference.$invalid
+    }">
       <label class="control-label">Reference Lookup</label>
       <div class="input-group">
         <input
@@ -29,30 +31,62 @@
           name="reference"
           class="form-control"
           ng-model="ReferenceLookupModalCtrl.reference"
-          ng-disabled="(ReferenceLookupModalCtrl.loading || !ReferenceLookupModalCtrl.path)"
+          ng-disabled="(ReferenceLookupModalCtrl.loading || !ReferenceLookupModalCtrl.target)"
           required>
         <span class="input-group-btn">
           <button
             class="btn btn-default"
             type="button"
             ng-click="ReferenceLookupModalCtrl.lookupReference()"
-            ng-disabled="(ReferenceLookupModalCtrl.loading || !ReferenceLookupModalCtrl.path)">
+            ng-disabled="(ReferenceLookupModalCtrl.loading || !ReferenceLookupModalCtrl.target)">
             <span ng-hide="vm.loading"><span class="glyphicon glyphicon-search"></span> Search</span>
             <span ng-show="vm.loading"><span class="glyphicon glyphicon-time"></span> Loading</span>
           </button>
         </span>
       </div>
+
+      <div class="help-block" ng-messages="ModalForm.reference.$error" ng-show="ModalForm.reference.$dirty">
+        <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+      </div>
+
+      <!-- success block -->
+      <p class="help-block" ng-show="ModalForm.reference.$dirty && ReferenceLookupModalCtrl.document">
+        <span class="text-success">
+          <span class="glyphicon glyphicon-ok"></span> Successfully found a receipt!
+        </span>
+      </p>
     </div>
 
     <!-- preview field for document -->
     <div class="form-group" ng-show="ReferenceLookupModalCtrl.document">
-      <label class="control-label">Preview</label>
-      <p class="form-control-static">I am a preview field.</p>
+      <label class="control-label">{{ ReferenceLookupModalCtrl.target.key | translate }}</label>
+      <dl>
+
+        <!-- document reference -->
+        <dt>{{ "COLUMNS.REFERENCE" | translate }}</dt>
+        <dd>{{ ReferenceLookupModalCtrl.document.reference }}</dd>
+
+        <!-- document date -->
+        <dt>{{ "COLUMNS.DATE" | translate }}</dt>
+        <dd>
+          {{ ReferenceLookupModalCtrl.document.date | date }}
+          (<span class="glyphicon glyphicon-time"></span>
+          <span am-time-ago="ReferenceLookupModalCtrl.document.date"></span>)
+        </dd>
+
+        <!-- the amount -->
+        <dt>{{ "COLUMNS.AMOUNT" | translate }}</dt>
+        <dd>{{ ReferenceLookupModalCtrl.document.amount | currency:ReferenceLookupModalCtrl.document.currency_id }}</dd>
+      </dl>
     </div>
   </div>
 
   <div class="modal-footer">
-    <button type="submit" class="btn btn-primary" ng-click="ReferenceLookupModalCtrl.submit(ModalForm.$invalid)">
+    <button
+      type="submit"
+      class="btn btn-primary"
+      ng-click="ReferenceLookupModalCtrl.submit(ModalForm.$invalid)"
+      ng-disabled="!ReferenceLookupModalCtrl.document">
       {{ "FORM.SUBMIT" | translate }}
     </button>
     <button type="button" class="btn btn-default" ng-click="ReferenceLookupModalCtrl.dismiss()">

--- a/client/src/partials/journal/modals/references.modal.html
+++ b/client/src/partials/journal/modals/references.modal.html
@@ -1,6 +1,6 @@
 <ng-form name="ModalForm">
   <div class="modal-header">
-    <h4>Receipt Lookup Modal</h4>
+    <h4>{{ "MODALS.REFERENCES.TITLE" | translate }}</h4>
   </div>
 
   <!-- main form body -->
@@ -8,15 +8,15 @@
 
     <!-- dropdown to choose receipt type -->
     <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.type.$error }">
-      <label class="control-label">Receipt Type</label>
+      <label class="control-label">{{ "MODALS.REFERENCES.TYPE" | translate }}</label>
       <select
         class="form-control"
         name="type"
         ng-model="ReferenceLookupModalCtrl.target"
-        ng-options="tgt as (tgt.key | translate) for tgt in ::ReferenceLookupModalCtrl.targets track by tgt.path"
+        ng-options="tgt as (tgt.key | translate) disable when tgt.disabled for tgt in ::ReferenceLookupModalCtrl.targets | orderBy:tgt.key"
         required
         >
-        <option value="" disabled>Select a Receipt Type</option>
+        <option value="" disabled>{{ "SELECT.RECEIPT" | translate }}</option>
       </select>
     </div>
 
@@ -24,7 +24,7 @@
     <div class="form-group has-feedback" ng-class="{
       'has-error' : ModalForm.reference.$dirty && ModalForm.reference.$invalid
     }">
-      <label class="control-label">Reference Lookup</label>
+      <label class="control-label">{{ "MODALS.REFERENCES.REFERENCE_LOOKUP" | translate }}</label>
       <div class="input-group">
         <input
           type="text"
@@ -50,33 +50,33 @@
       </div>
 
       <!-- success block -->
-      <p class="help-block" ng-show="ModalForm.reference.$dirty && ReferenceLookupModalCtrl.document">
+      <p class="help-block" ng-show="ModalForm.reference.$dirty && ReferenceLookupModalCtrl.receipt">
         <span class="text-success">
-          <span class="glyphicon glyphicon-ok"></span> Successfully found a receipt!
+          <span class="glyphicon glyphicon-ok"></span> {{ "MODALS.REFERENCES.SUCCESS" | translate }}
+        </span>
+      </p>
+
+      <p class="help-block" ng-show="ReferenceLookupModalCtrl.httpError">
+        <span class="text-danger">
+          <span class="glyphicon glyphicon-warning-sign"></span> {{ "MODALS.REFERENCES.NO_RECEIPT" | translate }}
         </span>
       </p>
     </div>
 
     <!-- preview field for document -->
-    <div class="form-group" ng-show="ReferenceLookupModalCtrl.document">
+    <!-- @todo: improve this when table column names are standardized -->
+    <div class="form-group" ng-show="ReferenceLookupModalCtrl.receipt">
       <label class="control-label">{{ ReferenceLookupModalCtrl.target.key | translate }}</label>
-      <dl>
-
+      <dl class="dl-horizontal">
         <!-- document reference -->
         <dt>{{ "COLUMNS.REFERENCE" | translate }}</dt>
-        <dd>{{ ReferenceLookupModalCtrl.document.reference }}</dd>
+        <dd>{{ ReferenceLookupModalCtrl.receipt.reference }}</dd>
 
         <!-- document date -->
-        <dt>{{ "COLUMNS.DATE" | translate }}</dt>
+        <dt>{{ "COLUMNS.ID" | translate }}</dt>
         <dd>
-          {{ ReferenceLookupModalCtrl.document.date | date }}
-          (<span class="glyphicon glyphicon-time"></span>
-          <span am-time-ago="ReferenceLookupModalCtrl.document.date"></span>)
+          {{ ReferenceLookupModalCtrl.receipt.uuid }}
         </dd>
-
-        <!-- the amount -->
-        <dt>{{ "COLUMNS.AMOUNT" | translate }}</dt>
-        <dd>{{ ReferenceLookupModalCtrl.document.amount | currency:ReferenceLookupModalCtrl.document.currency_id }}</dd>
       </dl>
     </div>
   </div>
@@ -86,7 +86,7 @@
       type="submit"
       class="btn btn-primary"
       ng-click="ReferenceLookupModalCtrl.submit(ModalForm.$invalid)"
-      ng-disabled="!ReferenceLookupModalCtrl.document">
+      ng-disabled="!ReferenceLookupModalCtrl.receipt">
       {{ "FORM.SUBMIT" | translate }}
     </button>
     <button type="button" class="btn btn-default" ng-click="ReferenceLookupModalCtrl.dismiss()">

--- a/client/src/partials/journal/modals/references.modal.html
+++ b/client/src/partials/journal/modals/references.modal.html
@@ -13,7 +13,7 @@
         class="form-control"
         name="type"
         ng-model="ReferenceLookupModalCtrl.path"
-        ng-options="tgt.path as tgt.key for tgt in ReferenceLookupModalCtrl.targets | translate track by tgt.path"
+        ng-options="tgt.path as (tgt.key | translate) for tgt in ::ReferenceLookupModalCtrl.targets track by tgt.path"
         required
         >
         <option value="" disabled>Select a Receipt Type</option>
@@ -29,16 +29,18 @@
           name="reference"
           class="form-control"
           ng-model="ReferenceLookupModalCtrl.reference"
-          ng-disabled="ReferenceLookupModalCtrl.loading"
+          ng-disabled="(ReferenceLookupModalCtrl.loading || !ReferenceLookupModalCtrl.path)"
           required>
-        <button
-          class="input-group-btn"
-          type="button"
-          ng-click="ReferenceModalCtrl.lookupReference()"
-          ng-disabled="ReferenceLookupModalCtrl.loading">
-          <span ng-hide="vm.loading"><span class="glyphicon glyphicon-search"></span> Search</span>
-          <span ng-show="vm.loading"><span class="glyphicon glyphicon-time"></span> Loading</span>
-        </button>
+        <span class="input-group-btn">
+          <button
+            class="btn btn-default"
+            type="button"
+            ng-click="ReferenceLookupModalCtrl.lookupReference()"
+            ng-disabled="(ReferenceLookupModalCtrl.loading || !ReferenceLookupModalCtrl.path)">
+            <span ng-hide="vm.loading"><span class="glyphicon glyphicon-search"></span> Search</span>
+            <span ng-show="vm.loading"><span class="glyphicon glyphicon-time"></span> Loading</span>
+          </button>
+        </span>
       </div>
     </div>
 

--- a/client/src/partials/journal/modals/references.modal.html
+++ b/client/src/partials/journal/modals/references.modal.html
@@ -1,0 +1,60 @@
+<ng-form name="ModalForm">
+  <div class="modal-header">
+    <h4>Receipt Lookup Modal</h4>
+  </div>
+
+  <!-- main form body -->
+  <div class="modal-body">
+
+    <!-- dropdown to choose receipt type -->
+    <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.type.$error }">
+      <label class="control-label">Receipt Type</label>
+      <select
+        class="form-control"
+        name="type"
+        ng-model="ReferenceLookupModalCtrl.path"
+        ng-options="tgt.path as tgt.key for tgt in ReferenceLookupModalCtrl.targets | translate track by tgt.path"
+        required
+        >
+        <option value="" disabled>Select a Receipt Type</option>
+      </select>
+    </div>
+
+    <!-- input to find the correct receipt by reference -->
+    <div class="form-group has-feedback" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.reference.$error }">
+      <label class="control-label">Reference Lookup</label>
+      <div class="input-group">
+        <input
+          type="text"
+          name="reference"
+          class="form-control"
+          ng-model="ReferenceLookupModalCtrl.reference"
+          ng-disabled="ReferenceLookupModalCtrl.loading"
+          required>
+        <button
+          class="input-group-btn"
+          type="button"
+          ng-click="ReferenceModalCtrl.lookupReference()"
+          ng-disabled="ReferenceLookupModalCtrl.loading">
+          <span ng-hide="vm.loading"><span class="glyphicon glyphicon-search"></span> Search</span>
+          <span ng-show="vm.loading"><span class="glyphicon glyphicon-time"></span> Loading</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- preview field for document -->
+    <div class="form-group" ng-show="ReferenceLookupModalCtrl.document">
+      <label class="control-label">Preview</label>
+      <p class="form-control-static">I am a preview field.</p>
+    </div>
+  </div>
+
+  <div class="modal-footer">
+    <button type="submit" class="btn btn-primary" ng-click="ReferenceLookupModalCtrl.submit(ModalForm.$invalid)">
+      {{ "FORM.SUBMIT" | translate }}
+    </button>
+    <button type="button" class="btn btn-default" ng-click="ReferenceLookupModalCtrl.dismiss()">
+      {{ "FORM.CANCEL" | translate }}
+    </button>
+  </div>
+</ng-form>

--- a/client/src/partials/journal/modals/references.modal.js
+++ b/client/src/partials/journal/modals/references.modal.js
@@ -1,7 +1,7 @@
 angular.module('bhima.controllers')
 .controller('ReferenceLookupModalController', ReferenceLookupModalController);
 
-ReferenceLookupModalController.$inject = [ '$uibModalInstance', '$timeout' ];
+ReferenceLookupModalController.$inject = [ '$uibModalInstance', '$timeout', '$translate' ];
 
 /**
  * Reference Lookup Modal Controller
@@ -19,7 +19,7 @@ ReferenceLookupModalController.$inject = [ '$uibModalInstance', '$timeout' ];
  * This is currently just a prototype, to be improved as services become
  * available to power the lookups.
  */
-function ReferenceLookupModalController(ModalInstance, $timeout) {
+function ReferenceLookupModalController(ModalInstance, $timeout, $translate) {
   var vm = this;
 
   /** bind the dismiss method */
@@ -64,14 +64,17 @@ function ReferenceLookupModalController(ModalInstance, $timeout) {
       // turn off loading
       toggleLoading();
 
-      // temporary mock data
+      // temporary mock data (with some randomness)
       vm.document = {
-        uuid : '03a329b2-03fe-4f73-b40f-56a2870cc7e6',
-        amount : 10.34,
-        date : new Date(Date.parse('2016-02-03'))
+        uuid:        '03a329b2-03fe-4f73-b40f-56a2870cc7e6',
+        amount:      Math.random() * 10000,
+        currency_id: (Math.random() > 0.5) ? 1 : 2,
+        date:        new Date(Date.parse('2015-06-01') + (Math.random() * 12930050020)),
+        reference:   vm.reference,
+        type:        $translate.instant(vm.target.key)
       };
 
-    }, 1200);
+    }, 1000);
   }
 
   /** modal submit */

--- a/client/src/partials/journal/modals/references.modal.js
+++ b/client/src/partials/journal/modals/references.modal.js
@@ -47,10 +47,14 @@ function ReferenceLookupModalController(ModalInstance, $timeout) {
     key : 'PAYSLIPS'
   }];
 
+  vm.lookupReference = lookupReference;
+
   function lookupReference() {
 
     // don't bother trying a lookup if there is no reference.
     if (!vm.reference) { return; }
+
+    delete vm.document;
 
     toggleLoading();
 
@@ -67,7 +71,7 @@ function ReferenceLookupModalController(ModalInstance, $timeout) {
         date : new Date(Date.parse('2016-02-03'))
       };
 
-    }, 3000);
+    }, 1200);
   }
 
   /** modal submit */

--- a/client/src/partials/journal/modals/references.modal.js
+++ b/client/src/partials/journal/modals/references.modal.js
@@ -1,0 +1,85 @@
+angular.module('bhima.controllers')
+.controller('ReferenceLookupModalController', ReferenceLookupModalController);
+
+ReferenceLookupModalController.$inject = [ '$uibModalInstance', '$timeout' ];
+
+/**
+ * Reference Lookup Modal Controller
+ *
+ * This modal contains lookups for the following documents, based on references:
+ *  1) Patient Invoices
+ *  2) Cash Payments
+ *  3) Journal Vouchers
+ *  4) Purchase Orders
+ *  5) Payslips (Payroll)
+ *
+ * The module itself is simple - it is a typeahead with an async validator to
+ * verfiy that the modal actually has data.
+ *
+ * This is currently just a prototype, to be improved as services become
+ * available to power the lookups.
+ */
+function ReferenceLookupModalController(ModalInstance, $timeout) {
+  var vm = this;
+
+  /** bind the dismiss method */
+  vm.dismiss = ModalInstance.dismiss;
+  vm.submit = submit;
+
+  /** loading indicator */
+  vm.loading = false;
+
+  /** target paths to look up from */
+  vm.targets = [{
+    path : '/cash/references/',
+    key : 'CASH_PAYMENTS'
+  }, {
+    path : '/sales/references/',
+    key : 'PATIENT_INVOICE'
+  }, {
+    path : '/purchases/references/',
+    key : 'PURCHASE_ORDERS'
+  }, {
+    path : '/vouchers/references/',
+    key : 'JOURNAL_VOUCHERS'
+  }, {
+    path : '/paychecks/references/',
+    key : 'PAYSLIPS'
+  }];
+
+  function lookupReference() {
+
+    // don't bother trying a lookup if there is no reference.
+    if (!vm.reference) { return; }
+
+    toggleLoading();
+
+    // mock lookups
+    $timeout(function () {
+
+      // turn off loading
+      toggleLoading();
+
+      // temporary mock data
+      vm.document = {
+        uuid : '03a329b2-03fe-4f73-b40f-56a2870cc7e6',
+        amount : 10.34,
+        date : new Date(Date.parse('2016-02-03'))
+      };
+
+    }, 3000);
+  }
+
+  /** modal submit */
+  function submit(invalid) {
+    if (invalid) { return; }
+
+    /** return the document retrieved from the server */
+    ModalInstance.close(vm.document);
+  }
+
+  /** toggle modal loading */
+  function toggleLoading() {
+    vm.loading = !vm.loading;
+  }
+}

--- a/client/src/partials/journal/voucher/voucher.html
+++ b/client/src/partials/journal/voucher/voucher.html
@@ -75,7 +75,7 @@
                   </label>
                   <div class="col-md-10">
                     <div class="input-group">
-                      <input type="text" class="form-control" name="documentId" ng-model="JournalVoucherCtrl.master.documentId" ng-dblclick="JournalVoucherCtrl.openReferenceLookupModal()">
+                      <input type="text" class="form-control" name="documentId" ng-model="JournalVoucherCtrl.master.documentId" ng-dblclick="JournalVoucherCtrl.openReferenceLookupModal()" readonly>
                       <span class="input-group-btn">
                         <button class="btn btn-default" ng-click="JournalVoucherCtrl.openReferenceLookupModal()" type="button">
                           <span class="glyphicon glyphicon-search"></span>

--- a/client/src/partials/journal/voucher/voucher.html
+++ b/client/src/partials/journal/voucher/voucher.html
@@ -1,264 +1,248 @@
-<header data-header>
-  {{ "JOURNAL_VOUCHER.TITLE" | translate }}
-</header>
-
-<nav>
-  <div class="pull-left">
-    <ol class="breadcrumb">
-      <li><a href="#/"><span class="glyphicon glyphicon-home"></span></a></li>
-      <li class="active">{{ "JOURNAL_VOUCHER.TITLE" | translate }}</li>
+<div class="flex-header">
+  <div class="bhima-title">
+    <ol class="headercrumb">
+      <li class="static">{{ "TREE.FINANCE" | translate }}</li>
+      <li class="title">{{ "JOURNAL_VOUCHER.TITLE" | translate }}</li>
     </ol>
   </div>
-  <div class="pull-right" ng-if="JournalVoucherCtrl.hasCachedForm">
-    <button type="button" class="btn btn-sm btn-success" ng-click="JournalVoucherCtrl.loadCachedForm()">
-      {{ "JOURNAL_VOUCHER.LOAD_CACHED_FORM" | translate }}
-    </button>
-  </div>
-</nav>
+</div>
 
-<main class="extend" ng-cloak>
-  <div class="row margin-top-10">
-    <div class="col-xs-8">
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          <i class="glyphicon glyphicon-list-alt"></i>
-          {{ "JOURNAL_VOUCHER.TITLE" | translate }}
-        </div>
+<div class="flex-util" ng-show="JournalVoucherCtrl.hasCachedForm">
+  <button type="button" class="btn btn-sm btn-success" ng-click="JournalVoucherCtrl.loadCachedForm()">
+    {{ "JOURNAL_VOUCHER.LOAD_CACHED_FORM" | translate }}
+  </button>
+</div>
 
 
-        <form class="form-horizontal" name="VoucherForm" class="voucher-form" ng-submit="JournalVoucherCtrl.submitForm()" novalidate>
+<div class="flex-content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-8">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <i class="glyphicon glyphicon-list-alt"></i>
+            {{ "JOURNAL_VOUCHER.TITLE" | translate }}
+          </div>
 
-          <div class="panel-body">
 
-            <div class="form-group" ng-class="{ 'has-error' : VoucherForm.description.$invalid && VoucherForm.description.$dirty }">
-              <label class="control-label col-xs-2">{{ "COLUMNS.DESCRIPTION" | translate }}</label>
-              <div class="col-xs-10">
-                <input type="text" class="form-bhima" name="description" ng-model="JournalVoucherCtrl.master.description" required>
-                <p ng-show="VoucherForm.description.$invalid && VoucherForm.description.$dirty" class="help-block">
-                  {{ "ERROR.ERR_NO_DESCRIPTION" | translate }} <!-- A description is required. -->
-                </p>
-              </div>
-            </div>
+          <form class="form-horizontal" name="VoucherForm" class="voucher-form" ng-submit="JournalVoucherCtrl.submitForm()" novalidate>
 
-            <div class="form-group" ng-class="{ 'has-error' : VoucherForm.date.$invalid && VoucherForm.date.$dirty }">
-              <label class="control-label col-xs-2">{{ "COLUMNS.DATE" | translate }}</label>
-              <div class="input-group col-xs-10">
-                <span class="input-group-addon"><i class="glyphicon glyphicon-calendar"></i></span>
-                <input type="date" class="form-bhima" name="date" ng-model="JournalVoucherCtrl.master.date" ng-max="{{ JournalVoucherCtrl.today }}" max="{{ JournalVoucherCtrl.today | date:'yyyy-MM-dd' }}"required>
-              </div>
-              <p ng-show="VoucherForm.date.$invalid && VoucherForm.date.$dirty" class="help-block col-md-offset-2" style="padding-top:30px;">
-                {{ "ERROR.ERR_NO_DATE" | translate }} <!-- A date is required. -->
-              </p>
-            </div>
+            <div class="panel-body">
 
-            <div class="form-group" ng-class="{ 'has-error' : VoucherForm.currencyId.$invalid && VoucherForm.currencyId.$dirty }">
-              <label class="control-label col-xs-2">{{ "COLUMNS.CURRENCY" | translate }}</label>
-              <div class="col-xs-10">
-                <select class="form-bhima" name="currencyId" ng-model="JournalVoucherCtrl.master.currencyId" ng-options="currency.id as currency.symbol for currency in JournalVoucherCtrl.currencies" required>
-                  <option value="" disabled>-- {{ "SELECT.CURRENCY" | translate }} --</option>
-                </select>
-                <p ng-show="VoucherForm.currencyId.$invalid && VoucherForm.currencyId.$dirty" class="help-block">
-                  {{ "ERROR.ERR_NO_CURRENCY" | translate }} <!-- The currency is required. -->
-                </p>
-              </div>
-            </div>
-
-            <div class="form-group" ng-if="JournalVoucherCtrl.showComment">
-              <label class="control-label col-xs-2">{{ "COLUMNS.COMMENT" | translate }}</label>
-              <div class="col-xs-10">
-                <input class="form-bhima" name="comment" ng-model="JournalVoucherCtrl.master.comment">
-              </div>
-            </div>
-
-            <div class="form-group" ng-if="JournalVoucherCtrl.showReference">
-              <label class="control-label col-xs-2">{{ "COLUMNS.REFERENCE" | translate }}</label>
-              <div class="input-group col-xs-10">
-                <span class="input-group-addon"><i class="glyphicon glyphicon-file"></i></span>
-                <input class="form-bhima" name="documentId" ng-model="JournalVoucherCtrl.master.documentId">
-              </div>
-            </div>
-
-            <div class="form-group">
-
-                <div class="col-xs-2"></div>
-                <div class="form-control-static col-xs-5"  ng-if="!JournalVoucherCtrl.showComment">
-                  <a ng-click="JournalVoucherCtrl.toggleComment()"> <i class="glyphicon glyphicon-plus-sign"></i>
-                    <b>{{ "JOURNAL_VOUCHER.ADD_COMMENT" | translate }}</b>
-                  </a>
+              <div class="form-group" ng-class="{ 'has-error' : VoucherForm.description.$invalid && VoucherForm.description.$dirty }">
+                  <label class="control-label col-md-2">{{ "COLUMNS.DESCRIPTION" | translate }}</label>
+                  <div class="col-md-10">
+                    <input type="text" class="form-control" name="description" ng-model="JournalVoucherCtrl.master.description" required>
+                    <p ng-show="VoucherForm.description.$invalid && VoucherForm.description.$dirty" class="help-block">
+                      {{ "ERROR.ERR_NO_DESCRIPTION" | translate }} <!-- A description is required. -->
+                    </p>
+                  </div>
                 </div>
 
-                <div class="form-control-static col-xs-5" ng-if="!JournalVoucherCtrl.showReference">
-                  <a ng-click="JournalVoucherCtrl.toggleReference()"> <i class="glyphicon glyphicon-plus-sign"></i>
-                    <b>{{ "JOURNAL_VOUCHER.ADD_REFERENCE_DOCUMENT" | translate }}</b>
-                  </a>
+                <div class="form-group" ng-class="{ 'has-error' : VoucherForm.date.$invalid && VoucherForm.date.$dirty }">
+                  <label class="control-label col-md-2">{{ "COLUMNS.DATE" | translate }}</label>
+                  <div class="input-group col-md-10">
+                    <span class="input-group-addon"><i class="glyphicon glyphicon-calendar"></i></span>
+                    <input type="date" class="form-control" name="date" ng-model="JournalVoucherCtrl.master.date" ng-max="{{ JournalVoucherCtrl.today }}" max="{{ JournalVoucherCtrl.today | date:'yyyy-MM-dd' }}"required>
+                  </div>
+                  <p ng-show="VoucherForm.date.$invalid && VoucherForm.date.$dirty" class="help-block col-md-offset-2" style="padding-top:30px;">
+                    {{ "ERROR.ERR_NO_DATE" | translate }} <!-- A date is required. -->
+                  </p>
                 </div>
 
-            </div>
+                <div class="form-group" ng-class="{ 'has-error' : VoucherForm.currencyId.$invalid && VoucherForm.currencyId.$dirty }">
+                  <label class="control-label col-md-2">{{ "COLUMNS.CURRENCY" | translate }}</label>
+                  <div class="col-md-10">
+                    <select class="form-control" name="currencyId" ng-model="JournalVoucherCtrl.master.currencyId" ng-options="currency.id as currency.symbol for currency in JournalVoucherCtrl.currencies" required>
+                      <option value="" disabled>-- {{ "SELECT.CURRENCY" | translate }} --</option>
+                    </select>
+                    <p ng-show="VoucherForm.currencyId.$invalid && VoucherForm.currencyId.$dirty" class="help-block">
+                      {{ "ERROR.ERR_NO_CURRENCY" | translate }} <!-- The currency is required. -->
+                    </p>
+                  </div>
+                </div>
 
-            <table class="table table-condensed" ng-controller="JournalVoucherTableController as TableCtrl">
-              <thead>
-                <tr>
-                  <th style="width:50%">{{ "COLUMNS.ACCOUNT" | translate }}</th>
-                  <th>{{ "COLUMNS.DEBIT" | translate }}</th>
-                  <th>{{ "COLUMNS.CREDIT" | translate }}</th>
-                  <th>{{ "COLUMNS.COST_CENTER" | translate }}</th>
-                  <th>{{ "COLUMNS.PROFIT_CENTER" | translate }}</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr ng-repeat="row in TableCtrl.rows">
-                  <td>
+                <div class="form-group" ng-if="JournalVoucherCtrl.showComment">
+                  <label class="control-label col-md-2">{{ "COLUMNS.COMMENT" | translate }}</label>
+                  <div class="col-md-10">
+                    <input class="form-control" name="comment" ng-model="JournalVoucherCtrl.master.comment">
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <label class="control-label col-md-2">
+                    {{ "COLUMNS.REFERENCE" | translate }}
+                  </label>
+                  <div class="col-md-10">
                     <div class="input-group">
+                      <input type="text" class="form-control" name="documentId" ng-model="JournalVoucherCtrl.master.documentId" ng-dblclick="JournalVoucherCtrl.openReferenceLookupModal()">
                       <span class="input-group-btn">
-                        <a class="btn btn-sm btn-default" ng-click="TableCtrl.toggleAccountSwitch(row)">
-                          <i class="glyphicon" ng-class="{ 'glyphicon-user' : row.selectAccount, 'glyphicon-th-list': !row.selectAccount }"></i>
-                        </a>
-                      </span>
-
-                      <input
-                        class="form-bhima"
-                        ng-if="row.selectAccount"
-                        ng-model="row.account"
-                        typeahead="account as TableCtrl.fmtAccount(account) for account in TableCtrl.accounts | filter:$viewValue | limitTo:20"
-                        typeahead-on-select="TableCtrl.setAccount(row)"
-                        typeahead-template-url="accountListItem.tmpl.html"
-                        placeholder="{{ 'SELECT.ACCOUNT' | translate }}"
-                      >
-
-                      <div ng-switch="row.deb_cred_type" ng-if="!row.selectAccount">
-
-                        <input
-                          class="form-bhima"
-                          ng-switch-when='D'
-                          ng-model="row.entity"
-                          typeahead="debtor as debtor.text for debtor in TableCtrl.debtors | filter:$viewValue | limitTo:20"
-                          typeahead-on-select="TableCtrl.setDebtorOrCreditor(row)"
-                          typeahead-template-url="entityListItem.tmpl.html"
-                          placeholder="{{ 'SELECT.DEB_CRED' | translate }}"
-                        >
-
-                        <input
-                          class="form-bhima"
-                          ng-switch-when='C'
-                          ng-model="row.entity"
-                          typeahead="creditor as creditor.text for creditor in TableCtrl.creditors | filter:$viewValue | limitTo:20"
-                          typeahead-on-select="TableCtrl.setDebtorOrCreditor(row)"
-                          typeahead-template-url="entityListItem.tmpl.html"
-                          placeholder="{{ 'SELECT.DEB_CRED' | translate }}"
-                        >
-                      </div>
-
-                      <span uib-dropdown class="input-group-btn dropdown" ng-if="!row.selectAccount">
-                        <a uib-dropdown-toggle class="btn btn-sm btn-default dropdown-toggle">
-                          {{ row.deb_cred_type | uppercase }}
-                          <span class="caret" data-caret="&#9660;"></span>
-                        </a>
-                        <ul class="uib-dropdown-menu">
-                          <li><a ng-click="TableCtrl.setDebtorOrCreditorType(row, 'D')">{{ "COLUMNS.DEBTOR" | translate }}</a></li>
-                          <li><a ng-click="TableCtrl.setDebtorOrCreditorType(row, 'C')">{{ "COLUMNS.CREDITOR" | translate }}</a></li>
-                        </ul>
+                        <button class="btn btn-default" ng-click="JournalVoucherCtrl.openReferenceLookupModal()" type="button">
+                          <span class="glyphicon glyphicon-search"></span>
+                        </button>
                       </span>
                     </div>
-                  </td>
-                  <td><input type="number" class="form-invoice" min="0" placeholder="0.00" ng-model="row.debit" ng-change="TableCtrl.totalDebit()" ng-disabled="row.credit>0"></td>
-                  <td><input type="number" class="form-invoice" min="0" placeholder="0.00" ng-model="row.credit" ng-change="TableCtrl.totalCredit()" ng-disabled="row.debit>0"></td>
+                  </div>
+                </div>
 
-                  <!-- select a cost center -->
-                  <td>
-                    <select class="form-bhima" ng-model="row.cc_id" ng-options="cc.id as cc.text for cc in TableCtrl.costcenters">
-                      <option value="">{{ "SELECT.NONE" | translate }}</option>
-                    </select>
-                  </td>
-
-                  <!-- select a profit center -->
-                  <td>
-                    <select class="form-bhima" ng-model="row.pc_id" ng-options="pc.id as pc.text for pc in TableCtrl.profitcenters">
-                      <option value="">{{ "SELECT.NONE" | translate }}</option>
-                    </select>
-                  </td>
-
-                  <td><a ng-click="TableCtrl.removeRow($index)" class="danger" ng-if="TableCtrl.rows.length > 2"><i class="glyphicon glyphicon-trash"></i></a></td>
-                </tr>
-                <tr>
-                  <td></td>
-                  <td>{{TableCtrl.totals.debits | currency:VoucherForm.currencyId.$modelValue}}</td>
-                  <td colspan="3">{{TableCtrl.totals.credits | currency:VoucherForm.currencyId.$modelValue}}</td>
-                  <td><i class="glyphicon" ng-class="{ 'glyphicon-ok-circle text-success' : TableCtrl.totals.credits === TableCtrl.totals.debits, 'glyphicon-ban-circle text-danger': TableCtrl.totals.credits !== TableCtrl.totals.debits }"></i></td>
-                </tr>
-              </tbody>
-              <tfoot>
-                <tr>
-                  <th colspan="6">
-                    <a ng-click="TableCtrl.addRow()">
-                      <i class="glyphicon glyphicon-plus-sign"></i>
-                      {{ "JOURNAL_VOUCHER.ADD_ROW" | translate }}
+                <div class="form-group">
+                  <div class="form-control-static col-md-5"  ng-if="!JournalVoucherCtrl.showComment">
+                    <a ng-click="JournalVoucherCtrl.toggleComment()"> <i class="glyphicon glyphicon-plus-sign"></i>
+                      <b>{{ "JOURNAL_VOUCHER.ADD_COMMENT" | translate }}</b>
                     </a>
-                  </th>
-                <tr>
+                  </div>
+                </div>
 
-                <tr>
-                  <th colspan="6" class="text-center">
-                    <p class="help-block" ng-if="JournalVoucherCtrl.clientTableError && !JournalVoucherCtrl.serverSuccessMessage">
-                      <span class="text-danger">
-                        <i class="glyphicon glyphicon-exclamation-sign"></i>
-                        {{ "ERROR.ERR_TRANSACTION_FORMAT" | translate }}
-                        <!-- The transaction doesn't look correctly formatted.  Did you forget an account? -->
-                      </span>
-                    </p>
-                    <p class="help-block text-danger" ng-if="JournalVoucherCtrl.serverFailureMessage">
-                      <span class="text-danger">
-                        <i class="glyphicon glyphicon-exclamation-sign text-danger"></i>
-                        {{ JournalVoucherCtrl.serverFailureMessage | translate }}
-                      </span>
-                    </p>
-                    <p class="help-block" ng-if="JournalVoucherCtrl.serverSuccessMessage">
-                      <span class="text-success">
-                        <i class="glyphicon glyphicon-ok"></i>
-                        {{ JournalVoucherCtrl.serverSuccessMessage | translate }}
-                        <!-- Post Successful! -->
-                      </span>
-                    </p>
-                  </th>
-                <tr>
-              </tfoot>
-            </table>
-          </div>
+                <table class="table table-condensed" ng-controller="JournalVoucherTableController as TableCtrl">
+                  <thead>
+                    <tr>
+                      <th style="width:50%">{{ "COLUMNS.ACCOUNT" | translate }}</th>
+                      <th>{{ "COLUMNS.DEBIT" | translate }}</th>
+                      <th>{{ "COLUMNS.CREDIT" | translate }}</th>
+                      <th>{{ "COLUMNS.COST_CENTER" | translate }}</th>
+                      <th>{{ "COLUMNS.PROFIT_CENTER" | translate }}</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr ng-repeat="row in TableCtrl.rows">
+                      <td>
+                        <div class="input-group">
+                          <span class="input-group-btn">
+                            <a class="btn btn-sm btn-default" ng-click="TableCtrl.toggleAccountSwitch(row)">
+                              <i class="glyphicon" ng-class="{ 'glyphicon-user' : row.selectAccount, 'glyphicon-th-list': !row.selectAccount }"></i>
+                            </a>
+                          </span>
 
-          <div class="panel-footer">
-            <div class="row">
-              <div class="col-sm-offset-10">
-                <button type="submit" class="btn btn-sm btn-primary" ng-disabled="VoucherForm.$invalid">
-                  {{ 'FORM.SUBMIT' | translate }}
-                </button>
+                          <input
+                            class="form-control"
+                            ng-if="row.selectAccount"
+                            ng-model="row.account"
+                            typeahead="account as TableCtrl.fmtAccount(account) for account in TableCtrl.accounts | filter:$viewValue | limitTo:20"
+                            typeahead-on-select="TableCtrl.setAccount(row)"
+                            typeahead-template-url="accountListItem.tmpl.html"
+                            placeholder="{{ 'SELECT.ACCOUNT' | translate }}"
+                          >
+
+                          <div ng-switch="row.deb_cred_type" ng-if="!row.selectAccount">
+
+                            <input
+                              class="form-control"
+                              ng-switch-when='D'
+                              ng-model="row.entity"
+                              typeahead="debtor as debtor.text for debtor in TableCtrl.debtors | filter:$viewValue | limitTo:20"
+                              typeahead-on-select="TableCtrl.setDebtorOrCreditor(row)"
+                              typeahead-template-url="entityListItem.tmpl.html"
+                              placeholder="{{ 'SELECT.DEB_CRED' | translate }}"
+                            >
+
+                            <input
+                              class="form-control"
+                              ng-switch-when='C'
+                              ng-model="row.entity"
+                              typeahead="creditor as creditor.text for creditor in TableCtrl.creditors | filter:$viewValue | limitTo:20"
+                              typeahead-on-select="TableCtrl.setDebtorOrCreditor(row)"
+                              typeahead-template-url="entityListItem.tmpl.html"
+                              placeholder="{{ 'SELECT.DEB_CRED' | translate }}"
+                            >
+                          </div>
+
+                          <span uib-dropdown class="input-group-btn dropdown" ng-if="!row.selectAccount">
+                            <a uib-dropdown-toggle class="btn btn-sm btn-default dropdown-toggle">
+                              {{ row.deb_cred_type | uppercase }}
+                              <span class="caret" data-caret="&#9660;"></span>
+                            </a>
+                            <ul class="uib-dropdown-menu">
+                              <li><a ng-click="TableCtrl.setDebtorOrCreditorType(row, 'D')">{{ "COLUMNS.DEBTOR" | translate }}</a></li>
+                              <li><a ng-click="TableCtrl.setDebtorOrCreditorType(row, 'C')">{{ "COLUMNS.CREDITOR" | translate }}</a></li>
+                            </ul>
+                          </span>
+                        </div>
+                      </td>
+                      <td><input type="number" class="form-invoice" min="0" placeholder="0.00" ng-model="row.debit" ng-change="TableCtrl.totalDebit()" ng-disabled="row.credit>0"></td>
+                      <td><input type="number" class="form-invoice" min="0" placeholder="0.00" ng-model="row.credit" ng-change="TableCtrl.totalCredit()" ng-disabled="row.debit>0"></td>
+
+                      <!-- select a cost center -->
+                      <td>
+                        <select class="form-control" ng-model="row.cc_id" ng-options="cc.id as cc.text for cc in TableCtrl.costcenters">
+                          <option value="">{{ "SELECT.NONE" | translate }}</option>
+                        </select>
+                      </td>
+
+                      <!-- select a profit center -->
+                      <td>
+                        <select class="form-control" ng-model="row.pc_id" ng-options="pc.id as pc.text for pc in TableCtrl.profitcenters">
+                          <option value="">{{ "SELECT.NONE" | translate }}</option>
+                        </select>
+                      </td>
+
+                      <td><a ng-click="TableCtrl.removeRow($index)" class="danger" ng-if="TableCtrl.rows.length > 2"><i class="glyphicon glyphicon-trash"></i></a></td>
+                    </tr>
+                    <tr>
+                      <td></td>
+                      <td>{{TableCtrl.totals.debits | currency:VoucherForm.currencyId.$modelValue}}</td>
+                      <td colspan="3">{{TableCtrl.totals.credits | currency:VoucherForm.currencyId.$modelValue}}</td>
+                      <td><i class="glyphicon" ng-class="{ 'glyphicon-ok-circle text-success' : TableCtrl.totals.credits === TableCtrl.totals.debits, 'glyphicon-ban-circle text-danger': TableCtrl.totals.credits !== TableCtrl.totals.debits }"></i></td>
+                    </tr>
+                  </tbody>
+                  <tfoot>
+                    <tr>
+                      <th colspan="6">
+                        <a ng-click="TableCtrl.addRow()">
+                          <i class="glyphicon glyphicon-plus-sign"></i>
+                          {{ "JOURNAL_VOUCHER.ADD_ROW" | translate }}
+                        </a>
+                      </th>
+                    <tr>
+
+                    <tr>
+                      <th colspan="6" class="text-center">
+                        <p class="help-block" ng-if="JournalVoucherCtrl.clientTableError && !JournalVoucherCtrl.serverSuccessMessage">
+                          <span class="text-danger">
+                            <i class="glyphicon glyphicon-exclamation-sign"></i>
+                            {{ "ERROR.ERR_TRANSACTION_FORMAT" | translate }}
+                            <!-- The transaction doesn't look correctly formatted.  Did you forget an account? -->
+                          </span>
+                        </p>
+                        <p class="help-block text-danger" ng-if="JournalVoucherCtrl.serverFailureMessage">
+                          <span class="text-danger">
+                            <i class="glyphicon glyphicon-exclamation-sign text-danger"></i>
+                            {{ JournalVoucherCtrl.serverFailureMessage | translate }}
+                          </span>
+                        </p>
+                        <p class="help-block" ng-if="JournalVoucherCtrl.serverSuccessMessage">
+                          <span class="text-success">
+                            <i class="glyphicon glyphicon-ok"></i>
+                            {{ JournalVoucherCtrl.serverSuccessMessage | translate }}
+                            <!-- Post Successful! -->
+                          </span>
+                        </p>
+                      </th>
+                    <tr>
+                  </tfoot>
+                </table>
               </div>
-            </div>
-          </div>
-        </form> <!-- end of form -->
-      </div>
-    </div>
 
-    <div class="col-xs-4">
-      <div class="alert alert-info">
-        <h4>{{ "JOURNAL_VOUCHER.TITLE" | translate }}</h4>
-        <p>{{ "JOURNAL_VOUCHER.DESCRIPTION_LONG" | translate }}</p>
+              <div class="panel-footer">
+                <div class="row">
+                  <div class="col-sm-offset-10">
+                    <button type="submit" class="btn btn-sm btn-primary" ng-disabled="VoucherForm.$invalid">
+                      {{ 'FORM.SUBMIT' | translate }}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </form> <!-- end of form -->
+          </div>
+        </div>
+
+        <div class="col-md-4">
+          <div class="alert alert-info">
+            <h4>{{ "JOURNAL_VOUCHER.TITLE" | translate }}</h4>
+            <p>{{ "JOURNAL_VOUCHER.DESCRIPTION_LONG" | translate }}</p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
-</main>
-
-<script type="text/ng-template" id="entityListItem.tmpl.html">
-  <a class="clk">
-    <span bind-html-unsafe="match.label | typeaheadHighlight:query"></span>
-  </a>
-</script>
-
-<script type="text/ng-template" id="accountListItem.tmpl.html">
-  <a class="clk">
-    <span ng-if="match.model.type === 'title'" class="text-warning">
-      <i class="glyphicon glyphicon-exclamation-sign"></i>
-    </span>
-    <span bind-html-unsafe="match.label | typeaheadHighlight:query"></span>
-  </a>
-</script>
-
+</div>

--- a/client/src/partials/journal/voucher/voucher.js
+++ b/client/src/partials/journal/voucher/voucher.js
@@ -211,8 +211,10 @@ function JournalVoucherController($scope, $http, AppCache, Modal) {
       keyboard : false
     });
 
+    /** bind the reference to the view */
     instance.result.then(function (result) {
-      console.log('result!', result);
+      vm.master.documentId = ['[', result.reference, '] ', result.type].join('');
+      vm.master.document_id = result.uuid;
     });
   }
 

--- a/client/src/partials/journal/voucher/voucher.js
+++ b/client/src/partials/journal/voucher/voucher.js
@@ -4,7 +4,7 @@ angular.module('bhima.controllers')
 .controller('JournalVoucherController', JournalVoucherController)
 .controller('JournalVoucherTableController', JournalVoucherTableController);
 
-JournalVoucherController.$inject = [ '$scope', '$http', 'appcache' ];
+JournalVoucherController.$inject = [ '$scope', '$http', 'appcache', '$uibModal' ];
 
 /**
 * This controller wraps all the global metadata
@@ -25,7 +25,7 @@ JournalVoucherController.$inject = [ '$scope', '$http', 'appcache' ];
 * EDIT: yes, we can do better.  These should use a service to share
 * data.
 */
-function JournalVoucherController($scope, $http, AppCache) {
+function JournalVoucherController($scope, $http, AppCache, Modal) {
   var dependencies = {},
       isDefined = angular.isDefined,
 
@@ -44,7 +44,6 @@ function JournalVoucherController($scope, $http, AppCache) {
   vm.today = new Date();
 
   vm.showComment = false;
-  vm.showReference = false;
   vm.hasCachedForm = false;
 
   // the master form
@@ -54,6 +53,8 @@ function JournalVoucherController($scope, $http, AppCache) {
     date : vm.today,
     rows : [] // the child
   };
+
+  vm.openReferenceLookupModal = openReferenceLookupModal;
 
   // load dependencies
   $http.get('/currencies')
@@ -67,11 +68,6 @@ function JournalVoucherController($scope, $http, AppCache) {
   // toggle comment field
   vm.toggleComment = function () {
     vm.showComment = !vm.showComment;
-  };
-
-  // toggle reference field
-  vm.toggleReference = function () {
-    vm.showReference = !vm.showReference;
   };
 
   // do the final submit checks
@@ -206,6 +202,19 @@ function JournalVoucherController($scope, $http, AppCache) {
       }
     });
   };
+
+  function openReferenceLookupModal() {
+    var instance = Modal.open({
+      size : 'md',
+      controller : 'ReferenceLookupModalController as ReferenceLookupModalCtrl',
+      templateUrl : 'partials/journal/modals/references.modal.html',
+      keyboard : false
+    });
+
+    instance.result.then(function (result) {
+      console.log('result!', result);
+    });
+  }
 
   // auto-detect if there is an old form
   findCachedForm();

--- a/client/src/partials/patients/registration/hospitalNumberInput.js
+++ b/client/src/partials/patients/registration/hospitalNumberInput.js
@@ -11,7 +11,6 @@ function HospitalNumber($q, $http) {
       registeredValue : '='
     },
     link : function (scope, elm, attrs, ctrl) { 
-      var nochecks = 0;
 
       ctrl.$asyncValidators.hospitalNumber = function (modelValue, viewValue) { 
         var deferred;

--- a/server/controllers/finance/purchase.js
+++ b/server/controllers/finance/purchase.js
@@ -3,8 +3,6 @@ var db = require('./../../lib/db');
 var uuid = require('./../../lib/guid');
 var journal = require('./journal');
 
-
-
 /** 
  * Utility method to ensure purchase items lines reference purchase.
  * @param {Object} purchaseItems - An Array of all purchase items to be written 

--- a/server/test/api/purchase.js
+++ b/server/test/api/purchase.js
@@ -1,25 +1,27 @@
-/* global describe, it, beforeEach */
+/* global beforeEach */
 
 var chai = require('chai');
 var expect = chai.expect;
+
 var helpers = require('./helpers');
 var uuid    = require('node-uuid');
+
 helpers.configure(chai);
 
-
 /**
-* The /projects API endpoint
+* The /purchase API endpoint
 *
-* This test suite implements full CRUD on the /projects HTTP API endpoint.
+* This test suite implements full CRUD on the /purchase HTTP API endpoint.
 */
 
-var PURCHASE_KEY = ['uuid', 'reference', 'cost', 'discount', 'purchase_date', 'paid', 'text', 'name', 'prenom', 'first',
+var PURCHASE_KEY = [
+  'uuid', 'reference', 'cost', 'discount', 'purchase_date', 'paid', 'text', 'name', 'prenom', 'first',
   'last', 'creditor_uuid', 'timestamp', 'note', 'paid_uuid', 'confirmed', 'closed', 'is_direct', 'is_donation', 'emitter_id',
-  'is_authorized', 'is_validate', 'confirmed_by', 'is_integration', 'purchaser_id', 'receiver_id'];  
+  'is_authorized', 'is_validate', 'confirmed_by', 'is_integration', 'purchaser_id', 'receiver_id'
+];
 
-describe('The /Purchase Order API endpoint', function () {
+describe('The /purchase API endpoint', function () {
   var agent = chai.request.agent(helpers.baseUrl);
-
 
   // purchase we will add during this test suite.
   var purchase_order = {
@@ -36,21 +38,21 @@ describe('The /Purchase Order API endpoint', function () {
     };
 
    var purchase_item = [
-    { 
-      uuid : uuid(), 
+    {
+      uuid : uuid(),
       inventory_uuid : '289cc0a1-b90f-11e5-8c73-159fdc73ab02',
       quantity : 200,
       unit_price : 0.0538,
-      total : 10.7520 
+      total : 10.7520
     },
-    { 
-      uuid : uuid(),       
+    {
+      uuid : uuid(),
       inventory_uuid : 'c48a3c4b-c07d-4899-95af-411f7708e296',
       quantity : 16000,
       unit_price : 0.0335,
-      total : 536.0000 
-    }    
-   ]; 
+      total : 536.0000
+    }
+   ];
 
   var purchase = {
     purchase_order : purchase_order,
@@ -63,7 +65,7 @@ describe('The /Purchase Order API endpoint', function () {
   };
 
 
-  // login before each request  
+  // login before each request
   beforeEach(helpers.login(agent));
 
   it('POST /purchase should create a new purchase order', function () {
@@ -97,12 +99,12 @@ describe('The /Purchase Order API endpoint', function () {
       .catch(helpers.handler);
   });
 
-  it('GET /purchase/ ? COMPLETE = 1 returns a complete List of purchase   ', function () { 
+  it('GET /purchase/ ? COMPLETE = 1 returns a complete List of purchase   ', function () {
     return agent.get('/purchase?complete=1')
       .then(function (result) {
         expect(result).to.have.status(200);
         expect(result).to.be.json;
-        expect(result.body[0]).to.contain.all.keys(PURCHASE_KEY); 
+        expect(result.body[0]).to.contain.all.keys(PURCHASE_KEY);
       })
       .catch(helpers.handler);
   });


### PR DESCRIPTION
This pull request implements a modal to look up invoices from various places using human readable references.  Ideally the user should be able to look up references from :
1. Journal Vouchers
2. Patient Invoices
3. Cash Payments
4. Purchase Orders
5. Payroll Payslips

Currently, only proper APIs exist for Patient Invoices, Cash Payments and Journal Vouchers.  The others are untested and experimental.

**Future Refinements** (after this PR)
1. Only send back the `uuid` and `label` for a receipt from the receipt modal to the parent controller.
2. Implement receipt "previews".  This requires our table columns to be standardized (`user_id`, `date`, etc) so that a generic receipt preview can be built using the properties sent back from the database without too much manipulation.
3. Implement end-to-end tests that test each function.  This is currently not possible since only client-side interfaces for Cash Payments exist.
