### PR TITLE
test: configure travis to run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ dist: trusty
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 
 services:
   - mysql
@@ -11,6 +13,7 @@ services:
 language: node_js
 node_js:
   - node
+  - '5'
   - '4.3'
   - '4.2'
   - '4.1'
@@ -22,7 +25,8 @@ before_script:
 script:
   - bash sh/deploy.sh
   - sleep 5
-  - mocha server/test/api
+  - ./node_modules/.bin/mocha server/test/api
+  - ./node_modules/.bin/karma start --single-run
 
 git:
   depth: 3

--- a/client/test/unit/directives/bhUnique.spec.js
+++ b/client/test/unit/directives/bhUnique.spec.js
@@ -1,51 +1,53 @@
-describe('Unique (async) validation directive', function () { 
+/* jshint expr: true */
+/* global inject, expect */
+describe('Unique (async) validation directive', function () {
   var $scope, form;
-  
+
   var MockUniqueValidatorService;
 
-  // these represent values that the external $http request would return as 
+  // these represent values that the external $http request would return as
   // already registered in the database
   var existingValues = [100, 110, 120];
 
   beforeEach(module('bhima.directives', 'bhima.services'));
-  
-  beforeEach(module(function ($provide) { 
 
-    // if this service is used by multiple directives/ controllers the mock 
-    // can be defined in an external /shared folder 
+  beforeEach(module(function ($provide) {
+
+    // if this service is used by multiple directives/ controllers the mock
+    // can be defined in an external /shared folder
     MockUniqueValidatorService = function ($q) {
-      return { 
-        check : function (validationUrl, viewValue) { 
-          return existingValues.includes(viewValue) ? $q.reject() : $q.resolve();
+      return {
+        check : function (validationUrl, viewValue) {
+          return existingValues.indexOf(viewValue) > -1 ? $q.reject() : $q.resolve();
         }
       };
     };
-  
+
     $provide.service('UniqueValidatorService', MockUniqueValidatorService);
   }));
 
-  beforeEach(inject(function ($compile, $rootScope) { 
+  beforeEach(inject(function ($compile, $rootScope) {
     $scope = $rootScope;
-    
+
     var element = angular.element(
-      '<form name="form">' + 
-      '<input ng-model="models.uniqueValue" name="uniqueValue" bh-unique="/validation_path">' + 
+      '<form name="form">' +
+      '<input ng-model="models.uniqueValue" name="uniqueValue" bh-unique="/validation_path">' +
       '</form>'
     );
 
-    $scope.models = { 
+    $scope.models = {
       uniqueValue : null
     };
 
     $compile(element)($scope);
     form = $scope.form;
   }));
-  
-  it('rejects a value that already exists', function () { 
-    
+
+  it('rejects a value that already exists', function () {
+
     // take the first exisitng value
     var existingValue = existingValues[0];
-    
+
     form.uniqueValue.$setViewValue(existingValue);
     $scope.$digest();
 
@@ -53,14 +55,14 @@ describe('Unique (async) validation directive', function () {
     expect(form.uniqueValue.$valid).to.be.false;
   });
 
-  it('accepts a value that is unique', function () { 
+  it('accepts a value that is unique', function () {
     var uniqueValue = 200;
-  
+
     form.uniqueValue.$setViewValue(uniqueValue);
     $scope.$digest();
 
     expect($scope.models.uniqueValue).to.equal(uniqueValue);
     expect(form.uniqueValue.$valid).to.equal.true;
-    
+
   });
 });

--- a/client/test/unit/services/SessionService.spec.js
+++ b/client/test/unit/services/SessionService.spec.js
@@ -1,6 +1,7 @@
 /* jshint expr: true */
 /* global inject, expect */
 describe('SessionService', function () {
+  'use strict';
 
   // shared services
   let Session;


### PR DESCRIPTION
This commit enables a virtual frame buffer on TravisCI for karma to leverage in running unit tests.  It then starts up karma to run a single pass of the unit test suite using the chrome browser.

Closes #357.

---

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process
and help build a stronger application.  Thanks!
