### PR TITLE
Prototype filter $dirty value with nested components

### DIFF
--- a/client/src/js/components/bhLocationSelect.js
+++ b/client/src/js/components/bhLocationSelect.js
@@ -10,6 +10,7 @@ angular.module('bhima.components')
     locationUuid:      '=', // two-way binding
     disable:           '<', // one-way binding
     validationTrigger: '<', // one-way binding
+    name:              '@'
   }
 });
 
@@ -169,7 +170,17 @@ function LocationSelectController(Locations, $scope, Modal) {
 
   /** updates the exposed location uuid for the client to use */
   function updateLocationUuid() {
-    vm.locationUuid = vm.village.uuid;
+
+    if (vm.village) {
+
+      // this exposes the true value of the component to the top level form validation
+      // and can be used in util.filterDirtyFormElements
+      /** @todo if this technique is considered useful it should be formalised (potential directive) */
+      if (angular.isDefined(vm.name)) {
+        $scope[vm.name].$bhValue = vm.village.uuid;
+      }
+      vm.locationUuid = vm.village.uuid;
+    }
   }
 
   /**
@@ -179,7 +190,7 @@ function LocationSelectController(Locations, $scope, Modal) {
    * @private
    */
   function loadLocation() {
-    
+
     // make sure we actually have an initial location (prevents needless firing
     // during $scope churn).
     if (!vm.locationUuid) { return; }
@@ -213,6 +224,8 @@ function LocationSelectController(Locations, $scope, Modal) {
         uuid : initial.countryUuid,
         country : initial.country,
       };
+
+      updateLocationUuid();
 
       // refresh all data sources to allow a user to use the <select> elements.
       loadProvinces()

--- a/client/src/js/components/bhLocationSelect.js
+++ b/client/src/js/components/bhLocationSelect.js
@@ -14,7 +14,7 @@ angular.module('bhima.components')
   }
 });
 
-LocationSelectController.$inject =  [ 'LocationService', '$scope' ];
+LocationSelectController.$inject =  [ 'LocationService', '$scope', '$timeout' ];
 
 /**
  * Location Select Controller
@@ -52,7 +52,7 @@ LocationSelectController.$inject =  [ 'LocationService', '$scope' ];
  * </bh-location-select>
  *
  */
-function LocationSelectController(Locations, $scope, Modal) {
+function LocationSelectController(Locations, $scope, $timeout) {
   var vm = this;
 
   /** loading indicator */
@@ -66,7 +66,32 @@ function LocationSelectController(Locations, $scope, Modal) {
   vm.modal = openAddLocationModal;
 
   // set default component name if none has been set
-  vm.name = vm.name || 'LocationSelectForm';
+  vm.name = vm.name || 'LocationComponentForm';
+
+  // wrap the alias call in a $timeout to ensure that the component link/ compile process has run
+  $timeout(aliasComponentForm);
+
+  /**
+   * This function assigns a reference to the components form onto the $scope
+   * object so that it can be accessed directly in the view. This is required
+   * because the component dynamically sets the form name based on the `vm.name`
+   * variable.
+   *
+   * This is a convenience method as the controller is available to the $scope
+   * thorugh the $ctrl variable. It translates the template from:
+   *
+   * `this[$ctrl.name].formVariable`
+   *
+   * into
+   *
+   *  `LocationForm.formVariable`
+   *
+   *  This improves readability and reduces the number of potential lookups required
+   *  in the Angular template.
+   */
+  function aliasComponentForm() {
+    $scope.LocationForm = $scope[vm.name];
+  }
 
   /** disabled bindings for individual <select>s */
   vm.disabled = {

--- a/client/src/js/components/bhLocationSelect.js
+++ b/client/src/js/components/bhLocationSelect.js
@@ -65,6 +65,9 @@ function LocationSelectController(Locations, $scope, Modal) {
   vm.updateLocationUuid = updateLocationUuid;
   vm.modal = openAddLocationModal;
 
+  // set default component name if none has been set
+  vm.name = vm.name || 'LocationSelectForm';
+
   /** disabled bindings for individual <select>s */
   vm.disabled = {
     village:  true,

--- a/client/src/js/services/util.js
+++ b/client/src/js/services/util.js
@@ -10,19 +10,27 @@ function UtilService($filter) {
     return response.data;
   };
 
-  service.filterDirtyFormElements = function filterDirtyFormElements(formDefinition) { 
+  service.filterDirtyFormElements = function filterDirtyFormElements(formDefinition) {
+
+    console.log('[util] formDefintion', formDefinition);
     var response = {};
 
-    angular.forEach(formDefinition, function (value, key) { 
+    angular.forEach(formDefinition, function (value, key) {
 
       // Determine angular elements, these can be ignored
       var isAngularAttribute = key.substring(0, 1) === '$';
-      
-      if (!isAngularAttribute) { 
-        
-        // Only format and assign dirty values that have changed 
-        if (value.$dirty) { 
-          response[key] = value.$modelValue;
+
+      if (!isAngularAttribute) {
+
+        // Only format and assign dirty values that have changed
+        if (value.$dirty) {
+
+          // any standard ng-model element will provide an $modelValue, according
+          // to the latest 2.x standards more complex bhima components or bhima
+          // component wrappers will expose $bhValue
+
+          // accounts for empty string values
+          response[key] = angular.isDefined(value.$modelValue) ? value.$modelValue : value.$bhValue;
         }
       }
     });
@@ -78,7 +86,7 @@ function UtilService($filter) {
 
   // Normalize a name:
   //  * remove all extra whitespace
-  //  * capitalize the first letter of each word in the name 
+  //  * capitalize the first letter of each word in the name
   //    (lowercase the rest of each word)
   //  * Undefined names are not changed (for form fields)
   service.normalizeName = function (name) {

--- a/client/src/js/services/util.js
+++ b/client/src/js/services/util.js
@@ -11,8 +11,6 @@ function UtilService($filter) {
   };
 
   service.filterDirtyFormElements = function filterDirtyFormElements(formDefinition) {
-
-    console.log('[util] formDefintion', formDefinition);
     var response = {};
 
     angular.forEach(formDefinition, function (value, key) {

--- a/client/src/partials/debtors/groups.edit.html
+++ b/client/src/partials/debtors/groups.edit.html
@@ -12,7 +12,8 @@
   <div class="row">
     <div class="col-md-5">
 
-      <div class="form" autocomplete="off" autocorrect="off" autocapitalize="off">
+      <!-- Debtor group details form elements -->
+      <div autocomplete="off" autocorrect="off" autocapitalize="off">
         <div
           class="form-group has-feedback"
           ng-class="{'has-error' : debtorGroup.name.$invalid && debtorGroup.$submitted}">

--- a/client/src/partials/debtors/groups.edit.html
+++ b/client/src/partials/debtors/groups.edit.html
@@ -1,4 +1,4 @@
-<div class="container-fluid">
+<div class="container-fluid" ng-form="debtorGroup">
 
   <div class="row">
     <div class="col-xs-12">
@@ -12,7 +12,7 @@
   <div class="row">
     <div class="col-md-5">
 
-      <form name="debtorGroup" class="form" autocomplete="off" autocorrect="off" autocapitalize="off">
+      <div class="form" autocomplete="off" autocorrect="off" autocapitalize="off">
         <div
           class="form-group has-feedback"
           ng-class="{'has-error' : debtorGroup.name.$invalid && debtorGroup.$submitted}">
@@ -55,7 +55,7 @@
 
           <label class="control-label">{{ "TABLE.COLUMNS.PRICE_LIST" | translate }}</label>
           <select
-            name="price_list"
+            name="price_list_uuid"
             ng-model="GroupEditCtrl.group.price_list_uuid"
             ng-options="priceList.uuid as priceList.label for priceList in GroupEditCtrl.priceLists"
             class="form-control">
@@ -82,7 +82,7 @@
 
         <div class="form-group">
           <label class="control-label">{{ "FORM.LABELS.NOTES" | translate }}</label>
-          <textarea class="form-control" ng-model="GroupEditCtrl.group.note" name="notes"></textarea>
+          <textarea class="form-control" ng-model="GroupEditCtrl.group.note" name="note"></textarea>
         </div>
 
         <div class="form-group">
@@ -103,6 +103,7 @@
         </div>
 
         <div class="form-group">
+          <!-- required -->
           <bh-location-select
             id="location"
             name="location_id"
@@ -110,7 +111,7 @@
             location-uuid="GroupEditCtrl.group.location_id"
             required></bh-location-select>
         </div>
-      </form>
+      </div>
 
       <!-- @todo remove temporary style hack -->
       <div class="clearfix" style="margin-bottom : 5px">
@@ -151,7 +152,7 @@
               </p>
               <div class="checkbox">
                 <label>
-                  <input ng-model="GroupEditCtrl.group.apply_subsidies" type="checkbox">
+                  <input ng-model="GroupEditCtrl.group.apply_subsidies" name="apply_subsidies" type="checkbox">
                   {{"DEBTOR_GRP.POLICIES.SUBSIDIES.LABEL" | translate }}
                 </label>
               </div>
@@ -165,7 +166,7 @@
               </p>
               <div class="checkbox">
                 <label>
-                  <input ng-model="GroupEditCtrl.group.apply_discounts" type="checkbox">
+                  <input ng-model="GroupEditCtrl.group.apply_discounts" name="apply_discounts" type="checkbox">
                   {{"DEBTOR_GRP.POLICIES.DISCOUNTS.LABEL" | translate }}
                 </label>
               </div>
@@ -179,7 +180,7 @@
               </p>
               <div class="checkbox">
                 <label>
-                  <input ng-model="GroupEditCtrl.group.apply_billing_services" ng-true-value="false" ng-false-value="true" type="checkbox">
+                  <input ng-model="GroupEditCtrl.group.apply_billing_services" name="apply_billing_services" ng-true-value="false" ng-false-value="true" type="checkbox">
                   {{ "DEBTOR_GRP.POLICIES.BILLING_SERVICES.LABEL" | translate }}
                 </label>
               </div>

--- a/client/src/partials/debtors/groups.update.js
+++ b/client/src/partials/debtors/groups.update.js
@@ -44,15 +44,17 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
     // ensure we don't make HTTP requests if the form is invalid - exit early
     if (debtorGroupForm.$invalid) {
       Notify.danger('FORM.ERRORS.RECORD_ERROR');
-      return false;
+      return;
     }
 
-    /** @todo filterDirtyFormElements should be updated to factor in nested forms */
-    // submitDebtorGroup = util.filterDirtyFormElements(debtorGroupForm);
-    submitDebtorGroup = angular.copy(vm.group);
+    // catch 'nothing has changed' and redirect to list page
+    if (debtorGroupForm.$pristine) {
+      Notify.warn('FORM.ERRORS.NO_CHANGE');
+      $state.go('debtorGroups.list', null, {reload : true});
+      return;
+    }
 
-    // hack price lists - classic
-    submitDebtorGroup.price_list_uuid = submitDebtorGroup.price_list_uuid || null;
+    submitDebtorGroup = util.filterDirtyFormElements(debtorGroupForm);
 
     // temporary work-around for displaying an entire account in the typeahead
     if (submitDebtorGroup.account_id) {

--- a/client/src/partials/templates/bhLocationSelect.tmpl.html
+++ b/client/src/partials/templates/bhLocationSelect.tmpl.html
@@ -3,12 +3,21 @@
   a child form is added for validation purposes, and to make the HTML easier
   to read.
 -->
-<fieldset ng-disabled="$ctrl.disable"  ng-form="{{$ctrl.name}}" ng-model="somevaluetwo" data-bh-location-select>
+<!--
+  ng-form name is dynamically set by the controller - this form is aliased
+  as 'LocationForm' and made available to the template through `aliasComponentForm()`
+-->
+
+<!-- name="LocationForm" -->
+<fieldset
+  ng-disabled="$ctrl.disable"
+  ng-form="{{$ctrl.name}}"
+  data-bh-location-select>
 
   <!-- allows a user to select a country -->
   <div class="form-group"
-    ng-class="{ 'has-error' : $ctrl.validationTrigger && this[$ctrl.name].country.$invalid }"
-    >
+    ng-class="{ 'has-error' : $ctrl.validationTrigger && LocationForm.country.$invalid }">
+
     <label class="control-label">{{ "FORM.LABELS.COUNTRY" | translate }}</label>
     <select
       class="form-control"
@@ -24,7 +33,7 @@
 
   <!-- allows a user to select a province based on the selected country uuid -->
   <div class="form-group"
-    ng-class="{ 'has-error' : $ctrl.validationTrigger && this[$ctrl.name].province.$invalid }"
+    ng-class="{ 'has-error' : $ctrl.validationTrigger && LocationForm.province.$invalid }"
     >
     <label class="control-label">{{ "FORM.LABELS.PROVINCE" | translate }}</label>
     <select
@@ -42,7 +51,7 @@
 
   <!-- allows a user to select a sector based on the selected province uuid -->
   <div class="form-group"
-    ng-class="{ 'has-error' : $ctrl.validationTrigger && this[$ctrl.name].sector.$invalid }"
+    ng-class="{ 'has-error' : $ctrl.validationTrigger && LocationForm.sector.$invalid }"
     >
     <label class="control-label">{{ "FORM.LABELS.SECTOR" | translate }}</label>
     <select
@@ -60,7 +69,7 @@
 
   <!-- allows a user to select a village based on the selected sector uuid -->
   <div class="form-group"
-    ng-class="{ 'has-error' : $ctrl.validationTrigger && this[$ctrl.name].village.$invalid }"
+    ng-class="{ 'has-error' : $ctrl.validationTrigger && LocationForm.village.$invalid }"
     >
     <label class="control-label">{{ "FORM.LABELS.VILLAGE" | translate }}</label>
     <select
@@ -76,7 +85,7 @@
     </select>
 
     <!-- validation messages shown on form errors-->
-    <p class="help-block text-danger" ng-messages="this[$ctrl.name].$error" ng-show="$ctrl.validationTrigger">
+    <p class="help-block text-danger" ng-messages="LocationForm.$error" ng-show="$ctrl.validationTrigger">
       <span ng-messages-include="partials/templates/messages.tmpl.html"></span>
     </p>
   </div>

--- a/client/src/partials/templates/bhLocationSelect.tmpl.html
+++ b/client/src/partials/templates/bhLocationSelect.tmpl.html
@@ -3,11 +3,11 @@
   a child form is added for validation purposes, and to make the HTML easier
   to read.
 -->
-<fieldset ng-disabled="$ctrl.disable" ng-form="LocationSelectForm" data-bh-location-select>
+<fieldset ng-disabled="$ctrl.disable"  ng-form="{{$ctrl.name}}" ng-model="somevaluetwo" data-bh-location-select>
 
   <!-- allows a user to select a country -->
   <div class="form-group"
-    ng-class="{ 'has-error' : $ctrl.validationTrigger && LocationSelectForm.country.$invalid }"
+    ng-class="{ 'has-error' : $ctrl.validationTrigger && this[$ctrl.name].country.$invalid }"
     >
     <label class="control-label">{{ "FORM.LABELS.COUNTRY" | translate }}</label>
     <select
@@ -24,7 +24,7 @@
 
   <!-- allows a user to select a province based on the selected country uuid -->
   <div class="form-group"
-    ng-class="{ 'has-error' : $ctrl.validationTrigger && LocationSelectForm.province.$invalid }"
+    ng-class="{ 'has-error' : $ctrl.validationTrigger && this[$ctrl.name].province.$invalid }"
     >
     <label class="control-label">{{ "FORM.LABELS.PROVINCE" | translate }}</label>
     <select
@@ -42,7 +42,7 @@
 
   <!-- allows a user to select a sector based on the selected province uuid -->
   <div class="form-group"
-    ng-class="{ 'has-error' : $ctrl.validationTrigger && LocationSelectForm.sector.$invalid }"
+    ng-class="{ 'has-error' : $ctrl.validationTrigger && this[$ctrl.name].sector.$invalid }"
     >
     <label class="control-label">{{ "FORM.LABELS.SECTOR" | translate }}</label>
     <select
@@ -60,7 +60,7 @@
 
   <!-- allows a user to select a village based on the selected sector uuid -->
   <div class="form-group"
-    ng-class="{ 'has-error' : $ctrl.validationTrigger && LocationSelectForm.village.$invalid }"
+    ng-class="{ 'has-error' : $ctrl.validationTrigger && this[$ctrl.name].village.$invalid }"
     >
     <label class="control-label">{{ "FORM.LABELS.VILLAGE" | translate }}</label>
     <select
@@ -74,9 +74,9 @@
       required>
       <option ng-if="$ctrl.sector" value="" disabled>{{ $ctrl.messages.village | translate }}</option>
     </select>
-    
+
     <!-- validation messages shown on form errors-->
-    <p class="help-block text-danger" ng-messages="LocationSelectForm.$error" ng-show="$ctrl.validationTrigger">
+    <p class="help-block text-danger" ng-messages="this[$ctrl.name].$error" ng-show="$ctrl.validationTrigger">
       <span ng-messages-include="partials/templates/messages.tmpl.html"></span>
     </p>
   </div>
@@ -87,5 +87,5 @@
       <span class="glyphicon glyphicon-modal-window"></span>
       {{ "FORM.LABELS.LOCATION_REGISTER" | translate }}
     </a>
-  </p> 
+  </p>
 </fieldset>


### PR DESCRIPTION
This commit introduces a very basic method that allows the standard
`util.filterDirtyFormElements` to work with complex nested components
(usually represented as forms).

This method has been tested on the `bh-location-select` component;
noteworthy changes:
- Accept a `name` parameter (as per standard form elements) and use it
  to name the form - this will become the attribute in the top level form.
- Whenever the components model value is set, expose this value to the
  component form through the value `$bhValue`
- Update util.filterDirtyFormElements to use `$bhValue` if
  `angular.isDefined($modelValue)` is `false`

Misc.
- Move scope of group `ng-form` to ensure all elements are included

---
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.
