### PR TITLE
chore(i18n): translate generic validation messages

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -3449,5 +3449,15 @@
    "REGISTERED"       : "Registered villages",
    "SECTOR"           : "Sector",
    "TITLE"            : "Village Manager"
+   },
+   "VALIDATION" : {
+    "MIN" : "This value is too small for this field.",
+    "MAX" : "This value is too large for this field.",
+    "REQUIRED" : "This field cannot be empty.",
+    "EMAIL" : "This field must be a valid email.",
+    "MINLENGTH" : "This input is too short.",
+    "MAXLENGTH" : "This input is too long.",
+    "NUMBER" : "This field must be a valid number.",
+    "DATE" : "This field must be a valid date."
    }
 }

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -3432,5 +3432,15 @@
    "REGISTERED"       : "Villages Enregistrés",
    "SECTOR"           : "Commune",
    "TITLE"            : "Gestion des Villages"
+   },
+   "VALIDATION" : {
+    "MIN" : "Cette valeur est trop petite pour ce champ.",
+    "MAX" : "Cette valeur est trop grande pour ce champ.",
+    "REQUIRED" : "Ce champ ne peut pas être vide.",
+    "EMAIL" : "Ce champ doit être un email valide.",
+    "MINLENGTH" : "Cette entrée est trop court.",
+    "MAXLENGTH" : "Cette entrée est trop longue.",
+    "NUMBER" : "Ce champ doit être un nombre.",
+    "DATE" : "Ce champ doit être une date valide."
    }
 }

--- a/client/src/partials/templates/messages.tmpl.html
+++ b/client/src/partials/templates/messages.tmpl.html
@@ -1,23 +1,23 @@
 <!-- displays "This value is too small for this field." -->
-<p ng-message="min">This value is too small for this field.</p>
+<p ng-message="min">{{ "VALIDATION.MIN" | translate }}</p>
 
 <!-- displays "This value is too large for this field." -->
-<p ng-message="max">This value is too large for this field.</p>
+<p ng-message="max">{{ "VALIDATION.MAX" | translate }}</p>
 
 <!-- displays "This field cannot be empty." -->
-<p ng-message="required">This field cannot be empty.</p>
+<p ng-message="required">{{ "VALIDATION.REQUIRED" | translate }}</p>
 
 <!-- displays "This field must be a valid email." -->
-<p ng-message="email">This field must be a valid email.</p>
+<p ng-message="email">{{ "VALIDATION.EMAIL" | translate }}</p>
 
 <!-- displays "This input is too short." -->
-<p ng-message="minlength">This input is too short.</p>
+<p ng-message="minlength">{{ "VALIDATION.MINLENGTH" | translate }}</p>
 
 <!-- displays "This input is too long." -->
-<p ng-message="maxlength">This input is too long.</p>
+<p ng-message="maxlength">{{ "VALIDATION.MAXLENGTH" | translate }}</p>
 
 <!-- displays "This field must be a valid number." -->
-<p ng-message="number">This field must be a valid number.</p>
+<p ng-message="number">{{ "VALIDATION.NUMBER" | translate }}</p>
 
 <!-- displays "This field must be a valid date." -->
-<p ng-message="date">This field must be a valid date.</p>
+<p ng-message="date">{{ "VALIDATION.DATE" | translate }}</p>


### PR DESCRIPTION
This commit adds translation keys for the generic validation messages
introduced in #89.  Both French and English translation are included.

Addresses https://github.com/IMA-WorldHealth/bhima-2.X/pull/89#discussion_r52294941
