### PR TITLE
(FIX) Resolve users and permissions directive issue

### DIFF
--- a/client/src/partials/permissions/permissions.html
+++ b/client/src/partials/permissions/permissions.html
@@ -33,171 +33,177 @@
         <h4>{{ "PERMISSIONS.HELP_TXT_1" | translate }}</h4>
       </div>
 
-      <!-- triggered on successful form creation -->
-      <uib-alert type="success" ng-switch-when="success">
-        <span class="glyphicon glyphicon-ok"></span> {{ PermissionCtrl.formMessage.code | translate }}
-      </uib-alert>
+      <!-- triggered on successful form creation --> 
+      <div ng-switch-when="success">
+        <uib-alert type="success" data-create-success>
+          <span class="glyphicon glyphicon-ok"></span> {{ PermissionsCtrl.formMessage.code | translate }}
+        </uib-alert>
+      </div>
 
       <!-- user creation view -->
-      <div ng-switch-when="create" class="panel panel-primary">
-        <div class="panel-heading">
-          {{ "PERMISSIONS.NEW_USER_FORM" | translate }}
+      <div ng-switch-when="create">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            {{ "PERMISSIONS.NEW_USER_FORM" | translate }}
+          </div>
+          <form class="panel-body" name="CreateForm" ng-submit="PermissionsCtrl.submit(CreateForm.$invalid)" novalidate>
+            <fieldset>
+
+              <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.firstname.$invalid }">
+                <label class="control-label">{{ "COLUMNS.FIRST_NAME" | translate }}</label>
+                <input name="firstname" ng-model="PermissionsCtrl.user.first" class="form-control" required>
+                <div class="help-block" ng-messages="CreateForm.firstname.$error" ng-show="CreateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
+              </div>
+
+              <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.lastname.$invalid }">
+                <label class="control-label">{{ "COLUMNS.LAST_NAME" | translate }}</label>
+                <input name="lastname" ng-model="PermissionsCtrl.user.last" class="form-control" required>
+                <div class="help-block" ng-messages="CreateForm.lastname.$error" ng-show="CreateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
+              </div>
+
+              <div class="form-group"  ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.username.$invalid }">
+                <label class="control-label">{{ "COLUMNS.USER_NAME" | translate }}</label>
+                <input name="username" ng-model="PermissionsCtrl.user.username" class="form-control" required>
+                <div class="help-block" ng-messages="CreateForm.username.$error" ng-show="CreateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
+              </div>
+
+              <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.email.$invalid }">
+                <label class="control-label">{{ "COLUMNS.EMAIL" | translate }}</label>
+                <input name="email" ng-model="PermissionsCtrl.user.email" class="form-control" type="email" required>
+                <div class="help-block" ng-messages="CreateForm.email.$error" ng-show="CreateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
+              </div>
+
+              <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.projects.$invalid }">
+                <label class="control-label">{{ "COLUMNS.PROJECTS" | translate }}</label>
+                <select
+                  name="projects"
+                  ng-model="PermissionsCtrl.user.projects"
+                  class="form-control"
+                  ng-options="project.id as project.name for project in PermissionsCtrl.projects"
+                  required
+                  multiple>
+                </select>
+                <div class="help-block" ng-messages="CreateForm.projects.$error" ng-show="CreateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
+              </div>
+
+              <div class="form-group has-feedback" ng-class="{ 'has-error' : CreateForm.$submitted && !PermissionsCtrl.validPassword() }">
+                <label class="control-label">{{ "COLUMNS.PASSWORD" | translate }}</label>
+                <input name="password" ng-model="PermissionsCtrl.user.password" class="form-control" type="password" required>
+                <i ng-if="!PermissionsCtrl.validPassword()" class="glyphicon glyphicon-warning-sign form-control-feedback" aria-hidden="true"></i>
+                <i ng-if="PermissionsCtrl.validPassword()" class="glyphicon glyphicon-ok form-control-feedback" aria-hidden="true"></i>
+              </div>
+
+              <div class="form-group has-feedback" ng-class="{ 'has-error' : CreateForm.$submitted && !PermissionsCtrl.validPassword() }">
+                <label class="control-label"> {{ "COLUMNS.PASSWORD" | translate }} ({{ "PERMISSIONS.RETYPE" | translate }})</label>
+                <input name="passwordVerify" ng-model="PermissionsCtrl.user.passwordVerify" class="form-control" type="password" required>
+                <i ng-if="!PermissionsCtrl.validPassword()" class="glyphicon glyphicon-warning-sign form-control-feedback" aria-hidden="true"></i>
+                <i ng-if="PermissionsCtrl.validPassword()" class="glyphicon glyphicon-ok form-control-feedback" aria-hidden="true"></i>
+                <p class="help-block" ng-if="CreateForm.$submitted && !PermissionsCtrl.validPassword()">
+                  {{ "FORM.PASSWORD_MATCH" | translate }}
+                </p>
+              </div>
+
+              <div class="form-group">
+                <button type="submit" class="btn btn-success" data-method="submit">
+                  <i class="glyphicon glyphicon-ok"></i> {{ 'FORM.SUBMIT' | translate }}
+                </button>
+                <button type="button" class="btn btn-default" ng-click="PermissionsCtrl.setState('default')">
+                  <i class="glyphicon glyphicon-ban-circle"></i> {{ 'FORM.CANCEL' | translate }}
+                </button>
+              </div>
+            </fieldset>
+          </form>
+        </div>  
+      </div> 
+      
+      <div ng-switch-when="update">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            {{ "PERMISSIONS.UPDATE_USER_FORM" | translate }}
+          </div>
+
+          <form class="panel-body" name="UpdateForm" ng-submit="PermissionsCtrl.submit(UpdateForm.$invalid)" novalidate>
+            <fieldset>
+
+              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.firstname.$invalid }">
+                <label class="control-label">{{ "COLUMNS.FIRST_NAME" | translate }}</label>
+                <input name="firstname" ng-model="PermissionsCtrl.user.first" class="form-control" required>
+                <div class="help-block" ng-messages="UpdateForm.firstname.$error" ng-show="UpdateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
+              </div>
+
+              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.lastname.$invalid }">
+                <label class="control-label">{{ "COLUMNS.LAST_NAME" | translate }}</label>
+                <input name="lastname" ng-model="PermissionsCtrl.user.last" class="form-control" required>
+                <div class="help-block" ng-messages="UpdateForm.lastname.$error" ng-show="UpdateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
+              </div>
+
+              <div class="form-group"  ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.username.$invalid }">
+                <label class="control-label">{{ "COLUMNS.USER_NAME" | translate }}</label>
+                <input name="username" ng-model="PermissionsCtrl.user.username" class="form-control" required>
+                <div class="help-block" ng-messages="UpdateForm.username.$error" ng-show="UpdateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
+              </div>
+
+              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.email.$invalid }">
+                <label class="control-label">{{ "COLUMNS.EMAIL" | translate }}</label>
+                <input name="email" ng-model="PermissionsCtrl.user.email" class="form-control" type="email">
+                <p class="help-block" ng-if="UpdateForm.$submitted && UpdateForm.email.$invalid">
+                  {{ "FORM.REQUIRED_EMAIL" | translate }}
+                </p>
+              </div>
+
+              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.projects.$invalid }">
+                <label class="control-label">{{ "COLUMNS.PROJECTS" | translate }}</label>
+                <select
+                  name="projects"
+                  ng-model="PermissionsCtrl.user.projects"
+                  class="form-control"
+                  ng-options="project.id as project.name for project in PermissionsCtrl.projects"
+                  required
+                  multiple>
+                </select>
+                <div class="help-block" ng-messages="UpdateForm.projects.$error" ng-show="UpdateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <button type="button" class="btn btn-warning btn-block" ng-click="PermissionsCtrl.setPasswordModal()">
+                  <i class="glyphicon glyphicon-lock"></i> {{ 'PERMISSIONS.UPDATE_PASSWORD' | translate }}
+                </button>
+              </div>
+
+              <div class="form-group">
+
+                <!-- TODO - make this a fancy button -->
+                <button type="submit" class="btn btn-success">
+                  <i class="glyphicon glyphicon-ok"></i> {{ 'FORM.SUBMIT' | translate }}
+                </button>
+
+                <button type="button" class="btn btn-default" ng-click="PermissionsCtrl.setState('default')">
+                  <i class="glyphicon glyphicon-ban-circle"></i> {{ 'FORM.CANCEL' | translate }}
+                </button>
+              </div>
+
+            </fieldset>
+          </form>
         </div>
-        <form class="panel-body" name="CreateForm" ng-submit="PermissionsCtrl.submit(CreateForm.$invalid)" novalidate>
-          <fieldset>
-
-            <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.firstname.$invalid }">
-              <label class="control-label">{{ "COLUMNS.FIRST_NAME" | translate }}</label>
-              <input name="firstname" ng-model="PermissionsCtrl.user.first" class="form-control" required>
-              <div class="help-block" ng-messages="CreateForm.firstname.$error" ng-show="CreateForm.$submitted">
-                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
-
-            <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.lastname.$invalid }">
-              <label class="control-label">{{ "COLUMNS.LAST_NAME" | translate }}</label>
-              <input name="lastname" ng-model="PermissionsCtrl.user.last" class="form-control" required>
-              <div class="help-block" ng-messages="CreateForm.lastname.$error" ng-show="CreateForm.$submitted">
-                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
-
-            <div class="form-group"  ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.username.$invalid }">
-              <label class="control-label">{{ "COLUMNS.USER_NAME" | translate }}</label>
-              <input name="username" ng-model="PermissionsCtrl.user.username" class="form-control" required>
-              <div class="help-block" ng-messages="CreateForm.username.$error" ng-show="CreateForm.$submitted">
-                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
-
-            <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.email.$invalid }">
-              <label class="control-label">{{ "COLUMNS.EMAIL" | translate }}</label>
-              <input name="email" ng-model="PermissionsCtrl.user.email" class="form-control" type="email" required>
-              <div class="help-block" ng-messages="CreateForm.email.$error" ng-show="CreateForm.$submitted">
-                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
-
-            <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.projects.$invalid }">
-              <label class="control-label">{{ "COLUMNS.PROJECTS" | translate }}</label>
-              <select
-                name="projects"
-                ng-model="PermissionsCtrl.user.projects"
-                class="form-control"
-                ng-options="project.id as project.name for project in PermissionsCtrl.projects"
-                required
-                multiple>
-              </select>
-              <div class="help-block" ng-messages="CreateForm.projects.$error" ng-show="CreateForm.$submitted">
-                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
-
-            <div class="form-group has-feedback" ng-class="{ 'has-error' : CreateForm.$submitted && !PermissionsCtrl.validPassword() }">
-              <label class="control-label">{{ "COLUMNS.PASSWORD" | translate }}</label>
-              <input name="password" ng-model="PermissionsCtrl.user.password" class="form-control" type="password" required>
-              <i ng-if="!PermissionsCtrl.validPassword()" class="glyphicon glyphicon-warning-sign form-control-feedback" aria-hidden="true"></i>
-              <i ng-if="PermissionsCtrl.validPassword()" class="glyphicon glyphicon-ok form-control-feedback" aria-hidden="true"></i>
-            </div>
-
-            <div class="form-group has-feedback" ng-class="{ 'has-error' : CreateForm.$submitted && !PermissionsCtrl.validPassword() }">
-              <label class="control-label"> {{ "COLUMNS.PASSWORD" | translate }} ({{ "PERMISSIONS.RETYPE" | translate }})</label>
-              <input name="passwordVerify" ng-model="PermissionsCtrl.user.passwordVerify" class="form-control" type="password" required>
-              <i ng-if="!PermissionsCtrl.validPassword()" class="glyphicon glyphicon-warning-sign form-control-feedback" aria-hidden="true"></i>
-              <i ng-if="PermissionsCtrl.validPassword()" class="glyphicon glyphicon-ok form-control-feedback" aria-hidden="true"></i>
-              <p class="help-block" ng-if="CreateForm.$submitted && !PermissionsCtrl.validPassword()">
-                {{ "FORM.PASSWORD_MATCH" | translate }}
-              </p>
-            </div>
-
-            <div class="form-group">
-              <button type="submit" class="btn btn-success" data-method="submit">
-                <i class="glyphicon glyphicon-ok"></i> {{ 'FORM.SUBMIT' | translate }}
-              </button>
-              <button type="button" class="btn btn-default" ng-click="PermissionsCtrl.setState('default')">
-                <i class="glyphicon glyphicon-ban-circle"></i> {{ 'FORM.CANCEL' | translate }}
-              </button>
-            </div>
-          </fieldset>
-        </form>
-      </div>
-
-      <div ng-switch-when="update" class="panel panel-primary">
-        <div class="panel-heading">
-          {{ "PERMISSIONS.UPDATE_USER_FORM" | translate }}
-        </div>
-
-        <form class="panel-body" name="UpdateForm" ng-submit="PermissionsCtrl.submit(UpdateForm.$invalid)" novalidate>
-          <fieldset>
-
-            <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.firstname.$invalid }">
-              <label class="control-label">{{ "COLUMNS.FIRST_NAME" | translate }}</label>
-              <input name="firstname" ng-model="PermissionsCtrl.user.first" class="form-control" required>
-              <div class="help-block" ng-messages="UpdateForm.firstname.$error" ng-show="UpdateForm.$submitted">
-                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
-
-            <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.lastname.$invalid }">
-              <label class="control-label">{{ "COLUMNS.LAST_NAME" | translate }}</label>
-              <input name="lastname" ng-model="PermissionsCtrl.user.last" class="form-control" required>
-              <div class="help-block" ng-messages="UpdateForm.lastname.$error" ng-show="UpdateForm.$submitted">
-                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
-
-            <div class="form-group"  ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.username.$invalid }">
-              <label class="control-label">{{ "COLUMNS.USER_NAME" | translate }}</label>
-              <input name="username" ng-model="PermissionsCtrl.user.username" class="form-control" required>
-              <div class="help-block" ng-messages="UpdateForm.username.$error" ng-show="UpdateForm.$submitted">
-                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
-
-            <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.email.$invalid }">
-              <label class="control-label">{{ "COLUMNS.EMAIL" | translate }}</label>
-              <input name="email" ng-model="PermissionsCtrl.user.email" class="form-control" type="email">
-              <p class="help-block" ng-if="UpdateForm.$submitted && UpdateForm.email.$invalid">
-                {{ "FORM.REQUIRED_EMAIL" | translate }}
-              </p>
-            </div>
-
-            <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.projects.$invalid }">
-              <label class="control-label">{{ "COLUMNS.PROJECTS" | translate }}</label>
-              <select
-                name="projects"
-                ng-model="PermissionsCtrl.user.projects"
-                class="form-control"
-                ng-options="project.id as project.name for project in PermissionsCtrl.projects"
-                required
-                multiple>
-              </select>
-              <div class="help-block" ng-messages="UpdateForm.projects.$error" ng-show="UpdateForm.$submitted">
-                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
-
-            <div class="form-group">
-              <button type="button" class="btn btn-warning btn-block" ng-click="PermissionsCtrl.setPasswordModal()">
-                <i class="glyphicon glyphicon-lock"></i> {{ 'PERMISSIONS.UPDATE_PASSWORD' | translate }}
-              </button>
-            </div>
-
-            <div class="form-group">
-
-              <!-- TODO - make this a fancy button -->
-              <button type="submit" class="btn btn-success">
-                <i class="glyphicon glyphicon-ok"></i> {{ 'FORM.SUBMIT' | translate }}
-              </button>
-
-              <button type="button" class="btn btn-default" ng-click="PermissionsCtrl.setState('default')">
-                <i class="glyphicon glyphicon-ban-circle"></i> {{ 'FORM.CANCEL' | translate }}
-              </button>
-            </div>
-
-          </fieldset>
-        </form>
-      </div>
+      </div> 
 
       <div ng-switch-when="permissions">
         <div class="panel panel-primary">

--- a/client/src/partials/permissions/permissions.js
+++ b/client/src/partials/permissions/permissions.js
@@ -1,8 +1,3 @@
-// This module is responsible for handling the creation
-// of users and assigning permissions to existing modules.
-
-// TODOs:
-// - Password Insecure alert or not
 angular.module('bhima.controllers')
 .controller('PermissionsController', PermissionsController);
 
@@ -11,20 +6,31 @@ PermissionsController.$inject = [
   'ProjectService', 'NodeTreeService'
 ];
 
+/** 
+ * Users and Permission Controller 
+ * 
+ * This module is responsible for handling the creation
+ * of users and assigning permissions to existing modules.
+ *
+ * @todo Password insecure alert or not
+ */
 function PermissionsController($window, $translate, $http, $uibModal, util, Session, Users, Projects, NT) {
   var vm = this;
 
-  var btnTemplate =
-    '<button ng-click="grid.appScope.edit(row.entity)" style="margin: 0 5px">{{ "FORM.EDIT" | translate }}</button>' +
-    '<button ng-click="grid.appScope.editPermissions(row.entity)">{{ "PERMISSIONS.EDIT_PERMISSIONS" | translate }}</button>';
-
+  var editTemplate =
+    '<div style="margin: 0px 5px 5px 5px;"><a class="btn btn-sm btn-default btn-block" ng-click="grid.appScope.edit(row.entity)">{{ "FORM.EDIT" | translate }}</a></div>';
+  
+  var permissionTemplate = 
+    '<div style="margin: 0px 5px 5px 5px;"><a class="btn btn-sm btn-default btn-block" ng-click="grid.appScope.editPermissions(row.entity)">{{ "PERMISSIONS.EDIT_PERMISSIONS" | translate }}</a></div>';
   // options for the UI grid
   vm.uiGridOptions = {
     appScopeProvider : vm, // ensure that the controller's `this` variable is bound to appScope
+    enableColumnMenus : false,
     columnDefs : [
       { field : 'displayname', name : 'Display Name' },
       { field : 'username', name : 'User Name' },
-      { name : 'Actions', cellTemplate: btnTemplate }
+      { name : 'edit', displayName : '', cellTemplate: editTemplate, enableSorting : false },
+      { name : 'permission', displayName : '', cellTemplate: permissionTemplate, enableSorting : false }
     ],
     enableSorting : true
   };
@@ -32,7 +38,7 @@ function PermissionsController($window, $translate, $http, $uibModal, util, Sess
   // the user object that is either edited or created
   vm.user = {};
 
-  // TODO -- manage state without strings
+  /** @todo manage state without strings */
   vm.state = 'default'; // this is default || create || update
 
   // bind methods

--- a/client/src/partials/permissions/permissions.js
+++ b/client/src/partials/permissions/permissions.js
@@ -184,7 +184,6 @@ function PermissionsController($window, $translate, $http, $uibModal, util, Sess
     }
 
     promise.then(function (data) {
-
       var msg = messages[vm.state];
 
       // go back to default state

--- a/client/test/e2e/permissions/permissions.spec.js
+++ b/client/test/e2e/permissions/permissions.spec.js
@@ -49,7 +49,7 @@ describe('Permissions Module', function () {
     FU.buttons.submit();
 
     // check for a success message
-    FU.exists(by.css('.bh-form-message.bh-form-message-success'), true);
+    FU.exists(by.css('[data-create-success]'), true);
   });
 
   // tests the form validation on the create page


### PR DESCRIPTION
- Restructured ng-switch so that components are inside `<div>` tages. This resolves the page breaking error with a uib-alert not able to be directly assigned a switch state.
- Updated tests to reflect the removal of the bg-form-message component. The module now uses a ui-alert to provide success feedback; data meta tag was used to ensure that the success state being tested was checked for specifically.
- (Re-factored UI Grid buttons and module comments)
