### PR TITLE
feature(build): variable build times

### DIFF
--- a/sh/integration-tests.sh
+++ b/sh/integration-tests.sh
@@ -9,6 +9,9 @@ DB_USER='bhima'
 DB_PASS='HISCongo2013'
 DB_NAME='bhima_test'
 
+# set build timeout
+TIMEOUT=${BUILD_TIMEOUT:-8}
+
 # build the test database
 mysql -u $DB_USER -p$DB_PASS -e "DROP DATABASE IF EXISTS $DB_NAME ;"
 mysql -u $DB_USER -p$DB_PASS -e "CREATE DATABASE $DB_NAME CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
@@ -22,7 +25,7 @@ echo "Building server ...."
 npm run dev &
 
 # make sure we have enough time for the server to start
-sleep 8
+sleep $TIMEOUT
 
 echo "Running tests ..."
 

--- a/sh/test-ends.sh
+++ b/sh/test-ends.sh
@@ -10,6 +10,9 @@ DB_USER="bhima"
 DB_PASS="HISCongo2013"
 DB_NAME="bhima_test"
 
+# set the build timeout
+TIMEOUT=${BUILD_TIMEOUT:-8}
+
 mysql -u $DB_USER -p$DB_PASS -e "DROP DATABASE bhima_test;"
 mysql -u $DB_USER -p$DB_PASS -e "CREATE DATABASE bhima_test;"
 mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/schema.sql
@@ -22,7 +25,7 @@ echo "Building server ...."
 npm run dev &
 
 # make sure we have enough time for the server to start
-sleep 8
+sleep $TIMEOUT
 
 echo "Running tests ..."
 


### PR DESCRIPTION
This commit adds the ability to set the environmental variables `BUILD_TIMEOUT` to control the time between building the repository and initializing the server and the tests starting. This allows slow machines to have a different build timeout from faster machines and waste less time.  Defaults to 8 seconds as before.

---

Hi! Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](./docs/STYLEGUIDE.md)
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub)
that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process
and help build a stronger application.  Thanks!
