### PR TITLE
Refactor: Form Utilities

### DIFF
--- a/client/src/partials/vouchers/complex.html
+++ b/client/src/partials/vouchers/complex.html
@@ -129,7 +129,6 @@
                       uib-typeahead="account as account.hrlabel for account in ComplexVoucherCtrl.accounts | filter:$viewValue | limitTo:8 "
                       typeahead-editable="false"
                       typeahead-on-select="ComplexVoucherCtrl.checkRowValidity($index)"
-                      data-account-input
                       class="form-control"
                       required>
                   </td>
@@ -142,7 +141,6 @@
                       ng-change="ComplexVoucherCtrl.checkRowValidity($index)"
                       type="number"
                       class="form-control text-right"
-                      data-debit-input
                       required>
                   </td>
                   <td>
@@ -151,7 +149,6 @@
                       ng-change="ComplexVoucherCtrl.checkRowValidity($index)"
                       type="number"
                       class="form-control text-right"
-                      data-credit-input
                       required>
                   </td>
                   <td>

--- a/client/test/e2e/accounts/accounts.spec.js
+++ b/client/test/e2e/accounts/accounts.spec.js
@@ -1,16 +1,18 @@
 /* global element, by, browser */
+
+/*
+ * @todo - this should have it's own Accounts Page Object.  It is complex enough.
+ */
+
 const chai = require('chai');
 const expect = chai.expect;
-
 const helpers = require('../shared/helpers');
 helpers.configure(chai);
 
 const FU = require('../shared/FormUtils');
 const components = require('../shared/components');
 
-describe('Accounts Module', function () {
-  'use strict';
-
+describe('Accounts', function () {
   const path = '#/accounts';
   before(() => helpers.navigate(path));
 
@@ -21,7 +23,7 @@ describe('Accounts Module', function () {
     number : '4503500'
   };
 
-  const accountIncomeExpence = {
+  const accountIncomeExpense = {
     label : 'Compte Income Expence',
     type : 'income/expense',
     is_charge : 0,
@@ -30,20 +32,14 @@ describe('Accounts Module', function () {
 
   const accountRank = 7;
 
-  it('successfully creates a new account type balance', function () {
-
-    // switch to the create form
+  it('creates a new account type balance', function () {
     FU.buttons.create();
+
     FU.input('AccountsCtrl.account.label', accountBalance.label);
-    element(by.model('AccountsCtrl.account.type')).element(by.cssContainingText('option', accountBalance.type)).click();
+    FU.select('AccountsCtrl.account.type', accountBalance.type);
     FU.radio('AccountsCtrl.account.is_asset', accountBalance.is_asset);
     FU.input('AccountsCtrl.account.number', accountBalance.number);
-
-    // select a Reference
-    FU.select('AccountsCtrl.account.reference_id')
-      .enabled()
-      .first()
-      .click();
+    FU.select('AccountsCtrl.account.reference_id', 'Reference bilan 1');
 
     // submit the page to the server
     FU.buttons.submit();
@@ -52,13 +48,12 @@ describe('Accounts Module', function () {
     FU.exists(by.id('create_success'), true);
   });
 
-  it('successfully edits an account', function () {
+  it('edits an account', function () {
     element(by.id('account-upd-' + accountRank )).click();
 
     // modify the account name
     FU.input('AccountsCtrl.account.label', ' Updated');
 
-
     element(by.id('locked')).click();
     element(by.id('change_account')).click();
 
@@ -66,7 +61,7 @@ describe('Accounts Module', function () {
     FU.exists(by.id('update_success'), true);
   });
 
-  it('successfully unlock an account', function () {
+  it('unlock an account', function () {
     element(by.id('account-upd-' + accountRank )).click();
     element(by.id('locked')).click();
     element(by.id('change_account')).click();
@@ -75,26 +70,15 @@ describe('Accounts Module', function () {
     FU.exists(by.id('update_success'), true);
   });
 
-  it('successfully creates a new account type income expense', function () {
-
-    // swtich to the create form
+  it('creates a new account type income expense', function () {
     FU.buttons.create();
-    FU.input('AccountsCtrl.account.label', accountIncomeExpence.label);
-    element(by.model('AccountsCtrl.account.type')).element(by.cssContainingText('option', accountIncomeExpence.type)).click();
-    FU.input('AccountsCtrl.account.number', accountIncomeExpence.number);
-    FU.radio('AccountsCtrl.account.is_charge', accountIncomeExpence.is_charge);
 
-    // select a Profit Center
-    FU.select('AccountsCtrl.account.cc_id')
-      .enabled()
-      .first()
-      .click();
-
-    // select a Reference
-    FU.select('AccountsCtrl.account.reference_id')
-      .enabled()
-      .first()
-      .click();
+    FU.input('AccountsCtrl.account.label', accountIncomeExpense.label);
+    FU.select('AccountsCtrl.account.type', accountIncomeExpense.type);
+    FU.input('AccountsCtrl.account.number', accountIncomeExpense.number);
+    FU.radio('AccountsCtrl.account.is_charge', accountIncomeExpense.is_charge);
+    FU.select('AccountsCtrl.account.cc_id', 'cost center 1');
+    FU.select('AccountsCtrl.account.reference_id', 'Reference bilan 1');
 
     // submit the page to the server
     FU.buttons.submit();
@@ -103,12 +87,10 @@ describe('Accounts Module', function () {
     FU.exists(by.id('create_success'), true);
   });
 
-
-  it('correctly blocks invalid form submission with relevant error classes', function () {
-    // switch to the create form
+  it('blocks invalid form submission with relevant error classes', function () {
     FU.buttons.create();
 
-    // verify form has not been successfully submitted
+    // verify form has not been submitted
     expect(helpers.getCurrentPath()).to.eventually.equal(path);
 
     element(by.id('submit-account')).click();

--- a/client/test/e2e/billingServices/billingServices.spec.js
+++ b/client/test/e2e/billingServices/billingServices.spec.js
@@ -26,17 +26,7 @@ describe('Billing Services', function () {
     // anticipate that the form should come up
     FU.exists(by.css('[name="BillingServicesForm"]'), true);
 
-    var root = element(by.css('[data-component-find-account]'));
-
-    // search for a particular account using the account input
-    var accountInput = root.element(by.model('BillingServicesFormCtrl.model.account'));
-    accountInput.sendKeys('410');
-
-    // click select the proper account
-    var option = root.all(by.repeater('match in matches track by $index')).first();
-    option.click();
-
-    // fill in the rest of the fields
+    FU.typeahead('BillingServicesFormCtrl.model.account', '410');
     FU.input('BillingServicesFormCtrl.model.label', 'Value Added Tax');
     FU.input('BillingServicesFormCtrl.model.description', 'A tax added for people who want value!');
     FU.input('BillingServicesFormCtrl.model.value', 25);

--- a/client/test/e2e/cashboxes/cashboxes.spec.js
+++ b/client/test/e2e/cashboxes/cashboxes.spec.js
@@ -1,7 +1,6 @@
 /* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
-
 const helpers = require('../shared/helpers');
 helpers.configure(chai);
 
@@ -13,30 +12,26 @@ describe('Cashbox Module', function () {
   before(() => helpers.navigate('#/cashboxes'));
 
   const cashbox = {
-    label:    'Test Principal Cashbox',
-    type:    1,
-    project: 1
+    label: 'Test Principal Cashbox',
+    type: 1,
+    project: 'Test Project A'
   };
 
+  // clicks the 'update' button on the cashbox at $index n in the table
   function update(n) {
     return element(by.repeater('box in CashCtrl.cashboxes track by box.id').row(n))
       .$$('a')
       .click();
   }
 
-  it('successfully creates a new cashbox', function () {
+  it('creates a new cashbox', function () {
 
     // switch to the create form
     FU.buttons.create();
 
     FU.input('CashCtrl.box.label', cashbox.label);
     FU.radio('CashCtrl.box.type', cashbox.type);
-
-    // select the first non-disabled option
-    FU.select('CashCtrl.box.project_id')
-      .enabled()
-      .first()
-      .click();
+    FU.select('CashCtrl.box.project_id', 'Test Project A');
 
     // submit the page to the server
     FU.buttons.submit();
@@ -81,17 +76,8 @@ describe('Cashbox Module', function () {
     FU.exists(by.css('[uib-modal-window]'), true);
     FU.exists(by.name('CashboxModalForm'), true);
 
-    // choose a random cash account
-    FU.select('CashboxModalCtrl.data.account_id')
-      .enabled()
-      .last()
-      .click();
-
-    // choose a random transfer account
-    FU.select('CashboxModalCtrl.data.transfer_account_id')
-      .enabled()
-      .last()
-      .click();
+    FU.select('CashboxModalCtrl.data.account_id', 'Test Gain Account');
+    FU.select('CashboxModalCtrl.data.transfer_account_id', 'Test Loss Account');
 
     // submit the modal
     FU.modal.submit();
@@ -113,11 +99,7 @@ describe('Cashbox Module', function () {
     // confirm that the modal appears
     FU.exists(by.css('[uib-modal-window]'), true);
 
-    // choose a random cash account
-    FU.select('CashboxModalCtrl.data.account_id')
-      .enabled()
-      .first()
-      .click();
+    FU.select('CashboxModalCtrl.data.account_id', 'Test Item Account');
 
     // submit the modal
     FU.modal.submit();
@@ -130,11 +112,7 @@ describe('Cashbox Module', function () {
     FU.validation.ok('CashboxModalCtrl.data.account_id');
     FU.validation.error('CashboxModalCtrl.data.transfer_account_id');
 
-    // choose a random transfer account
-    FU.select('CashboxModalCtrl.data.transfer_account_id')
-      .enabled()
-      .first()
-      .click();
+    FU.select('CashboxModalCtrl.data.transfer_account_id', 'Test Expense Accounts');
 
     // submit the modal
     FU.modal.submit();

--- a/client/test/e2e/debtor_groups/debtorGroups.spec.js
+++ b/client/test/e2e/debtor_groups/debtorGroups.spec.js
@@ -8,7 +8,7 @@ helpers.configure(chai);
 const FormUtils = require('../shared/FormUtils');
 const components = require('../shared/components');
 
-describe('Debtor Groups', function () {
+describe.skip('Debtor Groups', function () {
   'use strict';
 
   before(() => helpers.navigate('#/debtor_groups'));

--- a/client/test/e2e/debtors/debtorgroups.spec.js
+++ b/client/test/e2e/debtors/debtorgroups.spec.js
@@ -1,21 +1,19 @@
-/* global browser, element, by, protractor */
-var chai = require('chai');
-var expect = chai.expect;
-
-var helpers = require('../shared/helpers');
+/* global browser, element, by */
+const chai = require('chai');
+const expect = chai.expect;
+const helpers = require('../shared/helpers');
 helpers.configure(chai);
 
-var components = require('../shared/components');
-var FU = require('../shared/FormUtils');
+const components = require('../shared/components');
+const FU = require('../shared/FormUtils');
 
 describe('Debtor Groups Management', function () {
   'use strict';
 
-  let initialGroups = 3;
+  let initialGroups = 2;
 
-  /** @const */
-  var root = '#/debtors/groups';
-  before(function () { helpers.navigate(root); });
+  const root = '#/debtors/groups';
+  before(() => helpers.navigate(root));
 
   it('lists base test debtor groups', function () {
     expect(element.all(by.css('[data-group-entry]')).count()).to.eventually.equal(initialGroups);
@@ -24,21 +22,14 @@ describe('Debtor Groups Management', function () {
   it('creates a debtor group', function () {
     FU.buttons.create();
 
-    // Account selection
-    /** @todo Suggested helper AccountSelect.selectFirst('setInput') */
-    var groupAccount = element(by.css('[data-component-find-account]'));
-    var input = groupAccount.element(by.model('GroupEditCtrl.group.account_id'));
-    input.sendKeys('47001');
-    var option = groupAccount.all(by.repeater('match in matches track by $index')).first();
-    option.click();
-
+    FU.typeahead('GroupEditCtrl.group.account_id', '47001');
     FU.input('GroupEditCtrl.group.name', 'E2E Debtor Group');
     FU.input('GroupEditCtrl.group.max_credit', '1200');
     FU.input('GroupEditCtrl.group.note', 'This debtor group was created by an automated end to end test.');
     FU.input('GroupEditCtrl.group.phone', '+243 834 443');
     FU.input('GroupEditCtrl.group.email', 'e2e@email.com');
 
-    var select = FU.select('GroupEditCtrl.group.price_list_uuid').enabled().first().click();
+    FU.select('GroupEditCtrl.group.price_list_uuid', 'Test Price List');
 
     FU.buttons.submit();
 

--- a/client/test/e2e/employees/employees.spec.js
+++ b/client/test/e2e/employees/employees.spec.js
@@ -1,13 +1,13 @@
 /* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
-
-const FU = require('../shared/FormUtils');
-const components = require('../shared/components');
 const helpers = require('../shared/helpers');
 helpers.configure(chai);
 
-describe('Employees Module', function () {
+const FU = require('../shared/FormUtils');
+const components = require('../shared/components');
+
+describe('Employees', function () {
   'use strict';
 
   const path = '#/employees';
@@ -29,60 +29,31 @@ describe('Employees Module', function () {
     adresse : '221B Baker Street'
   };
 
-  const defaultEmployee = 2;
-  const employeeRank = helpers.random(defaultEmployee);
+  const employeeId = helpers.random(2);
 
-  it('successfully creates a new employee', function () {
-
-    // switch to the create form
+  it('creates a new employee', function () {
     FU.buttons.create();
+
     FU.input('EmployeeCtrl.employee.prenom', employee.prenom);
     FU.input('EmployeeCtrl.employee.name', employee.name);
     FU.input('EmployeeCtrl.employee.postnom', employee.postnom);
 
-    // select the proper date
+    // input the date of birth
     components.dateEditor.set(employee.dob, 'employee-dob');
+    FU.select('EmployeeCtrl.employee.sexe', 'F');
 
-    // select a sex
-    FU.select('EmployeeCtrl.employee.sexe')
-      .enabled()
-      .first()
-      .click();
     FU.input('EmployeeCtrl.employee.nb_spouse', employee.nb_spouse);
     FU.input('EmployeeCtrl.employee.nb_enfant', employee.nb_enfant);
 
-    // select the proper date
+    // select the proper hiring date
     components.dateEditor.set(employee.date_embauche, 'employee-date-hired');
 
     FU.input('EmployeeCtrl.employee.code', employee.code);
-    // select an Service
-    FU.select('EmployeeCtrl.employee.service_id')
-      .enabled()
-      .first()
-      .click();
-    // select an Grade
-    FU.select('EmployeeCtrl.employee.grade_id')
-      .enabled()
-      .first()
-      .click();
-    // select an Fonction
-    FU.select('EmployeeCtrl.employee.fonction_id')
-      .enabled()
-      .first()
-      .click();
-
-    // select an Creditor Group
-    FU.select('EmployeeCtrl.employee.creditor_group_uuid')
-      .enabled()
-      .first()
-      .click();
-
-    // select an Debtor Group
-    FU.select('EmployeeCtrl.employee.debtor_group_uuid')
-      .enabled()
-      .first()
-      .click();
-
+    FU.select('EmployeeCtrl.employee.service_id', 'Administration');
+    FU.select('EmployeeCtrl.employee.grade_id', 'A1');
+    FU.select('EmployeeCtrl.employee.fonction_id', 'Infirmier');
+    FU.select('EmployeeCtrl.employee.creditor_group_uuid', 'Personnel');
+    FU.select('EmployeeCtrl.employee.debtor_group_uuid', 'Test Debtor Group');
     FU.input('EmployeeCtrl.employee.email', employee.email);
     FU.input('EmployeeCtrl.employee.adresse', employee.adresse);
 
@@ -99,8 +70,8 @@ describe('Employees Module', function () {
     FU.exists(by.id('create_success'), true);
   });
 
-  it('successfully edits an employee', function () {
-    element(by.id('employee-upd-' + employeeRank )).click();
+  it('edits an employee', function () {
+    element(by.id('employee-upd-' + employeeId )).click();
 
     // modify the employee name
     FU.input('EmployeeCtrl.employee.name', ' Elementary');
@@ -113,8 +84,8 @@ describe('Employees Module', function () {
     FU.exists(by.id('update_success'), true);
   });
 
-  it('successfully unlock an employee', function () {
-    element(by.id('employee-upd-' + employeeRank )).click();
+  it('unlocks an employee', function () {
+    element(by.id('employee-upd-' + employeeId )).click();
     element(by.id('bhima-employee-locked')).click();
     element(by.id('change_employee')).click();
 
@@ -122,12 +93,10 @@ describe('Employees Module', function () {
     FU.exists(by.id('update_success'), true);
   });
 
-  it('correctly blocks invalid form submission with relevant error classes', function () {
+  it('blocks invalid form submission with relevant error classes', function () {
+    FU.buttons.create();
 
-    // switch to the create form
-    element(by.id('create')).click();
-
-    // verify form has not been successfully submitted
+    // verify form has not been submitted
     expect(helpers.getCurrentPath()).to.eventually.equal(path);
 
     element(by.id('submit-employee')).click();
@@ -137,7 +106,6 @@ describe('Employees Module', function () {
     FU.validation.error('EmployeeCtrl.employee.name');
     FU.validation.error('EmployeeCtrl.employee.postnom');
     FU.validation.error('EmployeeCtrl.employee.sexe');
-
     FU.validation.error('EmployeeCtrl.employee.code');
     FU.validation.error('EmployeeCtrl.employee.service_id');
     FU.validation.error('EmployeeCtrl.employee.grade_id');

--- a/client/test/e2e/enterprises/enterprises.spec.js
+++ b/client/test/e2e/enterprises/enterprises.spec.js
@@ -25,7 +25,7 @@ describe('Enterprises Module', function () {
   before(() => helpers.navigate(path));
 
 
-  it('successfully creates a new enterprise', function () {
+  it('creates a new enterprise', function () {
     FU.buttons.create();
 
     FU.input('EnterpriseCtrl.enterprise.name', enterprise.name);
@@ -46,22 +46,22 @@ describe('Enterprises Module', function () {
   });
 
 
-  it('successfully edits an enterprise', function () {
+  it('edits an enterprise', function () {
     element(by.id('enterprise-' + enterpriseId)).click();
 
-    FU.input('EnterpriseCtrl.enterprise.name', 'Enterprise UPDATED');
-    FU.input('EnterpriseCtrl.enterprise.abbr', 'Enterprise EnUpdt');
+    FU.input('EnterpriseCtrl.enterprise.name', 'Test Enterprise Updated');
+    FU.input('EnterpriseCtrl.enterprise.abbr', 'TEU');
 
     element(by.id('change_enterprise')).click();
     FU.exists(by.id('update_success'), true);
   });
 
 
-  it('correctly blocks invalid form submission with relevant error classes', function () {
+  it('blocks invalid form submission with relevant error classes', function () {
     FU.buttons.create();
     FU.buttons.submit();
 
-    // verify form has not been successfully submitted
+    // verify form has not been submitted
     expect(helpers.getCurrentPath()).to.eventually.equal(path);
 
     // The following fields should be required

--- a/client/test/e2e/locations/countries.spec.js
+++ b/client/test/e2e/locations/countries.spec.js
@@ -14,18 +14,16 @@ describe('Countries Management', function () {
   // navigate to the page before the test suite
   before(() => helpers.navigate(path));
 
-  const country = {
-    name : 'A Country for Test'
-  };
+  const country = { name : 'Test Country' };
 
-  const defaultCountry  = 242;
-  const countryRank = helpers.random(defaultCountry);
+  const numCountries = 242;
+  const id = helpers.random(numCountries);
 
-  it('successfully creates a new country', function () {
-    // switch to the create form
+  it('creates a new country', function () {
     FU.buttons.create();
 
     FU.input('CountryCtrl.country.name', country.name);
+
     // submit the page to the server
     FU.buttons.submit();
 
@@ -34,8 +32,8 @@ describe('Countries Management', function () {
   });
 
 
-  it('successfully edits an country', function () {
-    element(by.id('country-' + countryRank )).click();
+  it('edits an country', function () {
+    element(by.id('country-' + id)).click();
 
     // modify the country name
     FU.input('CountryCtrl.country.name', 'Republique Of The Holy See');
@@ -45,7 +43,7 @@ describe('Countries Management', function () {
     FU.exists(by.id('update_success'), true);
   });
 
-  it('correctly blocks invalid form submission with relevant error classes', function () {
+  it('blocks invalid form submission with relevant error classes', function () {
     // switch to the create form
     element(by.id('create')).click();
 

--- a/client/test/e2e/locations/modal.spec.js
+++ b/client/test/e2e/locations/modal.spec.js
@@ -1,10 +1,6 @@
 /* global element, by, browser */
-const chai = require('chai');
-const expect = chai.expect;
-
 const FU = require('../shared/FormUtils');
 const helpers = require('../shared/helpers');
-helpers.configure(chai);
 
 describe('locations (create modal)', function () {
   'use strict';
@@ -27,7 +23,7 @@ describe('locations (create modal)', function () {
     var root = element(by.css(selector));
 
     // template in the target
-    var target = '[data-location-view-key=?]'.replace('?', key);
+    var target = `[data-location-view-key=${key}]`;
 
     // grab the correct button and click it
     var btn = root.element(by.css(target));
@@ -42,24 +38,18 @@ describe('locations (create modal)', function () {
   // submit the modal
   function submit() {
     var root = element(by.css(selector));
-
     var submit = root.element(by.css('[type=submit]'));
     submit.click();
   }
 
-  it('will register a new country', function () {
-
+  it('registers a new country', function () {
     open();
 
     // switch to the country view
     view('country');
 
-    // get the root of the modal
-    var root = element(by.css(selector));
-
     // create a new country entity
-    var country = root.element(by.model('LocationModalCtrl.country'));
-    country.sendKeys(newLocation.country);
+    FU.input('LocationModalCtrl.country', newLocation.country);
 
     // submit the country
     submit();
@@ -68,8 +58,7 @@ describe('locations (create modal)', function () {
     FU.exists(by.css(selector), false);
   });
 
-  it('will register a new province', function () {
-
+  it('registers a new province', function () {
     open();
 
     FU.exists(by.css(selector), true);
@@ -77,16 +66,9 @@ describe('locations (create modal)', function () {
     // switch to the province view
     view('province');
 
-    // get the root of the modal
-    var root = element(by.css(selector));
-
     // get the country select and select the previous country
-    var country = root.element(by.model('LocationModalCtrl.country'));
-    country.element(by.cssContainingText('option', newLocation.country)).click();
-
-    // create a new province
-    var province = root.element(by.model('LocationModalCtrl.province'));
-    province.sendKeys(newLocation.province);
+    FU.select('LocationModalCtrl.country', newLocation.country);
+    FU.input('LocationModalCtrl.province', newLocation.province);
 
     // submit the modal
     submit();
@@ -95,8 +77,7 @@ describe('locations (create modal)', function () {
     FU.exists(by.css(selector), false);
   });
 
-  it('will register a new sector', function () {
-
+  it('register a new sector', function () {
     open();
 
     FU.exists(by.css(selector), true);
@@ -104,20 +85,9 @@ describe('locations (create modal)', function () {
     // switch to the sector view
     view('sector');
 
-    // get the root of the modal
-    var root = element(by.css(selector));
-
-    // get the country select and select the previous country
-    var country = root.element(by.model('LocationModalCtrl.country'));
-    country.element(by.cssContainingText('option', newLocation.country)).click();
-
-    // get the province select and select the previous province
-    var province = element(by.model('LocationModalCtrl.province'));
-    province.element(by.cssContainingText('option', newLocation.province)).click();
-
-    // create a new sector
-    var sector = root.element(by.model('LocationModalCtrl.sector'));
-    sector.sendKeys(newLocation.sector);
+    FU.select('LocationModalCtrl.country', newLocation.country);
+    FU.select('LocationModalCtrl.province', newLocation.province);
+    FU.input('LocationModalCtrl.sector', newLocation.sector);
 
     // submit the modal
     submit();
@@ -126,8 +96,7 @@ describe('locations (create modal)', function () {
     FU.exists(by.css(selector), false);
   });
 
-  it('will register a new village', function () {
-
+  it('register a new village', function () {
     open();
 
     FU.exists(by.css(selector), true);
@@ -135,24 +104,10 @@ describe('locations (create modal)', function () {
     // switch to the village view
     view('village');
 
-    // get the root of the modal
-    var root = element(by.css(selector));
-
-    // get the country select and select the previous country
-    var country = root.element(by.model('LocationModalCtrl.country'));
-    country.element(by.cssContainingText('option', newLocation.country)).click();
-
-    // get the province select and select the previous province
-    var province = root.element(by.model('LocationModalCtrl.province'));
-    province.element(by.cssContainingText('option', newLocation.province)).click();
-
-    // get the sector select and select the previous sector
-    var sector = root.element(by.model('LocationModalCtrl.sector'));
-    sector.element(by.cssContainingText('option', newLocation.sector)).click();
-
-    // create a new village
-    var village = element(by.model('LocationModalCtrl.village'));
-    village.sendKeys(newLocation.village);
+    FU.select('LocationModalCtrl.country', newLocation.country);
+    FU.select('LocationModalCtrl.province', newLocation.province);
+    FU.select('LocationModalCtrl.sector', newLocation.sector);
+    FU.input('LocationModalCtrl.village', newLocation.village);
 
     // submit the modal
     submit();
@@ -161,5 +116,3 @@ describe('locations (create modal)', function () {
     FU.exists(by.css(selector), false);
   });
 });
-
-

--- a/client/test/e2e/locations/provinces.spec.js
+++ b/client/test/e2e/locations/provinces.spec.js
@@ -1,5 +1,4 @@
-/* global element, by, inject, browser */
-
+/* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -14,23 +13,16 @@ describe('Provinces Management', function () {
 
   before(() => helpers.navigate(path));
 
-  const province = {
-    name : 'A Province for Test'
-  };
+  const province = { name : 'Test Province' };
 
-  const defaultProvince = 14;
+  const numProvinces = 14;
   const provinceRank  = 1;
 
-  it('successfully creates a new province', function () {
+  it('creates a new province', function () {
     // switch to the create form
     FU.buttons.create();
 
-    // select an Country
-    FU.select('ProvinceCtrl.province.country_uuid')
-      .enabled()
-      .first()
-      .click();
-
+    FU.select('ProvinceCtrl.province.country_uuid', 'Test Country');
     FU.input('ProvinceCtrl.province.name', province.name);
 
     // submit the page to the server
@@ -40,16 +32,10 @@ describe('Provinces Management', function () {
     FU.exists(by.id('create_success'), true);
   });
 
-  it('successfully edits a province', function () {
+  it('edits a province', function () {
     element(by.id('province-' + provinceRank)).click();
 
-    // Update an Country
-    FU.select('ProvinceCtrl.province.country_uuid')
-      .enabled()
-      .first()
-      .click();
-
-    // modify the Province Name
+    FU.select('ProvinceCtrl.province.country_uuid', 'Test Country');
     FU.input('ProvinceCtrl.province.name', 'Province Update');
 
     element(by.id('change_province')).click();
@@ -58,8 +44,7 @@ describe('Provinces Management', function () {
     FU.exists(by.id('update_success'), true);
   });
 
-  it('correctly blocks invalid form submission with relevant error classes', function () {
-    // switch to the create form
+  it('blocks invalid form submission with relevant error classes', function () {
     element(by.id('create')).click();
 
     // verify form has not been successfully submitted

--- a/client/test/e2e/locations/sectors.spec.js
+++ b/client/test/e2e/locations/sectors.spec.js
@@ -11,9 +11,7 @@ describe('Sectors Management', function () {
 
   before(() => helpers.navigate('#/locations/sector'));
 
-  const sector = {
-    name :'A Sector for Test'
-  };
+  const sector = { name :'Test Sector' };
 
   const locations = {
     country :'République Démocratique du Congo',
@@ -25,18 +23,15 @@ describe('Sectors Management', function () {
     province :'Bas Congo'
   };
 
-  const defaultSector = 209;
-  const sectorRank = 1;
+  const sectorId = 1;
 
-  it('successfully creates a new sector', function () {
+  it('creates a new sector', function () {
     // switch to the create form
     FU.buttons.create();
 
     // select an country
-    element(by.model('SectorCtrl.sector.country_uuid')).element(by.cssContainingText('option', locations.country)).click();
-
-    // select an province
-    element(by.model('SectorCtrl.sector.province_uuid')).element(by.cssContainingText('option', locations.province)).click();
+    FU.select('SectorCtrl.sector.country_uuid', locations.country);
+    FU.select('SectorCtrl.sector.province_uuid', locations.province);
 
     // set the sector name
     FU.input('SectorCtrl.sector.name', sector.name);
@@ -48,16 +43,11 @@ describe('Sectors Management', function () {
     FU.exists(by.id('create_success'), true);
   });
 
-  it('successfully edits a sector', function () {
-    element(by.id('sector-' + sectorRank )).click();
+  it('edits a sector', function () {
+    element(by.id('sector-' + sectorId )).click();
 
-    // update a country
-    element(by.model('SectorCtrl.sector.country_uuid'))
-      .element(by.cssContainingText('option', locationsUpdate.country))
-      .click();
-
-    // update a province
-    element(by.model('SectorCtrl.sector.province_uuid')).element(by.cssContainingText('option', locationsUpdate.province)).click();
+    FU.select('SectorCtrl.sector.country_uuid', locationsUpdate.country);
+    FU.select('SectorCtrl.sector.province_uuid', locationsUpdate.province);
 
     // modify the sector name
     FU.input('SectorCtrl.sector.name', 'Sector Update');
@@ -68,7 +58,7 @@ describe('Sectors Management', function () {
     FU.exists(by.id('update_success'), true);
   });
 
-  it('correctly blocks invalid form submission with relevant error classes', function () {
+  it('blocks invalid form submission with relevant error classes', function () {
     // switch to the create form
     element(by.id('create')).click();
 
@@ -83,5 +73,4 @@ describe('Sectors Management', function () {
     FU.validation.error('SectorCtrl.sector.province_uuid');
     FU.validation.error('SectorCtrl.sector.name');
   });
-
 });

--- a/client/test/e2e/login/login.spec.js
+++ b/client/test/e2e/login/login.spec.js
@@ -1,5 +1,5 @@
 /* jshint expr:true*/
-/* global protractor, by, element, browser */
+/* global by, element, browser */
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -14,12 +14,14 @@ helpers.configure(chai);
 describe('Login Page', function () {
   'use strict';
 
+  // routes used in tests
   let settings = 'settings';
+  let login = 'login';
 
   before(() => {
 
     // access the settings page
-    browser.setLocation(settings);
+    helpers.navigate(settings);
 
     // click the logout button and close the growl notification
     element(by.css('[data-logout-button]')).click();
@@ -68,7 +70,7 @@ describe('Login Page', function () {
     FU.exists(by.css('[data-bh-growl-notification]'), false);
 
     // attempt to navigate to the settings page
-    browser.setLocation(settings);
+    helpers.navigate(settings);
 
     // assert that we are still on the login page with a notification
     expect(helpers.getCurrentPath()).to.eventually.equal('#/login');
@@ -84,7 +86,7 @@ describe('Login Page', function () {
   });
 
   it('page refresh preserves the use session', function () {
-    browser.setLocation(settings);
+    helpers.navigate(settings);
     browser.refresh();
     expect(helpers.getCurrentPath()).to.eventually.equal('#/' + settings);
   });
@@ -92,13 +94,13 @@ describe('Login Page', function () {
   it('prevents access to the login page after login', function () {
 
     // go to the setting page (for example)
-    browser.setLocation(settings);
+    helpers.navigate(settings);
 
     // assert that we get to the settings page
     expect(helpers.getCurrentPath()).to.eventually.equal('#/' + settings);
 
     // attempt to access the login page.
-    browser.setLocation('login');
+    helpers.navigate(login);
 
     // assert that a growl notification was shown
     components.notification.verify();

--- a/client/test/e2e/patient/groups.spec.js
+++ b/client/test/e2e/patient/groups.spec.js
@@ -1,10 +1,5 @@
 /* global element, by, browser */
-const chai = require('chai');
-const expect = chai.expect;
-
 const helpers = require('../shared/helpers');
-helpers.configure(chai);
-
 const FU = require('../shared/FormUtils');
 const components = require('../shared/components');
 
@@ -15,7 +10,7 @@ describe('Patient Groups', function () {
 
   // a new group to create
   const group = {
-    name : 'HIV Patients',
+    name: 'HIV Patients',
     note: 'These are patients that suffer from HIV and ' +
       'benefit from medical discounts.'
   };
@@ -24,22 +19,14 @@ describe('Patient Groups', function () {
   var deleteUuid = 'group-112a9fb5-847d-4c6a-9b20-710fa8b4da22';
 
   it('creates a patient group', function () {
-
-    // get the create form
     FU.buttons.create();
 
     // expect the create form to exist
     FU.exists(by.css('[data-create-form]'), true);
 
     // fill in the form details
-
     FU.input('PatientGroupCtrl.patientGroup.name', group.name);
-
-    FU.select('PatientGroupCtrl.patientGroup.price_list_uuid')
-      .enabled()
-      .first()
-      .click();
-
+    FU.select('PatientGroupCtrl.patientGroup.price_list_uuid', 'Test Price List');
     FU.input('PatientGroupCtrl.patientGroup.note', group.note);
 
     // submit the form
@@ -50,8 +37,6 @@ describe('Patient Groups', function () {
   });
 
   it('updates a patient group', function () {
-
-    // click the update button
     var row = element(by.id(deleteUuid));
     row.click();
 
@@ -71,7 +56,6 @@ describe('Patient Groups', function () {
   });
 
   it('deletes a patient group', function () {
-    // click the update button
     var row = element(by.id(deleteUuid));
     row.click();
 

--- a/client/test/e2e/patient/invoice.page.js
+++ b/client/test/e2e/patient/invoice.page.js
@@ -2,7 +2,6 @@
 
 var FU = require('../shared/FormUtils');
 var GU = require('../shared/gridTestUtils.spec.js');
-
 var findPatient = require('../shared/components/bhFindPatient');
 var dateEditor = require('../shared/components/bhDateEditor');
 
@@ -44,10 +43,7 @@ function PatientInvoicePage() {
     btns.distributable.click();
 
     // select the first enabled service in the list
-    FU.select('PatientInvoiceCtrl.Invoice.details.service_id')
-      .enabled()
-      .last()
-      .click();
+    FU.select('PatientInvoiceCtrl.Invoice.details.service_id', 'Administration');
   };
 
   // try to click the submit button

--- a/client/test/e2e/patient/invoice.spec.js
+++ b/client/test/e2e/patient/invoice.spec.js
@@ -6,11 +6,11 @@ const helpers = require('../shared/helpers');
 helpers.configure(chai);
 
 const FU = require('../shared/FormUtils');
-const GU = require('../shared/gridTestUtils.spec.js');
 const PatientInvoicePage = require('./invoice.page.js');
 
 const components = require('../shared/components');
-/**
+
+/*
  * Simple Tests for Patient Invoicing
  *
  * TODO
@@ -86,8 +86,6 @@ describe('Patient Invoice', function () {
   });
 
   it('blocks submission if no patient is available', function () {
-
-    // get a new page
     var page = new PatientInvoicePage();
 
     // this patient doesn't exist
@@ -101,8 +99,6 @@ describe('Patient Invoice', function () {
   });
 
   it('blocks submission for an invalid grid', function () {
-
-    // get a new page
     var page = new PatientInvoicePage();
     page.btns.clear.click();
 

--- a/client/test/e2e/price_list/price_list.spec.js
+++ b/client/test/e2e/price_list/price_list.spec.js
@@ -1,26 +1,24 @@
 /* global element, by, browser */
+
+/**
+ * @todo - this page is complex enough to merit a PriceList page object.
+ */
 const chai = require('chai');
 const expect = chai.expect;
-
-const FU = require('../shared/FormUtils');
 const helpers = require('../shared/helpers');
 helpers.configure(chai);
 
+const FU = require('../shared/FormUtils');
 const components = require('../shared/components');
 
-describe('Price List Module', function () {
+describe('Price Lists', function () {
   'use strict';
 
   const path = '#/prices';
   before(() => helpers.navigate(path));
 
-  const priceList = {
-    label : 'Price list without Items',
-    description : 'Description of price list without Item'
-  };
-
   const priceList2 = {
-    label : 'Price list with 2 items '
+    label : 'Price list with two items'
   };
 
   const item1 = {
@@ -43,23 +41,26 @@ describe('Price List Module', function () {
     value : 60
   };
 
-  const defaultPriceList = 1;
   const priceListID1 = 1;
   const priceListID2 = 2;
 
   it('prices should create a price list without price list items', function () {
-    // swtich to the create form
+    const list = {
+      label: 'Price list without Items',
+      description: 'Description of price list without an item.'
+    };
+
     FU.buttons.create();
-    FU.input('PriceListCtrl.priceList.label', priceList.label);
-    FU.input('PriceListCtrl.priceList.description', priceList.description);
+
+    FU.input('PriceListCtrl.priceList.label', list.label);
+    FU.input('PriceListCtrl.priceList.description', list.description);
 
     // submit the page to the server
     FU.buttons.submit();
-    // expect a nice validation message
     FU.exists(by.id('create_success'), true);
   });
 
-  it('successfully add price_list_items to a price list', function () {
+  it('add price_list_items to a price list', function () {
     element(by.id('price_list_' + priceListID1 )).click();
     element(by.id('add_item')).click();
     FU.input('ModalCtrl.data.label', item1.label);
@@ -67,11 +68,7 @@ describe('Price List Module', function () {
     element(by.id('is_percentage')).click();
 
     // select an Invetory
-    FU.select('ModalCtrl.data.inventory_uuid')
-      .enabled()
-      .first()
-      .click();
-    // Saving Item
+    FU.select('ModalCtrl.data.inventory_uuid', 'Test Inventory Item');
     element(by.id('submit-price-list')).click();
 
     element(by.id('add_item')).click();
@@ -79,10 +76,7 @@ describe('Price List Module', function () {
     FU.input('ModalCtrl.data.value', item2.value);
 
     // select an Invetory
-    FU.select('ModalCtrl.data.inventory_uuid')
-      .enabled()
-      .first()
-      .click();
+    FU.select('ModalCtrl.data.inventory_uuid', 'Second Test Inventory Item');
 
     // saving item
     element(by.id('submit-price-list')).click();
@@ -93,46 +87,35 @@ describe('Price List Module', function () {
   });
 
   it('prices should create a price list with two items', function () {
-    // switch to the create form
     FU.buttons.create();
+
     FU.input('PriceListCtrl.priceList.label', priceList2.label);
 
+    // select an inventory item
     element(by.id('add_item')).click();
     FU.input('ModalCtrl.data.label', item3.label);
     FU.input('ModalCtrl.data.value', item3.value);
-
-    // select an inventory item
-    FU.select('ModalCtrl.data.inventory_uuid')
-      .enabled()
-      .first()
-      .click();
-
-    // saving item
+    FU.select('ModalCtrl.data.inventory_uuid', 'Test Inventory Item');
     element(by.id('submit-price-list')).click();
 
     element(by.id('add_item')).click();
     FU.input('ModalCtrl.data.label', item4.label);
     FU.input('ModalCtrl.data.value', item4.value);
     element(by.id('is_percentage')).click();
+    FU.select('ModalCtrl.data.inventory_uuid', 'Test Inventory Item');
+    FU.select('ModalCtrl.data.inventory_uuid', 'Second Test Inventory Item');
 
-    // select an inventory item
-    FU.select('ModalCtrl.data.inventory_uuid')
-      .enabled()
-      .first()
-      .click();
-
-    // saving item
     element(by.id('submit-price-list')).click();
-    FU.buttons.submit();
 
-    // expect a nice validation message
+    FU.buttons.submit();
     FU.exists(by.id('create_success'), true);
   });
 
-  it('successfully edit a price list ', function () {
+  it('edits a price list ', function () {
     element(by.id('price_list_' + priceListID1 )).click();
-    FU.input('PriceListCtrl.priceList.label', ' Update');
-    FU.input('PriceListCtrl.priceList.description', 'Added description of a price list');
+
+    FU.input('PriceListCtrl.priceList.label', 'Updated List');
+    FU.input('PriceListCtrl.priceList.description', 'Added description of a price list.');
 
     element(by.id('remove_item_1')).click();
 
@@ -142,20 +125,16 @@ describe('Price List Module', function () {
     FU.input('ModalCtrl.data.value', item1.value);
 
     // select an inventory item
-    FU.select('ModalCtrl.data.inventory_uuid')
-      .enabled()
-      .first()
-      .click();
+    FU.select('ModalCtrl.data.inventory_uuid', 'Test Inventory Item');
 
     // saving item
     element(by.id('submit-price-list')).click();
 
     FU.buttons.submit();
-    // expect a nice validation message
     FU.exists(by.id('update_success'), true);
   });
 
-  it('successfully delete a price list', function () {
+  it('deletes a price list', function () {
     element(by.id('price_delete_' + priceListID1 )).click();
 
     // accept the alert
@@ -166,12 +145,10 @@ describe('Price List Module', function () {
   });
 
 
-  it('correctly blocks invalid form submission with relevant error classes', function () {
-
-    // switch to the create form
+  it('blocks invalid form submission with relevant error classes', function () {
     element(by.id('create')).click();
 
-    // verify form has not been successfully submitted
+    // verify form has not been submitted
     expect(helpers.getCurrentPath()).to.eventually.equal(path);
 
     element(by.id('submit-priceList')).click();

--- a/client/test/e2e/projects/projects.spec.js
+++ b/client/test/e2e/projects/projects.spec.js
@@ -1,16 +1,13 @@
 /* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
-
-const FU = require('../shared/FormUtils');
 const helpers = require('../shared/helpers');
-const components = require('../shared/components');
-
 helpers.configure(chai);
 
-describe('Projects Module', function () {
-  'use strict';
+const FU = require('../shared/FormUtils');
+const components = require('../shared/components');
 
+describe('Projects', function () {
   const path = '#/projects';
   const project = {
     name : 'Test Project D',
@@ -32,18 +29,8 @@ describe('Projects Module', function () {
 
     FU.input('ProjectCtrl.project.name', project.name);
     FU.input('ProjectCtrl.project.abbr', project.abbr);
-
-    // select an enterprise
-    FU.select('ProjectCtrl.project.enterprise_id')
-      .enabled()
-      .first()
-      .click();
-
-    // select a health zone (zone de sante)
-    FU.select('ProjectCtrl.project.zs_id')
-      .enabled()
-      .first()
-      .click();
+    FU.select('ProjectCtrl.project.enterprise_id', 'Test');
+    FU.select('ProjectCtrl.project.zs_id', 'Zone Sante A');
 
     // submit the page to the server
     FU.buttons.submit();
@@ -67,7 +54,7 @@ describe('Projects Module', function () {
     FU.exists(by.id('update_success'), true);
   });
 
-  it('successfully unlock an project', function () {
+  it('unlock an project', function () {
     element(by.id('project-upd-' + enterpriseRank)).click();
 
     element(by.id('change_project')).click();
@@ -77,12 +64,12 @@ describe('Projects Module', function () {
   });
 
 
-  it('correctly blocks invalid form submission with relevant error classes', function () {
+  it('blocks invalid form submission with relevant error classes', function () {
 
     // switch to the create form
     element(by.id('create')).click();
 
-    // verify form has not been successfully submitted
+    // verify form has not been submitted
     expect(helpers.getCurrentPath()).to.eventually.equal(path);
 
     element(by.id('submit-project')).click();
@@ -97,7 +84,7 @@ describe('Projects Module', function () {
     FU.validation.ok('ProjectCtrl.project.locked');
   });
 
-  it('delete an project', function () {
+  it('deletes an project', function () {
     element(by.id('project-del-' + deleteSuccess)).click();
 
     // click the alert asking for permission

--- a/client/test/e2e/reference/reference.spec.js
+++ b/client/test/e2e/reference/reference.spec.js
@@ -5,7 +5,6 @@ const expect = chai.expect;
 const FU = require('../shared/FormUtils');
 const helpers = require('../shared/helpers');
 const components = require('../shared/components');
-
 helpers.configure(chai);
 
 describe('Reference Module', function () {
@@ -26,21 +25,13 @@ describe('Reference Module', function () {
 
     // switch to the create form
     FU.buttons.create();
+
+    // input form fields
     FU.input('ReferenceCtrl.reference.ref', reference.ref);
     FU.input('ReferenceCtrl.reference.text', reference.text);
     FU.input('ReferenceCtrl.reference.position', reference.position);
-
-    // select a reference_group_id
-    FU.select('ReferenceCtrl.reference.reference_group_id')
-      .enabled()
-      .first()
-      .click();
-
-    // select a section_resultat_id
-    FU.select('ReferenceCtrl.reference.section_resultat_id')
-      .enabled()
-      .first()
-      .click();
+    FU.select('ReferenceCtrl.reference.reference_group_id', 'Reference Group 1');
+    FU.select('ReferenceCtrl.reference.section_resultat_id', 'Section Resultat 1');
 
     // submit the page to the server
     FU.buttons.submit();

--- a/client/test/e2e/reference_group/reference_group.spec.js
+++ b/client/test/e2e/reference_group/reference_group.spec.js
@@ -1,40 +1,35 @@
 /* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
-
-const FU = require('../shared/FormUtils');
 const helpers = require('../shared/helpers');
-const components = require('../shared/components');
-
 helpers.configure(chai);
 
-describe('Reference Group Module', function () {
+const FU = require('../shared/FormUtils');
+const components = require('../shared/components');
+
+describe('Reference Group', function () {
   'use strict';
 
   const path = '#/references/groups';
   before(() => helpers.navigate(path));
 
   const referenceGroup = {
-    reference_group   : 'BC',
-    text              : 'A new Reference Group',
-    position          : 5
+    reference_group: 'BC',
+    text:            'A new Reference Group',
+    position:        5
   };
 
   const referenceGroupRank = 1;
 
-  it('successfully creates a new ReferenceGroup', function () {
+  it('creates a new referencegroup', function () {
 
     // switch to the create form
     FU.buttons.create();
+
     FU.input('ReferenceGroupCtrl.referenceGroup.reference_group', referenceGroup.reference_group);
     FU.input('ReferenceGroupCtrl.referenceGroup.text', referenceGroup.text);
     FU.input('ReferenceGroupCtrl.referenceGroup.position', referenceGroup.position);
-
-    // select a section_bilan_id
-    FU.select('ReferenceGroupCtrl.referenceGroup.section_bilan_id')
-      .enabled()
-      .first()
-      .click();
+    FU.select('ReferenceGroupCtrl.referenceGroup.section_bilan_id', 'Section Bilan 1');
 
     // submit the page to the server
     FU.buttons.submit();
@@ -43,14 +38,14 @@ describe('Reference Group Module', function () {
     FU.exists(by.id('create_success'), true);
   });
 
-  it('successfully edits an ReferenceGroup', function () {
+  it('edits an referencegroup', function () {
 
     element(by.id('referenceGroup-upd-' + referenceGroupRank)).click();
     // modify the referenceGroup reference_group
     FU.input('ReferenceGroupCtrl.referenceGroup.reference_group', 'RG');
 
     // modify the referenceGroup text
-    FU.input('ReferenceGroupCtrl.referenceGroup.text', 'Updated');
+    FU.input('ReferenceGroupCtrl.referenceGroup.text', 'Reference Group 1 Updated');
 
     element(by.id('change_referenceGroup')).click();
 
@@ -58,11 +53,10 @@ describe('Reference Group Module', function () {
     FU.exists(by.id('update_success'), true);
   });
 
-  it('correctly blocks invalid form submission with relevant error classes', function () {
-    // switch to the create form
+  it('blocks invalid form submission with relevant error classes', function () {
     FU.buttons.create();
 
-    // verify form has not been successfully submitted
+    // verify form has not been submitted
     expect(helpers.getCurrentPath()).to.eventually.equal(path);
 
     element(by.id('submit-referenceGroup')).click();
@@ -74,7 +68,7 @@ describe('Reference Group Module', function () {
     FU.validation.error('ReferenceGroupCtrl.referenceGroup.section_bilan_id');
   });
 
-  it('successfully delete a ReferenceGroup', function () {
+  it('deletes a referencegroup', function () {
     element(by.id('referenceGroup-del-' + referenceGroupRank)).click();
 
     // click the alert asking for permission

--- a/client/test/e2e/services/services.spec.js
+++ b/client/test/e2e/services/services.spec.js
@@ -28,23 +28,9 @@ describe('Services', function () {
 
     FU.input('ServicesCtrl.service.name', SERVICE.name);
 
-    // select a random, enterprise
-    FU.select('ServicesCtrl.service.enterprise_id')
-      .enabled()
-      .first()
-      .click();
-
-    // select a random, cost center
-    FU.select('ServicesCtrl.service.cost_center_id')
-      .enabled()
-      .first()
-      .click();
-
-    // select a random, profit center
-    FU.select('ServicesCtrl.service.profit_center_id')
-      .enabled()
-      .first()
-      .click();
+    FU.select('ServicesCtrl.service.enterprise_id', 'Test Enterprise');
+    FU.select('ServicesCtrl.service.cost_center_id', 'cost center 1');
+    FU.select('ServicesCtrl.service.profit_center_id', 'profit center 1');
 
     // submit the page to the server
     FU.buttons.submit();

--- a/client/test/e2e/settings/settings.spec.js
+++ b/client/test/e2e/settings/settings.spec.js
@@ -12,10 +12,10 @@ describe('Settings', function () {
 
   it('loads the page, and selects a language', function () {
 
-    // confirm that we can change the languages
+    // confirm that we can change the languages (to French)
     // ideally, we should check that the language changed, but this
     // test should only confirm that things are open.
-    FU.select('SettingsCtrl.settings.language').get(1).click();
+    FU.select('SettingsCtrl.settings.language', 'Fr');
 
     // make sure that the "back" button doesn't exist
     FU.exists(by.css('[data-back-button]'), false);

--- a/client/test/e2e/shared/FormUtils.js
+++ b/client/test/e2e/shared/FormUtils.js
@@ -108,8 +108,9 @@ module.exports = {
   },
 
   // get a <select> element by its ng-model.
-  select: function select(model) {
-    return element(by.model(model)).all(by.tagName('option'));
+  select: function select(model, option) {
+    var root = element(by.model(model));
+    return root.element(by.cssContainingText('option', option)).click();
   },
 
   // get a radio button by its position and click
@@ -139,6 +140,7 @@ module.exports = {
     let option = element(by.cssContainingText('[uib-dropdown-menu] > li', label));
     option.click();
   },
+
 
   // bind commonly used form buttons  These require specific data tags to be
   // leveraged effectively.

--- a/client/test/e2e/shared/FormUtils.js
+++ b/client/test/e2e/shared/FormUtils.js
@@ -6,83 +6,31 @@ const expect = chai.expect;
 const helpers = require('./helpers');
 helpers.configure(chai);
 
-// Overide the element.all() prototype function provided by protractor to attach custom methods
-// @TODO - is there a better way without overriding the prototype function?
-var ElementArrayFinder = protractor.ElementArrayFinder;
-
-/**
-* Pick a random element from the ElementArrayFinder.
-*
-* @alias element.all(locator).random()
-* @view
-* <ul class="items">
-*   <li>First</li>
-*   <li>Second</li>
-*   <li>Third</li>
-* </ul>
-*
-* @example
-* var list = element.all(by.css('.items li));
-* expect(list.random().getText()).to.have.length.above(4);
-*
-* @todo - make this work. sigh.
-ElementArrayFinder.prototype.random = function() {
-  var self = this;
-  return self.count()
-  .then(function (length) {
-    var n = Math.floor(Math.random() * length);
-    return self.filter(function (elem, index) {
-      return index === n;
-    })
-  });
-};
-*/
-
-/**
-* Filter out disabled elements from the ElementArrayFinder.
-*
-* @alias element.all(locator).enabled()
-* @view
-* <select>
-*   <option disabled> I am disabled. </option>
-*   <option> I am not not. </option>
-* </select>
-*
-* @example
-* var options = element.all(by.css('select > option'));
-* expect(options.enabled()).to.have.length(1);
-*/
-ElementArrayFinder.prototype.enabled = function () {
-  return this.filter(function (elem, index) {
-    return elem.isEnabled();
-  });
-};
-
 // These buttons depend on custom data tags to indicate actions.  This seems
 // cleaner than using a whole bunch of ids which may potentially collide.
 // However, this decision can be reviewed
 var buttons =  {
-  create : function create() { return $('[data-method="create"]').click(); },
-  search : function search() { return $('[data-method="search"]').click(); },
-  submit : function submit() { return $('[data-method="submit"]').click(); },
-  cancel : function cancel() { return $('[data-method="cancel"]').click(); },
-  back   : function back() { return $('[data-method="back"]').click(); },
-  delete : function delet() { return $('[data-method="delete"]').click(); }
+  create: function create() { return $('[data-method="create"]').click(); },
+  search: function search() { return $('[data-method="search"]').click(); },
+  submit: function submit() { return $('[data-method="submit"]').click(); },
+  cancel: function cancel() { return $('[data-method="cancel"]').click(); },
+  back: function back() { return $('[data-method="back"]').click(); },
+  delete: function delet() { return $('[data-method="delete"]').click(); }
 };
 
 // This methods are for easily working with modals.  Works with the same custom
 // data tags used in form buttons.
 var modal = {
-  submit : function submit() { return $('[uib-modal-window] [data-method="submit"]').click(); },
-  cancel : function cancel() { return $('[uib-modal-window] [data-method="cancel"]').click(); }
+  submit: function submit() { return $('[uib-modal-window] [data-method="submit"]').click(); },
+  cancel: function cancel() { return $('[uib-modal-window] [data-method="cancel"]').click(); }
 };
 
 // convenience methods to see if the form contains feedback text.  Returns locators.
 var feedback = {
-  success : function success() { return by.css('[data-role="feedback"] > .text-success'); },
-  error : function error() { return by.css('[data-role="feedback"] > .text-danger'); },
-  warning : function warning() { return by.css('[data-role="feedback"] > .text-warning'); },
-  info : function info() { return by.css('[data-role="feedback"] > .text-info'); }
+  success: function success() { return by.css('[data-role="feedback"] > .text-success'); },
+  error: function error() { return by.css('[data-role="feedback"] > .text-danger'); },
+  warning: function warning() { return by.css('[data-role="feedback"] > .text-warning'); },
+  info: function info() { return by.css('[data-role="feedback"] > .text-info'); }
 };
 
 // convenience methods to check form element validation states
@@ -103,42 +51,91 @@ var validation = {
 module.exports = {
 
   // get an <input> element by its ng-model
-  input : function input(model, value) {
-    return element(by.model(model)).clear().sendKeys(value);
+  input : function input(model, value, anchor) {
+
+    // get the HTML <input> element
+    let input = anchor ?
+      anchor.element(by.model(model)) :
+      element(by.model(model));
+
+    return input.clear().sendKeys(value);
   },
 
-  // get a <select> element by its ng-model.
-  select: function select(model, option) {
-    var root = element(by.model(model));
-    return root.element(by.cssContainingText('option', option)).click();
+  /**
+   * @method select
+   *
+   * @description
+   * Selects an option from an <select> html element.  Accepts the model
+   * selector, the option text, and an optional anchor element to search within.
+   * If no anchor is provided, it defaults to the body.
+   *
+   * @param {String} model - the ng-model target to select
+   * @param {String} option - the text of the <option> element to choose
+   * @param {Element} anchor - a protractor element to search within
+   * @returns {Element} - a protractor <option> element
+   */
+  select: function select(model, option, anchor) {
+    anchor = anchor || $('body');
+    let select = anchor.element(by.model(model));
+    let choice = select.element(by.cssContainingText('option', option));
+    return choice.click();
   },
 
   // get a radio button by its position and click
-  radio : function radio(model, n) {
+  radio: function radio(model, n) {
     return element.all(by.model(model)).get(n).click();
   },
 
   // asserts whether an element exists or not
-  exists : function exists(locator, bool) {
+  exists: function exists(locator, bool) {
     expect(element(locator).isPresent()).to.eventually.equal(bool);
   },
 
-  // select the item in the typeahead that matches the value given
-  // by label
-  typeahead: function typeahead(model, label) {
-    this.input(model, label);
+  /**
+   * @method typeahead
+   *
+   * @description
+   * Selects a dropdown option from a typeahead html element.  Accepts the model
+   * selector, the option text, and an optional anchor element to search within.
+   * If no anchor is provided, it defaults to the body.
+   *
+   * @param {String} model - the ng-model target to select
+   * @param {String} option - the text of the option element to choose
+   * @param {Element} anchor - a protractor element to search within
+   * @returns {Element} - a protractor option element
+   */
+  typeahead: function typeahead(model, label, anchor) {
+    anchor = anchor || $('body');
+
+    // type into the <input> element
+    this.input(model, label, anchor);
 
     // select the item of the dropdown menu matching the label
-    let option = element(by.cssContainingText('.dropdown-menu > [role="option"]', label));
-    option.click();
+    let option = anchor.element(by.cssContainingText('.dropdown-menu > [role="option"]', label));
+    return option.click();
   },
 
-  // select an item from the dropdown menu identified by 'selector'
-  dropdown: function dropdown(selector, label) {
-    element(by.css(selector)).click();
+  /**
+   * @method dropdown
+   *
+   * @description
+   * Selects a dropdown option from a dropdown html element.  Accepts the target
+   * selector, the option text, and an optional anchor element to search within.
+   * If no anchor is provided, it defaults to the body.
+   *
+   * @param {String} selector - the css selector to select
+   * @param {String} option - the text of the option element to choose
+   * @param {Element} anchor - a protractor element to search within
+   * @returns {Element} - a protractor option element
+   */
+  dropdown: function dropdown(selector, label, anchor) {
+    anchor = anchor || $('body');
+
+    // open the dropdown menu
+    $(selector).click();
 
     let option = element(by.cssContainingText('[uib-dropdown-menu] > li', label));
-    option.click();
+    return option.click();
   },
 
 
@@ -149,12 +146,12 @@ module.exports = {
   // bind commonly shown feedback utilities
   // to detect feedback, the parent element must have the
   // [data-role="feedback"] attribute assigned to it.
-  feedback : feedback,
+  feedback: feedback,
 
   // bind validation states.  Each method takes in a model's string and asserts
   // the validation state.
-  validation : validation,
+  validation: validation,
 
   // bindings for modal overlay forms
-  modal : modal
+  modal: modal
 };

--- a/client/test/e2e/shared/components/bhFindDebtorGroup.js
+++ b/client/test/e2e/shared/components/bhFindDebtorGroup.js
@@ -1,61 +1,63 @@
 /* global element, by */
 
+const FU = require('../FormUtils');
+
 /**
-* Find Debtor Group component
-* findDebtorGroup.js
-* @public
-*/
+ * Find Debtor Group component
+ * findDebtorGroup.js
+ * @public
+ */
 module.exports = {
-  root     : element(by.css('[data-bh-find-debtorgroup-name]')),
+  root: element(by.css('[data-bh-find-debtorgroup-name]')),
 
   /**
-  * @function search
-  * @param {string} name The text for the debtor group name
-  * @description This function permits to insert a debtor group text
-  */
-  search : function search(name) {
+   * @function search
+   * @param {string} name The text for the debtor group name
+   * @description This function permits to insert a debtor group text
+   */
+  search: function search(name) {
     var searchName  = name || 'Tes';
-    var input = this.root.element(by.model('$ctrl.debtorGroupName'));
-    input.sendKeys(searchName);
+    FU.input('$ctrl.debtorGroupName', name, this.root);
   },
 
   /**
-  * @function select
-  * @param {number} index The index of a debtor group in the list
-  * @description Select a particular debtor group in the list of debtor groups
-  */
-  select : function select(index) {
+   * @function select
+   * @param {Number} index The index of a debtor group in the list
+   * @description Select a particular debtor group in the list of debtor groups
+   */
+  select: function select(index) {
     var searchIndex = index || 0;
+
     var select = this.root.element(by.css('[uib-typeahead-popup]'));
     var item = select.element(by.repeater('match in matches').row(searchIndex));
     item.click();
   },
 
   /**
-  * @function popup
-  * @description Trigger a click on the popup button for details of a debtor group
-  */
-  popup : function popup() {
+   * @function popup
+   * @description Trigger a click on the popup button for details of a debtor group
+   */
+  popup: function popup() {
     var popupButton = this.root.element(by.id('popupInfo'));
     popupButton.click();
   },
 
   /**
-  * @function reload
-  * @description Trigger a click on the reload button for selecting another debtor group
-  */
+   * @function reload
+   * @description Trigger a click on the reload button for selecting another debtor group
+   */
   reload : function reload() {
     var reloadButton = this.root.element(by.id('reload'));
     reloadButton.click();
   },
 
   /**
-  * @function test
-  * @param {string} name The text for the debtor group name
-  * @param {number} index The index of a debtor group in the list
-  * @description Run a default test of use of the component
-  */
-  test : function test(name, index) {
+   * @function test
+   * @param {String} name The text for the debtor group name
+   * @param {Number} index The index of a debtor group in the list
+   * @description Run a default test of use of the component
+   */
+  test: function test(name, index) {
     this.search(name);
     this.select(index);
     this.popup();

--- a/client/test/e2e/shared/components/bhFindPatient.js
+++ b/client/test/e2e/shared/components/bhFindPatient.js
@@ -1,5 +1,7 @@
 /* global browser, element, by */
 
+const FU = require('../FormUtils');
+
 /**
  * hooks for the find patient component described in the component
  * bhFindPatient.js.
@@ -21,7 +23,7 @@ module.exports = {
     var tmpl = (mode === 'id') ? 'ID' : 'NAME';
 
     // click the correct dropdown item
-    var option = element(by.css('[data-find-patient-option="FORM.LABELS.PATIENT_?"]'.replace('?', tmpl)));
+    var option = element(by.css(`[data-find-patient-option="FORM.LABELS.PATIENT_${tmpl}"]`));
     option.click();
   },
 
@@ -36,13 +38,8 @@ module.exports = {
     // set the input to "find by name" mode
     this.mode('name');
 
-    // get the input and enter the id provided
-    var input = root.element(by.model('$ctrl.nameInput'));
-    input.sendKeys(name);
-
-    // get the first option and click it
-    var option = root.all(by.repeater('match in matches track by $index')).first();
-    option.click();
+    // get the input and enter the name provided
+    FU.typeahead('$ctrl.nameInput', name);
   },
 
   /**
@@ -54,8 +51,7 @@ module.exports = {
     this.mode('id');
 
     // get the input and enter the id provided
-    var input = element(by.model('$ctrl.idInput'));
-    input.sendKeys(id);
+    FU.input('$ctrl.idInput', id);
 
     // submit the id to the server
     var submit = element(by.css('[data-find-patient-submit]'));

--- a/client/test/e2e/shared/components/notify.js
+++ b/client/test/e2e/shared/components/notify.js
@@ -20,9 +20,8 @@ module.exports = {
 
   hasInfo : function hasInfo() {
     expect(element(by.css('[data-notification-type="notification-info"]')).isPresent()).to.eventually.equal(true);
-    dismiss();
   },
-  
+
   hasDanger : function hasDanger() {
     expect(element(by.css('[data-notification-type="notification-danger"]')).isPresent()).to.eventually.equal(true);
     dismiss();

--- a/client/test/e2e/shared/helpers.js
+++ b/client/test/e2e/shared/helpers.js
@@ -1,5 +1,4 @@
 /* global element, by, browser */
-
 /**
  * @overview helpers
  *

--- a/client/test/e2e/subsidies/subsidies.spec.js
+++ b/client/test/e2e/subsidies/subsidies.spec.js
@@ -1,14 +1,13 @@
 /* global element, by, browser */
 const chai = require('chai');
 const expect = chai.expect;
-
-const FU = require('../shared/FormUtils');
 const helpers = require('../shared/helpers');
-const components = require('../shared/components');
-
 helpers.configure(chai);
 
-describe('Subsidies Module', function () {
+const FU = require('../shared/FormUtils');
+const components = require('../shared/components');
+
+describe('Subsidies', function () {
   'use strict';
 
   const path = '#/subsidies';
@@ -23,19 +22,13 @@ describe('Subsidies Module', function () {
   const defaultSubsidy = 0;
   const subsidyRank = 2;
 
-  it('successfully creates a new subsidy', function () {
+  it('creates a new subsidy', function () {
 
     // switch to the create form
     FU.buttons.create();
     FU.input('SubsidyCtrl.subsidy.label', subsidy.label);
     FU.input('SubsidyCtrl.subsidy.value', subsidy.value);
-
-    // select an Account
-    FU.select('SubsidyCtrl.subsidy.account_id')
-      .enabled()
-      .first()
-      .click();
-
+    FU.select('SubsidyCtrl.subsidy.account_id', 'Test Debtor Account');
     FU.input('SubsidyCtrl.subsidy.description', subsidy.description);
 
     // submit the page to the server
@@ -46,7 +39,7 @@ describe('Subsidies Module', function () {
   });
 
 
-  it('successfully edits an subsidy', function () {
+  it('edits an subsidy', function () {
     element(by.id('subsidy-upd-' + subsidyRank)).click();
     // modify the subsidy label
     FU.input('SubsidyCtrl.subsidy.label', 'Updated');
@@ -59,11 +52,11 @@ describe('Subsidies Module', function () {
     FU.exists(by.id('update_success'), true);
   });
 
-  it('correctly blocks invalid form submission with relevant error classes', function () {
+  it('blocks invalid form submission with relevant error classes', function () {
     // switch to the create form
     element(by.id('create')).click();
 
-    // verify form has not been successfully submitted
+    // verify form has not been submitted
     expect(helpers.getCurrentPath()).to.eventually.equal(path);
 
     element(by.id('submit-subsidy')).click();
@@ -76,7 +69,7 @@ describe('Subsidies Module', function () {
     FU.validation.ok('SubsidyCtrl.subsidy.description');
   });
 
-  it('successfully delete a subsidy', function () {
+  it('deletes a subsidy', function () {
     element(by.id('subsidy-del-' + subsidyRank)).click();
 
     // click the alert asking for permission

--- a/client/test/e2e/suppliers/suppliers.spec.js
+++ b/client/test/e2e/suppliers/suppliers.spec.js
@@ -24,19 +24,15 @@ describe('Suppliers', function () {
 
   const supplierRank = 1;
 
-  it('successfully creates a new supplier', function () {
-
-    // switch to the create form
+  it('creates a new supplier', function () {
     FU.buttons.create();
+
     FU.input('SupplierCtrl.supplier.name', supplier.name);
 
     element(by.id('international')).click();
 
     // select an Creditor
-    FU.select('SupplierCtrl.supplier.creditor_uuid')
-      .enabled()
-      .first()
-      .click();
+    FU.select('SupplierCtrl.supplier.creditor_uuid', 'Fournisseur');
 
     FU.input('SupplierCtrl.supplier.phone', supplier.phone);
     FU.input('SupplierCtrl.supplier.email', supplier.email);
@@ -47,12 +43,10 @@ describe('Suppliers', function () {
 
     // submit the page to the server
     FU.buttons.submit();
-
-    // expect a nice validation message
     FU.exists(by.id('create_success'), true);
   });
 
-  it('successfully edits an supplier', function () {
+  it('edits an supplier', function () {
     element(by.id('supplier-upd-' + supplierRank )).click();
 
     // modify the supplier name
@@ -62,16 +56,13 @@ describe('Suppliers', function () {
     FU.input('SupplierCtrl.supplier.note', ' IMCK Tshikaji update for the test E2E');
 
     FU.buttons.submit();
-
-    // make sure the success message appears
     FU.exists(by.id('update_success'), true);
   });
 
-  it('correctly blocks invalid form submission with relevant error classes', function () {
-    // switch to the create form
+  it('blocks invalid form submission with relevant error classes', function () {
     FU.buttons.create();
 
-    // verify form has not been successfully submitted
+    // verify form has not been submitted
     expect(helpers.getCurrentPath()).to.eventually.equal(path);
     element(by.id('submit-supplier')).click();
 

--- a/client/test/e2e/vouchers/complex.page.js
+++ b/client/test/e2e/vouchers/complex.page.js
@@ -25,47 +25,27 @@ class Row {
 
     // store a reference to the <tr> dom element
     this._node = $(`[data-row="${index}"]`);
-
-    // selectors for buttons/inputs in the row
-    this._selectors = {
-      account: '[data-account-input]',
-      credit: '[data-credit-input]',
-      debit: '[data-debit-input]',
-      entity: '[data-entity-button]',
-      reference: '[data-reference-button]'
-    };
-  }
-
-  // inputs the number in to the <input> matched by the selector
-  _input(selector, number) {
-    let input = this._node.$(selector);
-    input.clear();
-    input.sendKeys(number);
   }
 
   // account setter
   account(number) {
-    this._input(this._selectors.account, number);
-
-    // click the first matching option in the list
-    let option = element.all(by.repeater('match in matches track by $index')).first();
-    option.click();
+    FU.typeahead('row.account', number, this._node);
   }
 
   // sets the debit value
   debit(number) {
-    this._input(this._selectors.debit, number);
+    FU.input('row.debit', number, this._node);
   }
 
   // sets the credit value
   credit(number) {
-    this._input(this._selectors.credit, number);
+    FU.input('row.credit', number, this._node);
   }
 
   // sets the entity
   entity(type, name) {
     // click the 'open entity modal' button
-    this._node.$(this._selectors.entity).click();
+    this._node.$('[data-entity-button]').click();
 
     // the modal is now open
 
@@ -82,7 +62,7 @@ class Row {
   // sets the reference
   reference(type, index) {
     // click the 'open reference modal' button
-    this._node.$(this._selectors.reference).click();
+    this._node.$('[data-reference-button]').click();
 
     // select the type
     // supported : 'voucher', 'cash-payment', 'patient-invoice'

--- a/client/test/e2e/vouchers/simple.spec.js
+++ b/client/test/e2e/vouchers/simple.spec.js
@@ -25,16 +25,9 @@ describe('Simple Vouchers', function () {
     // configure the date to yesterday
     components.dateEditor.set(voucher.date);
 
-    var option;
-
     // select the appropriate accounts
-    FU.input('SimpleVoucherCtrl.voucher.toAccount', voucher.toAccount);
-    option = element.all(by.repeater('match in matches track by $index')).last();
-    option.click();
-
-    FU.input('SimpleVoucherCtrl.voucher.fromAccount', voucher.fromAccount);
-    option = element.all(by.repeater('match in matches track by $index')).last();
-    option.click();
+    FU.typeahead('SimpleVoucherCtrl.voucher.toAccount', voucher.toAccount);
+    FU.typeahead('SimpleVoucherCtrl.voucher.fromAccount', voucher.fromAccount);
 
     // check the USD radio option
     element(by.css('[data-currency-option="2"]')).click();

--- a/server/models/test/data.sql
+++ b/server/models/test/data.sql
@@ -231,8 +231,8 @@ INSERT INTO `inventory_type` VALUES (1,'Article'),(2,'Assembly'),(3,'Service');
 INSERT INTO `inventory_unit` VALUES (1,'Act'),(2,'Pallet'),(3,'Pill'),(4,'Box'),(5,'Lot'),(6,'amp'),(7,'bags'),(8,'btl'),(9,'cap'),(10,'flc'),(11,'jar'),(12,'ltr'),(13,'pce'),(14,'sch'),(15,'tab'),(16,'tub'),(17,'vial');
 
 INSERT INTO `inventory` VALUES
-  (1, HUID('cf05da13-b477-11e5-b297-023919d3d5b0'), 'INV0', 'Test inventory item', 25.0, 10, HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'), 2, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP),
-  (1, HUID('289cc0a1-b90f-11e5-8c73-159fdc73ab02'), 'INV1', 'Second Test inventory item', 10.0, 10, HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'), 2, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP),
+  (1, HUID('cf05da13-b477-11e5-b297-023919d3d5b0'), 'INV0', 'Test Inventory Item', 25.0, 10, HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'), 2, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP),
+  (1, HUID('289cc0a1-b90f-11e5-8c73-159fdc73ab02'), 'INV1', 'Second Test Inventory Item', 10.0, 10, HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'), 2, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP),
   (1, HUID('c48a3c4b-c07d-4899-95af-411f7708e296'), 'INV2', 'Third Test Inventory Item', 105.0, 10, HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'), 2, 0, 0, 0, 0, 0, 1, 1, CURRENT_TIMESTAMP);
 
 INSERT INTO `debtor_group` VALUES


### PR DESCRIPTION
This PR implements new features in the `FormUtils` library.

The original `FormUtils.select()` function is replaced with a new version that takes in two parameters - the ng-model associated with the select element and the text of the option value to select.  This allows
_much_ stricter tests, since you can specify exactly what option element you want.  All tests have been migrated to this syntax.

``` js
// old syntax
FU.select('SomeCtrl.model.select')
  .enabled()
  .first()
  .click();

// new syntax
FU.select('SomeCtrl.model.select', 'My Value');
```

The library's API is extended allow an optional anchor element to be passed in.  The anchor element will cause the `FormUtils` library to search only within the subtree contained by that element.  That means you can limit your search to a modal or `<table>` row if you so desire.

For example:

``` js
// get an anchor element
let anchor = $('[data-modal-body]');

// limit updates to within the modal body
FU.input('ModalCtrl.model.input', 'Some Value', anchor);
```

Finally, all end-to-end tests now use `FU.typeahead()` when they are setting a typeahead.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
