### PR TITLE
fix(tests): revert mocha version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,9 +20,6 @@ const rimraf  = require('rimraf');
 const gutil   = require('gulp-util');
 const less    = require('gulp-less');
 
-    // mocha for server-side testing
-const mocha = require('gulp-mocha');
-
 // child process for custom scripts
 const exec = require('child_process').exec;
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "gulp-iife": "^0.3.0",
     "gulp-jshint": "^2.0.0",
     "gulp-less": "^3.0.3",
-    "gulp-mocha": "^2.1.3",
     "gulp-uglify": "^1.5.2",
     "gulp-util": "^3.0.7",
     "jshint": "^2.8.0",
@@ -73,7 +72,7 @@
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^1.0.1",
     "karma-mocha": "^1.0.1",
-    "mocha": "^2.4.5",
+    "mocha": "2.4.5",
     "protractor": "^3.1.1",
     "rimraf": "^2.4.3"
   },

--- a/sh/integration-tests.sh
+++ b/sh/integration-tests.sh
@@ -37,7 +37,7 @@ sleep $TIMEOUT
 echo "Running tests ..."
 
 # run the tests
-mocha server/test/api/
+../node_modules/.bin/mocha server/test/api/
 
 echo "Cleaning up test instance"
 


### PR DESCRIPTION
This commit fixes the mocha version at 2.4.5, since the latest version (2.5.0) [is broken](https://github.com/mochajs/mocha/issues/2272).  It also removes the unused dependency on `gulp-mocha`. Finally, it ensures that integration tests are calling local mocha instead of global mocha.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
