### PR TITLE
(Chore) Define rules for headercrumb overflow

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -215,7 +215,7 @@
 
   /** @todo determine if these should be assigned to another element */
   padding-top : 5px;
-  min-width : 250px;
+  min-width : 350px;
   height : 100vh;
 }
 
@@ -420,9 +420,11 @@ li.selected {
   padding: 8px 0px;
   list-style: none;
   border-radius: 2px;
+
 }
 ol.headercrumb {
   margin-bottom : 0px !important;
+  white-space : nowrap;
 }
 .headercrumb > li {
   display: inline-block;


### PR DESCRIPTION
This commit enforces the `white-space` CSS attribute to not wrap the
_**headercrumb(tm)**_ on smaller devices. This allows the navigation bar to 'push'
the module out of the way without wrapping/ compromising the _**headercrumb(tm)**_.

**Before no-wrap**
![mobile_before](https://cloud.githubusercontent.com/assets/2844572/15543417/b9fe8e40-228c-11e6-9190-b9467b19bf54.png)

**After no-wrap**
![mobile_after](https://cloud.githubusercontent.com/assets/2844572/15543422/c116ea38-228c-11e6-8b8a-847c9ca0dab4.png)

---

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.
