### PR TITLE
fix(location modal): validate only on $invalid

### DIFF
--- a/client/src/partials/templates/modals/location.modal.html
+++ b/client/src/partials/templates/modals/location.modal.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="form-group"
-      ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.country.$error }"
+      ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.country.$invalid }"
       >
       <label class="control-label">
         {{ "FORM.LABELS.COUNTRY" | translate }}
@@ -47,7 +47,7 @@
     </div>
 
     <div class="form-group"
-      ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.province.$error }"
+      ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.province.$invalid }"
       ng-if="LocationModalCtrl.view.index > 1"
       >
       <label class="control-label">
@@ -75,7 +75,7 @@
 
     <div class="form-group"
       ng-if="LocationModalCtrl.view.index > 2"
-      ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.sector.$error }"
+      ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.sector.$invalid }"
       >
       <label class="control-label">
         {{ "FORM.LABELS.SECTOR" | translate }}
@@ -100,7 +100,7 @@
 
     <div class="form-group"
       ng-if="LocationModalCtrl.view.index > 3"
-      ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.village.$error }"
+      ng-class="{ 'has-error' : LocationModalForm.$submitted && LocationModalForm.village.$invalid }"
       >
       <label class="control-label">
         {{ "FORM.LABELS.VILLAGE" | translate }}


### PR DESCRIPTION
This commit ensures that the location modal does not flash red when submitting.  This bug was introduced by watching `$error` instead of `$invalid` when displaying input validation and is corrected here.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
