### PR TITLE
feat: create API error functions

### DIFF
--- a/server/config/codes.js
+++ b/server/config/codes.js
@@ -7,9 +7,11 @@
 * @example
 * next(new res.codes.ERR_NOT_FOUND());
 * Promise.then(function () { throw new res.codes.ERR_NOT_FOUND(); }).catch(next);
+*
+* @deprecated This module should not longer be used.  See issue #182.
 */
 
-/** custom errorFactor function to throw in API endpoints */
+/** custom errorFactory function to throw in API endpoints */
 function makeError(name, defn) {
 
   // must call 'new' on this function
@@ -34,6 +36,7 @@ function makeError(name, defn) {
   return AppError;
 }
 
+/** @deprecated See issue #182 */
 module.exports = {
 
   /** application error codes */

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -103,6 +103,7 @@ exports.configure = function configure(app) {
 exports.errorHandling = function errorHandling(app) {
   'use strict';
 
+  app.use(interceptors.newErrorHandler);
   app.use(interceptors.apiErrorHandler);
   app.use(interceptors.databaseErrorHandler);
   app.use(interceptors.catchAllErrorHandler);

--- a/server/lib/errors/BadRequest.js
+++ b/server/lib/errors/BadRequest.js
@@ -1,0 +1,38 @@
+var util = require('util');
+
+/**
+ * This implements an HTTP error code that should eventually be passed through
+ * next() to an error handling middleware.
+ *
+ * @param {String} description - a custom description to be sent to the client
+ *
+ * @example
+ * // import the error into a controller
+ * const BadRequest = require('lib/errors/BadRequest');
+ *
+ * // use the error in either a promise chain or directly via next()
+ * return next(new BadRequest('Some description...'));
+ *
+ * @constructor
+ */
+function BadRequest(description) {
+  'use strict';
+
+  // make sure we have a working stack trace
+  Error.captureStackTrace(this, this.constructor);
+
+  // HTTP status code
+  this.status = 400;
+
+  // bhima status code (for $translation)
+  this.code = 'ERRORS.BAD_REQUEST';
+
+  // default to an empty string if no description passed in
+  this.description = description || '';
+}
+
+// prototypically inherit from the global error object
+util.inherits(BadRequest, Error);
+
+// expose the function to an external controller
+module.exports = BadRequest;

--- a/server/lib/errors/Forbidden.js
+++ b/server/lib/errors/Forbidden.js
@@ -1,0 +1,38 @@
+var util = require('util');
+
+/**
+ * This implements an HTTP error code that should eventually be passed through
+ * next() to an error handling middleware.
+ *
+ * @param {String} description - a custom description to be sent to the client
+ *
+ * @example
+ * // import the error into a controller
+ * const Forbidden = require('lib/errors/Forbidden');
+ *
+ * // use the error in either a promise chain or directly via next()
+ * return next(new Forbidden('Some description...'));
+ *
+ * @constructor
+ */
+function Forbidden(description) {
+  'use strict';
+
+  // make sure we have a working stack trace
+  Error.captureStackTrace(this, this.constructor);
+
+  // HTTP status code
+  this.status = 403;
+
+  // bhima status code (for $translation)
+  this.code = 'ERRORS.FORBIDDEN';
+
+  // default to an empty string if no description passed in
+  this.description = description || '';
+}
+
+// prototypically inherit from the global error object
+util.inherits(Forbidden, Error);
+
+// expose the function to an external controller
+module.exports = Forbidden;

--- a/server/lib/errors/InternalServerError.js
+++ b/server/lib/errors/InternalServerError.js
@@ -1,0 +1,38 @@
+var util = require('util');
+
+/**
+ * This implements an HTTP error code that should eventually be passed through
+ * next() to an error handling middleware.
+ *
+ * @param {String} description - a custom description to be sent to the client
+ *
+ * @example
+ * // import the error into a controller
+ * const InternalServerError = require('lib/errors/InternalServerError');
+ *
+ * // use the error in either a promise chain or directly via next()
+ * return next(new InternalServerError('Some description...'));
+ *
+ * @constructor
+ */
+function InternalServerError(description) {
+  'use strict';
+
+  // make sure we have a working stack trace
+  Error.captureStackTrace(this, this.constructor);
+
+  // HTTP status code
+  this.status = 500;
+
+  // bhima status code (for $translation)
+  this.code = 'ERRORS.INTERNAL_SERVER_ERROR';
+
+  // default to an empty string if no description passed in
+  this.description = description || '';
+}
+
+// prototypically inherit from the global error object
+util.inherits(InternalServerError, Error);
+
+// expose the function to an external controller
+module.exports = InternalServerError;

--- a/server/lib/errors/NotFound.js
+++ b/server/lib/errors/NotFound.js
@@ -1,0 +1,38 @@
+var util = require('util');
+
+/**
+ * This implements an HTTP error code that should eventually be passed through
+ * next() to an error handling middleware.
+ *
+ * @param {String} description - a custom description to be sent to the client
+ *
+ * @example
+ * // import the error into a controller
+ * const NotFound = require('lib/errors/NotFound');
+ *
+ * // use the error in either a promise chain or directly via next()
+ * return next(new NotFound('Some description...'));
+ *
+ * @constructor
+ */
+function NotFound(description) {
+  'use strict';
+
+  // make sure we have a working stack trace
+  Error.captureStackTrace(this, this.constructor);
+
+  // HTTP status code
+  this.status = 404;
+
+  // bhima status code (for $translation)
+  this.code = 'ERRORS.NOT_FOUND';
+
+  // default to an empty string if no description passed in
+  this.description = description || '';
+}
+
+// prototypically inherit from the global error object
+util.inherits(NotFound, Error);
+
+// expose the function to an external controller
+module.exports = NotFound;

--- a/server/lib/errors/Unauthorized.js
+++ b/server/lib/errors/Unauthorized.js
@@ -1,0 +1,38 @@
+var util = require('util');
+
+/**
+ * This implements an HTTP error code that should eventually be passed through
+ * next() to an error handling middleware.
+ *
+ * @param {String} description - a custom description to be sent to the client
+ *
+ * @example
+ * // import the error into a controller
+ * const Unauthorized = require('lib/errors/Unauthorized');
+ *
+ * // use the error in either a promise chain or directly pass to next()
+ * return next(new Unauthorized('Some description...'));
+ *
+ * @constructor
+ */
+function Unauthorized(description) {
+  'use strict';
+
+  // make sure we have a working stack trace
+  Error.captureStackTrace(this, this.constructor);
+
+  // HTTP status code
+  this.status = 401;
+
+  // bhima status code (for $translation)
+  this.code = 'ERRORS.UNAUTHORIZED';
+
+  // default to an empty string if no description passed in
+  this.description = description || '';
+}
+
+// prototypically inherit from the global error object
+util.inherits(Unauthorized, Error);
+
+// expose the function to an external controller
+module.exports = Unauthorized;

--- a/server/lib/errors/index.js
+++ b/server/lib/errors/index.js
@@ -1,0 +1,40 @@
+/**
+* @module lib/errors
+*
+* @desc These codes are to be attached to the res object, and used to throw errors
+* within the application.  The basic usage should be either:
+*
+* @example
+* // you can import the entire module ...
+* const errors = require('../lib/errors');
+*
+* // or a single error at a time (recommended).
+* const NotFound = require('../lib/errors/NotFound');
+*
+* // example usage for some route
+* app.get('/some/route/:id', function (res, req, next) {
+*   const id = req.params.id;
+*   db.exec('some sql', id)
+*   .then(function (rows) {
+*
+*     // there were no records returned!  Throw an error
+*     if (rows.length === 0) {
+*
+*       // recommended practice - call errors by name
+*       throw new NotFound(`Could not find a record with id: ${id}`);
+*
+*       // alternatively, we could have done the following:
+*       // throw new errors.NotFound('some description');
+*     }
+*   })
+*   .catch(next)
+*   .done();
+* });
+*/
+module.exports = {
+  BadRequest:          require('./BadRequest'),
+  Forbidden:           require('./Forbidden'),
+  Unauthorized:        require('./Unauthorized'),
+  NotFound:            require('./NotFound'),
+  InternalServerError: require('./InternalServerError')
+};

--- a/server/test/api/cash.js
+++ b/server/test/api/cash.js
@@ -157,9 +157,6 @@ describe('(/cash) Cash Payments Interface ', function () {
 
           // anticipate a 400 error from the API.
           helpers.api.errored(res, 400);
-
-          // check to make sure the error code is correct
-          expect(res.body.code).to.equal('CASH.VOUCHER.ERRORS.NO_CASH_ITEMS');
         })
         .catch(helpers.handler);
     });

--- a/server/test/api/helpers.js
+++ b/server/test/api/helpers.js
@@ -128,7 +128,7 @@ api.created = function created(res) {
 api.errored = function errored(res, status) {
   'use strict';
 
-  var keys = [ 'code', 'reason' ];
+  var keys = [ 'code' ];
 
   // make sure the response has the correct HTTP headers
   expect(res).to.have.status(status);
@@ -140,7 +140,6 @@ api.errored = function errored(res, status) {
 
   // ensure the error properties conform to standards
   expect(res.body.code).to.be.a('string');
-  expect(res.body.reason).to.be.a('string');
 };
 
 /**
@@ -236,5 +235,5 @@ api.listed = function listed(res, len) {
 
 /** The error keys sent back by the API */
 exports.errorKeys = [
-  'code', 'reason'
+  'code'
 ];

--- a/server/test/api/login.js
+++ b/server/test/api/login.js
@@ -56,7 +56,7 @@ describe('The /login API endpoint', function () {
       .then(function (res) {
         expect(res).to.have.status(401);
         expect(res.body).to.contain.all.keys(helpers.errorKeys);
-        expect(res.body.code).to.equal('ERR_BAD_CREDENTIALS');
+        expect(res.body.code).to.equal('ERRORS.UNAUTHORIZED');
       })
       .catch(helpers.handler);
   });
@@ -69,7 +69,7 @@ describe('The /login API endpoint', function () {
       .then(function (res) {
         expect(res).to.have.status(401);
         expect(res.body).to.contain.all.keys(helpers.errorKeys);
-        expect(res.body.code).to.equal('ERR_BAD_CREDENTIALS');
+        expect(res.body.code).to.equal('ERRORS.UNAUTHORIZED');
       })
       .catch(helpers.handler);
   });
@@ -81,7 +81,7 @@ describe('The /login API endpoint', function () {
       .then(function (res) {
         expect(res).to.have.status(401);
         expect(res.body).to.contain.all.keys(helpers.errorKeys);
-        expect(res.body.code).to.equal('ERR_BAD_CREDENTIALS');
+        expect(res.body.code).to.equal('ERRORS.UNAUTHORIZED');
       })
       .catch(helpers.handler);
   });


### PR DESCRIPTION
This commit creates error functions for common HTTP error status codes.
The following have been implemented:
1. BadRequest [400]
2. Unauthorized [401]
3. Forbidden [403]
4. NotFound [404]
5. InternalServerError [500]

Error functions are really easy to import and use in controllers.  See
the following example:

``` js

const NotFound = require('lib/errors/NotFound');

// throw the error to demonstrate that it is an error
try {
  throw new NotFound('An example description.');

  // NOTE - this used to be done like this:
  // throw new req.codes.ERR_NOT_FOUND();

// pass the error to the first error handling middleware
} catch (e) {
  next(e);
}
```

**NOTE** - this commit **deprecates** the use of `req.codes`.  All
controller code should now import the codes they need and no longer
depend the on `req.codes` property, as it will be removed in the future.

Closes #182.
