### PR TITLE
Adding id and data-method attributes in breadcrumb

### DIFF
--- a/client/src/partials/templates/breadcrumb.tmpl.html
+++ b/client/src/partials/templates/breadcrumb.tmpl.html
@@ -5,7 +5,7 @@
       <li class="static">
         <a href="#/">{{ "HOME.BHIMA" | translate }}</a>
       </li>
-      <li ng-repeat="p in vm.bcPaths" class="title">
+      <li ng-repeat="p in vm.bcPaths" class="title" id="{{ p.id }}" data-method="{{ p.dataMethod }}">
         <span ng-if="p.current">{{ p.label }}</span>
         <span ng-if="!p.current"><a ng-href="{{ p.link }}">{{ p.label }}</a></span>
       </li>
@@ -15,12 +15,12 @@
       <!-- dropdown buttons -->
       <div class="toolbar-item" ng-if="vm.bcDropdowns.length">
         <span ng-repeat="d in vm.bcDropdowns" uib-dropdown>
-          <button class="btn btn-sm" ng-class="d.color" uib-dropdown-toggle>
+          <button class="btn btn-sm" ng-class="d.color" id="{{ d.id }}" data-method="{{ d.dataMethod }}" uib-dropdown-toggle>
             {{ d.selected | translate }} <span class="caret"></span>
           </button>
           <ul class="pull-right" uib-dropdown-menu>
             <li ng-repeat="opt in d.option">
-              <a href="" ng-click="vm.helperDropdown(opt, d)">
+              <a href="" ng-click="vm.helperDropdown(opt, d)" id="{{ opt.id }}" data-method="{{ opt.dataMethod }}">
                 {{ opt.label | translate }}
               </a>
             </li>
@@ -31,16 +31,18 @@
       <!-- buttons -->
       <div class="toolbar-item btn-group btn-group-sm" ng-if="vm.bcButtons.length">
         <button class="btn"
+          id="{{ a.id }}"
           ng-class="a.color"
           ng-repeat="a in vm.bcButtons"
-          ng-click="a.action(a.label)">
+          ng-click="a.action(a.label)"
+          data-method="{{ a.dataMethod }}">
           <i class="{{ a.icon }}"></i> {{ a.label }}
         </button>
       </div>
 
       <!-- labels -->
       <div class="toolbar-item" ng-if="vm.bcLabels.length">
-        <label ng-repeat="l in vm.bcLabels">
+        <label ng-repeat="l in vm.bcLabels" id="{{ l.id }}" data-method="{{ l.dataMethod }}">
           <b><i class="{{ l.icon }}"></i> {{ l.label }}</b>
         </label>
       </div>


### PR DESCRIPTION
This PR add `id` and `data-method` attributes for selecting elements in the `breadcrumb` directive
