### PR TITLE
(FIX) Bug caught by failing supplier e2e test

### DIFF
--- a/client/src/partials/creditors/creditors.html
+++ b/client/src/partials/creditors/creditors.html
@@ -58,7 +58,7 @@
       <div class="col-xs-6" ng-switch="SupplierCtrl.view">
         <div ng-switch-default>
           <div class="alert alert-info">
-            <h4><strong>{{ "SUPPLIER.TITLE" | translate }}</strong></h4>
+            <h4>{{ "SUPPLIER.TITLE" | translate }}</h4>
             <p>{{ "SUPPLIER.INFO" | translate }}</p>
           </div>
         </div>
@@ -66,16 +66,14 @@
         <!-- Success saving Feed Back -->
         <div ng-switch-when="create_success">
           <div class="alert alert-success" id="create_success">
-            <h4>{{ 'SUPPLIER.REGISTRATION_SUCCESS' | translate }} </h4>
-            </p>
+            <h4>{{ "SUPPLIER.REGISTRATION_SUCCESS" | translate }}</h4>
           </div>
         </div>
 
         <!-- Success updating feedBack -->
         <div ng-switch-when="update_success">
           <div class="alert alert-success" id="update_success">
-            <h4>{{ 'SUPPLIER.UPDATE_SUCCESS' | translate }} </h4>
-            </p>
+            <h4>{{ "SUPPLIER.UPDATE_SUCCESS" | translate }} </h4>
           </div>
         </div>
 

--- a/client/test/e2e/suppliers/suppliers.spec.js
+++ b/client/test/e2e/suppliers/suppliers.spec.js
@@ -67,14 +67,15 @@ describe('Suppliers Module', function () {
 
 
   it('successfully edits an supplier', function () {
-
     element(by.id('supplier-upd-' + supplierRank )).click();
+    
     // modify the supplier name
     FU.input('SupplierCtrl.supplier.name', 'Updated');
+    
     // modify the supplier note
     FU.input('SupplierCtrl.supplier.note', ' IMCK Tshikaji update for the test E2E');
 
-     FU.buttons.submit();
+    FU.buttons.submit();
 
     // make sure the success message appears
     FU.exists(by.id('update_success'), true);
@@ -86,7 +87,6 @@ describe('Suppliers Module', function () {
 
     // Verify form has not been successfully submitted
     expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + path);
-
     element(by.id('submit-supplier')).click();
 
     // the following fields should be required

--- a/server/config/codes.js
+++ b/server/config/codes.js
@@ -162,4 +162,9 @@ module.exports = {
     httpStatus : 400,
     reason : 'You did not include enough information in your query.'
   }),
+  'ER_DATA_TOO_LONG' : makeError('DatabaseError', { 
+    code : 'DB.ER_DATA_TOO_LONG', 
+    httpStatus : 400,
+    reason : 'The value provided is longer than the database record limit.'
+  })
 };

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1864,7 +1864,7 @@ CREATE TABLE `supplier` (
   `address_2` text,
   `email` varchar(45) DEFAULT NULL,
   `fax` varchar(45) DEFAULT NULL,
-  `note` varchar(50) DEFAULT NULL,
+  `note` TEXT DEFAULT NULL,
   `phone` varchar(15) DEFAULT NULL,
   `international` tinyint(1) NOT NULL DEFAULT '0',
   `locked` tinyint(1) NOT NULL DEFAULT '0',


### PR DESCRIPTION
This commit resolves a bug caught by a failing e2e that was allowed into
the master branch. In future processes should be improved such that a
pull reqest must pass all e2e to be allowed to merge.

The 'note' field on the supplier entity was capped at 50 characters.
This meant that the e2e providing a longer note was failing and causing
a 500 error.

The solution:
- Increase the size of the 'note' field for suppliers by making it TEXT
- Implement the 'DB_DATA_TOO_LONG' error with the server error, the
  error should be handled as a 400 (Bad Request)
