### PR TITLE
(Fix) Clean up notifications when verified

### DIFF
--- a/client/test/e2e/debtors/debtorgroups.spec.js
+++ b/client/test/e2e/debtors/debtorgroups.spec.js
@@ -43,7 +43,6 @@ describe('Debtor Groups Management', function () {
     FU.buttons.submit();
 
     components.notification.verify();
-    components.notification.dismiss();
 
     expect(element.all(by.css('[data-group-entry]')).count()).to.eventually.equal(initialGroups + 1);
   });
@@ -59,6 +58,5 @@ describe('Debtor Groups Management', function () {
     FU.buttons.submit();
 
     components.notification.verify();
-    components.notification.dismiss();
   });
 });

--- a/client/test/e2e/login/login.spec.js
+++ b/client/test/e2e/login/login.spec.js
@@ -32,10 +32,6 @@ describe('Login Page', function () {
 
     FU.exists(by.css('.help-block'), false);
     components.notification.verify();
-
-    // close the growl notification
-    components.notification.dismiss();
-    FU.exists(by.css('[data-bh-growl-notification]'), false);
   });
 
   it('rejects user missing a username with (only) a help block', function () {
@@ -85,7 +81,6 @@ describe('Login Page', function () {
     element(by.id('submit')).click();
 
     expect(helpers.getCurrentPath()).to.eventually.equal('#/');
-    components.notification.verify();
   });
 
   it('page refresh preserves the use session', function () {

--- a/client/test/e2e/patient/invoice.spec.js
+++ b/client/test/e2e/patient/invoice.spec.js
@@ -114,9 +114,7 @@ describe('Patient Invoice', function () {
 
     page.submit();
 
-    /** @todo this should use the latest notification components tests methods when they are merged in #388*/
     components.notification.verify();
-    components.notification.dismiss();
   });
 
   it('shows appropriate error messages for required data');

--- a/client/test/e2e/shared/components/notify.js
+++ b/client/test/e2e/shared/components/notify.js
@@ -5,25 +5,37 @@ var expect  = chai.expect;
 module.exports = {
   verify : function verify() {
     expect(element(by.css('[data-bh-growl-notification]')).isPresent()).to.eventually.equal(true);
+    dismiss();
   },
 
   hasSuccess : function hasSuccess() {
     expect(element(by.css('[data-notification-type="notification-success"]')).isPresent()).to.eventually.equal(true);
+    dismiss();
   },
 
   hasWarn : function hasWarn() {
     expect(element(by.css('[data-notification-type="notification-warn"]')).isPresent()).to.eventually.equal(true);
+    dismiss();
   },
 
   hasInfo : function hasInfo() {
     expect(element(by.css('[data-notification-type="notification-info"]')).isPresent()).to.eventually.equal(true);
+    dismiss();
+  },
+  
+  hasDanger : function hasDanger() {
+    expect(element(by.css('[data-notification-type="notification-danger"]')).isPresent()).to.eventually.equal(true);
+    dismiss();
   },
 
   hasError : function hasError() {
     expect(element(by.css('[data-notification-type="notification-error"]')).isPresent()).to.eventually.equal(true);
+    dismiss();
   },
 
-  dismiss : function dismiss() {
-    return element(by.css('[data-dismiss="notification"]')).click();
-  }
+  dismiss
 };
+
+function dismiss() {
+  return element(by.css('[data-dismiss="notification"]')).click();
+}


### PR DESCRIPTION
This commit calls the dismiss() method automatically for every
verification. Manual dismissal has been removed from current tests. This
is inteded to clean up notifications to ensure other tests are not blocked
or provide false positives.

---

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.
