### PR TITLE
(Chore) hide session-file-store logs

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -29,6 +29,7 @@ exports.configure = function configure(app) {
   app.use(session({
     store             : new FileStore({
       reapInterval      : Number(process.env.SESS_REAP_INTERVAL),
+      logFn             : () => {}
     }),
     secret            : process.env.SESS_SECRET,
     saveUninitialized : Boolean(process.env.SESS_SAVE_UNINITIALIZED),


### PR DESCRIPTION
This commit suppresses the session-file-store logs by setting the
optional configuration option `logFn` in the express middleware
configuration. This allows end to end and integration tests to display
concise output without the verbose file store logs.

---

Hi! Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](./docs/STYLEGUIDE.md)
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub)
that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process
and help build a stronger application.  Thanks!
