### PR TITLE
(Feature) Client side error handling

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -880,12 +880,26 @@ function localStorageConfig($localStorageProvider) {
   $localStorageProvider.setKeyPrefix(PREFIX);
 }
 
+/**
+ * This function is responsible for configuring anulgar's $http service. Any 
+ * relevent services/ factories are registered at this point. 
+ *
+ * @params {Object} $httpProvider   Angular provider bject containing 
+ *                                  'interceptors' that are chained on any HTTP request
+ */
+function httpConfig($httpProvider) { 
+  
+  // register error handling interceptor 
+  $httpProvider.interceptors.push('ErrorInterceptor');
+}
+
 // configuration
 bhima.config(['$routeProvider', bhimaconfig]);
 bhima.config(['$translateProvider', translateConfig]);
 bhima.config(['tmhDynamicLocaleProvider', localeConfig]);
 bhima.config(['$httpProvider', authConfig]);
 bhima.config(['$localStorageProvider', localStorageConfig]);
+bhima.config(['$httpProvider', httpConfig]);
 
 // run
 bhima.run(['$rootScope', '$location', 'SessionService', 'amMoment', startupConfig]);

--- a/client/src/js/services/ErrorInterceptor.js
+++ b/client/src/js/services/ErrorInterceptor.js
@@ -1,0 +1,41 @@
+angular.module('bhima.services')
+.factory('ErrorInterceptor', ErrorInterceptor);
+
+ErrorInterceptor.$inject = ['$q'];
+  
+/** 
+ * Client Side Error Interceptor 
+ * 
+ * This service is responsible for mapping client side status codes to translatable 
+ * code and descriptions. The response object is then extended with these codes 
+ * exposing them to the controller and finally the view. The formatted translatable 
+ * codes and descriptions are formatted in the same way the server build Errors, 
+ * this allows the client to handle all errors in a uniform way. 
+ *
+ * @module services/ErrorInterceptor
+ */
+function ErrorInterceptor($q) { 
+  
+  // list all handled statuses
+  // status code : formatted response
+  var statusMap = { 
+    '-1' : { 
+      code : 'ERRORS.ERR_INTERNET_DISCONNECTED', 
+      description : 'The server could not respond because you are not connected to the internet.'
+    }
+  };
+
+  var interceptor = { 
+    responseError : function (response) { 
+      var lookupError = statusMap[response.status];
+  
+      // if the error status has a matched code we can extend the response object
+      // with the translatable codes/ description
+      if (angular.isDefined(lookupError)) { 
+        angular.extend(response, lookupError);
+      }
+      return $q.reject(response);
+    }
+  };
+  return interceptor;
+}


### PR DESCRIPTION
This commit implements handling basic client side errors using $http
interceptors (attached to $httpProvider). Errors that are received from
the server are sent with a well formatted known layout (containing
translatable codes, statuses and descriptions), the implemented http
interceptor (`ErrorInterceptor`) provides a map of client side errors to
well formatted translatable keys. This allows the client to handle
errors uniformly knowing that it will receive a well formed error
object.

Currently only one error is handled by this service however the
structure is there and can be easily extended.

``` js
'-1' : {
  code : `ERRORS.ERR_INTERNET_DISCONNECTED`,
  description : "..."...
```

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/228.
Closes #38  

---

Hi! Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](./docs/STYLEGUIDE.md)
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub)
that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process
and help build a stronger application.  Thanks!
