### PR TITLE
feat(binary uuids): implement binary(16) uuids for cash table

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -24,6 +24,7 @@
   "boss"          : false,
   "debug"         : false,
   "eqnull"        : false,
+  "esversion"     : 6,
   "evil"          : false,
   "expr"          : false,
   "funcscope"     : false,

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -13,6 +13,7 @@ var q       = require('q');
 var mysql   = require('mysql');
 var winston = require('winston');
 var util    = require('util');
+const uuid  = require('node-uuid');
 
 var con;
 
@@ -167,11 +168,26 @@ function sanitize(x) {
   return con.escape(x);
 }
 
+/**
+ * Converts a (dash separated) string uuid to a binary buffer for insertion
+ * into the database.
+ *
+ * @method bid
+ * @param {string} hexUuid - a 36 character length string to be inserted into
+ * the database
+ * @returns {buffer} uuid - a 16-byte binary buffer for insertion into the
+ * database
+ */
+function bid(hexUuid) {
+  return new Buffer(uuid.parse(hexUuid));
+}
+
 module.exports = {
   initialise:  initialise,
   exec:        exec,
   transaction: transaction,
   execute:     util.deprecate(execute, 'db.execute() is deprecated, use db.exec() instead.'),
   sanitize:    util.deprecate(sanitize, 'db.sanitize() is deprecated, use db.escape instead.'),
-  escape:      sanitize
+  escape:      sanitize,
+  bid:         bid
 };

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -92,10 +92,8 @@ CREATE TABLE `budget` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-
-DROP TABLE IF EXISTS `cash`;
 CREATE TABLE `cash` (
-  `uuid`            CHAR(36) NOT NULL,
+  `uuid`            BINARY(16) NOT NULL,
   `project_id`      SMALLINT(5) UNSIGNED NOT NULL,
   `reference`       INT(10) UNSIGNED NOT NULL DEFAULT 0,
   `date`            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -119,9 +117,37 @@ CREATE TABLE `cash` (
   FOREIGN KEY (`cashbox_id`) REFERENCES `cash_box` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- new triggers to manage creation of references
-CREATE TRIGGER cash_calculate_reference BEFORE INSERT ON cash
+-- triggers to manage creation of references
+CREATE TRIGGER cash_before_insert BEFORE INSERT ON cash
 FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM cash WHERE cash.project_id = new.project_id);
+
+CREATE TABLE `cash_item` (
+  `uuid`            BINARY(16) NOT NULL,
+  `cash_uuid`       BINARY(16) NOT NULL,
+  `amount`          DECIMAL(19,2) UNSIGNED NOT NULL DEFAULT 0.00,
+  `invoice_uuid`    CHAR(36) DEFAULT NULL,
+  PRIMARY KEY (`uuid`),
+  KEY `cash_uuid` (`cash_uuid`),
+  FOREIGN KEY (`cash_uuid`) REFERENCES `cash` (`uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `cash_discard` (
+  `uuid`              BINARY(16) NOT NULL,
+  `project_id`        SMALLINT(5) UNSIGNED NOT NULL,
+  `reference`         INT(10) UNSIGNED NOT NULL,
+  `cash_uuid`         BINARY(16) NOT NULL,
+  `date`              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `description`       text,
+  `user_id`           SMALLINT(5) UNSIGNED NOT NULL,
+  PRIMARY KEY (`uuid`),
+  KEY `reference` (`reference`),
+  KEY `project_id` (`project_id`),
+  KEY `user_id` (`user_id`),
+  KEY `cash_uuid` (`cash_uuid`),
+  FOREIGN KEY (`project_id`) REFERENCES `project` (`id`),
+  FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
+  FOREIGN KEY (`cash_uuid`) REFERENCES `cash` (`uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `cash_box`;
 CREATE TABLE `cash_box` (
@@ -157,39 +183,6 @@ CREATE TABLE `cash_box_account_currency` (
   FOREIGN KEY (`gain_exchange_account_id`) REFERENCES `account` (`id`),
   FOREIGN KEY (`loss_exchange_account_id`) REFERENCES `account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-
-DROP TABLE IF EXISTS `cash_discard`;
-CREATE TABLE `cash_discard` (
-  `uuid`              CHAR(36) NOT NULL,
-  `project_id`        SMALLINT(5) UNSIGNED NOT NULL,
-  `reference`         INT(10) UNSIGNED NOT NULL,
-  `cash_uuid`         CHAR(36) NOT NULL,
-  `date`              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `description`       TEXT,
-  `user_id`           SMALLINT(5) UNSIGNED NOT NULL,
-  PRIMARY KEY (`uuid`),
-  KEY `reference` (`reference`),
-  KEY `project_id` (`project_id`),
-  KEY `user_id` (`user_id`),
-  KEY `cash_uuid` (`cash_uuid`),
-  FOREIGN KEY (`project_id`) REFERENCES `project` (`id`),
-  FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
-  FOREIGN KEY (`cash_uuid`) REFERENCES `cash` (`uuid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-
-DROP TABLE IF EXISTS `cash_item`;
-CREATE TABLE `cash_item` (
-  `uuid`            CHAR(36) NOT NULL,
-  `cash_uuid`       CHAR(36) NOT NULL,
-  `amount`          DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.00,
-  `invoice_uuid`    CHAR(36) DEFAULT NULL,
-  PRIMARY KEY (`uuid`),
-  KEY `cash_uuid` (`cash_uuid`),
-  FOREIGN KEY (`cash_uuid`) REFERENCES `cash` (`uuid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
 
 DROP TABLE IF EXISTS `client`;
 CREATE TABLE `client` (
@@ -2030,3 +2023,25 @@ CREATE TABLE IF NOT EXISTS `voucher_item` (
 
 
 SET foreign_key_checks = 1;
+
+-- SQL FUNCTIONS
+
+DELIMITER //
+
+-- converts a hex uuid (36 chars) into a binary uuid (16 bytes)
+CREATE FUNCTION HUID(_uuid CHAR(36))
+RETURNS BINARY(16) DETERMINISTIC
+RETURN UNHEX(REPLACE(_uuid, '-', ''));
+//
+
+-- converts a binary uuid (16 bytes) to dash-delimited hex UUID (36 characters)
+CREATE FUNCTION BUID(b BINARY(16))
+RETURNS CHAR(36) DETERMINISTIC
+BEGIN
+  DECLARE hex CHAR(32);
+  SET hex = HEX(b);
+  RETURN LCASE(CONCAT_WS('-', SUBSTR(hex,1, 8), SUBSTR(hex, 9,4), SUBSTR(hex, 13,4), SUBSTR(hex, 17,4), SUBSTR(hex, 21, 12)));
+END
+//
+
+DELIMITER ;

--- a/server/test/api/cash.js
+++ b/server/test/api/cash.js
@@ -9,7 +9,7 @@ helpers.configure(chai);
 /**
 * The /cash API endpoint
 */
-describe('(/cash) Cash Payments Interface ::', function () {
+describe('(/cash) Cash Payments Interface ', function () {
   'use strict';
 
   var agent = chai.request.agent(helpers.baseUrl);
@@ -50,7 +50,7 @@ describe('(/cash) Cash Payments Interface ::', function () {
   });
 
   // Tests for the Caution Payment Interface
-  describe('Caution Payments ::', function () {
+  describe('Caution Payments ', function () {
 
     var CAUTION_PAYMENT = {
       amount:      15000,
@@ -95,8 +95,7 @@ describe('(/cash) Cash Payments Interface ::', function () {
 
 
   // Tests for the Payment Invoice Payment Interface
-  //
-  describe('Patient Invoice Payments ::', function () {
+  describe('Patient Invoice Payments ', function () {
 
     var SALE_PAYMENT = {
       amount:      1520,
@@ -275,15 +274,4 @@ describe('(/cash) Cash Payments Interface ::', function () {
         .catch(helpers.handler);
     });
   });
-
-
-  // The HTTP DELETE verb triggers a cash_discard record, but does not destroy any data
-  // (proposed rename: debit_note)
-  describe.skip('The Debit Note Interface ::', function () {
-    it('DELETE /cash/:uuid should create a cash_discard record');
-    it('DELETE /cash/:uuid should do nothing if the cash record is already discarded');
-    it('DELETE-d cash records should still be discoverable by GET /cash');
-    it('DELETE-d cash records should have the \'canceled\' property set');
-  });
-
 });


### PR DESCRIPTION
This commit implements a proof-of-concept binary UUID storage scheme for
the cash module.  The integration tests have been updated accordingly.

**Overview**
The introduction of binary uuids means that a little more work must be
done in the controllers and sql to insert/retrieve data.  Some commands
in Node and SQL have been added to ease this process.  I'll document
these differences as `before` and `after` scenarios.

READ

Before:

``` sql
SELECT uuid FROM table;
```

After:

``` sql
SELECT BUID(uuid) AS uuid FROM table;
```

**Note**: it is important to alias the column with `AS` in order to
preserve the property name `uuid`.  The command `BUID()` has been added
to our MySQL database instance to convert binary uuids into hexadecimal
uuids.

WRITE

Before:

``` js
var insertSql = 'INSERT INTO table SET ?;';
var updateSql = 'UPDATE table SET ? WHERE uuid = ?;';

var data = {
  uuid : /** some uuid */,
  /* other properties ... */
};

db.exec(insertSql, [ data ]).then(/* ... */).catch(/* .. */);
db.exec(updateSql, [ data, req.params.uuid ]).then(/* ... */).catch(/* .. */);
```

After:

``` js
var insertSql = 'INSERT INTO table SET ?;';
var updateSql = 'UPDATE table SET ? WHERE uuid = ?;';

var data = {
  uuid : /** some uuid */,
  /* other properties ... */
};

// convert the hex uuid into a binary uuid
data.uuid = db.bid(data.uuid);

// insert with the new data
db.exec(insertSql, [ data ]).then(/* ... */).catch(/* .. */);
db.exec(updateSql, [ data, db.bid(req.params.uuid) ]).then(/* ... */).catch(/* .. */);
```

I'd be curious if we can come up with a better API for binary
conversions.  The current method is pragmatic, but possibly unclear.

First implementation of #64.
