### PR TITLE
fix(gulp): remove es6 arrow functions to minify

### DIFF
--- a/client/src/js/services/journal/JournalPagination.js
+++ b/client/src/js/services/journal/JournalPagination.js
@@ -71,7 +71,7 @@ function JournalPaginationService() {
       if (upperBoundElement.trans_id === comparisonElement.trans_id) {
 
         // filter out this transaction id
-        data = data.filter(row => { return row.trans_id !== upperBoundElement.trans_id; });
+        data = data.filter(function (row) { return row.trans_id !== upperBoundElement.trans_id; });
       }
     }
 

--- a/client/src/js/services/journal/TransactionService.js
+++ b/client/src/js/services/journal/TransactionService.js
@@ -1,129 +1,128 @@
 angular.module('bhima.services')
 .service('TransactionService', TransactionService);
 
-// @todo uuid is currently only used for creating mock transactions - this should 
+// @todo uuid is currently only used for creating mock transactions - this should
 // be removed as soon as this is no longer needed
 TransactionService.$inject = ['$http', 'store', 'uuid'];
 
 /**
- * Transactions Service 
+ * Transactions Service
  *
- * This service is responsible for fetching transactions from the posting journal 
- * and providing a number of utility methods for manipulating and framing this 
- * information. Data can be served in one go or using a custom pagincation view 
- * serving transactions in pages. 
+ * This service is responsible for fetching transactions from the posting journal
+ * and providing a number of utility methods for manipulating and framing this
+ * information. Data can be served in one go or using a custom pagincation view
+ * serving transactions in pages.
  *
- * @todo Discuss as a team how pages would be most logically demonstrated with 
+ * @todo Discuss as a team how pages would be most logically demonstrated with
  * respect to transactions
- * @todo Service is designed to be called once per page - this use case should 
+ * @todo Service is designed to be called once per page - this use case should
  * be discussed
- * @todo Update service to use the latest posting journal interface/ API 
+ * @todo Update service to use the latest posting journal interface/ API
  */
-function TransactionService($http, Store, uuid) { 
+function TransactionService($http, Store, uuid) {
   var service = this;
 
-  // @todo update service to use latest posting jounral interface/ API 
+  // @todo update service to use latest posting jounral interface/ API
   var source = '/journal_list';
-  
-  // model to contain transactions - storing this information in a store 
+
+  // model to contain transactions - storing this information in a store
   // allows us to perform gets/puts based on a transactions UUID locally
-  var transactionModel = new Store({ 
+  var transactionModel = new Store({
     identifier : 'uuid'
   });
   transactionModel.setData([]);
-  
-  /** 
-   * Fetch transactions from the server based on the controllers requirements, 
+
+  /**
+   * Fetch transactions from the server based on the controllers requirements,
    * updates local transaction model.
-   * 
-   * @todo This method currently just fetches all transactions - factor 
+   *
+   * @todo This method currently just fetches all transactions - factor
    * in pagination logic
    */
-  function fetchTransactions() { 
+  function fetchTransactions() {
     $http.get(source)
-      .then(function (response) { 
+      .then(function (response) {
         var transactions = response.data;
-        
-        // @todo Discuss feasability of ES6 
-        transactions.map(item => transactionModel.post(item));
+
+        transactions.map(function (item) { return transactionModel.post(item); });
       });
   }
-  
+
   /** DEVELOPMENT UTILITIES --------------------------------------------------*/
 
-  /** 
+  /**
    * Mock transactions that would normally be returned from the server, this method
-   * is primarily designed to help test core journal features before all  of the 
-   * additional core finance pieces are completed. It will be depricated as soon 
-   * as 2.x is feature complete. 
+   * is primarily designed to help test core journal features before all  of the
+   * additional core finance pieces are completed. It will be depricated as soon
+   * as 2.x is feature complete.
    */
-  function mockTransactions() { 
-    
-    // configure mock configuration 
-    var numberOfTransactions = 100; 
+  function mockTransactions() {
+
+    // configure mock configuration
+    var numberOfTransactions = 100;
     var transactionPrefix = 'TRANS';
     var descriptionPrefix = 'Mock transaction for ID: ';
     var currencyId = 1;
     var accounts = [100, 101, 102, 200, 202, 203, 400, 500, 600];
 
     var transactions = [];
-    
-    // each iteration will create a new transaction, a transaction can contain any 
+
+    // each iteration will create a new transaction, a transaction can contain any
     // number of rows
-    for (var i = 0; i < numberOfTransactions; i++) { 
+    for (var i = 0; i < numberOfTransactions; i++) {
       var currentTransaction = buildMockTransaction(i);
       transactions = transactions.concat(currentTransaction);
     }
 
-    function buildMockTransaction(id) { 
-      var transaction; 
+    function buildMockTransaction(id) {
+      var transaction;
       var upperLines = 10;
       var upperCost = 10000;
       var numberOfLines = Math.round(Math.random() * upperLines);
       var cost = selectEvenNumber(upperCost);
       var date = selectDate();
       var transactionId = transactionPrefix.concat(id);
-      
+
       // array of (n) undefined elements
       transaction = Array.apply(null, { length : numberOfLines });
 
-      return transaction.map(function (row) { 
-        
+      return transaction.map(function (row) {
+
         return {
           uuid : uuid(),
           trans_id : transactionId,
           trans_date : date,
           description : descriptionPrefix.concat(transactionId),
           reference : id,
-          currency_id : currencyId, 
+          currency_id : currencyId,
           account_number : selectAccount(),
           account : selectEvenNumber,
-          
-          // @todo to verify aggregation these values will have to sum according 
+
+          // @todo to verify aggregation these values will have to sum according
           // to double entry accounting (balance)
           debit_equiv : selectEvenNumber(cost),
           credit_equiv : selectEvenNumber(cost),
-        };  
+        };
       });
     }
 
-    function selectDate() { 
+    function selectDate() {
       var start = new Date(2014, 0, 1);
       var end = new Date();
 
       return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
     }
 
-    function selectEvenNumber(max) { 
+    function selectEvenNumber(max) {
       var number = (Math.random() * max);
       return number - number % 2;
     }
 
-    function selectAccount() { 
+    function selectAccount() {
       return accounts[Math.round(Math.random() * (accounts.length - 1))];
     }
-    
-    transactions.map(item => transactionModel.post(item));
+
+    transactions.map(function (item) { return transactionModel.post(item); });
   }
 
   // set up service default state - populate with default data

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,6 @@
  * not all are required to build bhima?  In this format, there is no difference
  * between the install requirements of a developer and a production environment.
  */
-
 const gulp    = require('gulp');
 const gulpif  = require('gulp-if');
 const concat  = require('gulp-concat');
@@ -24,7 +23,7 @@ const less    = require('gulp-less');
 const exec = require('child_process').exec;
 
 // toggle client javascript minification
-const UGLIFY = false;
+const UGLIFY = true;
 
 // path to the jshintrc to use
 const JSHINT_PATH = '.jshintrc';


### PR DESCRIPTION
This commit fixes gulp-build with minification by removing the ES6 fat arrow functions from the client.  It turns out these break the `uglify` compiler.

It also turns on minification by default.  This can be switched off if it takes too long to run tests.

Closes #447.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
