### PR TITLE
feat(simple vouchers): implement simple journal vouchers

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -540,7 +540,7 @@
    "INCOME"                : "Income",
    "INDIRECT"              : "Indirect",
    "INITIAL_STOCK"         : "Initial stock",
-   "INVENTORY"             : "Inventory",   
+   "INVENTORY"             : "Inventory",
    "INVENTORY_CODE"        : "Inventory Code",
    "INVENTORY_GROUP"       : "Inventory Group",
    "INVENTORY_ITEM"        : "Inventory Item",
@@ -1585,7 +1585,8 @@
   "COUNTRY" : "Enter a country.",
   "PROVINCE" : "Enter a province.",
   "SECTOR" : "Enter a sector.",
-  "VILLAGE" : "Enter a village."
+  "VILLAGE" : "Enter a village.",
+  "DESCRIPTION" : "Enter a description."
 },
 "INVENTORY": {
    "GROUPS": {
@@ -2222,7 +2223,7 @@
    "NEW"              : "New Price List",
    "NO_RECORDS"       : "No Record",
    "POSTED"           : "Posted new price list!",
-   "PRICE_LIST_ITEMS" : "Price liste items",   
+   "PRICE_LIST_ITEMS" : "Price liste items",
    "REMOVE_SUCCESS"   : "Erased succefully !",
    "SAVE_LIST"        : "Save List",
    "SAVE_SUCCESS"     : "Saved successfully",
@@ -2230,7 +2231,7 @@
    "UNABLE_TO_DELETE" : "Price list cannot be deleted - it may currently be assigned to patient/ debtor groups",
    "UPDATE"           : "Update a Price List",
    "UPDATE_SUCCESS"    : "Updated successfully",
-   "WARN"             : "Warn"   
+   "WARN"             : "Warn"
    },
 "PRIMARY_CASH": {
    "CONFIGURE"        : "Configure Cash Box",
@@ -3284,6 +3285,7 @@
    "INVENTORY_MANAGEMENT"      : "Inventory Management",
    "INVENTORY_VIEW"            : "Stock",
    "JOURNAL_VOUCHER"           : "Journal Voucher",
+   "SIMPLE_VOUCHER"            : "Simple Voucher",
    "LOCATION"                  : "Locations Management",
    "LOSS_RECORDS"              : "Stock loss",
    "MAIN_CASH"                 : "Principal Cashbox",
@@ -3522,5 +3524,12 @@
     "MAXLENGTH" : "This input is too long.",
     "NUMBER" : "This field must be a valid number.",
     "DATE" : "This field must be a valid date."
-   }
+   },
+  "VOUCHERS" : {
+    "SIMPLE" : {
+      "TITLE" : "Transfer Slip",
+      "FROM_ACCOUNT" : "From Account",
+      "TO_ACCOUNT" : "To Account"
+    }
+  }
 }

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -193,6 +193,10 @@ function bhimaconfig($routeProvider) {
     controller: 'JournalVoucherController as JournalVoucherCtrl',
     templateUrl: 'partials/journal/voucher/voucher.html'
   })
+  .when('/vouchers/simple', {
+    controller: 'SimpleJournalVoucherController as SimpleVoucherCtrl',
+    templateUrl: 'partials/vouchers/simple.html'
+  })
 
   /* debtors routes */
 

--- a/client/src/js/services/VoucherService.js
+++ b/client/src/js/services/VoucherService.js
@@ -9,6 +9,7 @@ function VoucherService ($http, util) {
 
   service.create = create;
   service.read = read;
+  service.createSimple = createSimple;
 
   /** send an http request to create a voucher**/
   function create(voucher) {
@@ -21,6 +22,39 @@ function VoucherService ($http, util) {
      var url = baseUrl.concat(id || '');
      return $http.get(url)
      .then(util.unwrapHttpResponse);
+  }
+
+  /**
+   * Creates a simple journal voucher, transforming the object into double-entry
+   * accounting
+   * @method createSimple
+   * @param {object} voucher - the raw journal voucher
+   */
+  function createSimple(voucher) {
+
+    // create a local working copy for manipulation
+    var clean = angular.copy(voucher);
+
+    // in a simple journal voucher, there are two items
+    var items = [{
+      debit : clean.amount,
+      credit: 0,
+      account_id : clean.fromAccount.id
+    }, {
+      debit : 0,
+      credit : clean.amount,
+      account_id : clean.toAccount.id
+    }];
+
+    // clean up the voucher by removing view properties
+    delete clean.toAccount;
+    delete clean.fromAccount;
+
+    // bind the voucher items
+    clean.items = items;
+
+    return $http.post(baseUrl, clean)
+    .then(util.unwrapHttpResponse);
   }
 
   return service;

--- a/client/src/js/services/VoucherService.js
+++ b/client/src/js/services/VoucherService.js
@@ -53,7 +53,7 @@ function VoucherService ($http, util) {
     // bind the voucher items
     clean.items = items;
 
-    return $http.post(baseUrl, clean)
+    return $http.post(baseUrl, { voucher : clean })
     .then(util.unwrapHttpResponse);
   }
 

--- a/client/src/partials/debtor_groups/debtor_groups.html
+++ b/client/src/partials/debtor_groups/debtor_groups.html
@@ -88,8 +88,8 @@
                     class="form-control"
                     name="account"
                     placeholder="{{ 'PLACEHOLDERS.ENTER.ACCOUNT' | translate }}..."
-                    uib-typeahead="account.id as account.account_number for account in DebtorGroupCtrl.accounts.data | filter:$viewValue | limitTo:8" class="form-control"
-                    typeahead-template-url="partials/templates/typeahead/account.html"
+                    uib-typeahead="account.id as account.label for account in DebtorGroupCtrl.accounts.data | filter:$viewValue | limitTo:8" class="form-control"
+                    typeahead-template-url="partials/templates/typeahead/accounts.html"
                     ng-model="DebtorGroupCtrl.debtorGroup.account_id" required>
                   <div class="help-block" ng-messages="ActionForm.account.$error" ng-show="ActionForm.$submitted">
                     <div ng-messages-include="partials/templates/messages.tmpl.html"></div>

--- a/client/src/partials/templates/typeahead/account.html
+++ b/client/src/partials/templates/typeahead/account.html
@@ -1,5 +1,0 @@
-<!-- Account Templates  -->
-<a>
-  <strong>{{ match.model.account_number}}</strong>
-  <em>{{ match.model.account_txt}}</em>
-</a>

--- a/client/src/partials/templates/typeahead/accounts.html
+++ b/client/src/partials/templates/typeahead/accounts.html
@@ -1,0 +1,4 @@
+<!-- Account Templates  -->
+<a href="">
+  <span ng-bind-html="match.label | uibTypeaheadHighlight:query"></span>
+</a>

--- a/client/src/partials/vouchers/simple.html
+++ b/client/src/partials/vouchers/simple.html
@@ -15,7 +15,7 @@
           </div>
 
           <div class="panel-body">
-            <form name="SimpleVoucherForm" bh-submit="SimpleVoucherCtrl.submit(SimpleVoucherForm.$invalid)" autocomplete="off">
+            <form name="SimpleVoucherForm" bh-submit="SimpleVoucherCtrl.submit(SimpleVoucherForm)" autocomplete="off" novalidate>
 
               <div>
                 <label class="control-label">{{ "COLUMNS.DATE" | translate }}</label>
@@ -36,6 +36,7 @@
                   class="form-control"
                   name="description"
                   ng-model="SimpleVoucherCtrl.voucher.description"
+                  placeholder="{{ 'INPUT.DESCRIPTION' | translate }}"
                   required>
                 </textarea>
                 <div class="help-block" ng-messages="SimpleVoucherForm.description.$error" ng-show="SimpleVoucherForm.$submitted">
@@ -92,7 +93,7 @@
                     type="radio"
                     ng-model="SimpleVoucherCtrl.voucher.currency_id"
                     ng-value="currency.id"
-                    data-currency-option="{{ currency.currency_id }}"
+                    data-currency-option="{{ currency.id }}"
                     required>
                   {{ currency.label }}
                 </label>
@@ -112,7 +113,7 @@
               </bh-currency-input>
 
               <div class="form-group">
-                <button type="submit" class="btn btn-primary" data-method="submit">
+                <button type="submit" class="btn btn-primary" data-method="submit" ng-disabled="SimpleVoucherCtrl.created">
                   {{ "FORM.SUBMIT" | translate }}
                 </button>
 
@@ -121,7 +122,7 @@
                   type="button"
                   class="btn btn-default"
                   ng-show="SimpleVoucherCtrl.created"
-                  ng-click="SimpleVoucherCtrl.startup(); SimpleVoucherForm.$setPristine();">
+                  ng-click="SimpleVoucherCtrl.reset(); SimpleVoucherForm.$setPristine();">
                   {{ "FORM.RESET" | translate }}
                 </button>
               </div>

--- a/client/src/partials/vouchers/simple.html
+++ b/client/src/partials/vouchers/simple.html
@@ -1,0 +1,144 @@
+<!-- breadcrumb header -->
+<bh-breadcrumb
+  path="SimpleVoucherCtrl.paths">
+</bh-breadcrumb>
+
+<div class="flex-content">
+  <div class="container-fluid">
+    <div class="row">
+
+      <div class="col-md-6">
+
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            {{ "VOUCHERS.SIMPLE.TITLE" | translate }}
+          </div>
+
+          <div class="panel-body">
+            <form name="SimpleVoucherForm" bh-submit="SimpleVoucherCtrl.submit(SimpleVoucherForm.$invalid)" autocomplete="off">
+
+              <div>
+                <label class="control-label">{{ "COLUMNS.DATE" | translate }}</label>
+                <bh-date-editor
+                  date-value="SimpleVoucherCtrl.voucher.date"
+                  form="SimpleVoucherForm"
+                  validation-trigger="SimpleVoucherForm.$submitted"
+                  max-date="SimpleVoucherCtrl.timestamp"
+                >
+                </bh-date-editor>
+              </div>
+
+              <div
+                class="form-group"
+                ng-class="{ 'has-error' : SimpleVoucherForm.$submitted && SimpleVoucherForm.description.$invalid }">
+                <label class="control-label">{{ "COLUMNS.DESCRIPTION" | translate }}</label>
+                <textarea
+                  class="form-control"
+                  name="description"
+                  ng-model="SimpleVoucherCtrl.voucher.description"
+                  required>
+                </textarea>
+                <div class="help-block" ng-messages="SimpleVoucherForm.description.$error" ng-show="SimpleVoucherForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
+              </div>
+
+               <div
+                 class="form-group"
+                 ng-class="{ 'has-error' : SimpleVoucherForm.$submitted && SimpleVoucherForm.fromAccount.$invalid }">
+                 <label class="control-label">
+                   {{ "VOUCHERS.SIMPLE.FROM_ACCOUNT" | translate }}
+                 </label>
+                 <input
+                   class="form-control"
+                   name="fromAccount"
+                   placeholder="{{ 'PLACEHOLDERS.ENTER.ACCOUNT' | translate }}..."
+                   uib-typeahead="account as account.label for account in SimpleVoucherCtrl.accounts | filter:$viewValue | limitTo:10"
+                   typeahead-template-url="partials/templates/typeahead/accounts.html"
+                   ng-model="SimpleVoucherCtrl.voucher.fromAccount"
+                   required>
+                 <div class="help-block" ng-messages="SimpleVoucherForm.fromAccount.$error" ng-show="SimpleVoucherForm.$submitted">
+                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                 </div>
+               </div>
+
+               <div
+                 class="form-group"
+                 ng-class="{ 'has-error' : SimpleVoucherForm.$submitted && SimpleVoucherForm.toAccount.$invalid }">
+                 <label class="control-label">
+                   {{ "VOUCHERS.SIMPLE.TO_ACCOUNT" | translate }}
+                 </label>
+                 <input
+                   class="form-control"
+                   name="toAccount"
+                   placeholder="{{ 'PLACEHOLDERS.ENTER.ACCOUNT' | translate }}..."
+                   uib-typeahead="account as account.label for account in SimpleVoucherCtrl.accounts | filter:$viewValue | limitTo:10"
+                   typeahead-template-url="partials/templates/typeahead/accounts.html"
+                   ng-model="SimpleVoucherCtrl.voucher.toAccount"
+                   required>
+                 <div class="help-block" ng-messages="SimpleVoucherForm.toAccount.$error" ng-show="SimpleVoucherForm.$submitted">
+                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                 </div>
+               </div>
+
+              <!-- @TODO - use a currency selection component -->
+              <div
+                class="radio"
+                ng-class="{ 'has-error' : SimpleVoucherForm.$submitted && SimpleVoucherForm.currency.$invalid }">
+                <p><strong class="control-label">{{ "COLUMNS.CURRENCY" | translate }}</strong></p>
+                <label ng-repeat="currency in SimpleVoucherCtrl.currencies track by currency.id" class="radio-inline">
+                  <input
+                    name="currency"
+                    type="radio"
+                    ng-model="SimpleVoucherCtrl.voucher.currency_id"
+                    ng-value="currency.id"
+                    data-currency-option="{{ currency.currency_id }}"
+                    required>
+                  {{ currency.label }}
+                </label>
+
+                <div class="help-block" ng-messages="SimpleVoucherForm.currency.$error" ng-show="SimpleVoucherForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
+              </div>
+
+              <bh-currency-input
+                data-voucher-currency-input
+                currency-id="SimpleVoucherCtrl.voucher.currency_id"
+                model="SimpleVoucherCtrl.voucher.amount"
+                form="SimpleVoucherForm"
+                validation-trigger="SimpleVoucherForm.$submitted"
+                >
+              </bh-currency-input>
+
+              <div class="form-group">
+                <button type="submit" class="btn btn-primary" data-method="submit">
+                  {{ "FORM.SUBMIT" | translate }}
+                </button>
+
+                <!-- @todo - random hacks to make things look pretty - need  state handler-->
+                <button
+                  type="button"
+                  class="btn btn-default"
+                  ng-show="SimpleVoucherCtrl.created"
+                  ng-click="SimpleVoucherCtrl.startup(); SimpleVoucherForm.$setPristine();">
+                  {{ "FORM.RESET" | translate }}
+                </button>
+              </div>
+
+              <!-- translate the server-sent error for the client -->
+              <p class="text-danger" ng-show="SimpleVoucherCtrl.httpError">
+                <span class="glyphicon glyphicon-exclamation-sign"></span>{{ SimpleVoucherCtrl.httpError | translate }}
+              </p>
+
+              <!-- displays: "Record created successfully!" -->
+              <p class="text-success" ng-show="SimpleVoucherCtrl.created">
+                <span class="glyphicon glyphicon-ok-sign"></span> {{ "FORM.CREATED" | translate }}
+              </p>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/client/src/partials/vouchers/simple.js
+++ b/client/src/partials/vouchers/simple.js
@@ -1,0 +1,105 @@
+angular.module('bhima.controllers')
+.controller('SimpleJournalVoucherController', SimpleJournalVoucherController);
+
+SimpleJournalVoucherController.$inject = [
+  'AppCache', 'VoucherService', '$translate', 'AccountService',
+  'CurrencyService', 'SessionService'
+];
+
+/**
+ * Simple Journal Vouchers
+ *
+ * This module implements simply journal vouchers, crafted specially for cash
+ * transactions, but useable in any generic transactions that only require two
+ * Posting Journal lines.  It allows users to quickly create transactions by
+ * specifying two accounts and an amount to transfer between them.
+ *
+ * @constructor
+ *
+ * @todo - Implement caching mechanism for incomplete forms (via AppCache)
+ * @todo - Implement Voucher Templates to allow users to save pre-selected
+ * forms (via AppCache and the breadcrumb component).
+ */
+function SimpleJournalVoucherController(AppCache, Vouchers, $translate, Accounts, Currencies, Session) {
+  var vm = this;
+
+  // cache to save work-in-progress data and pre-fabricated templates
+  var cache = AppCache('JournalVouchers');
+
+  // bread crumb paths
+  vm.paths = [{
+    label : $translate.instant('VOUCHERS.SIMPLE.TITLE'),
+    current: true
+  }];
+
+  // bind the startup method as a reset method
+  vm.reset = startup;
+  vm.submit = submit;
+
+  // load the list of accounts
+  Accounts.list()
+  .then(function (accounts) {
+    vm.accounts = accounts;
+  });
+
+  // load the available currencies
+  Currencies.read()
+  .then(function (currencies) {
+
+    // format human readable labels
+    currencies.forEach(function (currency) {
+      currency.label = Currencies.format(currency.id);
+    });
+
+    // bind the currencies to the view
+    vm.currencies = currencies;
+  });
+
+  /** run the module on startup and refresh */
+  function startup() {
+
+    // delete any state indicators (if they exist)
+    delete vm.created;
+
+    // this is the voucher form to be submitted
+    vm.voucher = {};
+
+    // set up default voucher values
+    vm.voucher.date = new Date();
+    vm.voucher.description =
+      $translate.instant('VOUCHERS.SIMPLE.DESCRIPTION');
+
+    /** @todo - these should be set on the server */
+    vm.voucher.user_id = Session.user.id;
+    vm.voucher.project_id = Session.project.id;
+
+    // current timestamp to limit date
+    vm.timestamp = new Date();
+  }
+
+  function submit(invalid) {
+
+    // clear the old error if it exists
+    delete vm.httpError;
+
+    // stop submission if the form is invalid
+    if (invalid) { return; }
+
+    // turn the voucher into double-entry accounting
+    return Vouchers.createSimple(vm.voucher)
+    .then(function (res) {
+
+      /** @todo - need a better way to handle state */
+      vm.created = true;
+    })
+
+    // attach the error's translatable text to the view
+    .catch(function (response) {
+      if (response.data && response.data.code) {
+        vm.httpError = response.data.code;
+      }
+    });
+  }
+
+  startup();
+}

--- a/client/src/partials/vouchers/simple.js
+++ b/client/src/partials/vouchers/simple.js
@@ -66,8 +66,6 @@ function SimpleJournalVoucherController(AppCache, Vouchers, $translate, Accounts
 
     // set up default voucher values
     vm.voucher.date = new Date();
-    vm.voucher.description =
-      $translate.instant('VOUCHERS.SIMPLE.DESCRIPTION');
 
     /** @todo - these should be set on the server */
     vm.voucher.user_id = Session.user.id;
@@ -77,13 +75,15 @@ function SimpleJournalVoucherController(AppCache, Vouchers, $translate, Accounts
     vm.timestamp = new Date();
   }
 
-  function submit(invalid) {
+  function submit(form) {
 
     // clear the old error if it exists
     delete vm.httpError;
 
     // stop submission if the form is invalid
-    if (invalid) { return; }
+    if (form.$invalid) {
+      return;
+    }
 
     // turn the voucher into double-entry accounting
     return Vouchers.createSimple(vm.voucher)

--- a/client/test/e2e/vouchers/simple.spec.js
+++ b/client/test/e2e/vouchers/simple.spec.js
@@ -1,0 +1,59 @@
+/* global browser, element, by */
+
+var chai = require('chai');
+var expect = chai.expect;
+
+// import testing utiliites
+var components = require('../shared/components');
+var FU = require('../shared/FormUtils');
+var helpers = require('../shared/helpers');
+helpers.configure(chai);
+
+describe('Simple Vouchers', function () {
+  'use strict';
+  
+  var path = '#/vouchers/simple';
+
+  var voucher = {
+    date : new Date((new Date()).getDate() - 1),
+    toAccount : 'Test Debtor Group Account',
+    fromAccount: '4600 - Test Inventory Accounts',
+    description : 'Awesome description',
+    amount : 100
+  };
+
+  beforeEach(function () {
+    browser.get(path);
+  });
+
+  it('can create a simple voucher', function () {
+
+    // configure the date to yesterday
+    components.dateEditor.set(voucher.date);
+
+    var option;
+
+    // select the appropriate accounts
+    FU.input('SimpleVoucherCtrl.voucher.toAccount', voucher.toAccount);
+    option = element.all(by.repeater('match in matches track by $index')).last();
+    option.click();
+
+    FU.input('SimpleVoucherCtrl.voucher.fromAccount', voucher.fromAccount);
+    option = element.all(by.repeater('match in matches track by $index')).last();
+    option.click();
+
+    // check the USD radio option
+    element(by.css('[data-currency-option="2"]')).click();
+
+    // input the amount
+    components.currencyInput.set(voucher.amount);
+
+    // submit the form
+    FU.buttons.submit();
+
+    // assert that validation text appears
+    expect(element(by.css('.text-success')).isPresent()).to.eventually.equal(true);
+  });
+
+});
+

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -59,8 +59,8 @@ CREATE TABLE `assignation_patient` (
 
 DROP TABLE IF EXISTS `beneficiary`;
 CREATE TABLE `beneficiary` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `text` varchar(50) NOT NULL,
+  `id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `text` TEXT NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -81,10 +81,14 @@ CREATE TABLE billing_service (
 
 DROP TABLE IF EXISTS `budget`;
 CREATE TABLE `budget` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `account_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `period_id` mediumint(8) unsigned NOT NULL,
-  `budget` decimal(10,4) unsigned DEFAULT NULL,
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `account_id` INT UNSIGNED NOT NULL,
+  `period_id` MEDIUMINT(8) UNSIGNED NOT NULL,
+  `budget` DECIMAL(10,4) UNSIGNED DEFAULT NULL,
+  KEY `account_id` (`account_id`),
+  KEY `period_id` (`period_id`),
+  FOREIGN KEY (`account_id`) REFERENCES `account` (`id`),
+  FOREIGN KEY (`period_id`) REFERENCES `period` (`id`),
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -1986,14 +1990,21 @@ CREATE TABLE `village` (
 DROP TABLE IF EXISTS `voucher`;
 CREATE TABLE IF NOT EXISTS `voucher` (
   `uuid` char(36) NOT NULL,
-  `date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `project_id` tinyint(4) NOT NULL,
+  `date` DATETIME NOT NULL,
+  `project_id` SMALLINT(5) UNSIGNED NOT NULL,
   `reference` INT(10) UNSIGNED NOT NULL DEFAULT 0,
-  `currency_id` tinyint(4) NOT NULL,
-  `amount` decimal(19,4) unsigned NOT NULL DEFAULT '0.0000',
+  `currency_id` TINYINT(3) UNSIGNED NOT NULL,
+  `amount` decimal(19,4) unsigned NOT NULL DEFAULT 0.0000,
   `description` varchar(255) DEFAULT NULL,
   `document_uuid` char(36) DEFAULT NULL,
-  `user_id` tinyint(4) NOT NULL,
+  `user_id` SMALLINT(5) UNSIGNED NOT NULL,
+  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  KEY `project_id` (`project_id`),
+  KEY `currency_id` (`currency_id`),
+  KEY `user_id` (`user_id`),
+  FOREIGN KEY (`project_id`) REFERENCES `project` (`id`),
+  FOREIGN KEY (`currency_id`) REFERENCES `currency` (`id`),
+  FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
   PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -2005,13 +2016,16 @@ FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM vouc
 --
 DROP TABLE IF EXISTS `voucher_item`;
 CREATE TABLE IF NOT EXISTS `voucher_item` (
-  `uuid` char(36) NOT NULL,
-  `account_id` int(11) NOT NULL,
-  `debit` decimal(19,4) unsigned NOT NULL DEFAULT '0.0000',
-  `credit` decimal(19,4) unsigned NOT NULL DEFAULT '0.0000',
+  `uuid` CHAR(36) NOT NULL,
+  `account_id` INT UNSIGNED NOT NULL,
+  `debit` DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.0000,
+  `credit` DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.0000,
   `voucher_uuid` char(36) NOT NULL,
   PRIMARY KEY (`uuid`),
-  KEY `voucher_uuid` (`voucher_uuid`)
+  KEY `account_id` (`account_id`),
+  KEY `voucher_uuid` (`voucher_uuid`),
+  FOREIGN KEY (`account_id`) REFERENCES `account` (`id`),
+  FOREIGN KEY (`voucher_uuid`) REFERENCES `voucher` (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 

--- a/server/models/test/data.sql
+++ b/server/models/test/data.sql
@@ -18,6 +18,7 @@ INSERT INTO unit VALUES
   (21,  'Price List','TREE.PRICE_LIST','Configure price lists!',1,'/partials/price_list/','/prices'),
   (22,  'Exchange Rate','TREE.EXCHANGE','Set todays exchange rate!',1,'/partials/exchange_rate/','/exchange'),
   (26,  'Location Manager','TREE.LOCATION','',1,'/partials/locations/locations.html','/locations'),
+  (30,  'Accounting','TREE.ACCOUNTING','',0,'/partials/accounting/index.html','/accounting/'),
   (42,  'Project','TREE.PROJECT','',1,'/partials/projects/','/projects'),
   (48,  'Service Management','TREE.SERVICE','',1,'partials/services/','/services'),
   (57,  'Payroll','TREE.PAYROLL','',0,'partials/payroll/','/payroll/'),
@@ -26,7 +27,8 @@ INSERT INTO unit VALUES
   (82,  'Subsidies','TREE.SUBSIDY','Handles the subsidy situation',1,'/partials/subsidies/','/subsidies'),
   (105, 'Cashbox Management','TREE.CASHBOX_MANAGEMENT','',1,'/partials/cash/cashbox/','/cashboxes'),
   (106, 'Depot Management', 'TREE.DEPOTS_MANAGEMENT', 'Depot Management module', 1, '/partials/depots_management/', '/depots_management'),
-  (107, 'Debtor Groups Management', 'TREE.DEBTOR_GRP', 'Debtor Groups Management module', 1, '/partials/debtor_groups/', '/debtor_groups');
+  (107, 'Debtor Groups Management', 'TREE.DEBTOR_GRP', 'Debtor Groups Management module', 1, '/partials/debtor_groups/', '/debtor_groups'),
+  (134, 'Simple Journal Vouchers', 'TREE.SIMPLE_VOUCHER', 'Creates a simple transfer slip between two accounts', 30, '/partials/vouchers/simple', '/vouchers/simple');
 
 INSERT INTO `account_type` VALUES (1,'income/expense'),(2,'balance');
 INSERT INTO `language` VALUES (1,'Francais','fr', 'fr-be'), (2,'English','en', 'en-us'), (3,'Lingala','lg', 'fr-cd');
@@ -102,8 +104,11 @@ INSERT INTO permission (unit_id, user_id) VALUES
 -- Cash Payments
 (18,1),
 
--- Location Management 
+-- Location Management
 (26,1),
+
+-- [Folder] Accounting
+(30, 1),
 
 -- Projects
 (42,1),
@@ -136,7 +141,10 @@ INSERT INTO permission (unit_id, user_id) VALUES
 (106,1),
 
 --  Debtor Groups Management
-(107,1);
+(107,1),
+
+-- Simple Journal Vouchers
+(134, 1);
 
 -- give test permission to both projects
 INSERT INTO `project_permission` VALUES (1,1,1),(2,1,2);


### PR DESCRIPTION
This PR implements the base of the simple journal vouchers described in #172.  The simplified journal vouchers exist to facilitate cash transactions between two accounts and return a simple receipt.

In order to implement this module, a commit adds foreign keys into the `voucher` table in the database.
It brings the columns up to bhima-2.X standards and adds a `created_at` timestamp.

This commit also cleans up the Voucher API significantly, and fixes the tests appropriately.  The Voucher API now accepts a JSON object with a single `voucher` property, with the list of voucher items under the
`voucher.items` sub-property.  This makes the client-side code much cleaner.

Additional changes:
1. The server will assign UUIDs if they do not exist on the voucher
   and/or voucher items.
2. A utility method was written for mapping arrays of json objects to
   simple, ordered arrays.

Closes #172.

**TODOs**
1. Implement the account finder modal on the account `<input>`s as suggested by @sfount.
2. Implement caching functionality for the page.
