### PR TITLE
refactor: remove deprecated interfaces

### DIFF
--- a/server/controllers/finance/cashboxes.js
+++ b/server/controllers/finance/cashboxes.js
@@ -1,17 +1,12 @@
 /**
-* Cashboxes Controller
-*
-* This controller is responsible for creating and updating cashboxes.  Every
-* cashbox must have a name, and as many accounts as there are currencies
-* supported by the application.
-*/
+ * Cashboxes Controller
+ *
+ * This controller is responsible for creating and updating cashboxes.  Every
+ * cashbox must have a name, and as many accounts as there are currencies
+ * supported by the application.
+ */
 const db = require('../../lib/db');
 const NotFound = require('../../lib/errors/NotFound');
-
-/*
-* TODO - PROPOSAL: rename cash_box to cashbox in the database.  Easier for everything
-* in life.
-*/
 
 /**
 * GET /cashboxes
@@ -51,7 +46,7 @@ exports.list = function list(req, res, next) {
 
       // if the key exists, add it to a list of growing conditions
       if (key) {
-        conditions.push(k + ' = ' + db.sanitize(key));
+        conditions.push(k + ' = ' + db.escape(key));
       }
     });
   }

--- a/server/controllers/finance/fiscal.js
+++ b/server/controllers/finance/fiscal.js
@@ -190,7 +190,7 @@ function createPeriods(fiscalYearId, start, end) {
     template.push([fiscalYearId, i+1, periodStart, periodStop]);
   }
 
-  sql += db.sanitize(template) + ';';
+  sql += db.escape(template) + ';';
 
   // sanitize turns the template into (a,b), (c,d) ..
   return db.exec(sql);

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -1,25 +1,23 @@
 // server/lib/db.js
 
-// TODO rewrite documentation - this module can now be required by any controller module throughout the application
-// TODO Seperate DB wrapper and DB methods - this module should just initialise a new DB instance
-// new db(config, etc.) and return it in module exports
+// TODO separate DB wrapper and DB methods - this module should just initialise
+// a new DB instance new db(config, etc.) and return it in module exports
 
 // TODO EVERY query to the DB is currently handled on it's own connection, one
 // HTTP request can result in tens of connections. Performance checks for
-// sharing connections between request sessions (also allowing for shraring a
+// sharing connections between request sessions (also allowing for sharing a
 // transaction between unrelated components)
+'use strict';
 
-var q       = require('q');
-var mysql   = require('mysql');
-var winston = require('winston');
-var util    = require('util');
+const q       = require('q');
+const mysql   = require('mysql');
+const winston = require('winston');
 const uuid  = require('node-uuid');
 
-var con;
+let con;
 
-// Initiliase module on startup - create once and allow db to be required anywhere
+// initialize module on startup - create once and allow db to be required anywhere
 function initialise() {
-  'use strict';
 
   // configure MySQL via environmental variables
   if (process.env.DB_URL) {
@@ -51,17 +49,6 @@ function exec(sql, params) {
   });
 
   return dfd.promise;
-}
-
-function execute(sql, callback) {
-  con.getConnection(function (err, connection) {
-    if (err) { return callback(err); }
-    connection.query(sql, function (err, results) {
-      connection.release();
-      if (err) { return callback(err); }
-      return callback(null, results);
-    });
-  });
 }
 
 function execTransaction(queryList) {
@@ -132,14 +119,14 @@ function transaction() {
   self.addQuery = addQuery;
   self.execute = execution;
 
-  // Format the query, params request and insert into the list of querys to be
+  // Format the query, params request and insert into the list of queries to be
   // executed
   function addQuery(query, params) {
-
     self.queryList.push({
       query : query,
       params : params
     });
+
     return self;
   }
 
@@ -186,8 +173,6 @@ module.exports = {
   initialise:  initialise,
   exec:        exec,
   transaction: transaction,
-  execute:     util.deprecate(execute, 'db.execute() is deprecated, use db.exec() instead.'),
-  sanitize:    util.deprecate(sanitize, 'db.sanitize() is deprecated, use db.escape instead.'),
   escape:      sanitize,
   bid:         bid
 };

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -1,19 +1,12 @@
 /**
-* @module lib/util
-* @description This modolue contains useful utility functions
-*/
+ * @module lib/util
+ * @description This module contains useful utility functions
+ */
 
-/** javascript strict mode */
 'use strict';
-
-var util = require('util');
 
 /** The query string conditions builder */
 module.exports.queryCondition = queryCondition;
-
-/** The toMysqlDate function */
-module.exports.toMysqlDate = util.deprecate(toMysqlDate, 'util.toMysqlDate() is deprecated and will be removed soon. Please use db.js\'s native date parsing.');
-
 module.exports.take = take;
 
 /**
@@ -33,24 +26,6 @@ function queryCondition(sql, params) {
   sql += (Object.keys(params).length > 0) ? 'WHERE ' + criteria : '';
   return { query: sql, conditions : conditions };
 }
-
-/** @deprecated toMysqlDate - Please use db.js's native date parsing */
-function toMysqlDate (dateString) {
-  // This style of convert to MySQL date avoids changing
-  // the prototype of the global Date object
-  if (!dateString) { return new Date().toISOString().slice(0, 10); }
-
-  var date = new Date(dateString),
-    year = String(date.getFullYear()),
-    month = String(date.getMonth() + 1),
-    day = String(date.getDate());
-
-  month = month.length < 2 ? '0' + month : month;
-  day = day.length < 2 ? '0' + day : day;
-
-  return [year, month, day].join('-');
-}
-
 
 /**
  * Creates a filter to be passed to a Array.map() function.  This filter will
@@ -89,7 +64,7 @@ function toMysqlDate (dateString) {
 function take() {
 
   // get the arguments as an array
-  var keys = Array.prototype.slice.call(arguments);
+  let keys = Array.prototype.slice.call(arguments);
 
   // return the filter function
   return function filter(object) {

--- a/sh/integration-tests.sh
+++ b/sh/integration-tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# bash script mode
+set -euo pipefail
+
 # This assumes you run tests from the top level bhima directory.
 
 echo "Building test database for integration tests ..."

--- a/sh/test-ends.sh
+++ b/sh/test-ends.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# bash script mode
+set -euo pipefail
+
 # This assumes you run tests from the top level bhima directory.
 
 echo "Building test database for end to end tests ..."


### PR DESCRIPTION
This PR removes deprecated interfaces on the `db` and `util` objects.  The following have been removed:
1. rm `util.toMysqlDate()`
2. rm `db.sanitize()` (replaced with db.escape)

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process
and help build a stronger application.  Thanks!
