### PR TITLE
Fix(settings): correct broken imports in /settings controller

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -62,7 +62,7 @@
             <li>
               <a class="session" ng-click="AppCtrl.settings()">
                 <span class="glyphicon glyphicon-cog"></span>
-                <span class="link-label">User Settings</span>
+                <span class="link-label">{{ "SETTINGS.TITLE" | translate }}</span>
               </a>
             </li>
             <li>

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -59,10 +59,12 @@
 
         <div class="flex-footer" ng-cloak>
           <ul>
-            <li><a class="session" ng-click="AppCtrl.settings()">
-              <span class="glyphicon glyphicon-cog"></span>
-              <span class="link-label">User Settings</span>
-            </a></li>
+            <li>
+              <a class="session" ng-click="AppCtrl.settings()">
+                <span class="glyphicon glyphicon-cog"></span>
+                <span class="link-label">User Settings</span>
+              </a>
+            </li>
             <li>
               <a
                 id="expandnav"

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -49,7 +49,7 @@ function bhimaConfig($stateProvider, $urlRouterProvider, $urlMatcherFactoryProvi
     templateUrl: 'partials/exchange/exchange.html'
   })
   .state('settings', {
-    url : '/settings',
+    url : '/settings?previous',
     controller: 'settings as SettingsCtrl',
     templateUrl: 'partials/settings/settings.html'
   })

--- a/client/src/partials/bhima/application.js
+++ b/client/src/partials/bhima/application.js
@@ -2,11 +2,11 @@ angular.module('bhima.controllers')
 .controller('ApplicationController', ApplicationController);
 
 ApplicationController.$inject = [
-  '$location', '$timeout', 'AppCache', 'appstate',
-  'connect', 'util', 'SessionService', 'LanguageService'
+  '$timeout', 'AppCache', 'appstate', 'connect', 'util',
+  'SessionService', 'LanguageService', '$state'
 ];
 
-function ApplicationController($location, $timeout, AppCache, appstate, connect, util, Session, Languages) {
+function ApplicationController($timeout, AppCache, appstate, connect, util, Session, Languages, $state) {
   var vm = this;
 
   // load in the application cache
@@ -130,6 +130,6 @@ function ApplicationController($location, $timeout, AppCache, appstate, connect,
   };
 
   vm.settings = function settings() {
-    $location.path('/settings');
+    $state.go('settings', { previous : $state.$current.name });
   };
 }

--- a/client/src/partials/settings/settings.html
+++ b/client/src/partials/settings/settings.html
@@ -31,7 +31,11 @@
         </div>
 
 
-        <button ng-if="SettingsCtrl.previous" class="btn btn-default" ui-sref="{{ SettingsCtrl.previous }}">
+        <button
+          ng-if="SettingsCtrl.previous"
+          class="btn btn-default"
+          ui-sref="{{ SettingsCtrl.previous }}"
+          data-back-button>
           <span class="glyphicon glyphicon-circle-arrow-left"></span> {{ "UTIL.BACK" | translate }}
         </button>
 

--- a/client/src/partials/settings/settings.html
+++ b/client/src/partials/settings/settings.html
@@ -30,17 +30,17 @@
           </select>
         </div>
 
+
+        <button ng-if="SettingsCtrl.previous" class="btn btn-default" ui-sref="{{ SettingsCtrl.previous }}">
+          <span class="glyphicon glyphicon-circle-arrow-left"></span> {{ "UTIL.BACK" | translate }}
+        </button>
+
         <button
           class="btn btn-default"
           ng-click="SettingsCtrl.logout()">
           <span class="glyphicon glyphicon-log-out"></span> {{ "SETTINGS.LOGOUT" | translate }}
         </button>
-
       </div>
     </div>
-
-    <button ng-if="!!SettingsCtrl.url" class="btn btn-sm btn-default" ng-click="SettingsCtrl.back()">
-      <span class="glyphicon glyphicon-circle-arrow-left"></span> {{ "UTIL.BACK" | translate }}
-    </button>
   </div>
 </div>

--- a/client/src/partials/settings/settings.js
+++ b/client/src/partials/settings/settings.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
 .controller('settings', SettingsController);
 
 SettingsController.$inject = [
-  '$http', '$routeParams', '$location', 'LanguageService', 'SessionService'
+  '$state', 'LanguageService', 'SessionService'
 ];
 
 /**
@@ -10,30 +10,25 @@ SettingsController.$inject = [
  *
  * The settings page allows a user to control the local application settings,
  * such as display language.
+ *
+ * @constructor
  */
-function SettingsController($http, $routeParams, $location, Languages, Session) {
+function SettingsController($state, Languages, Session) {
   var vm = this;
 
   // the url to return to (using the back button)
-  vm.url = $routeParams.url || '';
+  vm.previous = $state.params.previous;
 
   // load settings from services
   vm.settings = { language : Languages.key };
+
+  // bind methods/services to the view
+  vm.languageService = Languages;
+  vm.logout = Session.logout;
 
   /** bind the language service for use in the view */
   Languages.read()
   .then(function (languages) {
     vm.languages = languages;
   });
-
-  vm.languageService = Languages;
-
-  /** returns a user to the previous url */
-  vm.back = back;
-
-  function back() {
-    $location.url(vm.url);
-  }
-
-  vm.logout = Session.logout;
 }

--- a/client/test/e2e/cash/cash.spec.js
+++ b/client/test/e2e/cash/cash.spec.js
@@ -28,17 +28,6 @@ describe('Cash Payments Module', function () {
     text : 'Test Primary Cashbox B',
   };
 
-  /**
-  * This function is used to extract the path after the URL hash
-  */
-  function getCurrentPath() {
-    return browser.getCurrentUrl()
-    .then(function (url) {
-      var partial = url.split('#')[1];
-      return '#'.concat(partial);
-    });
-  }
-
   describe('Cashbox Select Interface', function () {
 
     it('navigating to /cash/:unknownId should reroute to /cash', function () {
@@ -47,7 +36,7 @@ describe('Cash Payments Module', function () {
       browser.get(path.concat('/unknownId'));
 
       // the page should be rerouted to the '/cash' page.
-      expect(getCurrentPath()).to.eventually.equal(path);
+      expect(helpers.getCurrentPath()).to.eventually.equal(path);
     });
 
     it('navigating to a known cashbox should not be re-routed', function () {
@@ -59,7 +48,7 @@ describe('Cash Payments Module', function () {
       browser.get(target);
 
       // confirm that we actually go to the page
-      expect(getCurrentPath()).to.eventually.equal(target);
+      expect(helpers.getCurrentPath()).to.eventually.equal(target);
     });
 
     it('navigating directly to /cash should be re-routed to selected cashbox after a selection is made', function () {
@@ -73,13 +62,13 @@ describe('Cash Payments Module', function () {
       // make sure all $http/$timeout requests clear before moving forward
       browser.waitForAngular();
 
-      expect(getCurrentPath()).to.eventually.equal(target);
+      expect(helpers.getCurrentPath()).to.eventually.equal(target);
 
       // attempt to return to /cash manually
       browser.get(path);
 
       // expect that we were routed back to cashbox A
-      expect(getCurrentPath()).to.eventually.equal(target);
+      expect(helpers.getCurrentPath()).to.eventually.equal(target);
     });
 
     it('navigating to /cash after a selection is made should re-route to /cash/:id', function () {
@@ -95,13 +84,13 @@ describe('Cash Payments Module', function () {
       browser.waitForAngular();
 
       // confirm that we actually go to the page
-      expect(getCurrentPath()).to.eventually.equal(target);
+      expect(helpers.getCurrentPath()).to.eventually.equal(target);
 
       // attempt to return to the cash page manually
       browser.get(path);
 
       // the browser should be rerouted to the cashboxB page
-      expect(getCurrentPath()).to.eventually.equal(target);
+      expect(helpers.getCurrentPath()).to.eventually.equal(target);
     });
 
     it('should allow a user to select and deselect a cashbox', function () {
@@ -111,7 +100,7 @@ describe('Cash Payments Module', function () {
 
       // navigate to the cash payements module
       browser.get(targetInitial);
-      expect(getCurrentPath()).to.eventually.equal(targetInitial);
+      expect(helpers.getCurrentPath()).to.eventually.equal(targetInitial);
 
       // make sure we are in the correct cashbox
       var hasCashboxAText = EC.textToBePresentInElement($('[data-cashbox-text]'), cashboxA.text);
@@ -124,7 +113,7 @@ describe('Cash Payments Module', function () {
       browser.waitForAngular();
 
       // ensure we get back to the cashbox select module
-      expect(getCurrentPath()).to.eventually.equal(path);
+      expect(helpers.getCurrentPath()).to.eventually.equal(path);
 
       // attempt to navigate (via the buttons) to cashboxB as our new target
       var btn = element(by.id('cashbox-'.concat(cashboxB.id)));
@@ -133,7 +122,7 @@ describe('Cash Payments Module', function () {
       browser.waitForAngular();
 
       // verify that we get to the cashboxB page
-      expect(getCurrentPath()).to.eventually.equal(targetFinal);
+      expect(helpers.getCurrentPath()).to.eventually.equal(targetFinal);
     });
   });
 

--- a/client/test/e2e/settings/settings.spec.js
+++ b/client/test/e2e/settings/settings.spec.js
@@ -1,0 +1,47 @@
+/* global browser, element, by, protractor */
+
+var chai = require('chai');
+var expect = chai.expect;
+
+// import testing utiliites
+var helpers = require('../shared/helpers');
+helpers.configure(chai);
+
+var FU = require('../shared/FormUtils');
+
+describe('Settings', function () {
+
+  it('loads the page, and selects a language', function () {
+
+    // load the settings page w/o backwards navigation
+    browser.get('#/settings');
+
+    // confirm that we can change the languages
+    // ideally, we should check that the language changed, but this
+    // test should only confirm that things are open.
+    FU.select('SettingsCtrl.settings.language')
+      .enabled()
+      .last()
+      .click();
+
+    // make sure that the "back" button doesn't exist
+    FU.exists(by.css('[data-back-button]'), false);
+  });
+
+  it('uses the back button to return to previous state', function () {
+
+    // load the settings page w/o backwards navigation
+    browser.get('#/settings?previous=index');
+
+    var btn = '[data-back-button]';
+
+    // make sure that the "back" button doesn't exist
+    FU.exists(by.css(btn), true);
+
+    // click the back button
+    element(by.css(btn)).click();
+
+    // ensure we navigate back to the main page.
+    expect(helpers.getCurrentPath()).to.eventually.equal('#/');
+  });
+});

--- a/client/test/e2e/shared/helpers.js
+++ b/client/test/e2e/shared/helpers.js
@@ -1,9 +1,9 @@
 /* jshint expr:true */
-/* global element, by, beforeEach, inject, browser */
+/* global element, by, browser */
 
 /**
  * Test helpers
- * 
+ *
  * This module contains utilities that are useful in tests, but not specifically
  * tied to forms or modules.
  */
@@ -11,7 +11,7 @@
 /** gets a random number within the range(0, n) */
 exports.random = function random(n) {
   'use strict';
-  return Math.floor((n) * Math.random() + 1); 
+  return Math.floor((n) * Math.random() + 1);
 };
 
 exports.configure = function configure(chai) {
@@ -19,4 +19,12 @@ exports.configure = function configure(chai) {
 
   // enable promise chaining for chai assertions
   chai.use(require('chai-as-promised'));
+};
+
+exports.getCurrentPath = function getCurrentPath() {
+  return browser.getCurrentUrl()
+  .then(function (url) {
+    var partial = url.split('#')[1];
+    return '#'.concat(partial);
+  });
 };


### PR DESCRIPTION
This pull request fixes a bug with imports in the `SettingsController`.   The bug originated from a broken import during the transition to ui-router.  This bug was never noticed due to a lack of end to end tests.

This PR addresses this bug and prevents it in the future by implementing two end to end tests for the `/settings` page.  The tests verify that the page loads and has languages.  They also verify that the back button is displayed and works as expected.

---

Hi! Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](./docs/STYLEGUIDE.md)
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub)
that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process
and help build a stronger application.  Thanks!
