### PR TITLE
Revert "deps: use redis instead of file-session-store"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
 
 services:
   - mysql
-  - redis-server
 
 language: node_js
 node_js:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "body-parser": "^1.15.0",
     "compression": "^1.5.2",
     "connect-multiparty": "^2.0.0",
-    "connect-redis": "^3.0.2",
     "dot": "^1.0.3",
     "dotenv": "^2.0.0",
     "express": "^4.13.3",
@@ -45,6 +44,7 @@
     "node-uuid": "^1.4.7",
     "numeral": "^1.5.3",
     "q": "~1.4.1",
+    "session-file-store": "0.0.24",
     "winston": "^2.1.1",
     "wkhtmltopdf": "^0.1.5"
   },

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -5,7 +5,7 @@ var express    = require('express'),
     compress   = require('compression'),
     bodyParser = require('body-parser'),
     session    = require('express-session'),
-    RedisStore = require('connect-redis')(session),
+    FileStore  = require('session-file-store')(session),
     morgan     = require('morgan'),
     fs         = require('fs'),
     winston    = require('winston');
@@ -27,12 +27,15 @@ exports.configure = function configure(app) {
   // stores session in a file store so that server restarts do
   // not interrupt sessions.
   app.use(session({
-    store             : new RedisStore({}),
+    store             : new FileStore({
+      reapInterval      : Number(process.env.SESS_REAP_INTERVAL),
+    }),
     secret            : process.env.SESS_SECRET,
     saveUninitialized : Boolean(process.env.SESS_SAVE_UNINITIALIZED),
     resave            : Boolean(process.env.SESS_RESAVE),
     unset             : process.env.SESS_UNSET,
-    cookie            : { secure : true }
+    cookie            : { secure : true },
+    retries: 50
   }));
 
   // bind error codes to the express stack
@@ -60,7 +63,7 @@ exports.configure = function configure(app) {
     }
   });
 
-  // provide a stream for morgan to write to
+  // provide a stream for morgan to write to 
   winston.stream = {
     write : function (message, encoding) {
       winston.info(message.trim());


### PR DESCRIPTION
Reverts IMA-WorldHealth/bhima-2.X#232

> As some of the development machines are configured with 32 bit windows it looks like Redis is not supported by all contributors for the time being. I am reverting this pull request until we can guarantee everyone can install the server.
> 
> I recommend that everyone uses 64bit architecture, windows if that can be found and Linux Mint if not.
