### PR TITLE
feat(events): create server event emitter

### DIFF
--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -4,7 +4,7 @@
  *
  * Initialise link between server paths and controller logic
  *
- * @TODO Pass authenticate and authorize middleware down through
+ * @todo Pass authenticate and authorize middleware down through
  * controllers, allowing for modules to subscribe to different
  * levels of authority
  */
@@ -66,16 +66,20 @@ var referenceGroup       = require('../controllers/finance/referenceGroup');
 var sectionResultats     = require('../controllers/finance/sectionResultat');
 var sectionBilans        = require('../controllers/finance/sectionBilan');
 var creditors            = require('../controllers/finance/creditors.js');
+const events             = require('../controllers/events');
 
 // expose routes to the server.
-exports.configure = function (app) {
+exports.configure = function configure(app) {
   winston.debug('Configuring routes');
 
   // exposed to the outside without authentication
   app.get('/languages', users.getLanguages);
   app.get('/projects', projects.list);
-
   app.get('/units', units.list);
+
+  // event architecture
+  app.get('/events', events.list);
+  app.get('/stream', events.stream);
 
   app.post('/login', auth.login);
   app.get('/logout', auth.logout);
@@ -131,22 +135,20 @@ exports.configure = function (app) {
   app.put('/cost_centers/:id', costCenter.update);
   app.delete('/cost_centers/:id', costCenter.remove);
 
-  //API for service routes
-
+  // API for service routes
   app.post('/services', services.create);
   app.get('/services', services.list);
   app.get('/services/:id', services.detail);
   app.put('/services/:id', services.update);
   app.delete('/services/:id', services.remove);
 
-  //API for profit_center routes crud
+  // API for profit_center routes crud
   app.get('/profit_centers', profitCenter.list);
   app.get('/profit_centers/:id', profitCenter.detail);
   app.get('/profit_centers/:id/profit', profitCenter.getProfitValue);
   app.post('/profit_centers', profitCenter.create);
   app.put('/profit_centers/:id', profitCenter.update);
   app.delete('/profit_centers/:id', profitCenter.remove);
-
 
   //API for reference routes crud
   app.get('/references', reference.list);
@@ -182,7 +184,6 @@ exports.configure = function (app) {
   app.post('/subsidies', subsidies.create);
   app.put('/subsidies/:id', subsidies.update);
   app.delete('/subsidies/:id', subsidies.remove);
-
 
   // -> Add :route
   app.post('/report/build/:route', reports.build);

--- a/server/controllers/events.js
+++ b/server/controllers/events.js
@@ -1,0 +1,55 @@
+/**
+ * @overview
+ * This controller uses the eventd library to broadcast events to the client
+ * along a server-sent events channel.  It includes two channels:
+ *  1. `/stream` for real-time event broadcasts.
+ *  2. `/events` for listing all events in the last day
+ *
+ * @requires lib/db
+ * @requires lib/eventd
+ */
+
+'use strict';
+
+const db = require('../lib/db');
+const eventd = require('../lib/eventd');
+
+// GET /stream
+exports.stream = stream;
+
+// GET /events
+exports.list = list;
+
+// event stream to be set to the client
+function stream(req, res) {
+
+  // ensure the socket hangs open forever
+  res.set('Content-Type', 'text/event-stream');
+  res.set('Content-Control', 'no-cache');
+
+  // this listener publishes events to the client as server-sent events
+  function listener(data) {
+    res.write(`data: ${JSON.stringify(data)}\n\n`).flush();
+  }
+
+  // listen for server events and echo them to the client
+  eventd.subscribe(eventd.channels.ALL, listener);
+
+  // remove listener on when the client closes the connection
+  res.on('close', () => eventd.unsubscribe(eventd.channels.ALL, listener));
+}
+
+// list the events in the database
+function list(req, res, next) {
+  let sql = `
+    SELECT  event.data FROM event LIMIT 500;
+  `;
+
+  db.exec(sql)
+  .then(rows => {
+    let events = rows.map(row => JSON.parse(row.data));
+    res.status(200).json(events);
+  })
+  .catch(next)
+  .done();
+}

--- a/server/controllers/medical/patient.js
+++ b/server/controllers/medical/patient.js
@@ -1,12 +1,15 @@
 /**
+ * @module medical/patient
+ *
+ * @description
  * The /patient HTTP API endpoint
  *
  * This module is responsible for handling all crud operations relatives to patients
  * and define all patient api functions
  *
- * @module medical/patient
  *
  * @requires lib/db
+ * @requires lib/eventd
  * @requires lib/node-uuid
  * @requires lib/errors/BadRequest
  * @requires lib/errors/NotFound
@@ -18,6 +21,7 @@
 'use strict';
 
 const db = require('../../lib/db');
+const eventd = require('../../lib/eventd');
 const uuid = require('node-uuid');
 const BadRequest  = require('../../lib/errors/BadRequest');
 const NotFound = require('../../lib/errors/NotFound');
@@ -142,6 +146,14 @@ function create(req, res, next) {
       res.status(201).json({
         uuid : uuid.unparse(medical.uuid)
       });
+
+      // publish a CREATE event on the medical channel
+      eventd.publish(eventd.channels.MEDICAL, {
+        event: eventd.events.CREATE,
+        entity: eventd.entities.PATIENT,
+        user_id: req.session.user.id,
+        uuid: uuid.unparse(medical.uuid)
+      });
     })
     .catch(next)
     .done();
@@ -154,17 +166,18 @@ function generatePatientText(patient) {
 }
 
 /**
-* Returns details associated to a patient directly and indirectly
-*
-* @example
-* // GET /patients/uuid : Get details associated to a patient directly and indirectly
-* var patient = require('medical/patient');
-* patient.detail(req, res, next);
-*/
-
-/** @todo review if this many details should be returned under a patient end point */
+ * @method detail
+ *
+ * @description
+ * Returns details associated to a patient directly and indirectly.
+ *
+ * @example
+ * var patient = require('medical/patient');
+ * patient.detail(req, res, next);
+ *
+ * @todo review if this many details should be returned under a patient end point
+ */
 function detail(req, res, next) {
-
   handleFetchPatient(req.params.uuid)
     .then(function(patientDetail) {
       res.status(200).json(patientDetail);
@@ -191,6 +204,14 @@ function update(req, res, next) {
     })
     .then(function (updatedPatient) {
       res.status(200).json(updatedPatient);
+
+      // publish an UPDATE event on the medical channel
+      eventd.publish(eventd.channels.MEDICAL, {
+        event: eventd.events.UPDATE,
+        entity: eventd.entities.PATIENT,
+        user_id: req.session.user.id,
+        uuid: patientUuid
+      });
     })
     .catch(next)
     .done();
@@ -199,7 +220,7 @@ function update(req, res, next) {
 function handleFetchPatient(patientUuid) {
 
   // convert uuid to database usable binary uuid
-  var buid = db.bid(patientUuid);
+  let buid = db.bid(patientUuid);
 
   var patientDetailQuery =
     `SELECT BUID(p.uuid) as uuid, p.project_id, BUID(p.debtor_uuid) AS debtor_uuid, p.first_name,
@@ -472,11 +493,14 @@ function visit(req, res, next) {
     .done();
 }
 
+/**
+ * @function logVisit
+ */
 function logVisit(patientData, userId) {
-  var visitId = db.bid(uuid.v4());
-  var sql =
-    'INSERT INTO `patient_visit` (`uuid`, `patient_uuid`, `registered_by`) VALUES (?, ?, ?)';
-  return db.exec(sql, [visitId, db.bid(patientData.uuid), userId]);
+  let visitId = db.bid(uuid.v4());
+  let sql =
+    'INSERT INTO patient_visit (uuid, patient_uuid, registered_by) VALUES (?);';
+  return db.exec(sql, [[visitId, db.bid(patientData.uuid), userId]]);
 }
 
 function isEmpty(array) {

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -1,23 +1,35 @@
 /**
-* The /users HTTP API endpoint.
-*
-* This controller is responsible for implementing full CRUD on the user table
-* via the /users endpoint.  The following routes are supported:
-*   GET /users
-*   GET /users/:id
-*   GET /users/:id/permissions
-*   GET /users/:id/projects
-*   POST /users
-*   POST /users/:id/permissions
-*   POST /users/:id/projects
-*   PUT /users/:id
-*   PUT /users/:id/password
-*   DELETE /users/:id
-*/
-var db = require('../lib/db');
-var q  = require('q');
-var NotFound = require('../lib/errors/NotFound');
-var BadRequest = require('../lib/errors/BadRequest');
+ * @module controllers/users.js
+ *
+ * @description
+ * The /users HTTP API endpoint.
+ *
+ * This controller is responsible for implementing full CRUD on the user table
+ * via the /users endpoint.  The following routes are supported:
+ *   GET /users
+ *   GET /users/:id
+ *   GET /users/:id/permissions
+ *   GET /users/:id/projects
+ *   POST /users
+ *   POST /users/:id/permissions
+ *   POST /users/:id/projects
+ *   PUT /users/:id
+ *   PUT /users/:id/password
+ *   DELETE /users/:id
+ *
+ * @requires q
+ * @requires lib/db
+ * @requires lib/errors/NotFound
+ * @requires lib/errors/BadRequest
+ */
+
+'use strict';
+
+const q  = require('q');
+const db = require('../lib/db');
+const NotFound = require('../lib/errors/NotFound');
+const BadRequest = require('../lib/errors/BadRequest');
+const eventd = require('../lib/eventd');
 
 // namespaces for /users/:id/projects and /users/:id/permissions
 exports.projects = {};
@@ -30,11 +42,7 @@ exports.permissions = {};
 * of zero or more JSON objects, with id, and username keys.
 */
 exports.list = function list(req, res, next) {
-  'use strict';
-
-  var sql;
-
-  sql =
+  let sql =
     `SELECT user.id, CONCAT(user.first, ' ', user.last) AS displayname,
       user.username FROM user;`;
 
@@ -48,11 +56,9 @@ exports.list = function list(req, res, next) {
 
 // helper function to get a single user, including project details
 function lookupUserDetails(id) {
-  'use strict';
+  let data;
 
-  var sql, data;
-
-  sql =
+  let sql =
     `SELECT user.id, user.username, user.email, user.first, user.last,
       user.active, user.last_login AS lastLogin
     FROM user WHERE user.id = ?;`;
@@ -89,15 +95,15 @@ function lookupUserDetails(id) {
 
 
 /**
-* GET /users/:id
-*
-* This endpoint will return a single JSON object containing the full user row
-* for the user with matching ID.  If no matching user exists, it will return a
-* 404 error.
-*
-* For consistency with the CREATE method, this route also returns a user's project
-* permissions.
-*/
+ * GET /users/:id
+ *
+ * This endpoint will return a single JSON object containing the full user row
+ * for the user with matching ID.  If no matching user exists, it will return a
+ * 404 error.
+ *
+ * For consistency with the CREATE method, this route also returns a user's project
+ * permissions.
+ */
 exports.details = function details(req, res, next) {
   'use strict;';
 
@@ -115,8 +121,6 @@ exports.details = function details(req, res, next) {
 * Lists all the user project permissions for user with :id
 */
 exports.projects.list = function listProjects(req, res, next) {
-  'use strict';
-
   var sql =
     `SELECT pp.id, pp.project_id, project.name
     FROM project_permission AS pp JOIN project ON pp.project_id = project.id
@@ -136,8 +140,6 @@ exports.projects.list = function listProjects(req, res, next) {
 * Lists all the user permissions for user with :id
 */
 exports.permissions.list = function listPermissions(req, res, next) {
-  'use strict';
-
   var sql =
     `SELECT permission.id, permission.unit_id FROM permission
     WHERE permission.user_id = ?;`;
@@ -152,21 +154,19 @@ exports.permissions.list = function listPermissions(req, res, next) {
 
 
 /**
-* POST /users
-*
-* This endpoint creates a new user from a JSON object.  The following fields are
-* required and will result in a 400 error if not provided: username, password,
-* first, last, email, projects.
-*
-* Unlike before, the user is created with project permissions.  A user without project
-* access does not make any sense.
-*
-* If the checks succeed, the user password is hashed and stored in the database.
-* A single JSON is returned to the client with the user id.
-*/
+ * POST /users
+ *
+ * This endpoint creates a new user from a JSON object.  The following fields are
+ * required and will result in a 400 error if not provided: username, password,
+ * first, last, email, projects.
+ *
+ * Unlike before, the user is created with project permissions.  A user without project
+ * access does not make any sense.
+ *
+ * If the checks succeed, the user password is hashed and stored in the database.
+ * A single JSON is returned to the client with the user id.
+ */
 exports.create = function create(req, res, next) {
-  'use strict';
-
   var sql, requiredKeys, missingKeys, id,
       data = req.body;
 
@@ -213,6 +213,13 @@ exports.create = function create(req, res, next) {
 
     // send the ID back to the client
     res.status(201).json({ id : id });
+
+    eventd.publish(eventd.channels.APP, {
+      event : eventd.events.CREATE,
+      entity : eventd.entities.USER,
+      user_id : req.session.user.id,
+      id : id,
+    });
   })
   .catch(next)
   .done();
@@ -220,15 +227,13 @@ exports.create = function create(req, res, next) {
 
 
 /**
-* POST /users/:id/permissions
-*
-* Creates and updates a user's permissions.
-*/
+ * POST /users/:id/permissions
+ *
+ * Creates and updates a user's permissions.
+ */
 exports.permissions.assign = function assignPermissions(req, res, next) {
-  'use strict';
-
   // first step, DELETE the user's permissions
-  var sql =
+  let sql =
     'DELETE FROM permission WHERE user_id = ?;';
 
   db.exec(sql, [req.params.id])
@@ -250,7 +255,14 @@ exports.permissions.assign = function assignPermissions(req, res, next) {
     return db.exec(sql, [data]);
   })
   .then(function () {
-    res.status(201).send();
+    res.sendStatus(201);
+
+    eventd.publish(eventd.channels.APP, {
+      event: eventd.events.UPDATE,
+      entity: eventd.entities.PERMISSION,
+      user_id : req.session.user.id,
+      id: req.params.id,
+    });
   })
   .catch(next)
   .done();
@@ -260,8 +272,6 @@ exports.permissions.assign = function assignPermissions(req, res, next) {
 // User update helper function.  Updates a users's project permissions by first
 // clearing out all permissions and then re-writing.
 function helperUpdateProjectPermissions(id, projects) {
-  'use strict';
-
   var sql;
 
   // update the user's project permissions by first removing
@@ -287,18 +297,16 @@ function helperUpdateProjectPermissions(id, projects) {
 
 
 /**
-* PUT /users/:id
-*
-* This endpoint updates a user's information with ID :id.  If the user is not
-* found, the server sends back a 404 error.
-*
-* This method is reserved for changed all other user properties, but NOT the
-* user's password.  To change the user password, use a PUT to users/:id/password
-* with two password fields, password and passwordVerify.
-*/
+ * PUT /users/:id
+ *
+ * This endpoint updates a user's information with ID :id.  If the user is not
+ * found, the server sends back a 404 error.
+ *
+ * This method is reserved for changed all other user properties, but NOT the
+ * user's password.  To change the user password, use a PUT to users/:id/password
+ * with two password fields, password and passwordVerify.
+ */
 exports.update = function update(req, res, next) {
-  'use strict';
-
   var sql, promise,
       data = req.body,
       projects = req.body.projects;
@@ -343,20 +351,25 @@ exports.update = function update(req, res, next) {
   })
   .then(function (data) {
     res.status(200).json(data);
+
+    eventd.publish(eventd.channels.APP, {
+      event: eventd.events.UPDATE,
+      entity: eventd.entities.USER,
+      user_id : req.session.user.id,
+      id: req.params.id,
+    });
   })
   .catch(next)
   .done();
 };
 
 /**
-* PUT /users/:id/password
-*
-* This endpoint updates a user's password with ID :id.  If the user is not
-* found, the server sends back a 404 error.
-*/
+ * PUT /users/:id/password
+ *
+ * This endpoint updates a user's password with ID :id.  If the user is not
+ * found, the server sends back a 404 error.
+ */
 exports.password = function updatePassword(req, res, next) {
-  'use strict';
-
   // TODO -- strict check to see if the user is either signed in or has
   // sudo permissions.
 
@@ -376,13 +389,11 @@ exports.password = function updatePassword(req, res, next) {
 
 
 /**
-* DELETE /users/:id
-*
-* If the user exists delete it.
-*/
+ * DELETE /users/:id
+ *
+ * If the user exists delete it.
+ */
 exports.delete = function del(req, res, next) {
-  'use strict';
-
   var sql =
     'DELETE FROM user WHERE id = ?;';
 
@@ -394,7 +405,16 @@ exports.delete = function del(req, res, next) {
       throw new NotFound(`Could not find a user with id ${req.params.id}`);
     }
 
-    res.status(204).send();
+    // return to client
+    res.sendStatus(204);
+
+    // publish a DELETE event
+    eventd.publish(eventd.channels.APP, {
+      event: eventd.events.DELETE,
+      entity: eventd.entities.USER,
+      user_id : req.session.user.id,
+      id: req.params.id,
+    });
   })
   .catch(next)
   .done();
@@ -403,7 +423,6 @@ exports.delete = function del(req, res, next) {
 // GET /languages
 // TODO - where does this actually belong?
 exports.getLanguages = function languages(req, res, next) {
-  'use strict';
 
   var sql =
     `SELECT lang.id, lang.name, lang.key, lang.locale_key AS localeKey
@@ -420,8 +439,8 @@ exports.getLanguages = function languages(req, res, next) {
 // TODO -- remove this.
 exports.authenticatePin = function authenticatePin(req, res, next) {
   var decrypt = req.params.pin >> 5;
-  var sql = `SELECT pin FROM user WHERE user.id = ' + req.session.user.id
-    AND pin = '${decrypt}';`;
+  let sql =
+    `SELECT pin FROM user WHERE user.id = ${req.session.user.id} AND pin = '${decrypt}';`;
 
   db.exec(sql)
   .then(function (rows) {
@@ -432,4 +451,3 @@ exports.authenticatePin = function authenticatePin(req, res, next) {
   })
   .done();
 };
-

--- a/server/lib/eventd.js
+++ b/server/lib/eventd.js
@@ -1,0 +1,133 @@
+/**
+ * @overview
+ * This library is responsible for constructing and exposing the Eventd class
+ * to server methods.  Since NodeJS modules are singletons, there will only ever
+ * exist a single Eventd instance that all modules can subscribe to.
+ *
+ * The Eventd class is a simple event emitter that capture event emissions,
+ * attaches a timestamp and defers the callback for performance reasons.
+ *
+ * The Eventd is also responsible for writing event logs to the database.
+ *
+ * @todo eventually this should use redis for pub/sub to scale to multi-server
+ * or multi-core machines.
+ *
+ * @todo refine the ideas of channels, events, and entities to something that
+ * can be easily localized and used.
+ *
+ * @requires db
+ * @requires EventEmitter
+ * @requires winston
+ */
+'use strict';
+
+const db = require('./db');
+const EventEmitter = require('events');
+const winston = require('winston');
+
+// event constants
+const events = {
+  CREATE: 'create',
+  UPDATE: 'update',
+  DELETE: 'delete',
+  REPORT: 'report',
+  LOGIN: 'login',
+  LOGOUT: 'logout',
+};
+
+// event entities
+const entities = {
+  PATIENT : 'patient',
+  INVOICE : 'invoice',
+  PAYMENT : 'payment',
+  VOUCHER : 'voucher',
+  PATIENT_GROUP : 'patient group',
+  DEBTOR_GROUP : 'debtor_group',
+  EMPLOYEE : 'employee',
+  USER : 'user',
+  PERMISSION : 'permission',
+};
+
+// event channels
+const channels = {
+  ALL: 'all',
+  APP: 'app',
+  MEDICAL: 'medical',
+  FINANCE: 'finance'
+};
+
+// writes events into the event database table
+function databaseLogger(data) {
+  let record = {
+    timestamp: new Date(data.timestamp),
+    user_id: data.user_id,
+    channel: data.channel,
+    type: data.event,
+    data: JSON.stringify(data)
+  };
+  db.exec('INSERT INTO event SET ?', [record])
+  .catch(err => winston.error(err))
+  .done();
+}
+
+/**
+ * @class Eventd
+ *
+ * @description
+ * A singleton class for echoing events throughout the server backbone.  It is
+ * designed to be imported into controllers and used when significant events
+ * occur.
+ *
+ * This aliases many of the underlying event emitter methods with pub/sub
+ * method names in anticipation of going to a Redis-based event architecture.
+ * See the TODO at the top of this module.
+ */
+class Eventd extends EventEmitter {
+  constructor() {
+    super();
+
+    // register the database logger
+    this.subscribe(channels.ALL, databaseLogger);
+  }
+
+  // NOTE: setImmediate() is makes the event(s) asynchronous
+  publish(channel, data) {
+    data.timestamp = new Date();
+    data.channel = channel;
+
+    // skip if broadcasting on the ALL channel (we do this by default anyway)
+    if (channel !== channels.ALL) {
+      setImmediate(() => super.emit(channel, data));
+    }
+
+    // broadcast on the ALL channel for global listeners
+    setImmediate(() => super.emit(channels.ALL, data));
+  }
+
+  // alias EventEmitter.on()
+  subscribe(channel, callback) {
+    super.on(channel, callback);
+  }
+
+  // alias EventEmitter.removeListener()
+  unsubscribe(channel, callback) {
+    super.removeListener(channel, callback);
+  }
+
+  // event constants for emitters to consume (defined above)
+  get events() {
+    return events;
+  }
+
+  // possible channels to subscribe to using eventd.on()
+  get channels() {
+    return channels;
+  }
+
+  get entities() {
+    return entities;
+  }
+}
+
+// expose the event emitter
+module.exports = new Eventd();

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -753,6 +753,16 @@ CREATE TABLE `enterprise` (
   FOREIGN KEY (`loss_account_id`) REFERENCES `account` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+DROP TABLE IF EXISTS `event`;
+CREATE TABLE `event` (
+  `timestamp`   TIMESTAMP NOT NULL,
+  `user_id`     SMALLINT(5) UNSIGNED NOT NULL,
+  `channel`     TEXT NOT NULL,
+  `type`        TEXT NOT NULL,
+  `data`        TEXT NOT NULL, -- TODO, this should be JSON in newer MySQL
+  KEY `user_id` (`user_id`),
+  FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `exchange_rate`;
 CREATE TABLE `exchange_rate` (


### PR DESCRIPTION
This commit creates an event emitter that will serve events in real-time to any client listeners from throughout the application.  The current infrastructure uses the native `events` module in NodeJS, but future implementation might take advantage of redis for publish/subscribe.

Events are cached in a database table `event`, with schema defined in #390.  When a new client connects, they can download the previous events sending a GET request to the url `/events`.  They can subscribe to real-time events by opening an [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) to `/stream`.

Closes #390.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
