### PR TITLE
Patch end-to-end tests

### DIFF
--- a/client/test/e2e/cash/cash.spec.js
+++ b/client/test/e2e/cash/cash.spec.js
@@ -74,6 +74,9 @@ describe('Cash Payments Module', function () {
       // attempt to return to /cash manually
       browser.get(path);
 
+      // make sure all $http/$timeout requests clear before moving forward
+      browser.waitForAngular();
+
       // expect that we were routed back to cashbox B
       expect(getCurrentPath()).to.eventually.equal(target);
     });
@@ -92,6 +95,9 @@ describe('Cash Payments Module', function () {
 
       // attempt to return to the cash page manually
       browser.get(path);
+
+      // make sure all $http/$timeout requests clear before moving forward
+      browser.waitForAngular();
 
       // the browser should be rerouted to the cashboxB page
       expect(getCurrentPath()).to.eventually.equal(target);

--- a/client/test/e2e/projects/projects.spec.js
+++ b/client/test/e2e/projects/projects.spec.js
@@ -9,7 +9,7 @@ var helpers = require('../shared/helpers');
 
 helpers.configure(chai);
 
-describe('The Projects Module', function () {
+describe('Projects Module', function () {
   'use strict';
 
   var path = '#/projects';
@@ -125,7 +125,7 @@ describe('The Projects Module', function () {
   });
 
   it('cancellation of removal process of a project', function () {
-    
+
     // click the remove a project
     element(by.id('project-del-' + deleteError )).click();
 

--- a/client/test/e2e/services/services.spec.js
+++ b/client/test/e2e/services/services.spec.js
@@ -1,13 +1,14 @@
-/*global describe, it, element, by, beforeEach, inject, browser */
+/*global it, element, by, beforeEach, inject, browser */
 
 var chai = require('chai');
 var expect = chai.expect;
+
+var FormUtils = require('../shared/FormUtils');
 var helpers = require('../shared/helpers');
 helpers.configure(chai);
 
-var FormUtils = require('../shared/FormUtils');
+describe('Services Module', function () {
 
-describe('The Projects Module', function () {
   // shared methods
   var path = '#/services';
   var SERVICE = {
@@ -17,32 +18,32 @@ describe('The Projects Module', function () {
   var DEFAULT_SERVICE = 4;
   var SERVICE_RANK = helpers.random(DEFAULT_SERVICE);
 
-  var DELETE_SUCCESS = 5;
+  var DELETE_SUCCESS = 4;
   var DELETE_ERROR = 3;
-
 
   // navigate to the Service module before each test
   beforeEach(function () {
     browser.get(path);
   });
 
-  it('Successfully creates a new Service', function () {
+  it('successfully creates a new service', function () {
     FormUtils.buttons.create();
 
     FormUtils.input('ServicesCtrl.service.name', SERVICE.name);
-    // select a random, Enterprise
+
+    // select a random, enterprise
     FormUtils.select('ServicesCtrl.service.enterprise_id')
       .enabled()
       .first()
       .click();
 
-    // select a random, Cost Center 
+    // select a random, cost center
     FormUtils.select('ServicesCtrl.service.cost_center_id')
       .enabled()
       .first()
       .click();
 
-    // select a random, Profit center  
+    // select a random, profit center
     FormUtils.select('ServicesCtrl.service.profit_center_id')
       .enabled()
       .first()
@@ -54,8 +55,7 @@ describe('The Projects Module', function () {
     FormUtils.exists(by.id('create_success'), true);
   });
 
-
-  it('Successfully edits an Service', function () {
+  it('successfully edits an service', function () {
     element(by.id('service-upd-' + SERVICE_RANK )).click();
     FormUtils.input('ServicesCtrl.service.name', 'Updated');
     element(by.id('change_service')).click();
@@ -77,24 +77,23 @@ describe('The Projects Module', function () {
     // The following fields is not required
     FormUtils.validation.ok('ServicesCtrl.service.cost_center_id');
     FormUtils.validation.ok('ServicesCtrl.service.profit_center_id');
-  });  
+  });
 
-  it('Successfully delete an Service', function () {
+  it('successfully delete an service', function () {
     element(by.id('service-del-' + DELETE_SUCCESS )).click();
     browser.switchTo().alert().accept();
     FormUtils.exists(by.id('delete_success'), true);
   });
 
-  it('No way to delete a Service', function () {
+  it('no way to delete a service', function () {
     element(by.id('service-del-' + DELETE_ERROR )).click();
     browser.switchTo().alert().accept();
     FormUtils.exists(by.id('delete_error'), true);
   });
 
-  it('Cancellation of removal process of a Service', function () {
+  it('cancellation of removal process of a service', function () {
     element(by.id('service-del-' + DELETE_ERROR )).click();
     browser.switchTo().alert().dismiss();
     FormUtils.exists(by.id('default'), true);
   });
-
 });


### PR DESCRIPTION
This PR fixes typos in the services end-to-end tests that resulted in randomly failing tests.  The upper bound of the random range has been adjusted accordingly.

It also introduces `browser.waitForAngular()` into the cash tests in hopes that this will help slower machines run the cash tests successfully.  It should wait for $http/$timeout/Promises to clear before advancing to the next route.
