### PR TITLE
chore: binary uuids for vouchers

### DIFF
--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -85,7 +85,7 @@ function toMysqlDate (dateString) {
  * var filter = take('id', 'season');
  * var arrs = _.map(array, filter); // returns [[1, 'summer], [2, 'winter'], [3, 'fall']]
  *
- * @private
+ * @public
  */
 function take() {
 

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1974,21 +1974,18 @@ CREATE TABLE `village` (
   FOREIGN KEY (`sector_uuid`) REFERENCES `sector` (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
---
--- Structure de la table `voucher`
---
 DROP TABLE IF EXISTS `voucher`;
 CREATE TABLE IF NOT EXISTS `voucher` (
-  `uuid` char(36) NOT NULL,
-  `date` DATETIME NOT NULL,
-  `project_id` SMALLINT(5) UNSIGNED NOT NULL,
-  `reference` INT(10) UNSIGNED NOT NULL DEFAULT 0,
-  `currency_id` TINYINT(3) UNSIGNED NOT NULL,
-  `amount` decimal(19,4) unsigned NOT NULL DEFAULT 0.0000,
-  `description` varchar(255) DEFAULT NULL,
-  `document_uuid` char(36) DEFAULT NULL,
-  `user_id` SMALLINT(5) UNSIGNED NOT NULL,
-  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `uuid`            BINARY(16) NOT NULL,
+  `date`            DATETIME NOT NULL,
+  `project_id`      SMALLINT(5) UNSIGNED NOT NULL,
+  `reference`       INT(10) UNSIGNED NOT NULL DEFAULT 0,
+  `currency_id`     TINYINT(3) UNSIGNED NOT NULL,
+  `amount`          DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.00,
+  `description`     TEXT DEFAULT NULL,
+  `document_uuid`   BINARY(16) DEFAULT NULL,
+  `user_id`         SMALLINT(5) UNSIGNED NOT NULL,
+  `created_at`      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   KEY `project_id` (`project_id`),
   KEY `currency_id` (`currency_id`),
   KEY `user_id` (`user_id`),
@@ -1998,19 +1995,16 @@ CREATE TABLE IF NOT EXISTS `voucher` (
   PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TRIGGER voucher_calculate_reference BEFORE INSERT ON voucher
+CREATE TRIGGER voucher_before_insert BEFORE INSERT ON voucher
 FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM voucher WHERE voucher.project_id = NEW.project_id);
 
---
--- Structure de la table `voucher_item`
---
 DROP TABLE IF EXISTS `voucher_item`;
 CREATE TABLE IF NOT EXISTS `voucher_item` (
-  `uuid` CHAR(36) NOT NULL,
-  `account_id` INT UNSIGNED NOT NULL,
-  `debit` DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.0000,
-  `credit` DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.0000,
-  `voucher_uuid` char(36) NOT NULL,
+  `uuid`            BINARY(16) NOT NULL,
+  `account_id`      INT UNSIGNED NOT NULL,
+  `debit`           DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.0000,
+  `credit`          DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.0000,
+  `voucher_uuid`    BINARY(16) NOT NULL,
   PRIMARY KEY (`uuid`),
   KEY `account_id` (`account_id`),
   KEY `voucher_uuid` (`voucher_uuid`),


### PR DESCRIPTION
This commit updates the `voucher` and `voucher_item` tables to use
BINARY(16) for their uuids.  The updated fields are:
1. uuid
2. voucher_uuid
3. document_uuid

The server API has been updated appropriately so that the integration
tests pass.

A new error case has been caught where there are fewer than two rows
written to the vouchers table. In order for the double-entry accounting
to balance, there must be at minimum two rows posted.  Any less will
generate a `400 Bad Request` error.  The integration test suite has been
updated with this check.

Finally, the server has been updated to use the latest error generating
methods.

---

Hi! Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](./docs/STYLEGUIDE.md)
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub)
that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process
and help build a stronger application.  Thanks!
