### PR TITLE
refactor(simple vouchers): update to standards

### DIFF
--- a/client/src/js/components/bhBreadcrumb.js
+++ b/client/src/js/components/bhBreadcrumb.js
@@ -1,31 +1,45 @@
-/**
-* <bh-breadcrumb></bh-breadcrumb>
-*
-* The Breadcrumb component is responsible to display the breadcrumb navigation
-* and all action buttons attached to it.
-*
-* This component take these attributes :
-*   - path : which take an array which contains paths
-*   - button : which takes an array of button objects
-*   - dropdown : which takes an array of object as dropdown
-*   - label : which takes an array of label objects
-*
-* @example
-* // Simple breadcrumb navigation
-* // In the view
-* <bh-breadcrumb
-*   path="MyCtrl.bcPaths"
-*   button="MyCtrl.bcButtons"
-*   dropdown="MyCtrl.bcDropdowns"
-*   Label="MyCtrl.bcLabels">
-* </bh-breadcrumb>
-*/
+angular.module('bhima.components')
+.component('bhBreadcrumb', {
+  bindings: {
+    path: '<',
+    button: '<',
+    label: '<',
+    dropdown: '<'
+  },
+  templateUrl  : 'partials/templates/breadcrumb.tmpl.html',
+  controller   : BreadcrumbController,
+  controllerAs : 'vm'
+});
 
-/** Breadcrumb controller defintion */
+
+/**
+ *
+ * @class bhBreadcrumb
+ *
+ * @description
+ * The Breadcrumb component is responsible to display the breadcrumb navigation
+ * and all action buttons attached to it.
+ *
+ * This component take these attributes :
+ *   - path : which take an array which contains paths
+ *   - button : which takes an array of button objects
+ *   - dropdown : which takes an array of object as dropdown
+ *   - label : which takes an array of label objects
+ *
+ * @example
+ * <!-- Simple breadcrumb navigation in the view -->
+ * <bh-breadcrumb
+ *   path="MyCtrl.bcPaths"
+ *   button="MyCtrl.bcButtons"
+ *   dropdown="MyCtrl.bcDropdowns"
+ *   Label="MyCtrl.bcLabels">
+ * </bh-breadcrumb>
+*/
 function BreadcrumbController() {
   var vm = this;
 
-  /** Paths definition
+  /**
+   * Paths definition
    * @example
    * vm.bcPaths = [
    *  { label: 'path1', link: '#/path1_link_to_go' },
@@ -33,9 +47,10 @@ function BreadcrumbController() {
    *  { label: 'path3', link: '#/path1_link_to_go', current: true },
    * ];
    */
-  vm.bcPaths     = this.path || [];
+  vm.bcPaths = vm.path || [];
 
-  /** Buttons definition
+  /**
+   * Buttons definition
    * @example
    * vm.bcButtons = [
    *  { icon: 'glyphicon glyphicon-print', label: 'Print', action: buttonAction },
@@ -43,9 +58,10 @@ function BreadcrumbController() {
    *  { icon: 'glyphicon glyphicon-refresh', label: 'Refresh', action: buttonAction }
    * ];
    */
-  vm.bcButtons   = this.button || [];
+  vm.bcButtons = vm.button || [];
 
-  /** Labels definition
+  /**
+   * Labels definition
    * @example
    * vm.bcLabels = [
    *  { icon: 'glyphicon glyphicon-print', label: 'My Label 1' },
@@ -53,9 +69,10 @@ function BreadcrumbController() {
    *  { label: 'My label 3' }
    * ];
    */
-  vm.bcLabels    = this.label || [];
+  vm.bcLabels = vm.label || [];
 
-  /** Dropdowns definition
+  /**
+   * Dropdowns definition
    * @example
    * vm.bcDropdowns = [
    *  {
@@ -76,38 +93,16 @@ function BreadcrumbController() {
    *  }
    * ];
    */
-  vm.bcDropdowns = this.dropdown || [];
+  vm.bcDropdowns = vm.dropdown || [];
 
-  /** call the apropriate function and update the dropdown label */
-  vm.helperDropdown = function (child, parent) {
+  /** call the appropriate function and update the dropdown label */
+  vm.helperDropdown = function helperDropdown(child, parent) {
     parent.selected = child.label;
     child.action(child);
   };
 
-  /** Init dropdown buttons */
-  (function initDropdown() {
-    if (vm.bcDropdowns && vm.bcDropdowns.length > 0) {
-      vm.bcDropdowns.forEach(function (elem) {
-        elem.selected = elem.label;
-      });
-    }
-  })();
-
+  // init dropdown buttons
+  vm.bcDropdowns.forEach(function (elem) {
+    elem.selected = elem.label;
+  });
 }
-
-/** Breadcrumb Component definition */
-var breadcrumb = {
-    bindings   : {
-      path     : '<',
-      button   : '<',
-      label    : '<',
-      dropdown : '<'
-    },
-    templateUrl  : 'partials/templates/breadcrumb.tmpl.html',
-    controller   : BreadcrumbController,
-    controllerAs : 'vm'
-};
-
-/** Component for BHIMA */
-angular.module('bhima.components')
-.component('bhBreadcrumb', breadcrumb);

--- a/client/src/js/components/bhCurrencySelect.js
+++ b/client/src/js/components/bhCurrencySelect.js
@@ -14,7 +14,7 @@ angular.module('bhima.components')
 bhCurrencySelect.$inject = [ '$scope', 'CurrencyService' ];
 
 /**
- * @module components/bhCurrencySelect
+ * @class bhCurrencySelect
  *
  * @description
  * This is a radio button currency selection component for choosing currencies
@@ -63,6 +63,7 @@ function bhCurrencySelect($scope, Currencies) {
 
   // bind the currency service to the view
   $ctrl.service = Currencies;
+  $ctrl.valid = true;
 
   // default currencies to an empty list
   $ctrl.currencies = [];
@@ -84,9 +85,7 @@ function bhCurrencySelect($scope, Currencies) {
 
   // watch the disabledIds array for changes, and disable the ids in the the
   // view based on which ids are present in it
-  $scope.$watchCollection(function () {
-    return $ctrl.disableIds;
-  }, function (array) {
+  $scope.$watchCollection('$ctrl.disableIds', function (array) {
     if (!array) { return; }
 
     // loop through the currencies, disabling the currencies with ids in the

--- a/client/src/js/services/VoucherService.js
+++ b/client/src/js/services/VoucherService.js
@@ -61,7 +61,7 @@ function VoucherService(PrototypeApiService) {
     // bind the voucher items
     clean.items = items;
 
-    return PrototypeApiService.call(service, { voucher : clean });
+    return PrototypeApiService.create.call(service, { voucher : clean });
   }
 
   return service;

--- a/client/src/js/services/VoucherService.js
+++ b/client/src/js/services/VoucherService.js
@@ -29,11 +29,13 @@ function VoucherService(PrototypeApiService) {
     return PrototypeApiService.create.call(service, { voucher : voucher });
   }
 
-
   /**
-   * Creates a simple journal voucher, transforming the object into double-entry
-   * accounting
    * @method createSimple
+   *
+   * @description
+   * Creates a simple journal voucher, transforming the object into double-entry
+   * accounting.
+   *
    * @param {object} voucher - the raw journal voucher
    */
   function createSimple(voucher) {

--- a/client/src/less/bhima-bootstrap.less
+++ b/client/src/less/bhima-bootstrap.less
@@ -23,6 +23,12 @@
 @collapsed-offset: 56px;
 @nav-height:       51px;
 
+/* turn off horizontal resizing */
+textarea {
+  resize: vertical;
+  max-height: 250px;
+}
+
 /**
  * Notifications
  */

--- a/client/src/partials/templates/bhCurrencySelect.tmpl.html
+++ b/client/src/partials/templates/bhCurrencySelect.tmpl.html
@@ -1,5 +1,5 @@
 <ng-form name="$ctrl.form">
-  <div class="radio" ng-class="{ 'has-error' : ($ctrl.validationTrigger && $ctrl.form.$invalid) || !$ctrl.valid}" data-bh-currency-select>
+  <div class="radio" ng-class="{ 'has-error' : ($ctrl.validationTrigger && $ctrl.form.$invalid) || !$ctrl.valid }" data-bh-currency-select>
     <p class="control-label">
       <strong>{{ "FORM.LABELS.CURRENCY" | translate }}</strong>
     </p>

--- a/client/src/partials/templates/breadcrumb.tmpl.html
+++ b/client/src/partials/templates/breadcrumb.tmpl.html
@@ -2,12 +2,11 @@
   <div class="bhima-title">
 
     <ol class="headercrumb">
-      <li class="static">
-        <a href="#/">{{ "HOME.BHIMA" | translate }}</a>
-      </li>
-      <li ng-repeat="p in vm.bcPaths" class="title" id="{{ p.id }}" data-method="{{ p.dataMethod }}">
-        <span ng-if="p.current">{{ p.label }}</span>
-        <span ng-if="!p.current"><a ng-href="{{ p.link }}">{{ p.label }}</a></span>
+      <li ng-repeat="p in vm.bcPaths" id="{{ p.id }}" data-method="{{ p.dataMethod }}"  ng-class="{ 'static' : !$last, 'title' : $last }">
+        <span ng-hide="p.link">{{ p.label | translate }}</span>
+        <span ng-show="p.link">
+          <a ng-href="{{ p.link }}" href>{{ p.label | translate }}</a>
+        </span>
       </li>
     </ol>
 
@@ -20,7 +19,7 @@
           </button>
           <ul class="pull-right" uib-dropdown-menu>
             <li ng-repeat="opt in d.option">
-              <a href="" ng-click="vm.helperDropdown(opt, d)" id="{{ opt.id }}" data-method="{{ opt.dataMethod }}">
+              <a href ng-click="vm.helperDropdown(opt, d)" id="{{ opt.id }}" data-method="{{ opt.dataMethod }}">
                 {{ opt.label | translate }}
               </a>
             </li>
@@ -29,24 +28,23 @@
       </div>
 
       <!-- buttons -->
-      <div class="toolbar-item btn-group btn-group-sm" ng-if="vm.bcButtons.length">
+      <div class="toolbar-item btn-group btn-group-sm" ng-show="vm.bcButtons.length">
         <button class="btn"
           id="{{ a.id }}"
           ng-class="a.color"
           ng-repeat="a in vm.bcButtons"
           ng-click="a.action(a.label)"
           data-method="{{ a.dataMethod }}">
-          <i class="{{ a.icon }}"></i> {{ a.label }}
+          <span class="{{ a.icon }}"></span> {{ a.label }}
         </button>
       </div>
 
       <!-- labels -->
       <div class="toolbar-item" ng-if="vm.bcLabels.length">
         <label ng-repeat="l in vm.bcLabels" id="{{ l.id }}" data-method="{{ l.dataMethod }}">
-          <b><i class="{{ l.icon }}"></i> {{ l.label }}</b>
+          <strong><span class="{{ l.icon }}"></span> {{ l.label | translate }}</strong>
         </label>
       </div>
     </div>
-
   </div>
 </div>

--- a/client/src/partials/vouchers/simple.html
+++ b/client/src/partials/vouchers/simple.html
@@ -81,26 +81,11 @@
                  </div>
                </div>
 
-              <!-- @TODO - use a currency selection component -->
-              <div
-                class="radio"
-                ng-class="{ 'has-error' : SimpleVoucherForm.$submitted && SimpleVoucherForm.currency.$invalid }">
-                <p><strong class="control-label">{{ "FORM.LABELS.CURRENCY" | translate }}</strong></p>
-                <label ng-repeat="currency in SimpleVoucherCtrl.currencies track by currency.id" class="radio-inline">
-                  <input
-                    name="currency"
-                    type="radio"
-                    ng-model="SimpleVoucherCtrl.voucher.currency_id"
-                    ng-value="currency.id"
-                    data-currency-option="{{ currency.id }}"
-                    required>
-                  {{ currency.label }}
-                </label>
-
-                <div class="help-block" ng-messages="SimpleVoucherForm.currency.$error" ng-show="SimpleVoucherForm.$submitted">
-                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>
-              </div>
+               <bh-currency-select
+                 currency-id="SimpleVoucherCtrl.voucher.currency_id"
+                 validation-trigger="SimpleVoucherForm.$submitted"
+                 >
+               </bh-currency-select>
 
               <bh-currency-input
                 data-voucher-currency-input
@@ -111,24 +96,11 @@
                 >
               </bh-currency-input>
 
-              <div class="form-group">
-                <div class="pull-right">
-                  <bh-loading-button loading-state="SimpleVoucherForm.$loading" ng-disabled="SimpleVoucherCtrl.created">
-                    {{ "FORM.BUTTONS.SUBMIT" | translate }}
-                  </bh-loading-button>
-                </div>
-                <div class="clearfix"></div>
+              <div class="form-group text-right">
+                <bh-loading-button loading-state="SimpleVoucherForm.$loading" ng-disabled="SimpleVoucherCtrl.created">
+                  {{ "FORM.BUTTONS.SUBMIT" | translate }}
+                </bh-loading-button>
               </div>
-
-              <!-- translate the server-sent error for the client -->
-              <p class="alert alert-danger" ng-show="SimpleVoucherCtrl.httpError">
-                <span class="glyphicon glyphicon-exclamation-sign"></span>{{ SimpleVoucherCtrl.httpError | translate }}
-              </p>
-
-              <!-- displays: "Record created successfully!" -->
-              <p class="alert alert-success" ng-show="SimpleVoucherCtrl.created && SimpleVoucherForm.$pristine">
-                <span class="glyphicon glyphicon-ok-sign"></span> {{ "FORM.INFOS.SAVE_SUCCESS" | translate }}
-              </p>
             </form>
           </div>
         </div>

--- a/client/src/partials/vouchers/simple.js
+++ b/client/src/partials/vouchers/simple.js
@@ -52,8 +52,10 @@ function SimpleJournalVoucherController(AppCache, Vouchers, Accounts, Session, u
   }
 
   function submit(form) {
+
     // stop submission if the form is invalid
     if (form.$invalid) {
+      Notify.danger('FORM.ERRORS.RECORD_ERROR');
       return;
     }
 

--- a/client/src/partials/vouchers/simple.js
+++ b/client/src/partials/vouchers/simple.js
@@ -2,73 +2,45 @@ angular.module('bhima.controllers')
 .controller('SimpleJournalVoucherController', SimpleJournalVoucherController);
 
 SimpleJournalVoucherController.$inject = [
-  'AppCache', 'VoucherService', '$translate', 'AccountService',
-  'CurrencyService', 'SessionService', 'util'
+  'AppCache', 'VoucherService', 'AccountService', 'SessionService', 'util',
+  'NotifyService'
 ];
 
 /**
- * Simple Journal Vouchers
+ * @class SimpleJournalVouchers
  *
  * This module implements simply journal vouchers, crafted specially for cash
- * transactions, but useable in any generic transactions that only require two
+ * transactions, but usable in any generic transactions that only require two
  * Posting Journal lines.  It allows users to quickly create transactions by
  * specifying two accounts and an amount to transfer between them.
- *
- * @constructor
  *
  * @todo - Implement caching mechanism for incomplete forms (via AppCache)
  * @todo - Implement Voucher Templates to allow users to save pre-selected
  * forms (via AppCache and the breadcrumb component).
  */
-function SimpleJournalVoucherController(AppCache, Vouchers, $translate, Accounts, Currencies, Session, util) {
+function SimpleJournalVoucherController(AppCache, Vouchers, Accounts, Session, util, Notify) {
   var vm = this;
 
   // cache to save work-in-progress data and pre-fabricated templates
   var cache = AppCache('JournalVouchers');
 
-  vm.maxLength = util.maxTextLength; 
-  // bread crumb paths
-  vm.paths = [{
-    label : $translate.instant('VOUCHERS.SIMPLE.TITLE'),
-    current: true
-  }];
+  vm.maxLength = util.maxTextLength;
+  vm.paths = [
+    { label : 'TREE.FINANCE' },
+    { label : 'VOUCHERS.SIMPLE.TITLE' }
+  ];
 
-  // bind the startup method as a reset method
-  vm.reset = startup;
+  // bind the submit method
   vm.submit = submit;
 
   // load the list of accounts
-  Accounts.read(null, { detailed : 1 })
+  Accounts.read()
   .then(function (accounts) {
-    vm.accounts = removeChildren(accounts);
+    vm.accounts = accounts;
   });
 
-  function removeChildren(accounts) {
-    var accountsOnly = accounts.map(function (item) {
-      delete item.children;
-      return item;
-    });
-    return accountsOnly;
-  }
-
-  // load the available currencies
-  Currencies.read()
-  .then(function (currencies) {
-
-    // format human readable labels
-    currencies.forEach(function (currency) {
-      currency.label = Currencies.format(currency.id);
-    });
-
-    // bind the currencies to the view
-    vm.currencies = currencies;
-  });
-
-  /** run the module on startup and refresh */
+  /* run the module on startup and refresh */
   function startup() {
-
-    // delete any state indicators (if they exist)
-    delete vm.created;
 
     // current timestamp to limit date
     vm.timestamp = new Date();
@@ -76,43 +48,27 @@ function SimpleJournalVoucherController(AppCache, Vouchers, $translate, Accounts
     // set up default voucher values
     vm.voucher = {};
     vm.voucher.date = new Date();
-
+    vm.voucher.currency_id = Session.enterprise.currency_id;
   }
 
   function submit(form) {
-    // reset the state
-    vm.created = false;
-
-    // clear the old error if it exists
-    delete vm.httpError;
-
     // stop submission if the form is invalid
     if (form.$invalid) {
       return;
     }
 
-    /** @todo - these should be set on the server */
-    vm.voucher.user_id = Session.user.id;
-    vm.voucher.project_id = Session.project.id;
-
-    // turn the voucher into double-entry accounting
+    // submit the voucher
     return Vouchers.createSimple(vm.voucher)
     .then(function (res) {
+      Notify.success('FORM.INFO.UPDATE_SUCCESS');
 
-      /** @todo - need a better way to handle state */
-      vm.created = true;
-
-      /** setup the voucher object to init state */
+      /* setup the voucher object to init state */
       form.$setPristine();
-      vm.voucher = {};
-    })
 
-    // attach the error's translatable text to the view
-    .catch(function (response) {
-      if (response.data && response.data.code) {
-        vm.httpError = response.data.code;
-      }
-    });
+      // rerun the startup script
+      startup();
+    })
+    .catch(Notify.handleError);
   }
 
   startup();

--- a/client/test/e2e/vouchers/simple.spec.js
+++ b/client/test/e2e/vouchers/simple.spec.js
@@ -1,23 +1,22 @@
 /* global browser, element, by */
-const chai = require('chai');
-const expect = chai.expect;
-
 const components = require('../shared/components');
 const FU = require('../shared/FormUtils');
 const helpers = require('../shared/helpers');
-helpers.configure(chai);
 
 describe('Simple Vouchers', function () {
   'use strict';
 
   before(() => helpers.navigate('#/vouchers/simple'));
 
+  var yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+
   const voucher = {
-    date : new Date((new Date()).getDate() - 1),
-    toAccount : 'Test Debtor Group Account',
-    fromAccount: '4600 - Test Inventory Accounts',
-    description : 'Awesome description',
-    amount : 100
+    date: yesterday,
+    toAccount: 'Test Debtor Group Account',
+    fromAccount: 'Test Inventory Accounts',
+    description: 'Awesome description',
+    amount: 100.12
   };
 
   it('can create a simple voucher', function () {
@@ -25,20 +24,17 @@ describe('Simple Vouchers', function () {
     // configure the date to yesterday
     components.dateEditor.set(voucher.date);
 
+    FU.input('SimpleVoucherCtrl.voucher.description', voucher.description);
+
     // select the appropriate accounts
     FU.typeahead('SimpleVoucherCtrl.voucher.toAccount', voucher.toAccount);
     FU.typeahead('SimpleVoucherCtrl.voucher.fromAccount', voucher.fromAccount);
 
-    // check the USD radio option
-    element(by.css('[data-currency-option="2"]')).click();
-
-    // input the amount
+    components.currencySelect.set(2);
     components.currencyInput.set(voucher.amount);
 
     // submit the form
     FU.buttons.submit();
-
-    // assert that validation text appears
-    expect(element(by.css('.alert-success')).isPresent()).to.eventually.equal(true);
+    components.notification.hasSuccess();
   });
 });

--- a/server/controllers/finance/vouchers.js
+++ b/server/controllers/finance/vouchers.js
@@ -123,6 +123,9 @@ function create(req, res, next) {
     voucher.date = new Date();
   }
 
+  // attach session information
+  voucher.user_id = req.session.user.id;
+  voucher.project_id = req.session.project.id;
 
   // make sure the voucher has an id
   var vuid = voucher.uuid || uuid.v4();
@@ -166,8 +169,6 @@ function create(req, res, next) {
       uuid: vuid
     });
   })
-  .catch(function (err) {
-    next(err);
-  })
+  .catch(next)
   .done();
 }


### PR DESCRIPTION
This commit updates the simple vouchers to the latest 2.X standards.
1. The page now uses `Notify` for handling success and errors.
2. Use `bhCurrencySelect` for currency selection - includes bugfixes.
3. End to end tests use the new FU.typeahead() method to configure the
   typeaheads on the page.
4. UI updates
   1. The bhBreadcrumb component now does translation automatically
      instead of having to $translate in controllers.
   2. The breadcrumb now reads `Finance` / `Simple Voucher` instead of
      `Bhima`.

Additionally, all `<textarea>`s in the entire application are limited to resizing vertically, and are limited to a maximum height of 250px.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
