### PR TITLE
(Feature) Receipt client

### DIFF
--- a/client/src/js/services/receipts/ReceiptModal.js
+++ b/client/src/js/services/receipts/ReceiptModal.js
@@ -20,6 +20,7 @@ function ReceiptModal(Modal, Receipts) {
   var service = this;
   
   var receiptController = 'ReceiptModalController as ReceiptCtrl';
+  var receiptTemplate   = '/js/services/receipts/modal/receiptModal.tmpl.html';
   var receiptSize       = 'md';
   var receiptBackdrop   = 'static';
   var animateReceipt    = false;
@@ -30,18 +31,20 @@ function ReceiptModal(Modal, Receipts) {
 
     /** @todo Discuss if these should be overridable from the controller or if the config should be set here */
     var renderTarget      = 'json';
-    var invoiceTemplate   = '/partials/patient_invoice/receipt/invoice.receipt.tmpl.html';
+    var invoiceTemplate   = 'partials/patient_invoice/receipt/invoice.receipt.tmpl.html';
     var invoiceRequest    = Receipts.invoice(uuid, { render : renderTarget });
   
     /** @todo The template passed in should be the /services/modal template which will transclude the invoice template */
     var instance = Modal.open({
-      templateUrl : invoiceTemplate,
+      templateUrl : receiptTemplate,
       controller  : receiptController,
       size        : receiptSize,
       backdrop    : receiptBackdrop,
       animation   : animateReceipt,
       resolve     : { 
-        receipt : function receiptProvider() { return { promise : invoiceRequest }; }
+        receipt       : function receiptProvider() { return { promise : invoiceRequest }; },
+        template      : function templateProvider() { return invoiceTemplate; },
+        render        : function renderProvider() { return renderTarget; }
       }
     });
 

--- a/client/src/js/services/receipts/ReceiptModal.js
+++ b/client/src/js/services/receipts/ReceiptModal.js
@@ -1,0 +1,50 @@
+angular.module('bhima.services')
+.service('ReceiptModal', ReceiptModal);
+
+ReceiptModal.$inject = ['$uibModal', 'ReceiptService'];
+  
+/** 
+ * Receipts Modal Service 
+ *
+ * This service is responsible for combining receipt service data with the 
+ * receipts modal controller and providing a clean interface to be used within 
+ * module controllers. 
+ *  
+ * @todo Discuss how the render target PDF should be templated. Suggestion: 
+ *       - IF pdf   - use /src/services/receipts/modal/pdf.tmpl.html
+ *       - IF json  - specifiy individual target /partials/patient_invoice/receipt/...
+ *
+ * @module services/receipts/ReceiptModal
+ */
+function ReceiptModal(Modal, Receipts) { 
+  var service = this;
+  
+  var receiptController = 'ReceiptModalController as ReceiptCtrl';
+  var receiptSize       = 'md';
+  var receiptBackdrop   = 'static';
+  var animateReceipt    = false;
+
+  service.invoice = invoice;
+
+  function invoice(uuid) { 
+
+    /** @todo Discuss if these should be overridable from the controller or if the config should be set here */
+    var renderTarget      = 'json';
+    var invoiceTemplate   = '/partials/patient_invoice/receipt/invoice.receipt.tmpl.html';
+    var invoiceRequest    = Receipts.invoice(uuid, { render : renderTarget });
+  
+    /** @todo The template passed in should be the /services/modal template which will transclude the invoice template */
+    var instance = Modal.open({
+      templateUrl : invoiceTemplate,
+      controller  : receiptController,
+      size        : receiptSize,
+      backdrop    : receiptBackdrop,
+      animation   : animateReceipt,
+      resolve     : { 
+        receipt : function receiptProvider() { return { promise : invoiceRequest }; }
+      }
+    });
+
+    return instance.result;
+  }
+}

--- a/client/src/js/services/receipts/ReceiptService.js
+++ b/client/src/js/services/receipts/ReceiptService.js
@@ -1,0 +1,34 @@
+angular.module('bhima.services')
+.service('ReceiptService', ReceiptService);
+
+ReceiptService.$inject = ['$http', 'util'];
+
+/**
+ * Receipts Service 
+ * 
+ * This service is responsible for interfacing with any receipts routes on the
+ * server. 
+ *
+ * @todo  currently this server 1:1 maps with the ReceiptModal service/controller. 
+ *        This relationship improved or justified with unit tests.  
+ * @module services/receipts/ReciptService
+ */ 
+function ReceiptService($http, util) { 
+  var service = this;
+
+  service.invoice = invoice;
+  
+  /** 
+   * Fetch invoice report data from /reports/invoices/:uuid
+   *
+   * @params {String} uuid      Target invoice UUID to report on
+   * @params {Object} options   Configuration options for the server generated 
+   *                            report, this includes things like render target.
+   * @return {Promise}          Eventually returns report object from server
+   */
+  function invoice(uuid, options) { 
+    var route = '/reports/invoices/'.concat(uuid);
+    return $http.get(route, { params : options })
+      .then(util.unwrapHttpResponse);
+  }
+}

--- a/client/src/js/services/receipts/modal/receiptModal.tmpl.html
+++ b/client/src/js/services/receipts/modal/receiptModal.tmpl.html
@@ -1,0 +1,40 @@
+<div class="modal-header">
+  <ol class="headercrumb">
+    <li class="static">{{ "PATIENT_INVOICE.PAGE_TITLE" | translate }}</li>
+    <li class="title">Receipt <span class="label label-warning">HBB120</span></li>
+  </ol>
+</div>
+
+<!-- TODO Investigate if this should use latest ui-router standards -->
+<div ng-switch on="ReceiptCtrl.renderer">
+  
+  <!-- JSON Should be exposed to a view provided by the template passed to the -->
+  <!-- controller by the Receipt Modal service -->
+  <div ng-switch-when="json">
+
+    <!-- TODO Modal height etc. should be standardised -->
+    <div class="modal-body" style="height : 50vh; overflow-y: auto;">
+      <div ng-include="ReceiptCtrl.target"></div>
+    </div>
+  </div>
+
+  <!-- PDFs are downloaded through the GET request - they can be displayed using -->
+  <!-- ng-src -->
+  <div ng-switch-when="pdf">
+    
+    <!-- Google Chrome obejct seems to add 5px below outside or margin/padding model - this can be removed if it causes issues -->
+    <object id="pdf" ng-src="{{ReceiptCtrl.receipt}}" type="application/pdf" style="width : 100%; height : 50vh; margin-bottom : -5px;">
+      <!-- TODO: Translate -->
+      <p>Unable to display PDF. Please contact your system administrator</p>
+    </object>
+  </div>
+
+  <!-- CSV -->
+
+  <!-- Excel -->
+</div>
+
+<div class="modal-footer">
+  <button class="btn btn-default btn-sm">Close</button>
+  <button class="btn btn-primary btn-sm"><span class="glyphicon glyphicon-print"></span> Print</button>
+</div>

--- a/client/src/js/services/receipts/modal/receiptModalController.js
+++ b/client/src/js/services/receipts/modal/receiptModalController.js
@@ -1,0 +1,26 @@
+angular.module('bhima.controllers')
+.controller('ReceiptModalController', ReceiptModalController);
+
+ReceiptModalController.$inject = ['receipt'];
+
+/**
+ * Receipt Modal Controller 
+ *
+ * @params {Object} receipt   An object containing the receipt request (formatted
+ *                            by the service wrapping the receipt modal). The promise
+ *                            is stored in an object to ensure the modal is evaluated 
+ *                            before the HTTP request (promise) is resolved.
+ */
+function ReceiptModalController(receipt) { 
+  
+  receipt.promise
+    .then(function (result) { 
+      
+      // receipt has successfully loaded
+      
+    })
+    .catch(function (error) { 
+      
+      // receipt has failed - show error state
+    });
+}

--- a/client/src/js/services/receipts/modal/receiptModalController.js
+++ b/client/src/js/services/receipts/modal/receiptModalController.js
@@ -1,7 +1,7 @@
 angular.module('bhima.controllers')
 .controller('ReceiptModalController', ReceiptModalController);
 
-ReceiptModalController.$inject = ['receipt'];
+ReceiptModalController.$inject = ['receipt', 'template', 'render'];
 
 /**
  * Receipt Modal Controller 
@@ -10,9 +10,16 @@ ReceiptModalController.$inject = ['receipt'];
  *                            by the service wrapping the receipt modal). The promise
  *                            is stored in an object to ensure the modal is evaluated 
  *                            before the HTTP request (promise) is resolved.
+ * @params {String} template  Path to the template or resource to load 
+ * @params {String} render    Render target used to generate report 
  */
-function ReceiptModalController(receipt) { 
-  
+function ReceiptModalController(receipt, template, render) { 
+  var vm = this;
+  vm.target = template;
+  vm.renderer = render;
+  vm.receipt = receipt;
+
+  console.log(render);
   receipt.promise
     .then(function (result) { 
       

--- a/client/src/partials/patient_invoice/patientInvoice.js
+++ b/client/src/partials/patient_invoice/patientInvoice.js
@@ -3,7 +3,8 @@ angular.module('bhima.controllers')
 
 PatientInvoiceController.$inject = [
   '$q', '$location', 'PatientService', 'PriceLists', 'PatientInvoice',
-  'Invoice', 'util', 'ServiceService', 'SessionService', 'DateService'
+  'Invoice', 'util', 'ServiceService', 'SessionService', 'DateService',
+  'ReceiptModal'
 ];
 
 /**
@@ -18,12 +19,18 @@ PatientInvoiceController.$inject = [
  *
  * @module bhima/controllers/PatientInvoiceController
  */
-function PatientInvoiceController($q, $location, Patients, PriceLists, PatientInvoice, Invoice, util, Services, Session, Dates) {
+function PatientInvoiceController($q, $location, Patients, PriceLists, PatientInvoice, Invoice, util, Services, Session, Dates, Receipts) {
   var vm = this;
   vm.Invoice = new Invoice();
 
   // bind the enterprise to the enterprise currency
   vm.enterprise = Session.enterprise;
+  
+  Receipts.invoice('957e4e79-a6bb-4b4d-a8f7-c42152b2c2f6')
+    .then(function (result) { 
+     
+      // receipt closed fired
+    });
 
   var gridOptions = {
     appScopeProvider : vm,

--- a/client/src/partials/patient_invoice/receipt/invoice.receipt.tmpl.html
+++ b/client/src/partials/patient_invoice/receipt/invoice.receipt.tmpl.html
@@ -1,14 +1,26 @@
-<div class="modal-header">
-  <ol class="headercrumb">
-    <li class="static">{{ "PATIENT_INVOICE.PAGE_TITLE" | translate }}</li>
-    <li class="title">Receipt <span class="label label-primary">HBB120</span></li>
-  </ol>
-</div>
-
-<div class="modal-body">
-  <p>Modal Body</p>
-</div>
-
-<div class="modal-footer">
-  <p>Modal Footer</p>
-</div>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>First</th>
+      <th>Second</th>
+      <th>Third</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+    <tr><td>0</td><td>0</td><td>0</td></tr>
+  </tbody>
+</table>

--- a/client/src/partials/patient_invoice/receipt/invoice.receipt.tmpl.html
+++ b/client/src/partials/patient_invoice/receipt/invoice.receipt.tmpl.html
@@ -1,0 +1,14 @@
+<div class="modal-header">
+  <ol class="headercrumb">
+    <li class="static">{{ "PATIENT_INVOICE.PAGE_TITLE" | translate }}</li>
+    <li class="title">Receipt <span class="label label-primary">HBB120</span></li>
+  </ol>
+</div>
+
+<div class="modal-body">
+  <p>Modal Body</p>
+</div>
+
+<div class="modal-footer">
+  <p>Modal Footer</p>
+</div>


### PR DESCRIPTION
This pull requests implements the structure for client side receipts. There are many additional cases to consider however this provides the base for a solid tested example to be implemented on. 

The following services and API have been defined: 
`ReceiptService` - Responsible for interacting with the `reports/invoices/:uuid` route 
`ReceiptModal` - Can be injected into any angular controller/ service and used to invoke the receipts modal

Example usage: 

``` js
var id = '9efba'; //...

ReceiptModal.invoice(id)
  .then(function (result) { 
    // modal closed successfully
  })
  .catch(function (error) { 
    // modal close called
  });
```

Implements and completes #258 (3)
