### PR TITLE
feat(bhSubmit): submission hook which toggles form loading state

### DIFF
--- a/client/src/js/directives/bhSubmit.js
+++ b/client/src/js/directives/bhSubmit.js
@@ -1,0 +1,40 @@
+angular.module('bhima.directives')
+.directive('bhSubmit', bhSubmitDirective);
+
+function bhSubmitDirective() {
+  return {
+    restrict : 'A',
+    require : 'form', // make sure we are on an ngForm element
+    priority : 1,     // This must be a number greater than zero
+    scope : {
+      submit: '&bhSubmit'
+    },
+    link : function bhSubmitLinkFn($scope, $element, $attrs, $controller) {
+
+      // pick up the form controller
+      var FormController = $controller;
+
+      // bind the initial loading state to false
+      FormController.$loading = false;
+
+      // bind the $toggleLoading method to switch the form's loading state
+      FormController.$toggleLoading = function $toggleLoading() {
+        FormController.$loading = !FormController.$loading;
+      };
+
+      // bind to the 'submit' event
+      $element.bind('submit', function (e) {
+
+        // return the form if the input is invalid.
+        if (FormController.$invalid) { return; }
+
+        FormController.$toggleLoading();
+
+        $scope.submit()
+        .finally(function () {
+          FormController.$toggleLoading();
+        });
+      });
+    }
+  };
+}

--- a/client/src/partials/cash/cash.html
+++ b/client/src/partials/cash/cash.html
@@ -37,13 +37,13 @@
           </div>
           <div class="panel-body">
 
-            <form name="CashVoucherForm" ng-submit="CashCtrl.submit(CashVoucherForm.$invalid)" novalidate>
+            <form name="CashVoucherForm" bh-submit="CashCtrl.submit()" novalidate>
 
-              <fieldset ng-disabled="CashCtrl.loadingState">
+              <fieldset ng-disabled="CashVoucherForm.$loading">
 
                 <div class="form-group" ng-class="{ 'has-error' : CashVoucherForm.$submitted && !CashCtrl.payment.debtor_uuid }">
                   <label class="control-label">{{ "COLUMNS.PATIENT" | translate }}</label>
-                  <bh-find-patient type="inline" on-search-complete="CashCtrl.usePatient(patient)" required></bh-find-patient>
+                  <bh-find-patient type="inline" on-search-complete="CashCtrl.usePatient(patient)" required="1"></bh-find-patient>
                 </div>
 
                 <div>

--- a/client/src/partials/cash/cash.js
+++ b/client/src/partials/cash/cash.js
@@ -99,8 +99,6 @@ function CashController(Cash, Cashboxes, AppCache, Currencies, Modal, $routePara
 
     /** This is the actual payment form */
     vm.payment = { date : new Date() };
-    
-    vm.loadingState = false;
 
     // timestamp to compare date values
     vm.timestamp = new Date();
@@ -121,29 +119,23 @@ function CashController(Cash, Cashboxes, AppCache, Currencies, Modal, $routePara
   }
 
   // submits the form to the server
-  function submit(invalid) {
-
-    // remove any dangling HTTP errors from the view
-    vm.HttpError = null;
-
-    // if the form is invalid, reject it without any further processing.
-    if (invalid) { return; }
+  function submit() {
 
     // make sure the form cannot be clicked more than once via disabling.
-    toggleLoadingState();
 
     // add in the cashbox id
     vm.payment.cashbox_id = cashboxId;
 
     // submit the cash payment
-    Cash.create(vm.payment)
+    return Cash.create(vm.payment)
     .then(function (response) {
 
       // display the receipt in a modal
       openReceiptModal(response.uuid);
     })
-    .catch(handler)
-    .finally(toggleLoadingState);
+    .catch(function (error) {
+      vm.HttpError = error; 
+    });
   }
 
   /**
@@ -151,11 +143,6 @@ function CashController(Cash, Cashboxes, AppCache, Currencies, Modal, $routePara
   */
   function toggleVoucherType() {
     delete vm.payment.invoices;
-  }
-
-  // toggle loading state on off
-  function toggleLoadingState() {
-    vm.loadingState = !vm.loadingState;
   }
 
   // fired after a patient is found via the find-patient directive

--- a/client/src/partials/patients/registration/registration.js
+++ b/client/src/partials/patients/registration/registration.js
@@ -13,64 +13,64 @@ function PatientRegistrationController($scope, $location, patients, debtors, uti
   viewModel.finance = {};
   viewModel.medical = {};
   viewModel.options = {};
-  
+
   // Set up page elements data (debtor select data)
   debtors.groups()
-    .then(function (results) { 
+    .then(function (results) {
       viewModel.options.debtorGroups = results;
-    }); 
+    });
 
   // Define limits for DOB
   viewModel.minDOB = util.minDOB;
   viewModel.maxDOB = util.maxDOB;
-  
+
   viewModel.registerPatient = function registerPatient() {
     var createPatientDetails;
 
-    // Register submitted action - explicit as the button is outside of the scope of the form 
-    $scope.details.$setSubmitted(); 
-  
-    if ($scope.details.$invalid) { 
-      
+    // Register submitted action - explicit as the button is outside of the scope of the form
+    $scope.details.$setSubmitted();
+
+    if ($scope.details.$invalid) {
+
       // End propegation for invalid state - this could scroll to an $invalid element on the form
       return;
     }
 
-    createPatientDetails = { 
+    createPatientDetails = {
       medical : viewModel.medical,
       finance : viewModel.finance
     };
 
-    // Assign implicit information 
+    // Assign implicit information
     createPatientDetails.medical.project_id = Session.project.id;
-  
+
     patients.create(createPatientDetails)
-      .then(function (result) { 
-        
+      .then(function (result) {
+
         // Create patient success - mark as visiting
         return patients.logVisit({
           uuid : result.uuid
         });
       })
-      .then(function (confirmation) { 
+      .then(function (confirmation) {
         var patientCardPath = '/invoice/patient/';
-        
+
         //TODO Hospital card should recieve a value that notifies the user of register success
         $location.path(patientCardPath.concat(confirmation.uuid));
       });
   };
-  
+
   /**
    * Date and location utility methods
    */
   viewModel.enableFullDate = function enableFullDate() {
     viewModel.fullDateEnabled = true;
   };
-  
-  viewModel.calculateYOB = function calculateYOB(value) { 
+
+  viewModel.calculateYOB = function calculateYOB(value) {
     viewModel.medical.dob = value && value.length === 4 ? new Date(value + '-' + util.defaultBirthMonth) : undefined;
   };
-  
+
   //FIXME Location directive relies on the $scope object
   $scope.setOriginLocation = function setOriginLocation(uuid) {
     viewModel.medical.origin_location_id = uuid;


### PR DESCRIPTION
This commit creates a custom directive for form submission to be used on
ngForm directives.  It binds a property `$loading` to the FormController
to signify when the form is in a loading state.  This property can be
used within the form to toggle UI views (such as loading indicators,
etc).

The `bh-submit` directive must receive a callback function that returns
a promise.  See the CashController.submit() method for an example.

USAGE:

``` html
<form name="SomeCoolForm" bh-submit="SomeCtrl.submit()">

  <!-- form elements -->

  <!-- this <p> will only be shown when the form is loading -->
  <p ng-if="SomeCoolForm.$loading">
    I am loading!! :)
  </p>

</form>
```

``` js
// inside SomeCtrl.submit()

$ctrl.submit = function submit() {
  // do some preprocessing steps
  return $http.post('/some/route', data)
  .catch(function (error) {
    $ctrl.HttpError = error;
  });
}
```

This feature is up for review by the team.  If it seems to be the best
way to handle form (loading) state, then we can proceed to use it for
loading indicators and buttons.
