### PR TITLE
test(travis): build latest node on branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,9 @@ services:
 language: node_js
 node_js:
   - node
+  - '6'
   - '5'
   - '4'
-  - '4.3'
-  - '4.2'
-  - '4.1'
-  - '4.0'
 
 before_script:
   - bash sh/install.sh


### PR DESCRIPTION
This commit changes Travis to only build the latest on each branch of Node.  Instead of Node 4.1.X, we always build Node 4.X.X, under the assumption that new updates of the application will be coupled with upgrades to NodeJS.

Closes #386.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
