### PR TITLE
Introduce font awesome

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,8 @@
     "angular-dynamic-locale": "^0.1.30",
     "ngstorage": "^0.3.10",
     "Chart.js": "^2.1.3",
-    "angular-chart.js": "~1.0.0-alpha6"
+    "angular-chart.js": "~1.0.0-alpha6",
+    "components-font-awesome": "^4.6.3"
   },
   "devDependencies": {
     "angular-mocks": "^1.5.3"

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="css/bhima-bootstrap.css">
   <link rel="stylesheet" href="vendor/angular-ui-grid/ui-grid.min.css">
   <link rel="stylesheet" href="css/style.min.css">
+  <link rel="stylesheet" href="vendor/components-font-awesome/css/font-awesome.min.css">
 </head>
 
 <body ng-app="bhima" ng-strict-di>
@@ -65,7 +66,7 @@
           <ul>
             <li>
               <a class="session" ng-click="AppCtrl.settings()">
-                <span class="glyphicon glyphicon-cog"></span>
+                <span class="fa fa-cog"></span>
                 <span class="link-label">{{ "SETTINGS.TITLE" | translate }}</span>
               </a>
             </li>
@@ -76,8 +77,8 @@
                 ng-click="AppCtrl.toggleSidebar()">
                 <span
                   id="expandicon"
-                  class="glyphicon"
-                  ng-class="{'glyphicon-menu-right' : !AppCtrl.sidebarExpanded, 'glyphicon-menu-left' : AppCtrl.sidebarExpanded}">
+                  class="fa"
+                  ng-class="{'fa-angle-double-right' : !AppCtrl.sidebarExpanded, 'fa-angle-double-left' : AppCtrl.sidebarExpanded}">
                 </span>
               </a>
             </li>

--- a/client/src/partials/login/login.html
+++ b/client/src/partials/login/login.html
@@ -2,7 +2,8 @@
   <div class="container-fluid" style="height: 100%;">
     <div class="row">
       <div class="col-md-4 col-md-offset-4 col-xs-12">
-        <!-- @fixme - style hacks for content centering -->
+
+         <!--@fixme - style hacks for content centering-->
         <div class="panel panel-default" style="margin-top : calc(50vh - 190px); max-width: 400px; margin-right: auto; margin-left: auto">
           <div class="panel-heading clearfix">
             <strong>{{ "AUTH.LOGIN" | translate }}</strong>
@@ -28,7 +29,7 @@
                 <label class="control-label"> {{ "FORM.LABELS.USERNAME" | translate }} </label>
                 <div class="input-group">
                   <span class="input-group-addon" style="background-color: #fff;">
-                    <span class="glyphicon glyphicon-user"></span>
+                    <span class="fa fa-user"></span>
                   </span>
                   <input
                     name="username"
@@ -49,7 +50,7 @@
                 <label class="control-label"> {{ "FORM.LABELS.PASSWORD" | translate }} </label>
                 <div class="input-group">
                   <span class="input-group-addon" style="background-color: #fff;">
-                    <span class="glyphicon glyphicon-lock"></span>
+                    <span class="fa fa-lock"></span>
                   </span>
                   <input
                     name="password"
@@ -69,7 +70,7 @@
                 </label>
                 <div class="input-group">
                   <span class="input-group-addon" style="background-color: #fff;">
-                    <span class="glyphicon glyphicon-home"></span>
+                    <span class="fa fa-home"></span>
                   </span>
                   <select
                     name="project"

--- a/client/src/partials/templates/navigation.tmpl.html
+++ b/client/src/partials/templates/navigation.tmpl.html
@@ -8,11 +8,11 @@ Limitations of current templating structure:
     <li ng-repeat-start="unit in $ctrl.units">
       <a ng-click="$ctrl.toggleUnit(unit)">
         <span
-          class="glyphicon"
+          class="fa"
           ng-class="{
-          'glyphicon-exclamation-sign' : unit.children.length === 0,
-          'glyphicon-folder-open' : unit.open && unit.children.length > 0,
-          'glyphicon-folder-close' : !unit.open && unit.children.length > 0}">
+          'fa-exclamation-circle' : unit.children.length === 0,
+          'fa-folder-open' : unit.open && unit.children.length > 0,
+          'fa-folder' : !unit.open && unit.children.length > 0}">
         </span>
         <span class="tree-title">{{ unit.key | translate }}</span>
       </a>
@@ -26,7 +26,7 @@ Limitations of current templating structure:
       class="file"
       ng-class="{ 'selected' : child.selected }">
       <a ng-click="$ctrl.navigate(child)">
-        <span class="glyphicon glyphicon-file"></span>
+        <span class="fa fa-file"></span>
         <span class="tree-title">{{ child.key | translate }}</a></span>
       </a>
     </li>


### PR DESCRIPTION
This commit introduces a bower dependency on a [font awesome shim](https://github.com/components/font-awesome). It also
updates some elements of the application structure (navigation/ login) to
use font awesome icons.

**Glyphicon login**
![glyphicon](https://cloud.githubusercontent.com/assets/2844572/15541963/a53da316-2286-11e6-9750-443ebcb90184.png)

**Font awesome login**
![fa_login](https://cloud.githubusercontent.com/assets/2844572/15541961/a51e6b18-2286-11e6-83f2-8a7307084605.png)

**Glyphicon nav**
![glyphicon_nav](https://cloud.githubusercontent.com/assets/2844572/15541964/a54d6a26-2286-11e6-9848-9a3638308d53.png)

**Font awesome nav**
![fa_nav](https://cloud.githubusercontent.com/assets/2844572/15541962/a522c30c-2286-11e6-88a0-070825f629ec.png)

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/404

---
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.
