### PR TITLE
(Feature) Direct Print Component

### DIFF
--- a/client/src/js/components/bhLoadingButton.js
+++ b/client/src/js/components/bhLoadingButton.js
@@ -8,7 +8,7 @@ angular.module('bhima.components')
   transclude: true,
   template :
     '<button type="submit" class="btn" ng-class="$ctrl.buttonClass" ng-disabled="$ctrl.loadingState || $ctrl.disabled" data-method="submit">' +
-      '<span ng-show="$ctrl.loadingState"><span class="glyphicon glyphicon-refresh"></span> {{ "FORM.INFOS.LOADING" | translate }}</span>' +
+      '<span ng-show="$ctrl.loadingState"><span class="fa fa-circle-o-notch fa-spin"></span> {{ "FORM.INFOS.LOADING" | translate }}</span>' +
       '<span ng-hide="$ctrl.loadingState" ng-transclude>{{ "FORM.BUTTONS.SUBMIT" | translate }}</span>' +
     '</button>',
   controller : LoadingButtonController

--- a/client/src/js/components/bhPDFPrint.js
+++ b/client/src/js/components/bhPDFPrint.js
@@ -1,0 +1,126 @@
+angular.module('bhima.components')
+.component('bhPdfPrint', {
+  bindings : {
+    pdfUrl : '@',
+    options : '<'
+  },
+  template :
+    '<bh-loading-button button-class="btn-default" loading-state="$ctrl.$loading" ng-click="$ctrl.print()"></bh-loading-button>' +
+    '<iframe ng-src="{{$ctrl.src}}" id="{{$ctrl.embeddedContentId}}" style="display : none"></iframe>',
+  controller : bhPDFPrintController
+});
+
+bhPDFPrintController.$inject = ['$window', '$http', '$sce', '$timeout'];
+
+/**
+ * @class bhPDFPrintController
+ *
+ * @description
+ * This component allows printing of a BHIMA PDF report route. It abstracts the
+ * server request and PDF display directly calling the browser `print()` method.
+ * This directive can be used where there are no confirmation or configuration
+ * steps for the report and may be abstracted in the future to allow for the
+ * technology to be used in an export drop-down etc.
+ *
+ * The provided pdf url should be relative to the servers path and does not need
+ * to include the renderer option (this is performed by the component).
+ * Options will be passed as params in the get request.
+ *
+ * @todo Investigate abstracting direct print to browser window functionality to allow export drop-down
+ * @todo Namespace component so that more than one can be used on one page at a time
+ *
+ * @example
+ * let url = '/reports/receipt/invoice';
+ * let options = { filters : [] };
+ *
+ * <bh-pdf-print
+ *   pdf-url="url"
+ *   options="options">
+ * </bh-pdf-print>
+ */
+function bhPDFPrintController($window, $http, $sce, $timeout) {
+  var component = this;
+
+  /** @todo update all options (receipt modal + direct print directive to use bhConstants included in account management PR */
+  var pdfOptions = {
+    renderer : 'pdf'
+  };
+  var responseType = 'arraybuffer';
+  var pdfType = 'application/pdf';
+
+  // delay between GET request completion and loading indication, this is used
+  // to compensate for the delay in browsers opening the print dialog
+  var loadingIndicatorDelay = 1000;
+
+  component.$loading = false;
+  component.embeddedContentId = 'pdfdirect';
+
+  // expose the print method to the view
+  component.print = print;
+
+  function print() {
+    var url = component.pdfUrl;
+    var configuration = requestOptions();
+
+    component.$loading = true;
+
+    // return the value to allow the controller to perform error handling
+    return $http.get(url, {params : configuration, responseType : responseType})
+      .then(function (result) {
+        var file = new Blob([result.data], {type : pdfType});
+        var fileURL = URL.createObjectURL(file);
+
+        // expose the stored pdf to the hidden view
+        // the print method is automatically called with the load listener on the $window option
+        component.src = $sce.trustAsResourceUrl(fileURL);
+      })
+      .finally(function () {
+        $timeout(toggleLoading, loadingIndicatorDelay);
+      });
+  }
+
+  /**
+   * @method requestOptions
+   *
+   * @description
+   * Combine the pdf options and the report options passed in from the
+   * controller
+   */
+  function requestOptions() {
+    var combined = angular.copy(pdfOptions);
+    angular.extend(combined, component.options);
+    return combined;
+  }
+
+  function toggleLoading() {
+    component.$loading = !component.$loading;
+  }
+
+
+  // ensure that the template/ iframe element is available
+  // both the $onInit and $postLink methods are fired before guaranteeing the
+  // id has been dynamically set
+  $timeout(bindPrintEventMethod);
+
+  function bindPrintEventMethod() {
+    $window.frames[component.embeddedContentId].addEventListener('load', printEmbeddedContent);
+  }
+
+  /**
+   * @method printEmbeddedContent
+   *
+   * @description
+   *
+   * register a method to invoke print on the hidden iframe on load
+   * if print() is called as soon as the content is available it will not yet be
+   * ready to be printed - waiting until the load event is fired ensures everything
+   * is ready for printing.
+   */
+  function printEmbeddedContent(event) {
+    // ensure this is considered in Angular's $digest
+    $timeout(function () {
+      // invoke print on the target window
+      $window.frames[component.embeddedContentId].contentWindow.print();
+    });
+  }
+}

--- a/client/src/js/components/bhPDFPrint.js
+++ b/client/src/js/components/bhPDFPrint.js
@@ -42,6 +42,7 @@ bhPDFPrintController.$inject = ['$window', '$http', '$sce', '$timeout'];
  * </bh-pdf-print>
  */
 function bhPDFPrintController($window, $http, $sce, $timeout) {
+  var cachedRequest;
   var component = this;
 
   /** @todo update all options (receipt modal + direct print directive to use bhConstants included in account management PR */
@@ -65,6 +66,13 @@ function bhPDFPrintController($window, $http, $sce, $timeout) {
     var url = component.pdfUrl;
     var configuration = requestOptions();
 
+    // check to see if this request has been made before - if it has we will use the local resource
+    if (angular.equals(configuration, cachedRequest)) {
+      printEmbeddedContent();
+      return;
+    }
+
+    cachedRequest = configuration;
     component.$loading = true;
 
     // return the value to allow the controller to perform error handling

--- a/client/src/js/components/bhPDFPrint.js
+++ b/client/src/js/components/bhPDFPrint.js
@@ -4,8 +4,11 @@ angular.module('bhima.components')
     pdfUrl : '@',
     options : '<'
   },
+  transclude : true,
   template :
-    '<bh-loading-button button-class="btn-default" loading-state="$ctrl.$loading" ng-click="$ctrl.print()"></bh-loading-button>' +
+    '<bh-loading-button button-class="btn-default" loading-state="$ctrl.$loading" ng-click="$ctrl.print()">' +
+    '<span><i class="fa fa-print"></i> {{ "FORM.BUTTONS.PRINT" | translate }}</span>' +
+    '</bh-loading-button>' +
     '<iframe ng-src="{{$ctrl.src}}" id="{{$ctrl.embeddedContentId}}" style="display : none"></iframe>',
   controller : bhPDFPrintController
 });
@@ -92,6 +95,13 @@ function bhPDFPrintController($window, $http, $sce, $timeout) {
     return combined;
   }
 
+  /**
+   * @method toggleLoading
+   *
+   * @description
+   * This method is responsible for updating the loading state for the controllers
+   * HTTP requests.
+   */
   function toggleLoading() {
     component.$loading = !component.$loading;
   }

--- a/client/src/js/services/receipts/ReceiptModal.js
+++ b/client/src/js/services/receipts/ReceiptModal.js
@@ -26,7 +26,7 @@ function ReceiptModal(Modal, Receipts) {
   // expose available receipts
   service.invoice = invoice;
   service.patient = patient;
-  service.patientRegistrations = patientRegistrations;
+  /** service.patientRegistrations = patientRegistrations; */
 
   /**
    * Invokes a patient invoice receipt
@@ -81,8 +81,8 @@ function ReceiptModal(Modal, Receipts) {
     return instance.result;
   }
 
-  // in this case, the options are actually all filters from the ui-grid
-  function patientRegistrations(options) {
+  /** @deprecated ? */
+  /* function patientRegistrations(options) {
     var reportOptions = {
       title: 'PATIENT_REG.PATIENT_REGISTRATIONS',
       renderer: Receipts.renderers.PDF,
@@ -101,5 +101,5 @@ function ReceiptModal(Modal, Receipts) {
     var configuration = angular.extend(modalConfiguration, reportProvider);
     var instance = Modal.open(configuration);
     return instance.result;
-  }
+  }*/
 }

--- a/client/src/js/services/receipts/ReceiptModal.js
+++ b/client/src/js/services/receipts/ReceiptModal.js
@@ -80,26 +80,4 @@ function ReceiptModal(Modal, Receipts) {
     var instance = Modal.open(configuration);
     return instance.result;
   }
-
-  /** @deprecated ? */
-  /* function patientRegistrations(options) {
-    var reportOptions = {
-      title: 'PATIENT_REG.PATIENT_REGISTRATIONS',
-      renderer: Receipts.renderers.PDF,
-    };
-
-    options.renderer = Receipts.renderers.PDF;
-
-    var reportRequest = Receipts.patientRegistrations(options);
-    var reportProvider = {
-      resolve : {
-        receipt       : function reportProvider () { return { promise : reportRequest }; },
-        options       : function optionsProvider() { return reportOptions; },
-      }
-    };
-
-    var configuration = angular.extend(modalConfiguration, reportProvider);
-    var instance = Modal.open(configuration);
-    return instance.result;
-  }*/
 }

--- a/client/src/js/services/receipts/ReceiptService.js
+++ b/client/src/js/services/receipts/ReceiptService.js
@@ -54,17 +54,4 @@ function ReceiptService($http, util) {
     return $http.get(route, {params : options, responseType : responseType})
       .then(util.unwrapHttpResponse);
   }
-
-  /** @deprecated */
-  /* function patientRegistrations(options) {
-    var route = '/reports/patient/registrations';
-    var responseType = null;
-
-    if (options.renderer === renderers.PDF) {
-      responseType = 'arraybuffer';
-    }
-
-    return $http.get(route, {params : options, responseType : responseType})
-      .then(util.unwrapHttpResponse);
-  } */
 }

--- a/client/src/js/services/receipts/ReceiptService.js
+++ b/client/src/js/services/receipts/ReceiptService.js
@@ -22,7 +22,7 @@ function ReceiptService($http, util) {
   service.invoice = invoice;
   service.patient = patient;
   service.renderers = renderers;
-  service.patientRegistrations = patientRegistrations;
+  /** service.patientRegistrations = patientRegistrations; */
 
   /**
    * Fetch invoice report data from /reports/invoices/:uuid
@@ -55,7 +55,8 @@ function ReceiptService($http, util) {
       .then(util.unwrapHttpResponse);
   }
 
-  function patientRegistrations(options) {
+  /** @deprecated */
+  /* function patientRegistrations(options) {
     var route = '/reports/patient/registrations';
     var responseType = null;
 
@@ -65,5 +66,5 @@ function ReceiptService($http, util) {
 
     return $http.get(route, {params : options, responseType : responseType})
       .then(util.unwrapHttpResponse);
-  }
+  } */
 }

--- a/client/src/partials/patients/registry/registry.html
+++ b/client/src/partials/patients/registry/registry.html
@@ -22,6 +22,13 @@
           <span class="fa fa-print"></span> {{ "FORM.BUTTONS.PRINT" | translate }}
         </button>
       </div>
+
+      <div class="toolbar-item">
+        <bh-pdf-print
+          pdf-url="reports/patient/registrations"
+          options="PatientRegistryCtrl.filters">
+        </bh-pdf-print>
+      </div>
     </div>
   </div>
 </div>

--- a/client/src/partials/patients/registry/registry.html
+++ b/client/src/partials/patients/registry/registry.html
@@ -15,15 +15,6 @@
         </button>
       </div>
       <div class="toolbar-item">
-        <button
-            ng-click="PatientRegistryCtrl.print()"
-            data-method="print"
-            class="btn btn-default">
-          <span class="fa fa-print"></span> {{ "FORM.BUTTONS.PRINT" | translate }}
-        </button>
-      </div>
-
-      <div class="toolbar-item">
         <bh-pdf-print
           pdf-url="reports/patient/registrations"
           options="PatientRegistryCtrl.filters">
@@ -37,8 +28,7 @@
 <div class="flex-util" style="min-height : 35px; padding-top : 7px">
   <bh-filters-applied
     filters="PatientRegistryCtrl.filtersFmt"
-    on-remove-filter="PatientRegistryCtrl.onRemoveFilter(filter)"
-    >
+    on-remove-filter="PatientRegistryCtrl.onRemoveFilter(filter)">
   </bh-filters-applied>
 
   <a

--- a/client/src/partials/patients/registry/registry.js
+++ b/client/src/partials/patients/registry/registry.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
 .controller('PatientRegistryController', PatientRegistryController);
 
 PatientRegistryController.$inject = [
-  'PatientService', 'NotifyService', 'moment', 'ReceiptModal', 'AppCache', 'util'
+  'PatientService', 'NotifyService', 'moment', 'AppCache', 'util'
 ];
 
 /**
@@ -10,7 +10,7 @@ PatientRegistryController.$inject = [
  *
  * This module is responsible for the management of Patient Registry.
  */
-function PatientRegistryController(Patients, Notify, moment, Receipt, AppCache, util) {
+function PatientRegistryController(Patients, Notify, moment, AppCache, util) {
   var vm = this;
 
   var cache = AppCache('PatientRegistry');
@@ -27,7 +27,6 @@ function PatientRegistryController(Patients, Notify, moment, Receipt, AppCache, 
 
   vm.search = search;
 
-  vm.print = print;
   vm.onRemoveFilter = onRemoveFilter;
   vm.clearFilters = clearFilters;
 
@@ -119,14 +118,6 @@ function PatientRegistryController(Patients, Notify, moment, Receipt, AppCache, 
   function clearFilters() {
     cacheFilters({});
     load();
-  }
-
-  // open a print modal to print all patient registrations to date
-  function print() {
-    var options = angular.copy(vm.filters || {});
-
-    // @todo(jniles): Make reports and receipts use the same rendering modal
-    Receipt.patientRegistrations(options);
   }
 
   // toggles the loading indicator on or off


### PR DESCRIPTION
Proposal for a component that directly invokes the browser print dialog without an intermediate service or modal. 

This should be abstracted and extended in the future to allow the service to be called from a dropdown or any other component. 

Example usage:

``` html
<bh-pdf-print 
  pdf-url='/reports/invoice'>
</bh-pdf-print>
```

`pdf-url` - path to the PDF resource on the server. Note you do not have to include the `?render=pdf` flag. 
`options` - Optional configuration options that will be passed to the report generation 

**Component Button**
![screenshot 2016-06-28 at 12 21 58](https://cloud.githubusercontent.com/assets/2844572/16414133/e73a27aa-3d2d-11e6-94e0-6b0d1a9c8d60.png)

**Loading State** Requesting and storing the PDF as a blob
![screenshot 2016-06-28 at 12 22 02](https://cloud.githubusercontent.com/assets/2844572/16414134/e740fa3a-3d2d-11e6-890f-dbd1124c6844.png)

**Directly invoke brower print dialog**
![screenshot 2016-06-28 at 12 22 52](https://cloud.githubusercontent.com/assets/2844572/16414135/e74445f0-3d2d-11e6-9854-6fe284c0ce2a.png)

---
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.
