### PR TITLE
feat(bhCurrencySelect): currency selection radios

### DIFF
--- a/client/src/js/components/bhCurrencySelect.js
+++ b/client/src/js/components/bhCurrencySelect.js
@@ -1,0 +1,98 @@
+angular.module('bhima.components')
+.component('bhCurrencySelect', {
+  controller : bhCurrencySelect,
+  templateUrl : 'partials/templates/bhCurrencySelect.tmpl.html',
+  bindings : {
+    validationTrigger : '<',
+    currencyId : '=',
+    disableIds : '<',
+    onChange : '&'
+  }
+});
+
+bhCurrencySelect.$inject = [ '$scope', 'CurrencyService' ];
+
+/**
+ * Currency Selection Component
+ *
+ * This is a radio button currency selection component for choosing currencies
+ * in a form.  If a list of currencies are passed in, these are used instead of
+ * the application's currencies.
+ *
+ * @module components/bhCurrencySelect
+ *
+ * @example
+ * <!-- simple usage -->
+ * <bh-currency-select
+ *   currency-id="ParentCtrl.model.currencyId"
+ *   validation-trigger="ParentForm.$submitted"
+ *   >
+ * </bh-currency-select>
+ *
+ * <!--
+ *   complex usage: filter the currencies and register an onChange event
+ * -->
+ * <bh-currency-select
+ *   currency-id="ParentCtrl.model.currencyId"
+ *   on-change="ParentCtrl.currencyChangeEvent()"
+ *   disable-ids="ParentCtrl.disabledIds"
+ *   validation-trigger="ParentForm.$submitted"
+ *   >
+ * </bh-currency-select>
+ *
+ * BINDINGS
+ *  - [currency-id]
+ *      The model value for the underlying `<input>`s.  This
+ *      is two-way bound to the parent controller.
+ *
+ *  - [validation-trigger]
+ *      a boolean that can be passed in
+ *      to show validation messages will only show if this boolean is true.  It
+ *      is useful to bind `ParentForm.$submitted` value to this attribute.
+ *
+ *  - [on-change]
+ *      a callback bound the `ng-change` event on the `<input>`s.
+ *
+ *  - [disable-ids]
+ *      an array of currency ids to be disabled as required.
+ */
+function bhCurrencySelect($scope, Currencies) {
+  var $ctrl = this;
+
+  // bind the currency service to the view
+  $ctrl.service = Currencies;
+
+  // default currencies to an empty list
+  $ctrl.currencies = [];
+
+  // default to noop() if an onChange() method was not passed in
+  $ctrl.onChange = $ctrl.onChange || angular.noop();
+
+  // load all the available currencies
+  Currencies.read()
+  .then(function (currencies) {
+
+    // cache a label for faster view rendering
+    currencies.forEach(function (currency) {
+      currency.label = Currencies.format(currency.id);
+    });
+
+    $ctrl.currencies = currencies;
+  });
+
+  // watch the disabledIds array for changes, and disable the ids in the the
+  // view based on which ids are present in it
+  $scope.$watch(function () {
+    return $ctrl.disableIds;
+  }, function (array) {
+
+    // ensure the array exists and has values
+    if (!array || !array.length) { return; }
+
+    // loop through the currencies, disabling the currencies with ids in the
+    // disabledIds array.
+    $ctrl.currencies.forEach(function (currency) {
+      currency.disabled = array.indexOf(currency.id) > -1;
+    });
+  });
+}

--- a/client/src/partials/cash/cash.html
+++ b/client/src/partials/cash/cash.html
@@ -25,7 +25,7 @@
           <button class="btn btn-primary" ng-click="CashCtrl.openTransferModal()" data-perform-transfer>
             <span class="glyphicon glyphicon-export"></span> {{ "CASH.VOUCHER.CASHBOXES.TRANSFER" | translate }}
           </button>
-        </p>        
+        </p>
       </div>
 
       <!-- Cash Voucher Form -->
@@ -48,7 +48,7 @@
 
                 <div>
                   <label for="dateEditor" class="control-label">{{ "COLUMNS.DATE" | translate }}</label>
-                  <bh-date-editor 
+                  <bh-date-editor
                     date-value="CashCtrl.payment.date"
                     form="CashVoucherForm"
                     validation-trigger="CashVoucherForm.$submitted"
@@ -57,6 +57,7 @@
                 </div>
 
                 <!-- currency selection -->
+                <!--
                 <div class="radio" ng-class="{ 'has-error' : CashVoucherForm.$submitted && CashVoucherForm.currency.$invalid }">
                   <p><strong class="control-label">{{ "COLUMNS.CURRENCY" | translate }}</strong></p>
                   <label ng-repeat="currency in CashCtrl.cashbox.currencies track by currency.currency_id" class="radio-inline">
@@ -75,6 +76,15 @@
                     <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
                   </div>
                 </div>
+
+                -->
+                <bh-currency-select
+                  currency-id="CashCtrl.payment.currency_id"
+                  validation-trigger="CashVoucherForm.$submitted"
+                  on-change="CashCtrl.digestExchangeRate()"
+                  disable-ids="CashCtrl.disabledCurrencyIds"
+                  >
+                </bh-currency-select>
 
                 <!-- determine if we are creating a caution or an invoice payment -->
                 <div class="radio" ng-class="{ 'has-error' : CashVoucherForm.$submitted && CashVoucherForm.type.$invalid }">

--- a/client/src/partials/templates/bhCurrencySelect.tmpl.html
+++ b/client/src/partials/templates/bhCurrencySelect.tmpl.html
@@ -1,0 +1,26 @@
+<ng-form name="CurrencyForm">
+  <div class="radio" ng-class="{ 'has-error' : $ctrl.validationTrigger && CurrencyForm.$invalid }" data-bh-currency-select>
+    <p class="control-label">
+      <strong>{{ "COLUMNS.CURRENCY" | translate }}</strong>
+    </p>
+
+    <!-- repeat each currency in the application -->
+    <label ng-repeat="currency in $ctrl.currencies track by currency.id" class="radio-inline" ng-class="{ 'disabled' : currency.disabled }">
+      <input
+        name="currency"
+        type="radio"
+        ng-model="$ctrl.currencyId"
+        ng-value="currency.id"
+        ng-change="$ctrl.onChange"
+        data-currency-option="{{ currency.id }}"
+        ng-disabled="currency.disabled"
+        required>
+      {{ currency.label }}
+    </label>
+
+    <!-- radio button validation messages -->
+    <div class="help-block" ng-messages="CurrencyForm.currency.$error" ng-show="$ctrl.validationTrigger">
+      <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+    </div>
+  </div>
+</ng-form>

--- a/client/test/e2e/cash/cash.spec.js
+++ b/client/test/e2e/cash/cash.spec.js
@@ -167,16 +167,14 @@ describe('Cash Payments Module', function () {
       // select the proper patient
       components.findPatient.findByName(mockCautionPayment.patientName);
 
-
       // we will leave the date input as default
 
       // select the proper is caution type
       var cautionOption = element(by.css('[data-caution-option="1"]'));
       cautionOption.click();
 
-      // select the FC currency from the currency
-      var FC = element(by.css('[data-currency-option="1"]'));
-      FC.click();
+      // select the FC currency from the currency select
+      components.currencySelect.set(1);
 
       // enter the amount to pay for a caution
       components.currencyInput.set(mockCautionPayment.amount, null);
@@ -194,8 +192,7 @@ describe('Cash Payments Module', function () {
       // select the proper patient
       components.findPatient.findById(mockInvoicesPayment.patientId);
 
-      // select the properdate
-
+      // select the proper date
       components.dateEditor.set(mockInvoicesPayment.date);
 
       // select the "invoices payment" option type
@@ -217,8 +214,7 @@ describe('Cash Payments Module', function () {
       modalSubmit.click();
 
       // select the USD currency from the currency radio buttons
-      var USD = element(by.css('[data-currency-option="2"]'));
-      USD.click();
+      components.currencySelect.set(2);
 
       // enter the amount to pay for an invoice
       components.currencyInput.set(mockInvoicesPayment.amount, null);

--- a/client/test/e2e/shared/components.js
+++ b/client/test/e2e/shared/components.js
@@ -123,17 +123,17 @@ exports.locationSelect = {
  * @public
  */
 exports.currencyInput = {
-  selector : '[data-bh-currency-input]',  
+  selector : '[data-bh-currency-input]',
 
   /**
    * sets the value of the currency input.
-  */  
+  */
   set : function set(value, id) {
   // it might be clearer to do this in two steps.
     var root = element(id ? by.id(id) : by.css(this.selector));
     var elm  = root.element(by.model('$ctrl.model'));
     elm.sendKeys(value);
-  },  
+  },
 
   /**
    * get the value of the currency input.
@@ -268,13 +268,13 @@ exports.findDebtorGroup = {
   * @function test
   * @param {string} name The text for the debtor group name
   * @param {number} index The index of a debtor group in the list
-  * @description Run a default test of use of the component  
+  * @description Run a default test of use of the component
   */
   test : function test(name, index) {
-    this.search(name),
-    this.select(index),
-    this.popup(),
-    this.reload()
+    this.search(name);
+    this.select(index);
+    this.popup();
+    this.reload();
   }
 };
 
@@ -307,3 +307,32 @@ exports.dateEditor = {
     return DateInputText.getAttribute('date-value');
   }
 };
+
+/**
+ * test harness for the currency select component described in the component
+ * bhCurrencySelect.js.
+ * @public
+ */
+exports.currencySelect = {
+  selector : '[data-bh-currency-select]',
+
+  /**
+   * sets the value of the currency select.
+   * @todo - make value == ('FC' || 'USD') instead of an id.
+  */
+  set : function set(value, id) {
+
+    // get the root value of the
+    var root = element(id ? by.id(id) : by.css(this.selector));
+
+    // construct a locator for the value
+    var locator = '[data-currency-option="?"]'.replace('?', value);
+
+    // get the approrpriate option by the locator
+    var option = root.element(by.css(locator));
+
+    // click it!
+    option.click();
+  }
+};
+


### PR DESCRIPTION
This commit introduces the bhCurrencySelect radio component to select
currencies in forms.  The basic signature looks like this:

``` html
 <!-- simple usage -->
 <bh-currency-select
   currency-id="ParentCtrl.model.currencyId"
   validation-trigger="ParentForm.$submitted"
   >
 </bh-currency-select>

 <!--
   complex usage: disable currencies based on ids found in the
   disable-ids array and register an ngChange event.
 -->
 <bh-currency-select
   currency-id="ParentCtrl.model.currencyId"
   on-change="ParentCtrl.currencyChangeEvent()"
   disable-ids="ParentCtrl.disabledIds"
   validation-trigger="ParentForm.$submitted"
   >
 </bh-currency-select>
```

See the source code for implementation details.  The list of supported
bindings follows:
1. [currency-id] - the model value for the underlying `<input>`s.  This is two-way bound to the parent controller.
2. [validation-trigger] (_optional_) - a boolean that can be passed in to show validation messages will only show if this boolean is true.  It is useful to bind `ParentForm.$submitted` value to this attribute.
3. [on-change] (_optional_) - a callback bound the `ng-change` event on  the `<input>`s.
4. [disable-ids] (_optional_) - an array of currency ids to be disabled as required.

An implementation of the most complex case is given in the cash module, with passing end to end tests.

There is also a currency component wrapper that works as you would expect:

``` js
var components = require('../shared/components');

it('works like a charm!', function () {

  // set currency input to currencyId = 1 (FC)
  components.bhCurrencySelect.set(1);
});

it('supports an id lookup!', function () {

  // set the currency input with id='outgoing' to USD
  components.bhCurrencySelect.set(2, 'outgoing');

  // set the currency input with id='incoming' to USD
  components.bhCurrencySelect.set(2, 'incoming');
});
```

 Partially addresses #106.
