### PR TITLE
FIX(invoices): modal blocks empty selection

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -295,6 +295,10 @@
     "FLOW" : {
       "TITLE" : "Cash Flow"
     },
+  "MODALS" : {
+    "MISSING_DEBTOR_ID" : "No debtor selected!",
+    "EMPTY_SELECTION" : "No invoices selected.  Please select at least one invoice or dismiss the modal."
+  },
    "HELP_TXT_1"       : "This module enables to pay several invoice",
    "HELP_TXT_2"       : "Find Debtor with ",
    "NO_EXCHANGE_RATE" : "Error                                                     : The exchange rate does not exist!",

--- a/client/src/partials/cash/modals/invoices.modal.html
+++ b/client/src/partials/cash/modals/invoices.modal.html
@@ -7,7 +7,7 @@
   <!-- warn the client if not debtor id has been passed in -->
   <p ng-show="CashInvoiceModalCtrl.missingId" class="text-danger text-center">
     <span class="glyphicon glyphicon-alert"></span>
-    {{ "CASH.MODALS.MISSING_DEBTOR_ID" |translate }}
+    {{ "CASH.MODALS.MISSING_DEBTOR_ID" | translate }}
   </p>
 
   <!-- the ui grid to select debtor invoices -->
@@ -39,6 +39,10 @@
         </div>
       </div>
     </div>
+  </div>
+
+  <div ng-show="CashInvoiceModalCtrl.empty" class="text-warning">
+    <span class="glyphicon glyphicon-info-sign"></span> {{ "CASH.MODALS.EMPTY_SELECTION" | translate }}
   </div>
 </div>
 

--- a/client/src/partials/cash/modals/invoices.modal.js
+++ b/client/src/partials/cash/modals/invoices.modal.js
@@ -53,7 +53,7 @@ function CashInvoiceModalController(Debtors, debtorId, invoiceIds, ModalInstance
   function startup() {
 
     // start up the loading indicator
-    vm.loadingState = true;
+    toggleLoadingState();
 
     // load debtor invoices
     Debtors.invoices(debtorId).then(function (invoices) {
@@ -88,12 +88,15 @@ function CashInvoiceModalController(Debtors, debtorId, invoiceIds, ModalInstance
     vm.loadingState = !vm.loadingState;
   }
 
-
   // resolve the modal with the selected invoices to add to the cash payment bills
   function submit() {
 
     // retrieve the outstanding patient invoices from the ui grid
     var invoices = vm.getSelectedRows();
+
+    // block the submission if there are no
+    vm.empty = (invoices.length === 0);
+    if (vm.empty) { return; }
 
     // sum up the total cost of the selected rows
     var total = invoices.reduce(function (aggregate, invoice) {


### PR DESCRIPTION
This commit fixes #154.  The invoices modal now blocks submission with
an error message if the user does not select invoices from the UI grid
to pay against.
