### PR TITLE
(Refactor) Use client error intercept disconnect error (Patient Registation)

### DIFF
--- a/client/src/js/services/ErrorInterceptor.js
+++ b/client/src/js/services/ErrorInterceptor.js
@@ -21,7 +21,8 @@ function ErrorInterceptor($q) {
   var statusMap = { 
     '-1' : { 
       code : 'ERRORS.ERR_INTERNET_DISCONNECTED', 
-      description : 'The server could not respond because you are not connected to the internet.'
+      description : 'The server could not respond because you are not connected to the internet.',
+      status : -1
     }
   };
 
@@ -32,7 +33,11 @@ function ErrorInterceptor($q) {
       // if the error status has a matched code we can extend the response object
       // with the translatable codes/ description
       if (angular.isDefined(lookupError)) { 
-        angular.extend(response, lookupError);
+
+        // either compliment the current data object or create it if it does not 
+        // exist. `data` is where information from the server would be stored
+        response.data = response.data || {};
+        angular.extend(response.data, lookupError);
       }
       return $q.reject(response);
     }

--- a/client/src/partials/patients/registration/registration.js
+++ b/client/src/partials/patients/registration/registration.js
@@ -92,23 +92,7 @@ function PatientRegistrationController($location, ScrollTo, Patients, Debtors, S
    * @params  {object}  error   An Error object that has been sent from the server. 
    */
   function handleServerError(error) {
-    var NO_INTERNET_CONNECTION = -1;
-  
-    // case - there is no internet connection 
-    if (error.status === NO_INTERNET_CONNECTION) { 
-      viewModel.exception = { 
-        status : -1,
-        data : { 
-          code : 'ERRORS.NO_CONNECTION',
-          description : 'No internet connection found - please contact your system administrator'
-        }
-      };
-    } else { 
-      
-      // No cases have been matched - provide error details to the UI 
-      viewModel.exception = error; 
-    }
-    
+    viewModel.exception = error; 
     ScrollTo('exceptionAlert');
   }
 }


### PR DESCRIPTION
This commit removes code from the patient registration controller that
was specifically designed to catch and format the client side error
`INTERNET_DISCONNECTED`.

Since [#238](https://github.com/IMA-WorldHealth/bhima-2.X/pull/238)
client errors pass through a service found in
`services/ErrorInterceptor`. This service formats client side errors to
give them uniform attributes with server created Error objects. Because
this service implements the disconnected error this bespoke controller
error handling can be completely removed (Proving that the service is
intercepting and formating the $http requests correctly).

---
- [x] Run your code through JSHint.  [Check out our styleguide](./docs/STYLEGUIDE.md)
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.
