### PR TITLE
(Feature) Integrate invoice receipts

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -488,3 +488,65 @@ ol.headercrumb {
   position : relative;
   
 }
+
+/**
+ * Styles used for printing, receipts and reports 
+ * @todo move this to less
+ */
+.bh-modal-content { 
+  position : relative; 
+  padding : 15px;
+
+  /** @todo review this */
+  height : 50vh;
+  overflow-y : auto;
+}
+
+.receipt { 
+  width : 100%
+}
+
+/* Report tables */
+.total-row > td { 
+  font-weight : bold; 
+}
+
+@media print { 
+  body * { 
+    visibility : hidden;
+  }
+
+  /* FIXME .flex-content height is restricting the print view */
+  /* to two pages - this should be overriden to solve this problem */
+  .flex-content { }
+
+  /* Style required to fix single page overflow problem */
+  /* .flex-continar : height (cannot be 100%) */
+  .flex-container { 
+    height : inherit;
+  }
+  
+  /* .modal : overflow (cannot be hidden) */
+  .modal-open .modal { 
+    overflow-x : initial;
+    overflow-y : initial;
+  }
+
+  .modal { 
+    overflow : initial;
+  }
+
+  .bh-print, .bh-print * { 
+    visibility : visible;
+  }
+
+  .bh-print { 
+    position : absolute;
+    left : 0;
+    top : 0;
+  }
+  
+  .bh-modal-content { 
+    position : initial;
+  }
+}

--- a/client/src/js/services/receipts/ReceiptModal.js
+++ b/client/src/js/services/receipts/ReceiptModal.js
@@ -19,35 +19,37 @@ ReceiptModal.$inject = ['$uibModal', 'ReceiptService'];
 function ReceiptModal(Modal, Receipts) { 
   var service = this;
   
-  var receiptController = 'ReceiptModalController as ReceiptCtrl';
-  var receiptTemplate   = '/js/services/receipts/modal/receiptModal.tmpl.html';
-  var receiptSize       = 'md';
-  var receiptBackdrop   = 'static';
-  var animateReceipt    = false;
-
+  var modalConfiguration = { 
+    templateUrl : '/js/services/receipts/modal/receiptModal.tmpl.html',
+    controller  : 'ReceiptModalController as ReceiptCtrl',
+    size        : 'md',
+    backdrop    : 'static',
+    animation   : false
+  };
+  
+  // expose available receipts
   service.invoice = invoice;
 
   function invoice(uuid) { 
 
     /** @todo Discuss if these should be overridable from the controller or if the config should be set here */
-    var renderTarget      = 'json';
-    var invoiceTemplate   = 'partials/patient_invoice/receipt/invoice.receipt.tmpl.html';
-    var invoiceRequest    = Receipts.invoice(uuid, { render : renderTarget });
-  
-    /** @todo The template passed in should be the /services/modal template which will transclude the invoice template */
-    var instance = Modal.open({
-      templateUrl : receiptTemplate,
-      controller  : receiptController,
-      size        : receiptSize,
-      backdrop    : receiptBackdrop,
-      animation   : animateReceipt,
-      resolve     : { 
+    var options = { 
+      title       : 'PATIENT_INVOICE.PAGE_TITLE',
+      identifier  : 'reference',
+      renderer    : 'json',
+      template    : 'partials/patient_invoice/receipt/invoice.receipt.tmpl.html',
+    };
+    
+    var invoiceRequest = Receipts.invoice(uuid, { render : options.renderer });
+    var invoiceProvider = { 
+      resolve : { 
         receipt       : function receiptProvider() { return { promise : invoiceRequest }; },
-        template      : function templateProvider() { return invoiceTemplate; },
-        render        : function renderProvider() { return renderTarget; }
+        options       : function templateProvider() { return options; },
       }
-    });
-
+    };
+    
+    var configuration = angular.extend(modalConfiguration, invoiceProvider);
+    var instance = Modal.open(configuration);
     return instance.result;
   }
 }

--- a/client/src/js/services/receipts/modal/receiptModal.tmpl.html
+++ b/client/src/js/services/receipts/modal/receiptModal.tmpl.html
@@ -1,17 +1,3 @@
-<style>
-  .reportModal-content { 
-    position : relative;
-    padding : 15px;
-    height : 50vh;
-    overflow-y : auto;
-  }
-
-  @media print { 
-    .reportModal-content { 
-      position : initial;
-    }
-  }
-</style>
 <div class="modal-header">
   <ol class="headercrumb">
     <li class="static">{{ ReceiptCtrl.title | translate }}</li>
@@ -30,7 +16,7 @@
   <div ng-switch-when="json">
     
     <!-- TODO Modal height etc. should be standardised -->
-    <div class="reportModal-content">
+    <div class="bh-modal-content">
       <div ng-include="ReceiptCtrl.template"></div>
     </div>
   </div>

--- a/client/src/js/services/receipts/modal/receiptModal.tmpl.html
+++ b/client/src/js/services/receipts/modal/receiptModal.tmpl.html
@@ -52,6 +52,6 @@
 </div>
 
 <div class="modal-footer">
-  <button class="btn btn-default btn-sm">Close</button>
-  <button class="btn btn-primary btn-sm"><span class="glyphicon glyphicon-print"></span> Print</button>
+  <button class="btn btn-default btn-sm" ng-click="ReceiptCtrl.close()">Close</button>
+  <button class="btn btn-primary btn-sm" ng-click="ReceiptCtrl.print()"><span class="glyphicon glyphicon-print"></span> Print</button>
 </div>

--- a/client/src/js/services/receipts/modal/receiptModal.tmpl.html
+++ b/client/src/js/services/receipts/modal/receiptModal.tmpl.html
@@ -1,7 +1,24 @@
+<style>
+  .reportModal-content { 
+    position : relative;
+    padding : 15px;
+    height : 50vh;
+    overflow-y : auto;
+  }
+
+  @media print { 
+    .reportModal-content { 
+      position : initial;
+    }
+  }
+</style>
 <div class="modal-header">
   <ol class="headercrumb">
-    <li class="static">{{ "PATIENT_INVOICE.PAGE_TITLE" | translate }}</li>
-    <li class="title">Receipt <span class="label label-warning">HBB120</span></li>
+    <li class="static">{{ ReceiptCtrl.title | translate }}</li>
+    <li class="title">
+      {{ "COLUMNS.RECEIPT" | translate }}
+      <span ng-if="ReceiptCtrl.identifier" class="label label-warning">{{ReceiptCtrl.receipt[ReceiptCtrl.identifier]}}</span>
+    </li>
   </ol>
 </div>
 
@@ -11,10 +28,10 @@
   <!-- JSON Should be exposed to a view provided by the template passed to the -->
   <!-- controller by the Receipt Modal service -->
   <div ng-switch-when="json">
-
+    
     <!-- TODO Modal height etc. should be standardised -->
-    <div class="modal-body" style="height : 50vh; overflow-y: auto;">
-      <div ng-include="ReceiptCtrl.target"></div>
+    <div class="reportModal-content">
+      <div ng-include="ReceiptCtrl.template"></div>
     </div>
   </div>
 

--- a/client/src/js/services/receipts/modal/receiptModalController.js
+++ b/client/src/js/services/receipts/modal/receiptModalController.js
@@ -1,7 +1,7 @@
 angular.module('bhima.controllers')
 .controller('ReceiptModalController', ReceiptModalController);
 
-ReceiptModalController.$inject = ['receipt', 'template', 'render'];
+ReceiptModalController.$inject = ['receipt', 'options'];
 
 /**
  * Receipt Modal Controller 
@@ -13,18 +13,17 @@ ReceiptModalController.$inject = ['receipt', 'template', 'render'];
  * @params {String} template  Path to the template or resource to load 
  * @params {String} render    Render target used to generate report 
  */
-function ReceiptModalController(receipt, template, render) { 
+function ReceiptModalController(receipt, options) { 
   var vm = this;
-  vm.target = template;
-  vm.renderer = render;
-  vm.receipt = receipt;
+  
+  // expose options to the view
+  angular.extend(vm, options);
 
-  console.log(render);
   receipt.promise
     .then(function (result) { 
       
       // receipt has successfully loaded
-      
+      vm.receipt = result;
     })
     .catch(function (error) { 
       

--- a/client/src/js/services/receipts/modal/receiptModalController.js
+++ b/client/src/js/services/receipts/modal/receiptModalController.js
@@ -1,7 +1,7 @@
 angular.module('bhima.controllers')
 .controller('ReceiptModalController', ReceiptModalController);
 
-ReceiptModalController.$inject = ['receipt', 'options'];
+ReceiptModalController.$inject = ['$uibModalInstance', '$window', 'receipt', 'options'];
 
 /**
  * Receipt Modal Controller 
@@ -13,7 +13,7 @@ ReceiptModalController.$inject = ['receipt', 'options'];
  * @params {String} template  Path to the template or resource to load 
  * @params {String} render    Render target used to generate report 
  */
-function ReceiptModalController(receipt, options) { 
+function ReceiptModalController($modalInstance, $window, receipt, options) { 
   var vm = this;
   
   // expose options to the view
@@ -29,4 +29,12 @@ function ReceiptModalController(receipt, options) {
       
       // receipt has failed - show error state
     });
+
+  vm.print = function print() { 
+    $window.print();
+  };
+  
+  vm.close = function close() { 
+    $modalInstance.close();
+  };
 }

--- a/client/src/partials/patient_invoice/patientInvoice.js
+++ b/client/src/partials/patient_invoice/patientInvoice.js
@@ -25,13 +25,7 @@ function PatientInvoiceController($q, $location, Patients, PriceLists, PatientIn
 
   // bind the enterprise to the enterprise currency
   vm.enterprise = Session.enterprise;
-  
-  Receipts.invoice('957e4e79-a6bb-4b4d-a8f7-c42152b2c2f6')
-    .then(function (result) { 
-     
-      // receipt closed fired
-    });
-
+   
   var gridOptions = {
     appScopeProvider : vm,
     enableSorting : false,
@@ -95,9 +89,19 @@ function PatientInvoiceController($q, $location, Patients, PriceLists, PatientIn
       .then(handleCompleteInvoice);
   }
 
-  function handleCompleteInvoice(result) {
+  function handleCompleteInvoice(invoice) {
     vm.Invoice.items.removeCache();
-    $location.path('/invoice/sale/'.concat(result.uuid));
+  
+    Receipts.invoice(invoice.uuid)
+    .then(function (result) { 
+ 
+      // receipt closed fired
+      console.log('got closed');
+    })
+    .catch(function (error) { 
+      
+      // receipt closed rejected
+    });
   }
 
   // reset everything in the controller - default values

--- a/client/src/partials/patient_invoice/receipt/invoice.receipt.tmpl.html
+++ b/client/src/partials/patient_invoice/receipt/invoice.receipt.tmpl.html
@@ -1,26 +1,115 @@
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th>First</th>
-      <th>Second</th>
-      <th>Third</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-    <tr><td>0</td><td>0</td><td>0</td></tr>
-  </tbody>
-</table>
+<style>  
+
+  .total-row > td { 
+    font-weight : bold; 
+  }
+  @media print { 
+    body * { 
+      visibility : hidden;
+    }
+  
+    /* FIXME .flex-content height is restricting the print view */
+    /* to two pages - this should be overriden to solve this problem */
+    .flex-content { }
+
+    /* Style required to fix single page overflow problem */
+    /* .flex-continar : height (cannot be 100%) */
+    .flex-container { 
+      height : inherit;
+    }
+    
+    /* .modal : overflow (cannot be hidden) */
+    .modal-open .modal { 
+      overflow-x : initial;
+      overflow-y : initial;
+    }
+ 
+    .modal { 
+      overflow : initial;
+    }
+
+    .printme, .printme * { 
+      visibility : visible;
+    }
+    .printme { 
+      position : absolute;
+      left : 0;
+      top : 0;
+    }
+  }
+</style>
+ 
+<div style="width : 100%" id="receipt" class="printme">
+  
+  <div class="row">
+  <div class="col-xs-12">
+    <h4 style="text-decoration : underline;">
+      Patient Invoice
+    </h4>
+  </div>
+  </div>
+
+  <div class="row">
+  <!-- Use xs to ensure it never collapses -->
+  <div class="col-xs-4">
+    <label>{{ "PATIENT_INVOICE.RECIPIENT" | translate }}</label>
+    <p>
+      {{ReceiptCtrl.receipt.recipient.first_name}}
+      {{ReceiptCtrl.receipt.recipient.middle_name}}
+      {{ReceiptCtrl.receipt.recipient.last_name}}
+    </p>
+  </div>
+  <div class="col-xs-4">
+    <label>{{ "COLUMNS.TRANS_ID" | translate }}</label>
+    <p>{{ReceiptCtrl.receipt.reference}}</p>
+  </div>
+  <div class="col-xs-4">
+    <label>{{ReceiptCtrl.receipt.enterprise.name}}</label>
+    <p>{{ReceiptCtrl.receipt.enterprise.email}}</p>  
+    <p>{{ReceiptCtrl.receipt.enterprise.phone}}</p>  
+  </div>
+  </div>
+  
+  <div class="row">
+  <div class="col-xs-12">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>{{ 'COLUMNS.CODE' | translate }}</th>
+        <th>{{ 'COLUMNS.DESCRIPTION' | translate }}</th>
+        <th>{{ 'COLUMNS.QUANTITY' | translate }}</th>
+        <th>{{ 'COLUMNS.PRICE' | translate }}</th>
+        <th>{{ 'COLUMNS.AMOUNT' | translate }}</th>
+      </tr>
+    </thead>
+    
+    <!-- Line items -->
+    <tbody>
+      <tr ng-repeat="item in ReceiptCtrl.receipt.items">
+        <td>{{item.code}}</td>
+        <td>{{item.text}}</td>
+        <td>{{item.quantity}}</td>
+        <td>{{item.transaction_price}}</td>
+        <td>{{item.quantity * item.transaction_price}}</td>
+      </tr>
+    </tbody>
+    
+    <!-- Totals -->
+    <tbody>
+      <tr class="total-row">
+        <td colspan="4">{{ "INVOICE.TOTAL" | translate }}</td>
+        <td>{{ReceiptCtrl.receipt.cost | currency }}</td>
+      </tr>
+      <!-- <tr> -->
+      <!--   <td colspan="4">{{ "INVOICE.AMOUNT_RECEIVED" | translate }}</td> -->
+      <!--   <td>{{ ReceiptCtrl.receipt.credit | currency }}</td> -->
+      <!-- </tr> -->
+      <!-- <tr> -->
+      <!--   <td colspan="4">{{ "INVOICE.BALANCE_DUE" | translate }}</td> -->
+      <!--   <td>{{ReceiptCtrl.receipt.balance | currency }}</td> -->
+      <!-- </tr> -->
+    </tbody>
+  </table>
+  </div>
+  </div>
+</div>

--- a/client/src/partials/patient_invoice/receipt/invoice.receipt.tmpl.html
+++ b/client/src/partials/patient_invoice/receipt/invoice.receipt.tmpl.html
@@ -1,45 +1,4 @@
-<style>  
-
-  .total-row > td { 
-    font-weight : bold; 
-  }
-  @media print { 
-    body * { 
-      visibility : hidden;
-    }
-  
-    /* FIXME .flex-content height is restricting the print view */
-    /* to two pages - this should be overriden to solve this problem */
-    .flex-content { }
-
-    /* Style required to fix single page overflow problem */
-    /* .flex-continar : height (cannot be 100%) */
-    .flex-container { 
-      height : inherit;
-    }
-    
-    /* .modal : overflow (cannot be hidden) */
-    .modal-open .modal { 
-      overflow-x : initial;
-      overflow-y : initial;
-    }
- 
-    .modal { 
-      overflow : initial;
-    }
-
-    .printme, .printme * { 
-      visibility : visible;
-    }
-    .printme { 
-      position : absolute;
-      left : 0;
-      top : 0;
-    }
-  }
-</style>
- 
-<div style="width : 100%" id="receipt" class="printme">
+<div id="receipt" class="bh-print receipt">
   
   <div class="row">
   <div class="col-xs-12">
@@ -71,45 +30,45 @@
   </div>
   
   <div class="row">
-  <div class="col-xs-12">
-  <table class="table">
-    <thead>
-      <tr>
-        <th>{{ 'COLUMNS.CODE' | translate }}</th>
-        <th>{{ 'COLUMNS.DESCRIPTION' | translate }}</th>
-        <th>{{ 'COLUMNS.QUANTITY' | translate }}</th>
-        <th>{{ 'COLUMNS.PRICE' | translate }}</th>
-        <th>{{ 'COLUMNS.AMOUNT' | translate }}</th>
-      </tr>
-    </thead>
-    
-    <!-- Line items -->
-    <tbody>
-      <tr ng-repeat="item in ReceiptCtrl.receipt.items">
-        <td>{{item.code}}</td>
-        <td>{{item.text}}</td>
-        <td>{{item.quantity}}</td>
-        <td>{{item.transaction_price}}</td>
-        <td>{{item.quantity * item.transaction_price}}</td>
-      </tr>
-    </tbody>
-    
-    <!-- Totals -->
-    <tbody>
-      <tr class="total-row">
-        <td colspan="4">{{ "INVOICE.TOTAL" | translate }}</td>
-        <td>{{ReceiptCtrl.receipt.cost | currency }}</td>
-      </tr>
-      <!-- <tr> -->
-      <!--   <td colspan="4">{{ "INVOICE.AMOUNT_RECEIVED" | translate }}</td> -->
-      <!--   <td>{{ ReceiptCtrl.receipt.credit | currency }}</td> -->
-      <!-- </tr> -->
-      <!-- <tr> -->
-      <!--   <td colspan="4">{{ "INVOICE.BALANCE_DUE" | translate }}</td> -->
-      <!--   <td>{{ReceiptCtrl.receipt.balance | currency }}</td> -->
-      <!-- </tr> -->
-    </tbody>
-  </table>
-  </div>
+    <div class="col-xs-12">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>{{ 'COLUMNS.CODE' | translate }}</th>
+            <th>{{ 'COLUMNS.DESCRIPTION' | translate }}</th>
+            <th>{{ 'COLUMNS.QUANTITY' | translate }}</th>
+            <th>{{ 'COLUMNS.PRICE' | translate }}</th>
+            <th>{{ 'COLUMNS.AMOUNT' | translate }}</th>
+          </tr>
+        </thead>
+        
+        <!-- Line items -->
+        <tbody>
+          <tr ng-repeat="item in ReceiptCtrl.receipt.items">
+            <td>{{item.code}}</td>
+            <td>{{item.text}}</td>
+            <td>{{item.quantity}}</td>
+            <td>{{item.transaction_price}}</td>
+            <td>{{item.quantity * item.transaction_price}}</td>
+          </tr>
+        </tbody>
+        
+        <!-- Totals -->
+        <tbody>
+          <tr class="total-row">
+            <td colspan="4">{{ "INVOICE.TOTAL" | translate }}</td>
+            <td>{{ReceiptCtrl.receipt.cost | currency }}</td>
+          </tr>
+          <!-- <tr> -->
+          <!--   <td colspan="4">{{ "INVOICE.AMOUNT_RECEIVED" | translate }}</td> -->
+          <!--   <td>{{ ReceiptCtrl.receipt.credit | currency }}</td> -->
+          <!-- </tr> -->
+          <!-- <tr> -->
+          <!--   <td colspan="4">{{ "INVOICE.BALANCE_DUE" | translate }}</td> -->
+          <!--   <td>{{ReceiptCtrl.receipt.balance | currency }}</td> -->
+          <!-- </tr> -->
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/client/test/e2e/patient/invoice.spec.js
+++ b/client/test/e2e/patient/invoice.spec.js
@@ -19,7 +19,7 @@ var PatientInvoicePage = require('./invoice.page.js');
  *   - Test for price list
  *   - Test for discount
  */
-describe('patient invoice', function () {
+describe.only('patient invoice', function () {
   'use strict';
 
   /** @const */
@@ -44,12 +44,10 @@ describe('patient invoice', function () {
 
     // attempt to submit the page.
     page.submit();
-
-    // make sure we navigate away from the page
-    expect(browser.getCurrentUrl()).to.eventually.not.equal(helpers.baseUrl + path);
-
-    // assert that we got to the success page
-    expect(element(by.id('temp-success-message')).isPresent()).to.eventually.equal(true);
+    
+    /** @todo - this can validate totals and receipt content in the future */
+    browser.waitForAngular();
+    FU.exists(by.id('receipt'), true); 
   });
 
   it('invoices a patient for multiple items', function () {
@@ -87,12 +85,11 @@ describe('patient invoice', function () {
 
     // submit the page
     page.submit();
+  
+    browser.waitForAngular();
+    /** @todo - this can validate totals and receipt content in the future */
+    FU.exists(by.id('receipt'), true); 
 
-    // make sure we navigate away from the page
-    expect(browser.getCurrentUrl()).to.eventually.not.equal(helpers.baseUrl + path);
-
-    // assert that we got to the success page
-    expect(element(by.id('temp-success-message')).isPresent()).to.eventually.equal(true);
   });
 
 


### PR DESCRIPTION
This pull request integrates the receipt core functionality into the patient invoices page as described here https://github.com/IMA-WorldHealth/bhima-2.X/issues/258. 
- Implements very basic receipt template to render JSON data returned from the server
- Moves in-line styles into structure.css
- Re-factors receipt modal controller, removing duplication 
- Pass additional options into the receipt controller to separate receipts and invoices (hard coded values)
- Updated tests to expect a modal

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](./docs/STYLEGUIDE.md)
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull requests
