### PR TITLE
chore(test): use browser.setLocation()

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -997,7 +997,7 @@ function localStorageConfig($localStorageProvider) {
  * This function is responsible for configuring angular's $http service. Any
  * relevant services/ factories are registered at this point.
  *
- * @params {Object} $httpProvider   Angular provider inject containing
+ * @param {Object} $httpProvider   Angular provider inject containing
  *                                  'interceptors' that are chained on any HTTP request
  */
 function httpConfig($httpProvider) {

--- a/client/src/js/services/PatientService.js
+++ b/client/src/js/services/PatientService.js
@@ -4,7 +4,7 @@ angular.module('bhima.services')
 PatientService.$inject = [ '$http', 'util', 'SessionService' ];
 
 /**
- * Patient Service
+ * @module PatientService
  *
  * This service is reponsible for providing an interface between angular
  * module controllers and the server /patients API.
@@ -20,7 +20,6 @@ PatientService.$inject = [ '$http', 'util', 'SessionService' ];
  * // creates a patient
  * Patients.create(medicalDetails, financeDetails)...
  *
- * @module services/PatientService
  */
 function PatientService($http, util, Session) {
   var service = this;
@@ -56,8 +55,8 @@ function PatientService($http, util, Session) {
    * for submission and forwards it to the server /patients/create API. It can
    * be used for creating new patient records in the database.
    *
-   * @params {Object} medical   A patients medical information.
-   * @params {Object} finance   A patients financial information.
+   * @param {Object} medical   A patients medical information.
+   * @param {Object} finance   A patients financial information.
    * @returns {Object}          Promise object returning success/failure confirmation.
    */
   function create(medical, finance) {
@@ -107,8 +106,8 @@ function PatientService($http, util, Session) {
    * provided. Note: This process will clear all previous groups and leave the
    * patient subscribed to only the groups passed to this method.
    *
-   * @params {String} uuid              The target patient's UUID
-   * @params {Array}  subsribedGroups   An array of group UUIDs
+   * @param {String} uuid              The target patient's UUID
+   * @param {Array}  subscribedGroups  An array of group UUIDs
    * @return {Object}                   Promise object returning success/ failure
    *                                    confiramtion.
    */

--- a/client/src/js/services/ScrollService.js
+++ b/client/src/js/services/ScrollService.js
@@ -3,12 +3,12 @@ angular.module('bhima.services')
 
 ScrollService.$inject = ['$location', '$anchorScroll', '$timeout'];
 
-/** 
- * Scrolling Utility Service 
+/**
+ * Scrolling Utility Service
  *
- * This is a simple utility containing the logic for scrolling to a given element. 
- * The primary reason for this service is the number of imports it requires to 
- * scroll in Angular, this is just a semantic wrapper for a basic operation. 
+ * This is a simple utility containing the logic for scrolling to a given element.
+ * The primary reason for this service is the number of imports it requires to
+ * scroll in Angular, this is just a semantic wrapper for a basic operation.
  *
  * @example
  * Controller.$inject = ['ScrollService'];
@@ -19,48 +19,48 @@ ScrollService.$inject = ['$location', '$anchorScroll', '$timeout'];
  *
  * @module services/ScrollService
  */
-function ScrollService($location, $anchorScroll, $timeout) { 
+function ScrollService($location, $anchorScroll, $timeout) {
   var scrollDelay = 0;
-  
-  // Always scroll an additional 50 pixels to ensure element is visiable 
+
+  // Always scroll an additional 50 pixels to ensure element is visiable
   $anchorScroll.yOffset = 50;
 
-  /** 
+  /**
    * @deprecated
-   * 
-   * This method is responsible for scrolling to a specific element. It uses 
-   * angular $location and $anchorScroll services. 
-   * 
-   * @params {String} elementId   Element identifier (html attribute `id`) to 
-   *                              be scrolled to. 
+   *
+   * This method is responsible for scrolling to a specific element. It uses
+   * angular $location and $anchorScroll services.
+   *
+   * @param {String} elementId   Element identifier (html attribute `id`) to
+   *                              be scrolled to.
    */
-  function scrollTo(elementId) { 
-    
+  function scrollTo(elementId) {
+
     // Verify that the hash not already been set to this value
-    if ($location.hash() !== elementId) { 
-    
+    if ($location.hash() !== elementId) {
+
       // $location.hash will invoke anchor scroll
       $location.hash(elementId);
-    } else { 
-      
+    } else {
+
       // $location has has already been set - invoke scroll
       $anchorScroll();
     }
   }
 
-  /** 
-   * This is a wrapper method to ensure $anchorScroll is called within an $apply 
+  /**
+   * This is a wrapper method to ensure $anchorScroll is called within an $apply
    * block.
    *
-   * @toto Discuss if this workaround is required if everything is put together correctly 
+   * @toto Discuss if this workaround is required if everything is put together correctly
    *
-   * @params {String} elementId   Identifier to be passed on to scrollTo method.
+   * @param {String} elementId   Identifier to be passed on to scrollTo method.
    */
-  function applyScrollTo(elementId) { 
+  function applyScrollTo(elementId) {
     var invokeApply = true;
-   
+
     // we now make a call to $anchorScroll, directly passing the element ID, the
-    // primary difference between this and the scrollTo method is that it does 
+    // primary difference between this and the scrollTo method is that it does
     // not alter the browser URL (location hash) or history.
     $timeout($anchorScroll, scrollDelay, invokeApply, elementId);
   }

--- a/client/src/js/services/UniqueValidatorService.js
+++ b/client/src/js/services/UniqueValidatorService.js
@@ -4,51 +4,51 @@ angular.module('bhima.services')
 UniqueValidatorService.$inject = ['$http', 'util'];
 
 /**
- * Unique Validator Service 
+ * Unique Validator Service
  *
- * This service is responsible for making requests to server endpoints that result 
- * in a simple Boolean true/false value, both the URL and the value that should 
- * be verified are required. 
+ * This service is responsible for making requests to server endpoints that result
+ * in a simple Boolean true/false value, both the URL and the value that should
+ * be verified are required.
  *
- * The BHIMA `exists` API uses a very simply pattern that must be followed in order 
- * for this service to be used. The server route that checks for the entities 
- * existence should be defined as follows: 
- * 
+ * The BHIMA `exists` API uses a very simply pattern that must be followed in order
+ * for this service to be used. The server route that checks for the entities
+ * existence should be defined as follows:
+ *
  * GET /entity/attribute/:id /exists
  *
- * The service expects the validation server API to return a value of true or 
+ * The service expects the validation server API to return a value of true or
  * false; if a value of false is returned this value is valid and can be used; if
  * the result is true the value is taken.
  *
  * @module services/UniqueValidorService
  */
-function UniqueValidatorService($http, util) { 
+function UniqueValidatorService($http, util) {
   var service = this;
-  
+
   // expose service API
   service.check = check;
-  
+
   /**
    * This method will make a request to a provided server end point to validate
-   * if a value (also passed) results in true or false. This method is responsible 
-   * for unwrapping the respons. 
+   * if a value (also passed) results in true or false. This method is responsible
+   * for unwrapping the respons.
    *
-   * A URL is accepted to determine which server route should be requested to verify 
-   * the existence of the entity. This directive implements the `exists` API and 
-   * will append '/exists' to the end of the URL. 
-   * For example: 
+   * A URL is accepted to determine which server route should be requested to verify
+   * the existence of the entity. This directive implements the `exists` API and
+   * will append '/exists' to the end of the URL.
+   * For example:
    * `url`            : '/entity/attribute/'
    * `value`          : '10230'
-   * 
-   * `requested URL`  : '/entity/attribute/10230/exists' 
    *
-   * @params {String} url     Target server API URL 
-   * @params {String} value   Value to check against server API endpoint
+   * `requested URL`  : '/entity/attribute/10230/exists'
+   *
+   * @param {String} url     Target server API URL
+   * @param {String} value   Value to check against server API endpoint
    */
-  function check(url, value) { 
+  function check(url, value) {
     var existsApiPhrase = '/exists';
-    
-    // sanitise the URL - append a '/' to the end if it does not exist 
+
+    // sanitise the URL - append a '/' to the end if it does not exist
     var baseUrl = url.endsWith('/') ? url : url.concat('/');
     var target = baseUrl.concat(value, existsApiPhrase);
 

--- a/client/src/js/services/journal/JournalPagination.js
+++ b/client/src/js/services/journal/JournalPagination.js
@@ -6,109 +6,109 @@ JournalPaginationService.$inject = [];
 /**
  * Posting Journal Pagination Service
  *
- * This service contains pagination configuration and utility methods for the 
- * posting journal module. Custom pagination rules and functions are defined to 
+ * This service contains pagination configuration and utility methods for the
+ * posting journal module. Custom pagination rules and functions are defined to
  * ensure that transactions are respected across pages (when grouped).
  *
  * @todo  Discuss if pagination should be encapsulated by TransactionService; this
- *        logic could be incorperation whilst loading transactions however this may result 
+ *        logic could be incorperation whilst loading transactions however this may result
  *        in too much responsibility.
  *
- * @todo  Discuss if pagination is required in an accountants workflow - how many 
- *        rows are we expecting etc. 
+ * @todo  Discuss if pagination is required in an accountants workflow - how many
+ *        rows are we expecting etc.
  */
-function JournalPaginationService() { 
+function JournalPaginationService() {
   var service = this;
-  
+
   /**
-   * this variable configures the grid to use or ignore custom pagination; 
-   * true  - external (custom) pagination will be used, transactions are respected 
+   * this variable configures the grid to use or ignore custom pagination;
+   * true  - external (custom) pagination will be used, transactions are respected
    *         in page sizes calculated by the `fetchPage` function.
    * false - default (UI Grid) pagination is used, this does not respect transactions
    */
   var useExternalPagination = false;
 
-  // variable used to track and share the current grids API object 
+  // variable used to track and share the current grids API object
   var gridApi, serviceGridOptions;
   var serviceTransactions;
-  
+
   /** @const */
   var paginationPageSizes = [25, 50, 75, 100];
   var paginationPageSize = 25;
 
-  var paginationOptions = { 
+  var paginationOptions = {
     pageNumber : 1,
     pageSize : paginationPageSize
   };
- 
-  /** 
-   * This method returns a subset of data based 
-   * Known shortcomings : 
-   * - This method filters out transactions that overflow into the next page; if 
+
+  /**
+   * This method returns a subset of data based
+   * Known shortcomings :
+   * - This method filters out transactions that overflow into the next page; if
    *   there are transactions bigger than a page it will return nothing
    * - Not all corner cases have been anticipated re: sorting/ filtering/ grouping
    *
-   * @params newPage {object}   current page index
-   * @params pageSize {object}  page size passed in from gridOptions
+   * @param newPage {object}   current page index
+   * @param pageSize {object}  page size passed in from gridOptions
    */
-  function fetchPage(newPage) { 
-    
-    // Set the ideal page size to the configured limit - note the size only referers to transaction 
+  function fetchPage(newPage) {
+
+    // Set the ideal page size to the configured limit - note the size only referers to transaction
     // elements, not header rows
     var pageSize = paginationOptions.pageSize;
 
     // Get the current index into the data
     var currentRowIndex = (newPage - 1) * pageSize;
-    
+
     // take an optimistic slice of the current data
     var data = serviceTransactions.slice(currentRowIndex, currentRowIndex + pageSize);
-    
+
     var upperBound = currentRowIndex + pageSize;
     var upperBoundElement = serviceTransactions[upperBound];
     var comparisonElement = serviceTransactions[upperBound + 1];
 
-    if (angular.isDefined(comparisonElement)) { 
-      if (upperBoundElement.trans_id === comparisonElement.trans_id) { 
+    if (angular.isDefined(comparisonElement)) {
+      if (upperBoundElement.trans_id === comparisonElement.trans_id) {
 
-        // filter out this transaction id 
+        // filter out this transaction id
         data = data.filter(row => { return row.trans_id !== upperBoundElement.trans_id; });
       }
     }
-    
+
     // update current subset of data
     serviceGridOptions.data = data;
 
     // update pagination view valuels
     serviceGridOptions.totalItems = serviceTransactions.length;
     serviceGridOptions.paginationPageSize = data.length;
-    serviceGridOptions.paginationPageSizes = [data.length]; 
+    serviceGridOptions.paginationPageSizes = [data.length];
   }
 
-  function paginationInstance(gridOptions, transactions) { 
+  function paginationInstance(gridOptions, transactions) {
     var cacheGridApi = gridOptions.onRegisterApi;
-     
+
     serviceGridOptions = gridOptions;
     serviceTransactions = transactions;
 
-    gridOptions.onRegisterApi = function (api) { 
+    gridOptions.onRegisterApi = function (api) {
       gridApi = api;
-      
+
       // configure global pagination settings
       gridOptions.paginationPageSizes = paginationPageSizes;
       gridOptions.paginationPageSize = paginationPageSize;
-      
-      if (useExternalPagination) {  
+
+      if (useExternalPagination) {
         gridOptions.useExternalPagination = true;
 
         // bind external pagination method
         gridApi.pagination.on.paginationChanged(null, fetchPage);
-      
+
         // Settup initial page
         fetchPage(paginationOptions.pageNumber);
       }
 
       // call the method that had previously been registered to request the grids api
-      if (angular.isDefined(cacheGridApi)) { 
+      if (angular.isDefined(cacheGridApi)) {
         cacheGridApi(api);
       }
     };

--- a/client/src/js/services/receipts/ReceiptService.js
+++ b/client/src/js/services/receipts/ReceiptService.js
@@ -4,29 +4,29 @@ angular.module('bhima.services')
 ReceiptService.$inject = ['$http', 'util'];
 
 /**
- * Receipts Service 
- * 
- * This service is responsible for interfacing with any receipts routes on the
- * server. 
+ * Receipts Service
  *
- * @todo  currently this server 1:1 maps with the ReceiptModal service/controller. 
- *        This relationship improved or justified with unit tests.  
+ * This service is responsible for interfacing with any receipts routes on the
+ * server.
+ *
+ * @todo  currently this server 1:1 maps with the ReceiptModal service/controller.
+ *        This relationship improved or justified with unit tests.
  * @module services/receipts/ReciptService
- */ 
-function ReceiptService($http, util) { 
+ */
+function ReceiptService($http, util) {
   var service = this;
 
   service.invoice = invoice;
-  
-  /** 
+
+  /**
    * Fetch invoice report data from /reports/invoices/:uuid
    *
-   * @params {String} uuid      Target invoice UUID to report on
-   * @params {Object} options   Configuration options for the server generated 
+   * @param {String} uuid      Target invoice UUID to report on
+   * @param {Object} options   Configuration options for the server generated
    *                            report, this includes things like render target.
    * @return {Promise}          Eventually returns report object from server
    */
-  function invoice(uuid, options) { 
+  function invoice(uuid, options) {
     var route = '/reports/invoices/'.concat(uuid);
     return $http.get(route, { params : options })
       .then(util.unwrapHttpResponse);

--- a/client/src/js/services/receipts/modal/receiptModalController.js
+++ b/client/src/js/services/receipts/modal/receiptModalController.js
@@ -4,37 +4,37 @@ angular.module('bhima.controllers')
 ReceiptModalController.$inject = ['$uibModalInstance', '$window', 'receipt', 'options'];
 
 /**
- * Receipt Modal Controller 
+ * Receipt Modal Controller
  *
- * @params {Object} receipt   An object containing the receipt request (formatted
+ * @param {Object} receipt   An object containing the receipt request (formatted
  *                            by the service wrapping the receipt modal). The promise
- *                            is stored in an object to ensure the modal is evaluated 
+ *                            is stored in an object to ensure the modal is evaluated
  *                            before the HTTP request (promise) is resolved.
- * @params {String} template  Path to the template or resource to load 
- * @params {String} render    Render target used to generate report 
+ * @param {String} template  Path to the template or resource to load
+ * @param {String} render    Render target used to generate report
  */
-function ReceiptModalController($modalInstance, $window, receipt, options) { 
+function ReceiptModalController($modalInstance, $window, receipt, options) {
   var vm = this;
-  
+
   // expose options to the view
   angular.extend(vm, options);
 
   receipt.promise
-    .then(function (result) { 
-      
+    .then(function (result) {
+
       // receipt has successfully loaded
       vm.receipt = result;
     })
-    .catch(function (error) { 
-      
+    .catch(function (error) {
+
       // receipt has failed - show error state
     });
 
-  vm.print = function print() { 
+  vm.print = function print() {
     $window.print();
   };
-  
-  vm.close = function close() { 
+
+  vm.close = function close() {
     $modalInstance.close();
   };
 }

--- a/client/src/partials/cash/modals/receipt.modal.html
+++ b/client/src/partials/cash/modals/receipt.modal.html
@@ -102,7 +102,7 @@
 </div>
 
 <div class="modal-footer">
-  <button  class="btn btn-success" ng-click="CashReceiptModalCtrl.cancel()">
+  <button class="btn btn-success" ng-click="CashReceiptModalCtrl.cancel()" data-modal-action="dismiss">
     {{ "FORM.BUTTONS.DISMISS" | translate }}
   </button>
 </div>

--- a/client/src/partials/cash/modals/transfer.modal.html
+++ b/client/src/partials/cash/modals/transfer.modal.html
@@ -18,13 +18,13 @@
       <div ng-if="CashTransferModalCtrl.currency_id">
         <p>{{"FORM.LABELS.BALANCE" | translate}} : {{CashTransferModalCtrl.cashAccountBalance.balance | currency:CashTransferModalCtrl.currency_id}}</p>
       </div>
-    </uib-alert>   
+    </uib-alert>
 
     <hr/>
 
     <div class="radio" ng-class="{ 'has-error' : TransferForm.$submitted && TransferForm.currency.$invalid }">
       <p><strong class="control-label">{{ "FORM.LABELS.CURRENCY" | translate }}</strong></p>
-      <label 
+      <label
         ng-repeat="currency in CashTransferModalCtrl.cashBox.currencies track by currency.currency_id"
         class="radio-inline">
           <input
@@ -63,8 +63,7 @@
       class="btn btn-primary"
       data-method="submit"
       ng-disabled="!CashTransferModalCtrl.cashBox"
-      data-transfer-modal-submit
-      >
+      data-modal-action="submit">
       {{ "FORM.BUTTONS.SUBMIT" | translate }}
     </button>
 
@@ -72,7 +71,7 @@
       type="button"
       class="btn btn-default"
       ng-click="CashTransferModalCtrl.cancel()"
-      data-transfer-modal-cancel>
+      data-modal-action="dismiss">
       {{ "FORM.BUTTONS.CANCEL" | translate }}
     </button>
   </div>

--- a/client/src/partials/exchange/modal.html
+++ b/client/src/partials/exchange/modal.html
@@ -1,4 +1,4 @@
-<form  name="ModalForm" ng-submit="ModalCtrl.submit(ModalForm.$invalid)" novalidate>
+<form name="ModalForm" ng-submit="ModalCtrl.submit(ModalForm.$invalid)" novalidate>
   <div class="modal-header">
     <h4>{{ 'EXCHANGE.ADDING_RATE' | translate }}</h4>
   </div>
@@ -9,24 +9,26 @@
     </uib-alert>
 
     <div class="form-group">
-      <label>{{ "EXCHANGE.ENTERPRISE_CURRENCY" | translate }}</label> 
+      <label>{{ "EXCHANGE.ENTERPRISE_CURRENCY" | translate }}</label>
       <p class="form-control-static">{{ ModalCtrl.enterpriseCurrency }} : {{ 1 |  currency:ModalCtrl.enterpriseCurrencyId }}</p>
     </div>
 
     <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.rate.$invalid }">
       <label class="control-label">{{ ModalCtrl.text | translate }} : {{ ModalCtrl.data.date | date }} : {{ ModalCtrl.selectedCurrency }}</label>
-      <input type="number" class="form-control" name="rate" required id="bhima-project-abbr" min="0" ng-model="ModalCtrl.data.rate">
+      <input type="number" class="form-control" name="rate" required min="0" ng-model="ModalCtrl.data.rate">
       <div class="help-block" ng-messages="ModalForm.rate.$error" ng-show="ModalForm.$submitted">
         <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-      </div>      
+      </div>
     </div>
 
   </div>
 
   <div class="modal-footer">
-    <button class="btn btn-default" id="submit-project" type="submit" data-method="submit">
+    <button type="button" class="btn btn-default" ng-click="ModalCtrl.cancel()" data-method="cancel">
+      {{ "FORM.BUTTONS.CANCEL" | translate }}
+    </button>
+    <button type="submit" class="btn btn-primary" data-method="submit">
       {{ "FORM.BUTTONS.SUBMIT" | translate }}
     </button>
-    <button type="button" class="btn btn-default" ng-click="ModalCtrl.cancel()">{{ "FORM.BUTTONS.CANCEL" | translate }}</button>
   </div>
 </form>

--- a/client/src/partials/patients/registration/registration.html
+++ b/client/src/partials/patients/registration/registration.html
@@ -10,10 +10,9 @@
 <div class="flex-content">
   <div class="container-fluid">
 
-    <!-- Module wide error handling -->
+    <!-- module wide error handling -->
     <div class="row">
       <div class="col-md-12">
-
         <uib-alert id="exceptionAlert" type="danger" ng-show="PatientRegCtrl.exception">
           <span class="glyphicon glyphicon-exclamation-sign"></span>
           <b>{{ PatientRegCtrl.exception.data.code | translate }}</b> ({{PatientRegCtrl.exception.status}} - {{PatientRegCtrl.exception.data.description}})

--- a/client/src/partials/patients/registration/registration.js
+++ b/client/src/partials/patients/registration/registration.js
@@ -89,7 +89,7 @@ function PatientRegistrationController($location, ScrollTo, Patients, Debtors, S
    * @todo  Discuss if this should be a library to account for standard client side errors,
    *        -1 for offline etc. This should not have to be done everywhere.
    *        This could be implemented with an $http interceptor.
-   * @params  {object}  error  An Error object that has been sent from the server.
+   * @param  {object}  error  An Error object that has been sent from the server.
    */
   function handleServerError(error) {
     viewModel.exception = error;

--- a/client/test/e2e/accounts/accounts.spec.js
+++ b/client/test/e2e/accounts/accounts.spec.js
@@ -13,7 +13,7 @@ describe('Accounts Module', function () {
   'use strict';
 
   const path = '#/accounts';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const accountBalance = {
     label : 'Compte de Balance',

--- a/client/test/e2e/billingServices/billingServices.spec.js
+++ b/client/test/e2e/billingServices/billingServices.spec.js
@@ -16,7 +16,7 @@ describe('Billing Services', function () {
   const path = '#/admin/billing_services';
   const gridId = 'BillingServicesGrid';
 
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   it('can create a billing service', function () {
 

--- a/client/test/e2e/cash/cash.spec.js
+++ b/client/test/e2e/cash/cash.spec.js
@@ -117,7 +117,7 @@ describe('Cash Payments Module', function () {
 
     /** navigate to the page before each function */
     beforeEach(function () {
-      browser.get(path);
+      helpers.navigate(path);
     });
 
     // this code assumes that the find-patient directive is well tested.
@@ -160,9 +160,12 @@ describe('Cash Payments Module', function () {
 
       // expect the receipt modal to appear
       FU.exists(by.css('[data-cash-receipt-modal]'), true);
+
+      // dismiss the modal
+      element(by.css('[data-modal-action="dismiss"]')).click();
     });
 
-    /** @todo - once posting is figured out, this test should be uncommented and work */
+    /** @todo - once invoice posting is figured out, this test should be uncommented and work */
     it.skip('should make a payment against previous invoices', function () {
       var gridId = 'debtorInvoicesGrid';
 
@@ -202,13 +205,16 @@ describe('Cash Payments Module', function () {
 
       // expect the receipt modal to appear
       FU.exists(by.css('[data-cash-receipt-modal]'), true);
+
+      // dismiss the modal
+      element(by.css('[data-modal-action="dismiss"]')).click();
     });
   });
 
   describe('Cash Transfer ', function (){
 
-    /** navigate to the page before tests */
-    before(() => browser.get(path));
+    // navigate to the page before tests
+    before(() => helpers.navigate(path));
 
     // This transfer should succeed
     const mockTransfer = {
@@ -229,10 +235,11 @@ describe('Cash Payments Module', function () {
       components.currencyInput.set(mockTransfer.amount, 'transferCurrencyInput');
 
       // submit the modal button
-      var transferSubmitBtn =  element(by.id('submit-transfer'));
+      var transferSubmitBtn = element(by.id('submit-transfer'));
       transferSubmitBtn.click();
 
       FU.exists(by.id('succeed-label'), true);
+      element(by.css('[data-modal-action="dismiss"]')).click();
     });
   });
 });

--- a/client/test/e2e/cashboxes/cashboxes.spec.js
+++ b/client/test/e2e/cashboxes/cashboxes.spec.js
@@ -10,7 +10,7 @@ const components = require('../shared/components');
 
 describe('Cashbox Module', function () {
 
-  before(() => browser.get('#/cashboxes'));
+  before(() => helpers.navigate('#/cashboxes'));
 
   const cashbox = {
     label:    'Test Principal Cashbox',

--- a/client/test/e2e/debtor_groups/debtorGroups.spec.js
+++ b/client/test/e2e/debtor_groups/debtorGroups.spec.js
@@ -11,7 +11,7 @@ const components = require('../shared/components');
 describe('Debtor Groups', function () {
   'use strict';
 
-  before(() => browser.get('#/debtor_groups'));
+  before(() => helpers.navigate('#/debtor_groups'));
 
   const groupUuid = '4de0fe47-177f-4d30-b95f-cff8166400b4';
 

--- a/client/test/e2e/debtors/debtorgroups.spec.js
+++ b/client/test/e2e/debtors/debtorgroups.spec.js
@@ -15,7 +15,7 @@ describe('Debtor Groups Management', function () {
 
   /** @const */
   var root = '#/debtors/groups';
-  before(function () { browser.get(root); });
+  before(function () { helpers.navigate(root); });
 
   it('lists base test debtor groups', function () {
     expect(element.all(by.css('[data-group-entry]')).count()).to.eventually.equal(initialGroups);

--- a/client/test/e2e/depots_management/depots_management.spec.js
+++ b/client/test/e2e/depots_management/depots_management.spec.js
@@ -9,7 +9,7 @@ helpers.configure(chai);
 describe('Depots Management', function () {
 
   // navigate to the page
-  before(() => browser.get('#/depots_management'));
+  before(() => helpers.navigate('#/depots_management'));
 
   const depot = {
     text : 'E2E_new_depot',

--- a/client/test/e2e/donors/donors.spec.js
+++ b/client/test/e2e/donors/donors.spec.js
@@ -8,7 +8,7 @@ const helpers = require('../shared/helpers');
 helpers.configure(chai);
 
 describe('Donor Management', function () {
-  before(() => browser.get('#/donors'));
+  before(() => helpers.navigate('#/donors'));
 
   const donor = {
     name : 'IMA WorldHealth (E2E)'

--- a/client/test/e2e/employees/employees.spec.js
+++ b/client/test/e2e/employees/employees.spec.js
@@ -11,7 +11,7 @@ describe('Employees Module', function () {
   'use strict';
 
   const path = '#/employees';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const employee = {
     code : 'HBB80',

--- a/client/test/e2e/enterprises/enterprises.spec.js
+++ b/client/test/e2e/enterprises/enterprises.spec.js
@@ -22,7 +22,7 @@ describe('Enterprises Module', function () {
   };
 
   // navigate to the enterprise module before running tests
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
 
   it('successfully creates a new enterprise', function () {

--- a/client/test/e2e/exchange/exchange.spec.js
+++ b/client/test/e2e/exchange/exchange.spec.js
@@ -7,11 +7,11 @@ const FU = require('../shared/FormUtils');
 const components = require('../shared/components');
 helpers.configure(chai);
 
-describe('Exchange Rate Module', function () {
+describe('Exchange Rate', function () {
   'use strict';
 
   const path = '#/exchange';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const exchangeRate = {
     date : new Date('06-30-2015'),
@@ -125,5 +125,7 @@ describe('Exchange Rate Module', function () {
 
     // The following fields should be required
     FU.validation.error('ModalCtrl.data.rate');
+
+    FU.buttons.cancel();
   });
 });

--- a/client/test/e2e/journal/journal.spec.js
+++ b/client/test/e2e/journal/journal.spec.js
@@ -18,7 +18,7 @@ describe('Posting Journal Core', function () {
 
   // this will be run before every single test ('it') - navigating the browser
   // to the correct page.
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   it('displays initial transactions loaded from database', function () {
     var journal = new JournalCorePage();
@@ -53,5 +53,5 @@ describe('Posting Journal Core', function () {
     .then(function (visibleColumnsNumberAfter){
       expect(visibleColumnsNumberBefore).to.eventually.equal(visibleColumnsNumberAfter + 1);
     });
-  });  
+  });
 });

--- a/client/test/e2e/locations/countries.spec.js
+++ b/client/test/e2e/locations/countries.spec.js
@@ -1,4 +1,4 @@
-/* global element, by, inject, browser */
+/* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -12,7 +12,7 @@ describe('Countries Management', function () {
   const path = '#/locations/country';
 
   // navigate to the page before the test suite
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const country = {
     name : 'A Country for Test'

--- a/client/test/e2e/locations/modal.spec.js
+++ b/client/test/e2e/locations/modal.spec.js
@@ -1,5 +1,4 @@
-/* global element, by, inject, browser */
-
+/* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -10,7 +9,7 @@ helpers.configure(chai);
 describe('locations (create modal)', function () {
   'use strict';
 
-  before(() => browser.get('#/patients/register'));
+  before(() => helpers.navigate('#/patients/register'));
 
   /** location to be created */
   var newLocation = {

--- a/client/test/e2e/locations/provinces.spec.js
+++ b/client/test/e2e/locations/provinces.spec.js
@@ -12,7 +12,7 @@ describe('Provinces Management', function () {
 
   const path = '#/locations/province';
 
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const province = {
     name : 'A Province for Test'

--- a/client/test/e2e/locations/sectors.spec.js
+++ b/client/test/e2e/locations/sectors.spec.js
@@ -9,7 +9,7 @@ helpers.configure(chai);
 describe('Sectors Management', function () {
   'use strict';
 
-  before(() => browser.get('#/locations/sector'));
+  before(() => helpers.navigate('#/locations/sector'));
 
   const sector = {
     name :'A Sector for Test'

--- a/client/test/e2e/locations/villages.spec.js
+++ b/client/test/e2e/locations/villages.spec.js
@@ -1,4 +1,4 @@
-/* global element, by, inject, browser */
+/* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -10,7 +10,7 @@ describe('Villages Management', function () {
   'use strict';
 
   const path = '#/locations/village';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const village = {
     name : 'A Village for Test'

--- a/client/test/e2e/patient/groups.spec.js
+++ b/client/test/e2e/patient/groups.spec.js
@@ -1,5 +1,4 @@
 /* global element, by, browser */
-
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -12,7 +11,7 @@ const components = require('../shared/components');
 describe('Patient Groups', function () {
 
   // navigate to the page before running test suite
-  before(() => browser.get('#/patients/groups'));
+  before(() => helpers.navigate('#/patients/groups'));
 
   // a new group to create
   const group = {

--- a/client/test/e2e/patient/invoice.spec.js
+++ b/client/test/e2e/patient/invoice.spec.js
@@ -23,9 +23,7 @@ describe('Patient Invoice', function () {
   const path = '#/invoices/patient';
 
   // navigate to the patient invoice page
-  beforeEach(function () {
-    browser.get(path);
-  });
+  beforeEach(() => helpers.navigate(path));
 
   it.skip('invoices a patient for a single item', function () {
     var page = new PatientInvoicePage();

--- a/client/test/e2e/patient/registration.spec.js
+++ b/client/test/e2e/patient/registration.spec.js
@@ -12,7 +12,7 @@ describe('patient registration', function () {
   'use strict';
 
   const registrationPath = '#/patients/register';
-  beforeEach(() => browser.get(registrationPath));
+  beforeEach(() => helpers.navigate(registrationPath));
 
   const mockPatient = {
     first_name : 'Mock',
@@ -70,6 +70,9 @@ describe('patient registration', function () {
   // with the system
   describe('form validation', function () {
 
+    // refresh the page to make sure previous data is cleared
+    before(() => browser.refresh());
+
     it('correctly blocks invalid form submission with relevent error classes', function () {
 
       // submit the patient registration form
@@ -101,17 +104,6 @@ describe('patient registration', function () {
 
       FU.input('PatientRegCtrl.yob', testMinYear);
       FU.exists(by.css('[data-date-error]'), true);
-    });
-
-    it('correctly identifies duplicate hospital numbers (async)', function () {
-
-      // resend the (assumed) correctly registered patients hospital number
-      FU.input('PatientRegCtrl.medical.hospital_no', mockPatient.hospital_no);
-      FU.exists(by.id('unique-error-icon'), true);
-
-      // put in a unique hospital number
-      FU.input('PatientRegCtrl.medical.hospital_no', uniqueHospitalNumber);
-      FU.exists(by.id('unique-error-icon'), false);
     });
   });
 

--- a/client/test/e2e/patient/registry.spec.js
+++ b/client/test/e2e/patient/registry.spec.js
@@ -1,4 +1,4 @@
-/* global element, by, inject, browser */
+/* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
 const helpers = require('../shared/helpers');
@@ -9,7 +9,7 @@ describe('Patient Registry UI Grid ', function () {
   'use strict';
 
   const path = '#/patients/registry';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   it('grid should have 3 visible rows', function () {
     var defaultVisibleRowNumber = 3;

--- a/client/test/e2e/permissions/permissions.spec.js
+++ b/client/test/e2e/permissions/permissions.spec.js
@@ -1,4 +1,4 @@
-/* global inject, browser, element, by */
+/* global browser, element, by */
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -9,7 +9,7 @@ helpers.configure(chai);
 
 describe('Permissions Module', function () {
 
-  before(() => browser.get('#/permissions'));
+  before(() => helpers.navigate('#/permissions'));
 
   const mockUser = {
     first:    'Mock',

--- a/client/test/e2e/price_list/price_list.spec.js
+++ b/client/test/e2e/price_list/price_list.spec.js
@@ -1,4 +1,4 @@
-/* global element, by, inject, browser */
+/* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -12,7 +12,7 @@ describe('Price List Module', function () {
   'use strict';
 
   const path = '#/prices';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const priceList = {
     label : 'Price list without Items',

--- a/client/test/e2e/projects/projects.spec.js
+++ b/client/test/e2e/projects/projects.spec.js
@@ -18,7 +18,7 @@ describe('Projects Module', function () {
   };
 
   // navigate to the project module before starting
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const defaultProject = 3;
   const enterpriseRank = helpers.random(defaultProject);

--- a/client/test/e2e/reference/reference.spec.js
+++ b/client/test/e2e/reference/reference.spec.js
@@ -1,4 +1,4 @@
-/* global element, by, inject, browser */
+/* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -12,7 +12,7 @@ describe('Reference Module', function () {
   'use strict';
 
   const path = '#/references';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const reference = {
     ref : 'AD',

--- a/client/test/e2e/reference_group/reference_group.spec.js
+++ b/client/test/e2e/reference_group/reference_group.spec.js
@@ -1,4 +1,4 @@
-/* global element, by, inject, browser */
+/* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -12,7 +12,7 @@ describe('Reference Group Module', function () {
   'use strict';
 
   const path = '#/references/groups';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const referenceGroup = {
     reference_group   : 'BC',

--- a/client/test/e2e/sectionResultat/sectionResultat.spec.js
+++ b/client/test/e2e/sectionResultat/sectionResultat.spec.js
@@ -1,4 +1,4 @@
-/* global element, by, inject, browser */
+/* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -12,7 +12,7 @@ describe('Section Resultats Module', function () {
   'use strict';
 
   const path = '#/section_resultat';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const sectionResultat = {
     text : 'A Special Section Result',
@@ -71,7 +71,7 @@ describe('Section Resultats Module', function () {
 
     // click the alert asking for permission
     components.modalAction.confirm();
- 
+
     // make sure that the delete message appears
     FU.exists(by.id('delete_success'), true);
   });

--- a/client/test/e2e/section_bilan/section_bilan.spec.js
+++ b/client/test/e2e/section_bilan/section_bilan.spec.js
@@ -12,7 +12,7 @@ describe('Section Bilan Module', function () {
   'use strict';
 
   const path = '#/section_bilan';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const sectionBilan = {
     text : 'A Special Section Result',

--- a/client/test/e2e/services/services.spec.js
+++ b/client/test/e2e/services/services.spec.js
@@ -2,17 +2,17 @@
 const chai = require('chai');
 const expect = chai.expect;
 
-const FormUtils = require('../shared/FormUtils');
+const FU = require('../shared/FormUtils');
 const helpers = require('../shared/helpers');
 const components = require('../shared/components');
 
 helpers.configure(chai);
 
-describe('Services Module', function () {
+describe('Services', function () {
 
   // shared methods
   const path = '#/services';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const SERVICE = {
     name : 'A service E2E',
@@ -24,44 +24,44 @@ describe('Services Module', function () {
   const DELETE_ERROR = 3;
 
   it('successfully creates a new service', function () {
-    FormUtils.buttons.create();
+    FU.buttons.create();
 
-    FormUtils.input('ServicesCtrl.service.name', SERVICE.name);
+    FU.input('ServicesCtrl.service.name', SERVICE.name);
 
     // select a random, enterprise
-    FormUtils.select('ServicesCtrl.service.enterprise_id')
+    FU.select('ServicesCtrl.service.enterprise_id')
       .enabled()
       .first()
       .click();
 
     // select a random, cost center
-    FormUtils.select('ServicesCtrl.service.cost_center_id')
+    FU.select('ServicesCtrl.service.cost_center_id')
       .enabled()
       .first()
       .click();
 
     // select a random, profit center
-    FormUtils.select('ServicesCtrl.service.profit_center_id')
+    FU.select('ServicesCtrl.service.profit_center_id')
       .enabled()
       .first()
       .click();
 
     // submit the page to the server
-    FormUtils.buttons.submit();
+    FU.buttons.submit();
 
-    FormUtils.exists(by.id('create_success'), true);
+    FU.exists(by.id('create_success'), true);
   });
 
   it('successfully edits an service', function () {
     element(by.id('service-upd-' + SERVICE_RANK)).click();
-    FormUtils.input('ServicesCtrl.service.name', 'Updated');
+    FU.input('ServicesCtrl.service.name', 'Updated');
     element(by.id('change_service')).click();
 
-    FormUtils.exists(by.id('update_success'), true);
+    FU.exists(by.id('update_success'), true);
   });
 
   it('correctly blocks invalid form submission with relevant error classes', function () {
-    FormUtils.buttons.create();
+    FU.buttons.create();
 
     // verify form has not been successfully submitted
     expect(helpers.getCurrentPath()).to.eventually.equal(path);
@@ -69,30 +69,30 @@ describe('Services Module', function () {
     element(by.id('submit-service')).click();
 
     // The following fields should be required
-    FormUtils.validation.error('ServicesCtrl.service.name');
-    FormUtils.validation.error('ServicesCtrl.service.enterprise_id');
+    FU.validation.error('ServicesCtrl.service.name');
+    FU.validation.error('ServicesCtrl.service.enterprise_id');
 
     // The following fields is not required
-    FormUtils.validation.ok('ServicesCtrl.service.cost_center_id');
-    FormUtils.validation.ok('ServicesCtrl.service.profit_center_id');
+    FU.validation.ok('ServicesCtrl.service.cost_center_id');
+    FU.validation.ok('ServicesCtrl.service.profit_center_id');
   });
 
   it('successfully delete an service', function () {
     element(by.id('service-del-' + DELETE_SUCCESS )).click();
     components.modalAction.confirm();
 
-    FormUtils.exists(by.id('delete_success'), true);
+    FU.exists(by.id('delete_success'), true);
   });
 
   it('no way to delete a service', function () {
     element(by.id('service-del-' + DELETE_ERROR )).click();
     components.modalAction.confirm();
-    FormUtils.exists(by.id('delete_error'), true);
+    FU.exists(by.id('delete_error'), true);
   });
 
   it('cancellation of removal process of a service', function () {
     element(by.id('service-del-' + DELETE_ERROR )).click();
     components.modalAction.dismiss();
-    FormUtils.exists(by.id('default'), true);
+    FU.exists(by.id('default'), true);
   });
 });

--- a/client/test/e2e/settings/settings.spec.js
+++ b/client/test/e2e/settings/settings.spec.js
@@ -1,4 +1,4 @@
-/* global browser, element, by, protractor */
+/* global browser, element, by */
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -8,7 +8,7 @@ helpers.configure(chai);
 
 describe('Settings', function () {
 
-  before(() => browser.get('#/settings'));
+  before(() => helpers.navigate('#/settings'));
 
   it('loads the page, and selects a language', function () {
 
@@ -27,7 +27,7 @@ describe('Settings', function () {
   it('uses the back button to return to previous state', function () {
 
     // load the settings page w/o backwards navigation
-    browser.get('#/settings?previous=index');
+    helpers.navigate('#/settings?previous=index');
 
     var btn = '[data-back-button]';
 

--- a/client/test/e2e/shared/helpers.js
+++ b/client/test/e2e/shared/helpers.js
@@ -1,26 +1,34 @@
-/* jshint expr:true */
 /* global element, by, browser */
 
 /**
- * Test helpers
+ * @overview helpers
  *
- * This module contains utilities that are useful in tests, but not specifically
+ * @description
+ * This file contains utilities that are useful in tests, but not specifically
  * tied to forms or modules.
  */
 
-/** gets a random number within the range(0, n) */
+'use strict';
+
+// gets a random number within the range(0, n)
 exports.random = function random(n) {
-  'use strict';
   return Math.floor((n) * Math.random() + 1);
 };
 
+// wrapper for browser navigation without reloading the page
+exports.navigate = function navigate(path) {
+  let destination = path.replace('#/', '');
+  browser.setLocation(destination);
+};
+
+// configures the chai assertion library
 exports.configure = function configure(chai) {
-  'use strict';
 
   // enable promise chaining for chai assertions
   chai.use(require('chai-as-promised'));
 };
 
+// get the browser path after the hash
 exports.getCurrentPath = function getCurrentPath() {
   return browser.getCurrentUrl()
   .then(function (url) {

--- a/client/test/e2e/subsidies/subsidies.spec.js
+++ b/client/test/e2e/subsidies/subsidies.spec.js
@@ -1,4 +1,4 @@
-/* global element, by, inject, browser */
+/* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -12,7 +12,7 @@ describe('Subsidies Module', function () {
   'use strict';
 
   const path = '#/subsidies';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const subsidy = {
     label : 'IMA SUBSIDY',

--- a/client/test/e2e/suppliers/suppliers.spec.js
+++ b/client/test/e2e/suppliers/suppliers.spec.js
@@ -6,11 +6,11 @@ const FU = require('../shared/FormUtils');
 const helpers = require('../shared/helpers');
 helpers.configure(chai);
 
-describe('Suppliers Module', function () {
+describe('Suppliers', function () {
   'use strict';
 
   const path = '#/creditors';
-  before(() => browser.get(path));
+  before(() => helpers.navigate(path));
 
   const supplier = {
     name : 'Alpha Lmtd',

--- a/client/test/e2e/vouchers/simple.spec.js
+++ b/client/test/e2e/vouchers/simple.spec.js
@@ -10,7 +10,7 @@ helpers.configure(chai);
 describe('Simple Vouchers', function () {
   'use strict';
 
-  before(() => browser.get('#/vouchers/simple'));
+  before(() => helpers.navigate('#/vouchers/simple'));
 
   const voucher = {
     date : new Date((new Date()).getDate() - 1),

--- a/server/lib/renderers/json.js
+++ b/server/lib/renderers/json.js
@@ -1,17 +1,18 @@
 /**
- * BHIMA JSON Report Renderer (Wrapper) 
+ * @overview
+ * BHIMA JSON Report Renderer (Wrapper)
  *
- * This server library is responsible for rendering reports in JSON format. 
+ * This server library is responsible for rendering reports in JSON format.
  * It adheres to the standard BHIMA Report Renderer API, accepting data
- * and options and returning a single compiled object. 
+ * and options and returning a single compiled object.
  *
- * This renderer demonstrates the API however is mostly a wrapper to be used 
+ * This renderer demonstrates the API however is mostly a wrapper to be used
  * uniformly with the other renderers (PDF/ HTML/ CSV).
  *
- * @todo    JSON Wrapper is currently just a wrapper to provide a uniform API, it 
+ * @todo    JSON Wrapper is currently just a wrapper to provide a uniform API, it
  *          could also provide functionality like JSON verification (JSON parse/
  *          JSON stringify).
- * 
+ *
  * @module  lib/renderers/json
  */
 var q = require('q');
@@ -21,15 +22,15 @@ module.exports = renderJSON;
 /**
  * JSON Render Method
  *
- * @params {Object} data      Contains data in any format that will be used to 
- *                            drive the final report - this will be exposed to 
- *                            the view by the renderer. 
- * @params {Object} options   (Optional) parameters that can be passed to switch 
+ * @param {Object} data      Contains data in any format that will be used to
+ *                            drive the final report - this will be exposed to
+ *                            the view by the renderer.
+ * @param {Object} options   (Optional) parameters that can be passed to switch
  *                            render features on/off.
  *
  * @returns {Object}          JSON Object representing a report that can be sent
  *                            to the client.
  */
-function renderJSON(data, options) { 
+function renderJSON(data, options) {
   return q.resolve(data);
 }


### PR DESCRIPTION
This commit changes all tests to use `helpers.navigate()`, which is an alias for `browser.setLocation()` for navigation.  This has performance advantages since it not longer requires app to download and parse the page as `browser.get()` does.

Additionally, the incorrect JSDoc syntax `@params` has been replaced with `@param` wherever it can be found.

Closes #380.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
