### PR TITLE
feat(bhFormDefaults): form defaults automatically

### DIFF
--- a/client/src/js/directives/bhFormDefaults.js
+++ b/client/src/js/directives/bhFormDefaults.js
@@ -1,0 +1,22 @@
+angular.module('bhima.directives')
+.directive('bhFormDefaults', bhFormDefaults);
+
+/**
+ * @class bhFormDefaults
+ *
+ * @description
+ * The bhFormDefaults directive allows us to set custom attributes on any form
+ * in the application and ensure they all behave the same.  It also creates a
+ * single location for changing any of the attributes on the form in the future.
+ */
+function bhFormDefaults() {
+  return {
+    restrict: 'A',
+    require: 'form',
+    link: function bhFormDefaultsLinkFn($scope, $element, $attrs, $controller) {
+      $attrs.$set('autocomplete', 'none');
+      $attrs.$set('autocapitalize', 'none');
+      $attrs.$set('autocorrect', 'none');
+    }
+  };
+}

--- a/client/src/partials/accounts/templates/chart-modal.html
+++ b/client/src/partials/accounts/templates/chart-modal.html
@@ -3,11 +3,11 @@
     <h3>New Account</h3>
   </div>
   <div class="modal-body">
-    <form role="form" class="form-horizontal" name="accountForm" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+    <form role="form" class="form-horizontal" name="accountForm" bh-form-defaults novalidate>
       <div class="form-group">
         <label class="col-xs-2 control-label" for="coa-accn">Account Number:</label>
         <div class="col-xs-10">
-          <input 
+          <input
             class="form-control"
             placeholder="e.g. 100000"
             type="number"
@@ -38,7 +38,7 @@
             ng-options="a.id as a.type for a in types"
             id="coa-acctype"
             required
-            > 
+            >
           </select>
         </div>
       </div>
@@ -89,7 +89,7 @@
                 value="0"
                 model="account.fixed"
               >
-              Variable 
+              Variable
             </label>
           </div>
         </div>

--- a/client/src/partials/billing_services/modal.html
+++ b/client/src/partials/billing_services/modal.html
@@ -1,5 +1,5 @@
 <!-- billing service form -->
-<form name="BillingServicesForm" bh-submit="BillingServicesFormCtrl.submit(BillingServicesForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+<form name="BillingServicesForm" bh-submit="BillingServicesFormCtrl.submit(BillingServicesForm)" bh-form-defaults novalidate>
 
   <div class="modal-header">
     <h4>{{ BillingServicesFormCtrl.title | translate }}<span ng-show="BillingServicesFormCtrl.label">: {{ BillingServicesFormCtrl.label }}</span></h4>

--- a/client/src/partials/cash/cash.html
+++ b/client/src/partials/cash/cash.html
@@ -32,7 +32,7 @@
           </div>
           <div class="panel-body">
 
-            <form name="CashVoucherForm" bh-submit="CashCtrl.submit(CashVoucherForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="CashVoucherForm" bh-submit="CashCtrl.submit(CashVoucherForm)" bh-form-defaults novalidate>
 
               <fieldset ng-disabled="CashVoucherForm.$loading">
 

--- a/client/src/partials/cash/cashboxes/cashboxes.html
+++ b/client/src/partials/cash/cashboxes/cashboxes.html
@@ -60,9 +60,7 @@
             <form
               name="CreateForm"
               bh-submit="CashCtrl.submit(CreateForm)"
-              autocomplete="off"
-              autocapitalize="off"
-              autocorrect="off"
+              bh-form-defaults
               novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.label.$invalid }">
@@ -135,9 +133,7 @@
               <form
                 name="UpdateForm"
                 bh-submit="CashCtrl.submit(UpdateForm)"
-                autocomplete="off"
-                autocapitalize="off"
-                autocorrect="off"
+                bh-form-defaults
                 novalidate>
                 <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.label.$invalid }">
                   <label class="control-label">

--- a/client/src/partials/cash/cashboxes/modal.html
+++ b/client/src/partials/cash/cashboxes/modal.html
@@ -1,4 +1,4 @@
-<form name="CashboxModalForm" bh-submit="CashboxModalCtrl.submit(CashboxModalForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+<form name="CashboxModalForm" bh-submit="CashboxModalCtrl.submit(CashboxModalForm)" bh-form-defaults novalidate>
   <div class="modal-header">
     <h4>{{ "CASHBOX.CONFIG_ACCOUNTS" | translate }} <small>{{ CashboxModalCtrl.cashbox.text }}</small></h4>
   </div>

--- a/client/src/partials/cash/modals/transfer.modal.html
+++ b/client/src/partials/cash/modals/transfer.modal.html
@@ -1,4 +1,4 @@
-<form name="TransferForm" ng-submit="CashTransferModalCtrl.submit(TransferForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+<form name="TransferForm" ng-submit="CashTransferModalCtrl.submit(TransferForm.$invalid)" bh-form-defaults novalidate>
 
   <div class="modal-header">
     <h4>{{ "CASH.VOUCHER.CASHBOXES.TRANSFER" | translate }}</h4>

--- a/client/src/partials/debtors/groups.edit.html
+++ b/client/src/partials/debtors/groups.edit.html
@@ -1,4 +1,4 @@
-<div class="container-fluid" ng-form="debtorGroup" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+<div class="container-fluid" ng-form="debtorGroup" bh-form-defaults novalidate>
 
   <div class="row">
     <div class="col-xs-12">
@@ -13,7 +13,7 @@
     <div class="col-md-5">
 
       <!-- Debtor group details form elements -->
-      <div autocomplete="off" autocorrect="off" autocapitalize="off">
+      <div>
         <div
           class="form-group has-feedback"
           ng-class="{'has-error' : debtorGroup.name.$invalid && debtorGroup.$submitted}">

--- a/client/src/partials/depots/depots.html
+++ b/client/src/partials/depots/depots.html
@@ -58,7 +58,7 @@
         <div ng-switch-when="action">
           <form class="panel panel-primary"
             ng-class="{ 'panel-danger': DepotCtrl.action === 'remove'}"
-            name="ActionForm" ng-submit="DepotCtrl.submit(ActionForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            name="ActionForm" ng-submit="DepotCtrl.submit(ActionForm)" bh-form-defaults novalidate>
             <div class="panel-heading">
               {{ DepotCtrl.actionTitle | translate }}
             </div>

--- a/client/src/partials/employees/employees.html
+++ b/client/src/partials/employees/employees.html
@@ -22,9 +22,9 @@
           <div class="panel-heading">
             {{ "EMPLOYEE.EMPLOYEES" | translate }}
           </div>
-          
+
           <!-- FIX ME -->
-          <!-- Employee research must be done in a ui-grid  -->         
+          <!-- Employee research must be done in a ui-grid  -->
 
           <table class="table table-condensed">
             <thead>
@@ -74,7 +74,7 @@
         <div ng-switch-default>
           <div class="alert alert-info" id="default">
             <h4>{{ 'EMPLOYEE.TITLE' | translate }}</h4>
-            <p>{{ 'EMPLOYEE.INFO' | translate }}</p>         
+            <p>{{ 'EMPLOYEE.INFO' | translate }}</p>
           </div>
         </div>
 
@@ -93,14 +93,14 @@
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ 'EMPLOYEE.REGISTRATION_FORM' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="EmployeeCtrl.submit(CreateForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form class="panel-body" name="CreateForm" ng-submit="EmployeeCtrl.submit(CreateForm.$invalid)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.prenom.$invalid }">
                 <label class="control-label" for="bhima-employee-prenom">{{ 'FORM.LABELS.FIRST_NAME' | translate }}</label>
                 <input type="text" class="form-control" name="prenom" ng-maxlength="EmployeeCtrl.maxLength" id="bhima-employee-prenom" ng-model="EmployeeCtrl.employee.prenom" required>
                 <div class="help-block" ng-messages="CreateForm.prenom.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.name.$invalid }">
@@ -108,7 +108,7 @@
                 <input type="text" class="form-control" name="name" ng-maxlength="EmployeeCtrl.maxLength" id="bhima-employee-name" ng-model="EmployeeCtrl.employee.name" required>
                 <div class="help-block" ng-messages="CreateForm.name.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.postnom.$invalid }">
@@ -116,15 +116,15 @@
                 <input type="text" class="form-control" name="postnom" ng-maxlength="EmployeeCtrl.maxLength" id="bhima-employee-postnom" ng-model="EmployeeCtrl.employee.postnom" required>
                 <div class="help-block" ng-messages="CreateForm.postnom.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <!-- date editor component -->
-              <bh-date-editor 
+              <bh-date-editor
                 id="employee-dob"
-                date-value="EmployeeCtrl.employee.dob" 
-                validation-trigger="details.$submitted" 
-                min-date="EmployeeCtrl.minDOB" 
+                date-value="EmployeeCtrl.employee.dob"
+                validation-trigger="details.$submitted"
+                min-date="EmployeeCtrl.minDOB"
                 max-date="EmployeeCtrl.maxDOB">
               </bh-date-editor>
 
@@ -137,7 +137,7 @@
                 </select>
                 <div class="help-block" ng-messages="CreateForm.sexe.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.nb_spouse.$invalid }">
@@ -146,20 +146,20 @@
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.nb_enfant.$invalid }">
-                <label class="control-label" for="bhima-employee-nb_enfant">{{ 'FORM.LABELS.NB_CHILDREN' | translate }}</label>              
+                <label class="control-label" for="bhima-employee-nb_enfant">{{ 'FORM.LABELS.NB_CHILDREN' | translate }}</label>
                 <input type="number" class="form-control" name="nb_enfant" min="0" id="bhima-employee-nb_enfant" ng-model="EmployeeCtrl.employee.nb_enfant">
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.locked.$invalid }">
                 <label class="control-label">
                   <input type="checkbox" name="locked" ng-true-value="1" ng-false-value="0" id="bhima-employee-locked" ng-model="EmployeeCtrl.employee.locked">  {{ "FORM.LABELS.LOCKED" | translate }}
-                </label>  
-              </div> 
+                </label>
+              </div>
 
-              <bh-date-editor 
+              <bh-date-editor
                 id="employee-date-hired"
-                date-value="EmployeeCtrl.employee.date_embauche" 
-                validation-trigger="details.$submitted" 
+                date-value="EmployeeCtrl.employee.date_embauche"
+                validation-trigger="details.$submitted"
                 max-date="EmployeeCtrl.maxDateEmbauche">
               </bh-date-editor>
 
@@ -168,7 +168,7 @@
                 <input type="text" class="form-control" name="code" ng-maxlength="EmployeeCtrl.length20" id="bhima-employee-code" ng-model="EmployeeCtrl.employee.code" required>
                 <div class="help-block" ng-messages="CreateForm.code.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.service_id.$invalid }">
@@ -178,7 +178,7 @@
                 </select>
                 <div class="help-block" ng-messages="CreateForm.service_id.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.grade_id.$invalid }">
@@ -188,7 +188,7 @@
                 </select>
                 <div class="help-block" ng-messages="CreateForm.grade_id.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.fonction_id.$invalid }">
@@ -198,9 +198,9 @@
                 </select>
                 <div class="help-block" ng-messages="CreateForm.fonction_id.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
-              
+
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.creditor_group_uuid.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.CREDITOR_GROUP" | translate }}</label>
                 <select class="form-control" name="creditor_group_uuid" ng-model="EmployeeCtrl.employee.creditor_group_uuid" id="bhima-employee-creditor_group_uuid" ng-options="cg.uuid as cg.name for cg in EmployeeCtrl.creditorGroups | orderBy:'name'" required>
@@ -208,9 +208,9 @@
                 </select>
                 <div class="help-block" ng-messages="CreateForm.creditor_group_uuid.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
-              
+
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.debtor_group_uuid.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.DEBITOR_GROUP" | translate }}</label>
                 <select class="form-control" name="debtor_group_uuid" ng-model="EmployeeCtrl.employee.debtor_group_uuid" id="bhima-employee-debtor_group_uuid" ng-options="dg.uuid as dg.name for dg in EmployeeCtrl.debtorGroups | orderBy:'name'" required>
@@ -218,7 +218,7 @@
                 </select>
                 <div class="help-block" ng-messages="CreateForm.debtor_group_uuid.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.phone.$invalid }">
@@ -226,7 +226,7 @@
                 <input type="phone" class="form-control" name="phone" ng-maxlength="EmployeeCtrl.length20" id="bhima-employee-phone" ng-model="EmployeeCtrl.employee.phone">
                 <div class="help-block" ng-messages="CreateForm.phone.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.email.$invalid }">
@@ -234,7 +234,7 @@
                 <input type="email" class="form-control" name="email" id="bhima-employee-email" ng-maxlength="EmployeeCtrl.length70" ng-model="EmployeeCtrl.employee.email">
                 <div class="help-block" ng-messages="CreateForm.email.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.adresse.$invalid }">
@@ -242,7 +242,7 @@
                 <input type="adresse" class="form-control" name="adresse" ng-maxlength="EmployeeCtrl.length50" id="bhima-employee-adresse" ng-model="EmployeeCtrl.employee.adresse" required >
                 <div class="help-block" ng-messages="CreateForm.adresse.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <bh-location-select
@@ -255,7 +255,7 @@
                 <input type="text" class="form-control" name="bank" ng-maxlength="EmployeeCtrl.length30" id="bhima-employee-bank" ng-model="EmployeeCtrl.employee.bank">
                 <div class="help-block" ng-messages="CreateForm.bank.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.bank_account.$invalid }">
@@ -263,7 +263,7 @@
                 <input type="text" class="form-control" name="bank_account" ng-maxlength="EmployeeCtrl.length30" id="bhima-employee-bank_account" ng-model="EmployeeCtrl.employee.bank_account">
                 <div class="help-block" ng-messages="CreateForm.bank_account.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group">
@@ -275,20 +275,20 @@
                 </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
 
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ 'EMPLOYEE.EDIT' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="UpdateForm" ng-submit="EmployeeCtrl.submit(UpdateForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form class="panel-body" name="UpdateForm" ng-submit="EmployeeCtrl.submit(UpdateForm.$invalid)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.prenom.$invalid }">
                 <label class="control-label" for="bhima-employee-prenom">{{ 'FORM.LABELS.FIRST_NAME' | translate }}</label>
                 <input type="text" class="form-control" name="prenom" ng-maxlength="EmployeeCtrl.maxLength" id="bhima-employee-prenom" ng-model="EmployeeCtrl.employee.prenom" required>
                 <div class="help-block" ng-messages="UpdateForm.prenom.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.name.$invalid }">
@@ -296,7 +296,7 @@
                 <input type="text" class="form-control" name="name" ng-maxlength="EmployeeCtrl.maxLength" id="bhima-employee-name" ng-model="EmployeeCtrl.employee.name" required>
                 <div class="help-block" ng-messages="UpdateForm.name.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.postnom.$invalid }">
@@ -304,14 +304,14 @@
                 <input type="text" class="form-control" name="postnom" ng-maxlength="EmployeeCtrl.maxLength" id="bhima-employee-postnom" ng-model="EmployeeCtrl.employee.postnom" required>
                 <div class="help-block" ng-messages="UpdateForm.postnom.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
-              <bh-date-editor 
+              <bh-date-editor
                 id="employee-dob"
-                date-value="EmployeeCtrl.employee.dob" 
-                validation-trigger="details.$submitted" 
-                min-date="EmployeeCtrl.minDOB" 
+                date-value="EmployeeCtrl.employee.dob"
+                validation-trigger="details.$submitted"
+                min-date="EmployeeCtrl.minDOB"
                 max-date="EmployeeCtrl.maxDOB">
               </bh-date-editor>
 
@@ -324,7 +324,7 @@
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.sexe.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.nb_spouse.$invalid }">
@@ -340,23 +340,23 @@
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.locked.$invalid }">
                 <label class="control-label">
                   <input type="checkbox" name="locked" ng-true-value="1" ng-false-value="0" id="bhima-employee-locked" ng-model="EmployeeCtrl.employee.locked">  {{ "FORM.LABELS.LOCKED" | translate }}
-                </label>  
-              </div> 
+                </label>
+              </div>
 
 
-              <bh-date-editor 
+              <bh-date-editor
                 id="employee-date-hired"
-                date-value="EmployeeCtrl.employee.date_embauche" 
-                validation-trigger="details.$submitted" 
+                date-value="EmployeeCtrl.employee.date_embauche"
+                validation-trigger="details.$submitted"
                 max-date="EmployeeCtrl.maxDateEmbauche">
-              </bh-date-editor>                
+              </bh-date-editor>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.code.$invalid }">
                 <label class="control-label" for="bhima-employee-code">{{ 'FORM.LABELS.CODE' | translate }}</label>
                 <input type="text" class="form-control" name="code" id="bhima-employee-code" ng-model="EmployeeCtrl.employee.code" required>
                 <div class="help-block" ng-messages="UpdateForm.code.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.service_id.$invalid }">
@@ -366,7 +366,7 @@
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.service_id.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.grade_id.$invalid }">
@@ -376,7 +376,7 @@
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.grade_id.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.fonction_id.$invalid }">
@@ -386,9 +386,9 @@
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.fonction_id.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
-              
+
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && UpdateForm.creditor_group_uuid.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.CREDITOR_GROUP" | translate }}</label>
                 <select class="form-control" name="creditor_group_uuid" ng-model="EmployeeCtrl.employee.creditor_group_uuid" id="bhima-employee-creditor_group_uuid" ng-options="cg.uuid as cg.name for cg in EmployeeCtrl.creditorGroups | orderBy:'name'" required>
@@ -396,9 +396,9 @@
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.creditor_group_uuid.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
-              
+
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && UpdateForm.debtor_group_uuid.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.DEBITOR_GROUP" | translate }}</label>
                 <select class="form-control" name="debtor_group_uuid" ng-model="EmployeeCtrl.employee.debtor_group_uuid" id="bhima-employee-debtor_group_uuid" ng-options="dg.uuid as dg.name for dg in EmployeeCtrl.debtorGroups | orderBy:'name'" required>
@@ -406,7 +406,7 @@
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.debtor_group_uuid.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.phone.$invalid }">
@@ -414,7 +414,7 @@
                 <input type="phone" class="form-control" name="phone" ng-maxlength="EmployeeCtrl.length20" id="bhima-employee-phone" ng-model="EmployeeCtrl.employee.phone">
                 <div class="help-block" ng-messages="UpdateForm.phone.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.email.$invalid }">
@@ -422,7 +422,7 @@
                 <input type="email" class="form-control" name="email" ng-maxlength="EmployeeCtrl.length70" id="bhima-employee-email" ng-model="EmployeeCtrl.employee.email">
                 <div class="help-block" ng-messages="UpdateForm.email.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.adresse.$invalid }">
@@ -430,7 +430,7 @@
                 <input type="adresse" class="form-control" name="adresse" ng-maxlength="EmployeeCtrl.length50" id="bhima-employee-adresse" ng-model="EmployeeCtrl.employee.adresse" required >
                 <div class="help-block" ng-messages="UpdateForm.adresse.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <bh-location-select
@@ -443,7 +443,7 @@
                 <input type="text" class="form-control" name="bank" ng-maxlength="EmployeeCtrl.length30" id="bhima-employee-bank" ng-model="EmployeeCtrl.employee.bank">
                 <div class="help-block" ng-messages="UpdateForm.bank.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.bank_account.$invalid }">
@@ -451,21 +451,21 @@
                 <input type="text" class="form-control" name="bank_account" ng-maxlength="EmployeeCtrl.length30" id="bhima-employee-bank_account" ng-model="EmployeeCtrl.employee.bank_account">
                 <div class="help-block" ng-messages="UpdateForm.bank_account.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group">
-                  <button class="btn btn-default" id="change_employee" type="submit" data-method="submit">
-                    {{ "FORM.BUTTONS.SUBMIT" | translate }}
-                  </button>
-                  <button class="btn btn-default" type="button" ng-click="EmployeeCtrl.cancel()" data-method="cancel">
-                    {{ "FORM.BUTTONS.CANCEL" | translate }}
-                  </button>
+                <button class="btn btn-default" id="change_employee" type="submit" data-method="submit">
+                  {{ "FORM.BUTTONS.SUBMIT" | translate }}
+                </button>
+                <button class="btn btn-default" type="button" ng-click="EmployeeCtrl.cancel()" data-method="cancel">
+                  {{ "FORM.BUTTONS.CANCEL" | translate }}
+                </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/enterprises/enterprises.html
+++ b/client/src/partials/enterprises/enterprises.html
@@ -77,9 +77,7 @@
             <form
               name="CreateForm"
               bh-submit="EnterpriseCtrl.submit(CreateForm)"
-              autocomplete="off"
-              autocapitalize="off"
-              autocorrect="off"
+              bh-form-defaults
               novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.name.$invalid }">
@@ -169,9 +167,7 @@
             <form
               name="UpdateForm"
               ng-submit="EnterpriseCtrl.submit(UpdateForm)"
-              autocomplete="off"
-              autocapitalize="off"
-              autocorrect="off"
+              bh-form-defaults
               novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.name.$invalid }">

--- a/client/src/partials/exchange/exchange.html
+++ b/client/src/partials/exchange/exchange.html
@@ -43,69 +43,71 @@
           <div class="panel-heading">
             {{ "EXCHANGE.ENTERPRISE_CURRENCY" | translate }} {{ ExchangeCtrl.formatCurrency(ExchangeCtrl.enterprise.currency_id) }}
           </div>
+          <div class="panel-body">
 
-          <form name="RateForm" class="panel-body form-horizontal" ng-submit="ExchangeCtrl.submit(RateForm.$invalid)" autocomplete="off" novalidate>
+            <form name="RateForm" class="form-horizontal" ng-submit="ExchangeCtrl.submit(RateForm.$invalid)" bh-form-defaults novalidate>
 
-            <bh-date-editor
-              date-value="ExchangeCtrl.form.date"
-              max-date="ExchangeCtrl.today"
-              validation-trigger="RateForm.$submitted"
-              disabled="!ExchangeCtrl.form.previous"
-              >
-            </bh-date-editor>
+              <bh-date-editor
+                date-value="ExchangeCtrl.form.date"
+                max-date="ExchangeCtrl.today"
+                validation-trigger="RateForm.$submitted"
+                disabled="!ExchangeCtrl.form.previous"
+                >
+              </bh-date-editor>
 
-            <div class="form-group">
-              <div class="checkbox">
-                <label>
-                  <input name="previous" id="previous" type="checkbox" ng-model="ExchangeCtrl.form.previous">
-                  {{ "FORM.LABELS.PREVIOUS_DATE" | translate }}
-                </label>
-              </div>
-            </div>
-
-            <div class="form-group" ng-repeat="(id, row) in ExchangeCtrl.current">
-              <label class="control-label col-md-6">{{ ExchangeCtrl.formatCurrency(id) }} </label>
-              <div class="col-md-6">
-                {{ row.rate | currency:id }}
-                <a class="btn btn-warning text-right" id="current-{{ $index + 1 }}" ng-click="ExchangeCtrl.setExchangeRate(id, row)">{{ "FORM.BUTTONS.SUBMIT" | translate }}</a>
-              </div>
-            </div>
-            <div ng-if="!ExchangeCtrl.current">
-              <div  class="form-group" ng-repeat="currency in ExchangeCtrl.outCurrencies">
-                <label class="control-label col-md-6">{{ ExchangeCtrl.formatCurrency(currency.id) }} </label>
-                <div class="col-md-6">
-                  {{ 0 | currency:currency.id }}
-                  <a class="btn btn-warning text-right" id="current-{{ $index + 1 }}" ng-click="ExchangeCtrl.setExchangeRate(currency.id,'')">{{ "FORM.BUTTONS.SUBMIT" | translate }}</a>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label>
+                    <input name="previous" id="previous" type="checkbox" ng-model="ExchangeCtrl.form.previous">
+                    {{ "FORM.LABELS.PREVIOUS_DATE" | translate }}
+                  </label>
                 </div>
               </div>
-            </div>
-            <span data-role="feedback" ng-switch="ExchangeCtrl.feedback">
-              <span ng-switch-default></span>
 
-              <span ng-switch-when="create_success" id="create_success" class="text-success">
-                <i class="glyphicon glyphicon-ok-sign"></i> {{ "FORM.INFOS.SAVE_SUCCESS" | translate }}
-              </span>
+              <div class="form-group" ng-repeat="(id, row) in ExchangeCtrl.current">
+                <label class="control-label col-md-6">{{ ExchangeCtrl.formatCurrency(id) }} </label>
+                <div class="col-md-6">
+                  {{ row.rate | currency:id }}
+                  <a class="btn btn-warning text-right" id="current-{{ $index + 1 }}" ng-click="ExchangeCtrl.setExchangeRate(id, row)">{{ "FORM.BUTTONS.SUBMIT" | translate }}</a>
+                </div>
+              </div>
+              <div ng-if="!ExchangeCtrl.current">
+                <div  class="form-group" ng-repeat="currency in ExchangeCtrl.outCurrencies">
+                  <label class="control-label col-md-6">{{ ExchangeCtrl.formatCurrency(currency.id) }} </label>
+                  <div class="col-md-6">
+                    {{ 0 | currency:currency.id }}
+                    <a class="btn btn-warning text-right" id="current-{{ $index + 1 }}" ng-click="ExchangeCtrl.setExchangeRate(currency.id,'')">{{ "FORM.BUTTONS.SUBMIT" | translate }}</a>
+                  </div>
+                </div>
+              </div>
+              <span data-role="feedback" ng-switch="ExchangeCtrl.feedback">
+                <span ng-switch-default></span>
 
-              <span ng-switch-when="update_success" id="update_success" class="text-success">
-                <i class="glyphicon glyphicon-ok-sign"></i> {{ "FORM.INFOS.UPDATE_SUCCESS" | translate }}
-              </span>
+                <span ng-switch-when="create_success" id="create_success" class="text-success">
+                  <i class="glyphicon glyphicon-ok-sign"></i> {{ "FORM.INFOS.SAVE_SUCCESS" | translate }}
+                </span>
 
-              <span ng-switch-when="delete_success" id="delete_success" class="text-success">
-                <i class="glyphicon glyphicon-ok-sign"></i> {{ "FORM.INFOS.DELETE_SUCCESS" | translate }}
-              </span>
+                <span ng-switch-when="update_success" id="update_success" class="text-success">
+                  <i class="glyphicon glyphicon-ok-sign"></i> {{ "FORM.INFOS.UPDATE_SUCCESS" | translate }}
+                </span>
 
-              <span ng-switch-when="invalid-date" id="invalid-date" class="text-danger">
-                <i class="glyphicon glyphicon-warning-sign"></i> {{ "FORM.VALIDATIONS.INVALID_DATE" | translate }}
+                <span ng-switch-when="delete_success" id="delete_success" class="text-success">
+                  <i class="glyphicon glyphicon-ok-sign"></i> {{ "FORM.INFOS.DELETE_SUCCESS" | translate }}
+                </span>
+
+                <span ng-switch-when="invalid-date" id="invalid-date" class="text-danger">
+                  <i class="glyphicon glyphicon-warning-sign"></i> {{ "FORM.VALIDATIONS.INVALID_DATE" | translate }}
+                </span>
               </span>
-            </span>
-          </form>
+            </form>
+          </div>
         </div>
 
         <div class="panel panel-default" ng-switch-when="update">
           <div class="panel-heading">
             {{ "EXCHANGE.ENTERPRISE_CURRENCY" | translate }} {{ ExchangeCtrl.formatCurrency(ExchangeCtrl.enterprise.currency_id) }}
           </div>
-          <form name="RateForm" class="panel-body form-horizontal" ng-submit="ExchangeCtrl.submit(RateForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+          <form name="RateForm" class="panel-body form-horizontal" ng-submit="ExchangeCtrl.submit(RateForm.$invalid)" bh-form-defaults novalidate>
             <h3>{{ "EXCHANGE.REVIEW" | translate }} :</h3>
 
             <bh-date-editor
@@ -126,7 +128,7 @@
                   {{ "FORM.BUTTONS.SUBMIT" | translate }}
                 </button>
                 <button class="btn btn-danger" id="delete" type="button" ng-click="ExchangeCtrl.del(ExchangeCtrl.form.id)" data-method="delete">
-                  <i class="glyphicon glyphicon-trash"></i> {{ "FORM.BUTTONS.DELETE" | translate }} 
+                  <i class="glyphicon glyphicon-trash"></i> {{ "FORM.BUTTONS.DELETE" | translate }}
                 </button>
               </div>
             </div>

--- a/client/src/partials/exchange/modal.html
+++ b/client/src/partials/exchange/modal.html
@@ -1,4 +1,4 @@
-<form name="ModalForm" ng-submit="ModalCtrl.submit(ModalForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+<form name="ModalForm" ng-submit="ModalCtrl.submit(ModalForm.$invalid)" bh-form-defaults novalidate>
   <div class="modal-header">
     <h4>{{ 'EXCHANGE.ADDING_RATE' | translate }}</h4>
   </div>

--- a/client/src/partials/fiscal/fiscal.manage.html
+++ b/client/src/partials/fiscal/fiscal.manage.html
@@ -1,4 +1,4 @@
-<form name="FiscalForm" ng-submit="FiscalManageCtrl.submit(FiscalForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+<form name="FiscalForm" ng-submit="FiscalManageCtrl.submit(FiscalForm)" bh-form-defaults novalidate>
   <div class="row">
     <div class="col-xs-12">
       <p><a ng-href="#/fiscal">
@@ -14,20 +14,20 @@
         <div ng-if="FiscalCtrl.state.current.name==='fiscal.create'" class="panel-heading">{{ "FISCAL.NEW_FISCAL_YEAR" | translate }}</div>
         <div ng-if="FiscalCtrl.state.current.name==='fiscal.update'" class="panel-heading">{{ "FISCAL.UPDATE_FISCAL_YEAR" | translate }}</div>
         <div class="panel-body">
-          
+
           <div class="form-group" ng-class="{ 'has-error' : FiscalForm.$submitted && FiscalForm.label.$invalid }">
             <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>
             <input type="text" class="form-control" ng-maxlength="FiscalManageCtrl.maxLength" name="label" ng-model="FiscalManageCtrl.fiscal.label" required>
             <div class="help-block" ng-messages="FiscalForm.label.$error" ng-show="FiscalForm.$submitted">
               <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-            </div>                
+            </div>
           </div>
 
           <!-- date editor component -->
-          <bh-date-editor 
+          <bh-date-editor
             id="start_date"
             date-value="FiscalManageCtrl.fiscal.start_date"
-            validation-trigger="details.$submitted" 
+            validation-trigger="details.$submitted"
             required="required">
           </bh-date-editor>
 
@@ -36,11 +36,11 @@
             <input type="number" class="form-control" ng-keyup="FiscalManageCtrl.endDate()" max="12" min="1" name="number_of_months" ng-model="FiscalManageCtrl.fiscal.number_of_months" required>
             <div class="help-block" ng-messages="FiscalForm.number_of_months.$error" ng-show="FiscalForm.$submitted">
               <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-            </div>                
+            </div>
           </div>
 
           <div ng-if="FiscalManageCtrl.fiscal.number_of_months && FiscalManageCtrl.fiscal.start_date" style="color:#bbb; font-weight: bold;">
-            {{ "FORM.LABELS.END_DATE" | translate}} : {{ FiscalManageCtrl.end_date | date:'yyyy-MM-dd' }} <span class="glyphicon glyphicon-calendar"></span>                
+            {{ "FORM.LABELS.END_DATE" | translate}} : {{ FiscalManageCtrl.end_date | date:'yyyy-MM-dd' }} <span class="glyphicon glyphicon-calendar"></span>
           </div>
 
           <div class="form-group" ng-class="{ 'has-error' : FiscalForm.$submitted && FiscalForm.note.$invalid }">
@@ -48,13 +48,13 @@
             <textarea class="form-control" name="note" id="note" ng-maxlength="FiscalManageCtrl.maxLength" ng-model="FiscalManageCtrl.fiscal.note" rows="3"></textarea>
             <div class="help-block" ng-messages="FiscalForm.note.$error" ng-show="FiscalForm.$submitted">
               <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-            </div>        
+            </div>
           </div>
           <div class="pull-right">
             <button data-method="submit" type="submit" class="btn btn-primary btn-sm">{{ "FORM.BUTTONS.SUBMIT" | translate }}
             </button>
           </div>
-        </div>     
+        </div>
       </div>
     </div>
 
@@ -71,7 +71,7 @@
         </div>
       </div>
     </div>
-  
+
     <div ng-if="FiscalCtrl.state.current.name==='fiscal.update'" class="col-md-6">
       <div class="panel-heading">
         <strong>{{ "FORM.INFOS.OTHER_ACTIONS" | translate }}</strong>

--- a/client/src/partials/locations/country/country.html
+++ b/client/src/partials/locations/country/country.html
@@ -12,11 +12,11 @@
 <div class="flex-util">
   <a href="#/locations" class="btn btn-default btn-sm">
     <span class="glyphicon glyphicon-globe"></span> {{ 'LOCATION.LOCATION_MANAGER' | translate }}
-  </a> 
+  </a>
 
   <button class="btn btn-sm btn-default" id="create" ng-click="CountryCtrl.create()" data-method="create">
     <span class="glyphicon glyphicon-plus-sign"></span> {{'COUNTRY.NEW_COUNTRY' | translate}}
-  </button> 
+  </button>
 </div>
 
 
@@ -54,7 +54,7 @@
         <div ng-switch-default>
           <div class="alert alert-info" id="default">
             <h4>{{ 'COUNTRY.CONFIGURATION' | translate }}</h4>
-            <p>{{ 'COUNTRY.DESCRIPTION' | translate }}</p>     
+            <p>{{ 'COUNTRY.DESCRIPTION' | translate }}</p>
           </div>
         </div>
 
@@ -76,16 +76,16 @@
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ 'COUNTRY.REGISTER' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="CountryCtrl.submit(CreateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
-            
+            <form name="CreateForm" ng-submit="CountryCtrl.submit(CreateForm)" bh-form-defaults novalidate>
+
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.country.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.COUNTRY" | translate }}</label>
                 <input type="text" placeholder="{{ 'FORM.PLACEHOLDERS.ENTER_COUNTRY' | translate }}" ng-maxlength="CountryCtrl.countryLength" class="form-control" name="country" ng-model="CountryCtrl.country.name" required>
                 <div class="help-block" ng-messages="CreateForm.country.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
-              
+
               <div class="form-group">
                 <button class="btn btn-default" id="submit-country" type="submit" data-method="submit">
                   {{ "FORM.BUTTONS.SAVE" | translate }}
@@ -93,24 +93,24 @@
                 <button class="btn btn-default" type="button" ng-click="CountryCtrl.cancel()" data-method="cancel">
                   {{ "FORM.BUTTONS.RESET" | translate }}
                 </button>
-              </div>             
+              </div>
             </form>
-          </div>        
+          </div>
         </div>
 
         <!-- Form for updating country -->
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ 'COUNTRY.EDIT' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="UpdateForm" ng-submit="CountryCtrl.submit(UpdateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="UpdateForm" ng-submit="CountryCtrl.submit(UpdateForm)" bh-form-defaults novalidate>
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.country.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.COUNTRY" | translate }}</label>
                 <input type="text" placeholder="{{ 'FORM.PLACEHOLDERS.ENTER_COUNTRY' | translate }}" ng-maxlength="CountryCtrl.countryLength" class="form-control" name="country" ng-model="CountryCtrl.country.name" required>
                 <div class="help-block" ng-messages="UpdateForm.country.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
-              
+
               <div class="form-group">
                 <button class="btn btn-default" id="change_country" type="submit" data-method="submit">
                   {{ "FORM.BUTTONS.SAVE" | translate }}
@@ -118,12 +118,12 @@
                 <button class="btn btn-default" type="button" ng-click="CountryCtrl.cancel()" data-method="cancel">
                   {{ "FORM.BUTTONS.RESET" | translate }}
                 </button>
-              </div>               
+              </div>
             </form>
-          </div>         
+          </div>
         </div>
 
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/locations/province/province.html
+++ b/client/src/partials/locations/province/province.html
@@ -12,11 +12,11 @@
 <div class="flex-util">
   <a href="#/locations" class="btn btn-default btn-sm">
     <span class="glyphicon glyphicon-globe"></span> {{ 'LOCATION.LOCATION_MANAGER' | translate }}
-  </a> 
+  </a>
 
   <button class="btn btn-sm btn-default" id="create" ng-click="ProvinceCtrl.create()" data-method="create">
     <span class="glyphicon glyphicon-plus-sign"></span> {{'PROVINCE.ADD' | translate}}
-  </button> 
+  </button>
 </div>
 
 
@@ -56,7 +56,7 @@
         <div ng-switch-default>
           <div class="alert alert-info" id="default">
              <b>{{'PROVINCE.CONFIGURATION' | translate}} </b>
-             <p>{{'PROVINCE.DESCRIPTION' | translate}}     
+             <p>{{'PROVINCE.DESCRIPTION' | translate}}
           </div>
         </div>
 
@@ -78,15 +78,15 @@
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ 'PROVINCE.REGISTER' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="ProvinceCtrl.submit(CreateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form class="panel-body" name="CreateForm" ng-submit="ProvinceCtrl.submit(CreateForm)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.country.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.COUNTRY" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="country" 
-                  ng-model="ProvinceCtrl.province.country_uuid" 
-                  id="country"  
+                <select
+                  class="form-control"
+                  name="country"
+                  ng-model="ProvinceCtrl.province.country_uuid"
+                  id="country"
                   ng-options="c.uuid as c.name for c in ProvinceCtrl.countries | orderBy:'name'"
                   ng-change="ProvinceCtrl.loadProvinces()"
                   required>
@@ -94,7 +94,7 @@
                 </select>
                 <div class="help-block" ng-messages="CreateForm.country.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.province.$invalid }">
@@ -102,9 +102,9 @@
                 <input type="text" placeholder="{{ 'FORM.PLACEHOLDERS.ENTER_PROVINCE' | translate }}" ng-maxlength="ProvinceCtrl.maxLength" class="form-control" name="province" ng-model="ProvinceCtrl.province.name" required>
                 <div class="help-block" ng-messages="CreateForm.province.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                  
+                </div>
               </div>
-              
+
               <div class="form-group">
                 <button class="btn btn-default" id="submit-province" type="submit" data-method="submit">
                   {{ "FORM.BUTTONS.SAVE" | translate }}
@@ -114,21 +114,21 @@
                 </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
 
         <!-- Form for updating Province -->
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ 'PROVINCE.EDIT' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="UpdateForm" ng-submit="ProvinceCtrl.submit(UpdateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form class="panel-body" name="UpdateForm" ng-submit="ProvinceCtrl.submit(UpdateForm)" bh-form-defaults novalidate>
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.country.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.COUNTRY" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="country" 
-                  ng-model="ProvinceCtrl.province.country_uuid" 
-                  id="country"  
+                <select
+                  class="form-control"
+                  name="country"
+                  ng-model="ProvinceCtrl.province.country_uuid"
+                  id="country"
                   ng-options="c.uuid as c.name for c in ProvinceCtrl.countries | orderBy:'name'"
                   ng-change="ProvinceCtrl.loadProvinces()"
                   required>
@@ -136,7 +136,7 @@
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.country.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.province.$invalid }">
@@ -144,9 +144,9 @@
                 <input type="text" placeholder="{{ 'FORM.PLACEHOLDERS.ENTER_PROVINCE' | translate }}" class="form-control" ng-maxlength="ProvinceCtrl.maxLength" name="province" ng-model="ProvinceCtrl.province.name" required>
                 <div class="help-block" ng-messages="UpdateForm.province.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
-              
+
               <div class="form-group">
                 <button class="btn btn-default" id="change_province" type="submit" data-method="submit">
                   {{ "FORM.BUTTONS.SAVE" | translate }}
@@ -156,10 +156,10 @@
                 </button>
               </div>
             </form>
-          </div>         
+          </div>
         </div>
 
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/locations/sector/sector.html
+++ b/client/src/partials/locations/sector/sector.html
@@ -12,11 +12,11 @@
 <div class="flex-util">
   <a href="#/locations" class="btn btn-default btn-sm">
     <span class="glyphicon glyphicon-globe"></span> {{ 'LOCATION.LOCATION_MANAGER' | translate }}
-  </a> 
+  </a>
 
   <button class="btn btn-sm btn-default" id="create" ng-click="SectorCtrl.create()" data-method="create">
     <span class="glyphicon glyphicon-plus-sign"></span> {{'SECTOR.NEW_SECTOR' | translate}}
-  </button> 
+  </button>
 </div>
 
 
@@ -56,7 +56,7 @@
         <div ng-switch-default>
           <div class="alert alert-info" id="default">
             <h4>{{ 'SECTOR.CONFIG' | translate }}</h4>
-            <p>{{ 'SECTOR.INFO' | translate }}</p>        
+            <p>{{ 'SECTOR.INFO' | translate }}</p>
           </div>
         </div>
 
@@ -78,15 +78,15 @@
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ 'SECTOR.REGISTER' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="SectorCtrl.submit(CreateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="CreateForm" ng-submit="SectorCtrl.submit(CreateForm)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.country.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.COUNTRY" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="country" 
-                  ng-model="SectorCtrl.sector.country_uuid" 
-                  id="country"  
+                <select
+                  class="form-control"
+                  name="country"
+                  ng-model="SectorCtrl.sector.country_uuid"
+                  id="country"
                   ng-options="c.uuid as c.name for c in SectorCtrl.countries | orderBy:'name'"
                   ng-change="SectorCtrl.loadProvinces()"
                   required>
@@ -94,23 +94,23 @@
                 </select>
                 <div class="help-block" ng-messages="CreateForm.country.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.province.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.PROVINCE" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="province" 
-                  ng-model="SectorCtrl.sector.province_uuid" 
-                  id="province"  
+                <select
+                  class="form-control"
+                  name="province"
+                  ng-model="SectorCtrl.sector.province_uuid"
+                  id="province"
                   ng-options="p.uuid as p.name for p in SectorCtrl.provinces | orderBy:'name'"
                   required>
                   <option value="" disabled> -- {{ SectorCtrl.messages.province | translate }} -- </option>
                 </select>
                 <div class="help-block" ng-messages="CreateForm.province.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.sector.$invalid }">
@@ -118,9 +118,9 @@
                 <input type="text" placeholder="{{ 'FORM.PLACEHOLDERS.ENTER_SECTOR' | translate }}" ng-maxlength="SectorCtrl.maxLength" class="form-control" name="sector" ng-model="SectorCtrl.sector.name" required>
                 <div class="help-block" ng-messages="CreateForm.sector.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
-              
+
               <div class="form-group">
                 <button class="btn btn-default" id="submit-sector" type="submit" data-method="submit">
                   {{ "FORM.BUTTONS.SAVE" | translate }}
@@ -131,21 +131,21 @@
               </div>
 
             </form>
-          </div>        
+          </div>
         </div>
 
         <!-- Form for updating Sector -->
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ 'SECTOR.EDIT' | translate }}</div>
-          <div class="panel-body">        
-            <form class="panel-body" name="UpdateForm" ng-submit="SectorCtrl.submit(UpdateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+          <div class="panel-body">
+            <form name="UpdateForm" ng-submit="SectorCtrl.submit(UpdateForm)" bh-form-defaults novalidate>
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.country.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.COUNTRY" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="country" 
-                  ng-model="SectorCtrl.sector.country_uuid" 
-                  id="country"  
+                <select
+                  class="form-control"
+                  name="country"
+                  ng-model="SectorCtrl.sector.country_uuid"
+                  id="country"
                   ng-options="c.uuid as c.name for c in SectorCtrl.countries | orderBy:'name'"
                   ng-change="SectorCtrl.loadProvinces()"
                   required>
@@ -153,23 +153,23 @@
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.country.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                  
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.province.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.PROVINCE" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="province" 
-                  ng-model="SectorCtrl.sector.province_uuid" 
-                  id="province"  
+                <select
+                  class="form-control"
+                  name="province"
+                  ng-model="SectorCtrl.sector.province_uuid"
+                  id="province"
                   ng-options="p.uuid as p.name for p in SectorCtrl.provinces | orderBy:'name'"
                   required>
                   <option value="" disabled> -- {{ SectorCtrl.messages.province | translate }} -- </option>
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.province.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.sector.$invalid }">
@@ -177,9 +177,9 @@
                 <input type="text" placeholder="{{ 'FORM.PLACEHOLDERS.ENTER_SECTOR' | translate }}" ng-maxlength="SectorCtrl.maxLength" class="form-control" name="sector" ng-model="SectorCtrl.sector.name" required>
                 <div class="help-block" ng-messages="UpdateForm.sector.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
-              
+
               <div class="form-group">
                 <button class="btn btn-default" id="change_sector" type="submit" data-method="submit">
                   {{ "FORM.BUTTONS.SAVE" | translate }}
@@ -187,12 +187,12 @@
                 <button class="btn btn-default" type="button" ng-click="SectorCtrl.cancel()" data-method="cancel">
                   {{ "FORM.BUTTONS.RESET" | translate }}
                 </button>
-              </div>             
+              </div>
             </form>
-          </div>         
+          </div>
         </div>
 
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/locations/village/village.html
+++ b/client/src/partials/locations/village/village.html
@@ -12,18 +12,18 @@
 <div class="flex-util">
   <a href="#/locations" class="btn btn-default btn-sm">
     <span class="glyphicon glyphicon-globe"></span> {{ 'LOCATION.LOCATION_MANAGER' | translate }}
-  </a> 
+  </a>
 
   <button class="btn btn-sm btn-default" id="create" ng-click="VillageCtrl.create()" data-method="create">
     <span class="glyphicon glyphicon-plus-sign"></span> {{'VILLAGE.NEW_VILLAGE' | translate}}
-  </button> 
+  </button>
 </div>
 
 
 <div class="flex-content">
   <div class="container-fluid">
     <div class="row">
-    <!-- Complete list of registred Villages -->
+    <!-- Complete list of registered villages -->
       <div class="col-xs-6">
         <div class="panel panel-default" style="overflow: auto; max-height: 500px;">
           <div class="panel-heading">
@@ -56,7 +56,7 @@
         <div ng-switch-default>
           <div class="alert alert-info" id="default">
             <h4>{{ 'VILLAGE.CONFIG' | translate }}</h4>
-            <p>{{ 'VILLAGE.INFO' | translate }}</p>        
+            <p>{{ 'VILLAGE.INFO' | translate }}</p>
           </div>
         </div>
 
@@ -78,56 +78,55 @@
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ 'VILLAGE.REGISTER' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="VillageCtrl.submit(CreateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
-
+            <form name="CreateForm" ng-submit="VillageCtrl.submit(CreateForm)" bh-form-defaults  novalidate>
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.country.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.COUNTRY" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="country" 
-                  ng-model="VillageCtrl.village.country_uuid" 
-                  id="country"  
+                <select
+                  class="form-control"
+                  name="country"
+                  ng-model="VillageCtrl.village.country_uuid"
+                  id="country"
                   ng-options="c.uuid as c.name for c in VillageCtrl.countries | orderBy:'name'"
                   ng-change="VillageCtrl.loadProvinces()"
                   required>
-                  <option value="" disabled> -- {{ VillageCtrl.messages.country | translate }} -- </option>
+                  <option value="" disabled>{{ VillageCtrl.messages.country | translate }}</option>
                 </select>
                 <div class="help-block" ng-messages="CreateForm.country.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.province.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.PROVINCE" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="province" 
-                  ng-model="VillageCtrl.village.province_uuid" 
-                  id="province"  
+                <select
+                  class="form-control"
+                  name="province"
+                  ng-model="VillageCtrl.village.province_uuid"
+                  id="province"
                   ng-options="p.uuid as p.name for p in VillageCtrl.provinces | orderBy:'name'"
                   ng-change="VillageCtrl.loadSectors()"
                   required>
-                  <option value="" disabled> -- {{ VillageCtrl.messages.province | translate }} -- </option>
+                  <option value="" disabled>{{ VillageCtrl.messages.province | translate }}</option>
                 </select>
                 <div class="help-block" ng-messages="CreateForm.province.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.sector.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.SECTOR" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="sector" 
-                  ng-model="VillageCtrl.village.sector_uuid" 
-                  id="sector"  
-                  ng-options="s.uuid as s.name for s in VillageCtrl.sectors | orderBy:'name'" 
+                <select
+                  class="form-control"
+                  name="sector"
+                  ng-model="VillageCtrl.village.sector_uuid"
+                  id="sector"
+                  ng-options="s.uuid as s.name for s in VillageCtrl.sectors | orderBy:'name'"
                   required>
-                  <option value="" disabled> -- {{ VillageCtrl.messages.sector | translate }} -- </option>
+                  <option value="" disabled>{{ VillageCtrl.messages.sector | translate }}</option>
                 </select>
                 <div class="help-block" ng-messages="CreateForm.sector.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.village.$invalid }">
@@ -135,9 +134,9 @@
                 <input type="text" placeholder="{{ 'FORM.PLACEHOLDERS.ENTER_VILLAGE' | translate }}" ng-maxlength="VillageCtrl.maxLength" class="form-control" name="village" ng-model="VillageCtrl.village.name" required>
                 <div class="help-block" ng-messages="CreateForm.village.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
-              
+
               <div class="form-group">
                 <button class="btn btn-default" id="submit-village" type="submit" data-method="submit">
                   {{ "FORM.BUTTONS.SAVE" | translate }}
@@ -154,62 +153,62 @@
               </div>
 
             </form>
-          </div>        
+          </div>
         </div>
 
         <!-- Form for updating Village -->
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ 'VILLAGE.EDIT' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="UpdateForm" ng-submit="VillageCtrl.submit(UpdateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="UpdateForm" ng-submit="VillageCtrl.submit(UpdateForm)" bh-form-defaults novalidate>
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.country.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.COUNTRY" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="country" 
-                  ng-model="VillageCtrl.village.country_uuid" 
-                  id="country"  
+                <select
+                  class="form-control"
+                  name="country"
+                  ng-model="VillageCtrl.village.country_uuid"
+                  id="country"
                   ng-options="c.uuid as c.name for c in VillageCtrl.countries | orderBy:'name'"
                   ng-change="VillageCtrl.loadProvinces()"
                   required>
-                  <option value="" disabled> -- {{ VillageCtrl.messages.country | translate }} -- </option>
+                  <option value="" disabled>{{ VillageCtrl.messages.country | translate }}</option>
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.country.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                  
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.province.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.PROVINCE" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="province" 
-                  ng-model="VillageCtrl.village.province_uuid" 
-                  id="province"  
+                <select
+                  class="form-control"
+                  name="province"
+                  ng-model="VillageCtrl.village.province_uuid"
+                  id="province"
                   ng-options="p.uuid as p.name for p in VillageCtrl.provinces | orderBy:'name'"
                   ng-change="VillageCtrl.loadSectors()"
                   required>
-                  <option value="" disabled> -- {{ VillageCtrl.messages.province | translate }} -- </option>
+                  <option value="" disabled>{{ VillageCtrl.messages.province | translate }}</option>
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.province.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.sector.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.SECTOR" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="sector" 
-                  ng-model="VillageCtrl.village.sector_uuid" 
-                  id="sector"  
-                  ng-options="s.uuid as s.name for s in VillageCtrl.sectors | orderBy:'name'" 
+                <select
+                  class="form-control"
+                  name="sector"
+                  ng-model="VillageCtrl.village.sector_uuid"
+                  id="sector"
+                  ng-options="s.uuid as s.name for s in VillageCtrl.sectors | orderBy:'name'"
                   required>
-                  <option value="" disabled> -- {{ VillageCtrl.messages.sector | translate }} -- </option>
+                  <option value="" disabled>{{ VillageCtrl.messages.sector | translate }}</option>
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.sector.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.village.$invalid }">
@@ -217,9 +216,9 @@
                 <input type="text" placeholder="{{ 'FORM.PLACEHOLDERS.ENTER_VILLAGE' | translate }}" ng-maxlength="VillageCtrl.maxLength" class="form-control" name="village" ng-model="VillageCtrl.village.name" required>
                 <div class="help-block" ng-messages="UpdateForm.village.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
-              
+
               <div class="form-group">
                 <button class="btn btn-default" id="change_village" type="submit" data-method="submit">
                   {{ "FORM.BUTTONS.SAVE" | translate }}
@@ -234,12 +233,10 @@
                 class="text-danger" data-role="feedback" style="margin-top:10px;">
                 <i class="glyphicon glyphicon-remove-sign"></i> {{ "FORM.ERRORS.HAS_ERRORS" | translate }}
               </div>
-
             </form>
-          </div>         
+          </div>
         </div>
-
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/login/login.html
+++ b/client/src/partials/login/login.html
@@ -22,7 +22,7 @@
           </div>
 
           <div class="panel-body">
-            <form name="LoginForm" bh-submit="LoginCtrl.login(LoginForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="LoginForm" bh-submit="LoginCtrl.login(LoginForm)" bh-form-defaults novalidate>
               <div
                 class="form-group"
                 ng-class="{ 'has-error' : LoginForm.$submitted && LoginForm.username.$invalid }">
@@ -37,8 +37,6 @@
                     class="form-control"
                     ng-model="LoginCtrl.credentials.username"
                     placeholder="{{ 'FORM.PLACEHOLDERS.ENTER_USERNAME' | translate }}"
-                    autocomplete="off"
-                    autocorrect="off"
                     autofocus
                     required />
                 </div>

--- a/client/src/partials/patient_invoice/patientInvoice.html
+++ b/client/src/partials/patient_invoice/patientInvoice.html
@@ -15,7 +15,7 @@
       <div class="col-xs-12">
         <div class="panel panel-default">
           <div class="panel-body">
-            <form name="detailsForm" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="detailsForm" bh-form-defaults novalidate>
               <div class="col-md-6">
 
                 <div class="form-group">

--- a/client/src/partials/patients/edit/edit.html
+++ b/client/src/partials/patients/edit/edit.html
@@ -38,7 +38,7 @@
             {{ "PATIENT_EDIT.FINANCIAL_INFO" | translate }}
           </div>
           <div class="panel-body">
-            <form name="finance" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="finance" bh-form-defaults novalidate>
 
               <!-- Patient Group -->
               <div class="form-group">
@@ -92,7 +92,7 @@
 
       <div class="col-md-7 col-md-pull-5">
 
-        <form name="patientDetails" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+        <form name="patientDetails" bh-form-defaults novalidate>
           <div class="panel panel-default">
             <div class="panel-heading">
               {{ "FORM.LABELS.PATIENT_DETAILS" | translate }}
@@ -120,7 +120,7 @@
                     <input id="second-name" class="form-control" ng-maxlength="PatientEditCtrl.length150" name="last_name" ng-model="PatientEditCtrl.medical.last_name" required>
                     <div class="help-block" ng-messages="patientDetails.last_name.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                    
+                    </div>
                   </div>
                 </div>
 
@@ -134,7 +134,7 @@
                     <input id="middle-name" class="form-control" name="middle_name" ng-maxlength="PatientEditCtrl.length150" ng-model="PatientEditCtrl.medical.middle_name" required>
                     <div class="help-block" ng-messages="patientDetails.middle_name.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                     
+                    </div>
                   </div>
                 </div>
 
@@ -148,7 +148,7 @@
                     <input id="new-first-name" class="form-control" name="firstName" ng-maxlength="PatientEditCtrl.length150" ng-model="PatientEditCtrl.medical.first_name">
                     <div class="help-block" ng-messages="patientDetails.firstName.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                     
+                    </div>
                   </div>
                 </div>
 
@@ -172,7 +172,7 @@
                       required>
                     <div class="help-block" ng-messages="patientDetails.hospital_no.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                      
+                    </div>
                     <span ng-if="patientDetails.$error.hospitalNumber" class="glyphicon glyphicon-remove form-control-feedback"></span>
                     <span ng-if="patientDetails.$pending.hospitalNumber"  class="glyphicon glyphicon-hourglass form-control-feedback"></span>
                     <!-- <p ng-if="patientDetails.$pending.hospitalNumber" class="help-block">Checking hospital number is unique...</p> -->
@@ -259,7 +259,7 @@
                     <input type="text" name="title" ng-maxlength="PatientEditCtrl.length30" class="form-control" id="title" ng-model="PatientEditCtrl.medical.title">
                     <div class="help-block" ng-messages="patientDetails.title.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                     
+                    </div>
                   </div>
                 </div>
 
@@ -269,7 +269,7 @@
                     <input type="text" class="form-control" id="form-control" ng-maxlength="PatientEditCtrl.length12" name="phone" ng-model="PatientEditCtrl.medical.phone">
                     <div class="help-block" ng-messages="patientDetails.phone.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                     
+                    </div>
                   </div>
                 </div>
 
@@ -279,7 +279,7 @@
                     <input type="email" class="form-control" id="email" name="email" ng-maxlength="PatientEditCtrl.length40" ng-model="PatientEditCtrl.medical.email">
                     <div class="help-block" ng-messages="patientDetails.email.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                    
+                    </div>
                   </div>
                 </div>
 
@@ -289,7 +289,7 @@
                     <input type="text" class="form-control" id="address1" name="address_1" ng-maxlength="PatientEditCtrl.length40" ng-model="PatientEditCtrl.medical.address_1">
                     <div class="help-block" ng-messages="patientDetails.address_1.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                     
+                    </div>
                   </div>
                 </div>
 
@@ -299,7 +299,7 @@
                     <input type="text" class="form-control" name="address_2" id="address2" ng-maxlength="PatientEditCtrl.length40" ng-model="PatientEditCtrl.medical.address_2">
                     <div class="help-block" ng-messages="patientDetails.address_2.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                     
+                    </div>
                   </div>
                 </div>
 
@@ -309,7 +309,7 @@
                     <input type="text" class="form-control" name="father_name" ng-maxlength="PatientEditCtrl.length150" id="father_name" ng-model="PatientEditCtrl.medical.father_name">
                     <div class="help-block" ng-messages="patientDetails.father_name.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                    
+                    </div>
                   </div>
                 </div>
 
@@ -319,7 +319,7 @@
                     <input type="text" class="form-control" id="mother_name" ng-maxlength="PatientEditCtrl.length150" name="mother_name" ng-model="PatientEditCtrl.medical.mother_name">
                     <div class="help-block" ng-messages="patientDetails.mother_name.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                    
+                    </div>
                   </div>
                 </div>
 
@@ -329,7 +329,7 @@
                     <input type="text" class="form-control" id="religion" ng-maxlength="PatientEditCtrl.length50" name="religion" ng-model="PatientEditCtrl.medical.religion">
                     <div class="help-block" ng-messages="patientDetails.religion.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                     
+                    </div>
                   </div>
                 </div>
 
@@ -339,7 +339,7 @@
                     <input type="text" class="form-control" id="marital" ng-maxlength="PatientEditCtrl.length50" name="marital_status" ng-model="PatientEditCtrl.medical.marital_status">
                     <div class="help-block" ng-messages="patientDetails.marital.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                     
+                    </div>
                   </div>
                 </div>
 
@@ -349,7 +349,7 @@
                     <input type="text" class="form-control" id="profession" ng-maxlength="PatientEditCtrl.length150" name="profession" ng-model="PatientEditCtrl.medical.profession">
                     <div class="help-block" ng-messages="patientDetails.profession.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                    
+                    </div>
                   </div>
                 </div>
 
@@ -359,7 +359,7 @@
                     <input type="text" class="form-control" id="employer" ng-maxlength="PatientEditCtrl.length150" name="employer" ng-model="PatientEditCtrl.medical.employer">
                     <div class="help-block" ng-messages="patientDetails.employer.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                     
+                    </div>
                   </div>
                 </div>
 
@@ -369,7 +369,7 @@
                     <input type="text" class="form-control" id="spouse" ng-maxlength="PatientEditCtrl.length150" name="spouse" ng-model="PatientEditCtrl.medical.spouse">
                     <div class="help-block" ng-messages="patientDetails.spouse.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                     
+                    </div>
                   </div>
                 </div>
 
@@ -379,7 +379,7 @@
                     <input type="text" class="form-control" id="spouse_profession" ng-maxlength="PatientEditCtrl.length150" name="spouse_profession" ng-model="PatientEditCtrl.medical.spouse_profession">
                     <div class="help-block" ng-messages="patientDetails.spouse_profession.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                    
+                    </div>
                   </div>
                 </div>
 
@@ -389,7 +389,7 @@
                     <input type="text" class="form-control" id="spouse_employer" ng-maxlength="PatientEditCtrl.length150" name="spouse_employer" ng-model="PatientEditCtrl.medical.spouse_employer">
                     <div class="help-block" ng-messages="patientDetails.spouse_employer.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                     
+                    </div>
                   </div>
                 </div>
 
@@ -399,7 +399,7 @@
                     <textarea class="form-control" id="notes" name="notes" ng-maxlength="PatientEditCtrl.maxLength" ng-model="PatientEditCtrl.medical.notes" rows="4"></textarea>
                     <div class="help-block" ng-messages="patientDetails.notes.$error" ng-show="patientDetails.$submitted">
                       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                    </div>                     
+                    </div>
                   </div>
                 </div>
               </div>

--- a/client/src/partials/patients/edit/updateDebtorGroup.tmpl.html
+++ b/client/src/partials/patients/edit/updateDebtorGroup.tmpl.html
@@ -7,7 +7,7 @@
   <p class="text-info">
   {{ "FORM.INFOS.GROUPS_DEBTOR" | translate }}
   </p>
-  <form name="groupForm" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+  <form name="groupForm" bh-form-defaults novalidate>
     <div class="form-group has-feedback">
 
       <label for="debtor-group" class="control-label">{{ "FORM.LABELS.GROUPS_DEBTOR_TITLE" | translate }}</label>

--- a/client/src/partials/patients/edit/updatePatientGroups.tmpl.html
+++ b/client/src/partials/patients/edit/updatePatientGroups.tmpl.html
@@ -11,7 +11,7 @@
   {{ "PATIENT_EDIT.WARN" | translate }}
   </p>
 
-  <form name="groupForm" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+  <form name="groupForm" bh-form-defaults novalidate>
     <div class="form-group has-feedback">
 
       <label class="control-label">{{ "FORM.LABELS.GROUPS_PATIENT_TITLE" | translate }}</label>

--- a/client/src/partials/patients/groups/groups.html
+++ b/client/src/partials/patients/groups/groups.html
@@ -70,7 +70,7 @@
             </div>
 
             <div class="panel-body">
-              <form name="CreateForm" bh-submit="PatientGroupCtrl.submit(CreateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate data-create-form>
+              <form name="CreateForm" bh-submit="PatientGroupCtrl.submit(CreateForm)" bh-form-defaults novalidate data-create-form>
 
                 <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.name.$invalid }">
                   <label class="control-label">
@@ -130,7 +130,7 @@
             </div>
 
             <div class="panel-body">
-              <form bh-submit="PatientGroupCtrl.submit(UpdateForm)" name="UpdateForm" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate data-update-form>
+              <form bh-submit="PatientGroupCtrl.submit(UpdateForm)" name="UpdateForm" bh-form-defaults novalidate data-update-form>
                 <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.name.$invalid }">
                   <label class="control-label">
                     {{ "FORM.LABELS.NAME" | translate }}

--- a/client/src/partials/patients/registration/registration.html
+++ b/client/src/partials/patients/registration/registration.html
@@ -14,9 +14,7 @@
     <form
       name="PatientRegistrationForm"
       bh-submit="PatientRegCtrl.submit(PatientRegistrationForm)"
-      autocomplete="off"
-      autocapitalize="off"
-      autocorrect="off"
+      bh-form-defaults
       novalidate>
 
       <div class="row">
@@ -84,7 +82,6 @@
                       <input
                         name="hospitalNumber"
                         class="form-control"
-                        autocomplete="off"
                         ng-model="PatientRegCtrl.medical.hospital_no"
                         bh-unique="/patients/hospital_number"
                         ng-maxlength="PatientRegCtrl.length150"

--- a/client/src/partials/patients/registry/search.modal.html
+++ b/client/src/partials/patients/registry/search.modal.html
@@ -1,10 +1,8 @@
 <form
   name="ModalForm"
   ng-submit="ModalCtrl.submit(ModalForm)"
-  autocomplete="off"
-  autocapitalize="off"
-  autocorrect="off"
   data-modal="patient-search"
+  bh-form-defaults
   novalidate>
 
   <div class="modal-header">

--- a/client/src/partials/permissions/permissions.html
+++ b/client/src/partials/permissions/permissions.html
@@ -33,7 +33,7 @@
         <h4>{{ "PERMISSIONS.DESCRIPTION" | translate }}</h4>
       </div>
 
-      <!-- triggered on successful form creation --> 
+      <!-- triggered on successful form creation -->
       <div ng-switch-when="success">
         <uib-alert type="success" data-create-success>
           <span class="glyphicon glyphicon-ok"></span> {{ PermissionsCtrl.formMessage.code | translate }}
@@ -46,7 +46,7 @@
           <div class="panel-heading">
             {{ "PERMISSIONS.ADDING_USER" | translate }}
           </div>
-          <form class="panel-body" name="CreateForm" ng-submit="PermissionsCtrl.submit(CreateForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+          <form class="panel-body" name="CreateForm" ng-submit="PermissionsCtrl.submit(CreateForm.$invalid)" bh-form-defaults novalidate>
             <fieldset>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.firstname.$invalid }">
@@ -123,16 +123,16 @@
               </div>
             </fieldset>
           </form>
-        </div>  
-      </div> 
-      
+        </div>
+      </div>
+
       <div ng-switch-when="update">
         <div class="panel panel-primary">
           <div class="panel-heading">
             {{ "PERMISSIONS.UPDATING_USER" | translate }}
           </div>
 
-          <form class="panel-body" name="UpdateForm" ng-submit="PermissionsCtrl.submit(UpdateForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+          <form class="panel-body" name="UpdateForm" ng-submit="PermissionsCtrl.submit(UpdateForm.$invalid)" bh-form-defaults novalidate>
             <fieldset>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.firstname.$invalid }">
@@ -203,7 +203,7 @@
             </fieldset>
           </form>
         </div>
-      </div> 
+      </div>
 
       <div ng-switch-when="permissions">
         <div class="panel panel-primary">

--- a/client/src/partials/permissions/permissionsPasswordModalTemplate.html
+++ b/client/src/partials/permissions/permissionsPasswordModalTemplate.html
@@ -2,7 +2,7 @@
   <h4>{{ 'PERMISSIONS.SET_PASSWORD' | translate }}</h4>
 </div>
 
-<form class="modal-body" name="PasswordForm" ng-submit="ModalCtrl.submit(PasswordForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+<form class="modal-body" name="PasswordForm" ng-submit="ModalCtrl.submit(PasswordForm.$invalid)" bh-form-defaults novalidate>
   <div class="form-group has-feedback" ng-class="{ 'has-error' : PasswordForm.$submitted && !ModalCtrl.validPassword() }">
     <label class="control-label">{{ "FORM.LABELS.PASSWORD" | translate }}</label>
     <input name="password" ng-model="ModalCtrl.user.password" class="form-control" type="password" required>

--- a/client/src/partials/price_list/modal.html
+++ b/client/src/partials/price_list/modal.html
@@ -1,4 +1,4 @@
-<form  name="ModalForm" ng-submit="ModalCtrl.submit(ModalForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+<form  name="ModalForm" ng-submit="ModalCtrl.submit(ModalForm.$invalid)" bh-form-defaults novalidate>
   <div class="modal-header">
     <h4>{{ 'PRICE_LIST.PRICE_LIST_ITEMS' | translate }}</h4>
   </div>
@@ -10,7 +10,7 @@
       <input type="text" class="form-control" name="label" ng-maxlength="ModalCtrl.length250" ng-model="ModalCtrl.data.label" required>
       <div class="help-block" ng-messages="ModalForm.label.$error" ng-show="ModalForm.$submitted">
         <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-      </div>      
+      </div>
     </div>
 
     <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.value.$invalid }">
@@ -18,13 +18,13 @@
       <input type="number" class="form-control" name="value" ng-model="ModalCtrl.data.value" required>
       <div class="help-block" ng-messages="ModalForm.value.$error" ng-show="ModalForm.$submitted">
         <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-      </div>      
+      </div>
     </div>
 
     <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.is_percentage.$invalid }">
       <label class="control-label">
         <input type="checkbox"  name="is_percentage" id="is_percentage" ng-true-value="1" ng-false-value="0" ng-model="ModalCtrl.data.is_percentage">  {{ 'FORM.LABELS.IS_PERCENT' | translate }}
-      </label>  
+      </label>
     </div>
 
     <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.inventory_uuid.$invalid }">
@@ -34,7 +34,7 @@
       </select>
       <div class="help-block" ng-messages="ModalForm.inventory_uuid.$error" ng-show="ModalForm.$submitted">
         <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-      </div>      
+      </div>
     </div>
 
   </div>

--- a/client/src/partials/price_list/pricelist.html
+++ b/client/src/partials/price_list/pricelist.html
@@ -9,7 +9,7 @@
 
 <div class="flex-util">
   <button class="btn btn-sm btn-default" id="create" ng-click="PriceListCtrl.create()" data-method="create">
-    <span class="glyphicon glyphicon-plus-sign"></span> {{ "PRICE_LIST.NEW_PRICE_LIST" | translate }} 
+    <span class="glyphicon glyphicon-plus-sign"></span> {{ "PRICE_LIST.NEW_PRICE_LIST" | translate }}
   </button>
 </div>
 
@@ -28,7 +28,7 @@
             <thead>
               <tr ng-if="PriceListCtrl.loading" class="text-center">
                 <td colspan="3"><loading-indicator></loading-indicator></td>
-              </tr>            
+              </tr>
               <tr>
                 <th>{{ "TABLE.COLUMNS.DESCRIPTION" | translate }}</th>
                 <th colspan="2" style="width: 20%;">{{ "TABLE.COLUMNS.ACTION" | translate }}</th>
@@ -42,7 +42,7 @@
               </tr>
               <tr ng-if="PriceListCtrl.priceList.data.length===0">
                 <td colspan="3"><i>{{ 'PRICE_LIST.NO_RECORDS' | translate }}</i></tr>
-              </tr>            
+              </tr>
             </tbody>
           </table>
         </div>
@@ -56,7 +56,7 @@
             <ul style="list-style-type: none; padding-left: 15px;">
               <li><i class="glyphicon glyphicon-pencil"></i> {{ "PRICE_LIST.HELP_TXT_2" | translate }}</li>
               <li><i class="glyphicon glyphicon-trash"></i> {{ "PRICE_LIST.HELP_TXT_3" | translate }}</li>
-            </ul>      
+            </ul>
           </div>
         </div>
 
@@ -87,14 +87,14 @@
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ "PRICE_LIST.ADD_PRICE_LIST" | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="PriceListCtrl.submit(CreateForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="CreateForm" ng-submit="PriceListCtrl.submit(CreateForm.$invalid)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.label.$invalid }">
                 <label class="control-label">{{ 'FORM.LABELS.DESIGNATION' | translate }}</label>
                 <input type="text" class="form-control" ng-maxlength="PriceListCtrl.length250" name="label" ng-model="PriceListCtrl.priceList.label" required>
                 <div class="help-block" ng-messages="CreateForm.label.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.description.$invalid }">
@@ -102,15 +102,15 @@
                 <textarea class="form-control" name="description" ng-maxlength="PriceListCtrl.maxLength" id="description" ng-model="PriceListCtrl.priceList.description" rows="3"></textarea>
                 <div class="help-block" ng-messages="CreateForm.description.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
-              
+
               <hr>
               <div class="form-group">
                   <a class="btn btn-xs btn-default" id="add_item" ng-click="PriceListCtrl.addItem()">
                     <span class="glyphicon glyphicon-plus"></span>{{'PRICE_LIST.ADD_ITEMS' | translate}}
                   </a>
-              </div> 
+              </div>
 
               <table class="table table-condensed">
                 <thead>
@@ -129,9 +129,9 @@
                     <td> <span class="glyphicon" ng-class="{'glyphicon-ok' : !!item.is_percentage}"></span> </td>
                     <td> {{ PriceListCtrl.getInventory(item.inventory_uuid) }} </td>
                     <td colspan="6"><a class="btn btn-xs btn-default" id="remove_item_{{$index+1}}" ng-click="PriceListCtrl.removeItem(item)" ><i class="glyphicon glyphicon-trash"></i></a></td>
-                  </tr> 
+                  </tr>
                 </tbody>
-              </table>              
+              </table>
               <hr>
 
               <div class="form-group">
@@ -143,20 +143,20 @@
                 </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
 
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ 'PRICE_LIST.UPDATE' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="UpdateForm" ng-submit="PriceListCtrl.submit(UpdateForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="UpdateForm" ng-submit="PriceListCtrl.submit(UpdateForm.$invalid)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.label.$invalid }">
                 <label class="control-label">{{ 'FORM.LABELS.DESIGNATION' | translate }}</label>
                 <input type="text" class="form-control" name="label" ng-maxlength="PriceListCtrl.length250" ng-model="PriceListCtrl.priceList.label" required>
                 <div class="help-block" ng-messages="UpdateForm.label.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>               
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.description.$invalid }">
@@ -164,16 +164,16 @@
                 <textarea class="form-control" name="description" ng-maxlength="PriceListCtrl.maxLength" id="description" ng-model="PriceListCtrl.priceList.description" rows="3"></textarea>
                 <div class="help-block" ng-messages="UpdateForm.description.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                  
+                </div>
               </div>
 
-              
+
               <hr>
               <div class="form-group">
                   <a class="btn btn-xs btn-default" id="add_item" ng-click="PriceListCtrl.addItem()">
                     <span class="glyphicon glyphicon-plus"></span>{{'PRICE_LIST.ADD_ITEMS' | translate}}
                   </a>
-              </div>            
+              </div>
               <table class="table table-condensed">
                 <thead>
                   <tr>
@@ -184,16 +184,16 @@
                     <th colspan="6">{{ "TABLE.COLUMNS.ACTION" | translate }}</th>
                   </tr>
                 </thead>
-                <tbody>                
+                <tbody>
                   <tr ng-repeat="item in PriceListCtrl.pricelistItems | orderBy:'label'">
                     <td> {{ item.label }} </td>
                     <td> {{ item.value }} </td>
                     <td> <span class="glyphicon" ng-class="{'glyphicon-ok' : !!item.is_percentage}"></span> </td>
                     <td> {{ PriceListCtrl.getInventory(item.inventory_uuid) }} </td>
                     <td colspan="6"><a class="btn btn-xs btn-default" id="remove_item_{{$index+1}}" ng-click="PriceListCtrl.removeItem(item)" ><i class="glyphicon glyphicon-trash"></i></a></td>
-                  </tr> 
+                  </tr>
                 </tbody>
-              </table>              
+              </table>
               <hr>
 
               <div class="form-group">
@@ -205,9 +205,9 @@
                 </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/projects/projects.html
+++ b/client/src/partials/projects/projects.html
@@ -70,9 +70,7 @@
             <form
               name="CreateForm"
               bh-submit="ProjectCtrl.submit(CreateForm)"
-              autocomplete="off"
-              autocapitalize="off"
-              autocorrect="off"
+              bh-form-defaults
               novalidate>
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.name.$invalid }">
                 <label class="control-label">{{ 'FORM.LABELS.NAME' | translate }}</label>
@@ -148,9 +146,7 @@
             <form
               name="UpdateForm"
               bh-submit="ProjectCtrl.submit(UpdateForm)"
-              autocomplete="off"
-              autocapitalize="off"
-              autocorrect="off"
+              bh-form-defaults
               novalidate>
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.name.$invalid }">
                 <label class="control-label">{

--- a/client/src/partials/references/groups/groups.html
+++ b/client/src/partials/references/groups/groups.html
@@ -32,7 +32,7 @@
                 <th>{{ "TABLE.COLUMNS.REFERENCE_GROUP" | translate}}</th>
                 <th>{{ "TABLE.COLUMNS.LABEL" | translate}}</th>
                 <th>{{ "TABLE.COLUMNS.POSITION" | translate}}</th>
-                <th>{{ "TABLE.COLUMNS.BALANCE_SECTION" | translate}}</th> 
+                <th>{{ "TABLE.COLUMNS.BALANCE_SECTION" | translate}}</th>
                 <th colspan="2">{{ "TABLE.COLUMNS.ACTION" | translate }}</th>
               </tr>
             </thead>
@@ -40,8 +40,8 @@
               <tr ng-if="ReferenceGroupCtrl.session.loading" class="text-center">
                 <td colspan="7"><loading-indicator></loading-indicator></td>
               </tr>
-              <tr 
-              ng-repeat="ref in ReferenceGroupCtrl.referenceGroups | orderBy:'number' | orderBy:'text' " 
+              <tr
+              ng-repeat="ref in ReferenceGroupCtrl.referenceGroups | orderBy:'number' | orderBy:'text' "
               ng-class="{'rowSelected' : ReferenceGroupCtrl.referenceGroup.id === ref.id}" >
                 <td>{{$index + 1}}</td>
                 <td>{{ ref.reference_group }}</td>
@@ -53,7 +53,7 @@
               </tr>
               <tr ng-if="!ReferenceGroupCtrl.referenceGroups.length">
                 <td colspan="6">{{ "REFERENCE_GROUP.NO_REFERENCES" | translate }}</td>
-              </tr> 
+              </tr>
 
             </tbody>
           </table>
@@ -92,14 +92,14 @@
           <div class="alert alert-danger" id="delete_error">
             <h4>{{ ReferenceGroupCtrl.HTTPError.data.code | translate }} </h4>
           </div>
-        </div>        
+        </div>
 
         <!-- Form for adding referenceGroup -->
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ "REFERENCE_GROUP.NEW_REFERENCE" | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="ReferenceGroupCtrl.submit(CreateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
-            
+            <form name="CreateForm" ng-submit="ReferenceGroupCtrl.submit(CreateForm)" bh-form-defaults novalidate>
+
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.reference_group.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.REFERENCE_GROUP" | translate }}</label>
                 <input type="text" class="form-control" name="reference_group" ng-maxlength="ReferenceGroupCtrl.referenceAbbrLength" ng-model="ReferenceGroupCtrl.referenceGroup.reference_group" required>
@@ -107,13 +107,13 @@
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
                 </div>
               </div>
-            
+
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.text.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.LABEL" | translate }}</label>
                 <input type="text" class="form-control" ng-maxlength="ReferenceGroupCtrl.maxLength" name="text" ng-model="ReferenceGroupCtrl.referenceGroup.text" required>
                 <div class="help-block" ng-messages="CreateForm.text.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <hr>
@@ -123,23 +123,23 @@
                 <input type="number" class="form-control"  min="0" name="position" ng-model="ReferenceGroupCtrl.referenceGroup.position" required>
                 <div class="help-block" ng-messages="CreateForm.position.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.section_bilan_id.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.BALANCE_SECTION" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="section_bilan_id" 
-                  ng-model="ReferenceGroupCtrl.referenceGroup.section_bilan_id" 
-                  id="section_bilan_id"  
+                <select
+                  class="form-control"
+                  name="section_bilan_id"
+                  ng-model="ReferenceGroupCtrl.referenceGroup.section_bilan_id"
+                  id="section_bilan_id"
                   ng-options="section.id as section.text for section in ReferenceGroupCtrl.sectionBilans"
                   required>
                   <option value="" disabled> -- {{ "FORM.SELECTS.SELECT_BALANCE_SECTION" | translate }} -- </option>
                 </select>
                 <div class="help-block" ng-messages="CreateForm.section_bilan_id.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                  
+                </div>
               </div>
 
               <div class="form-group">
@@ -151,29 +151,29 @@
                 </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
 
         <!-- Form for updating referenceGroup -->
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ "REFERENCE_GROUP.UPD_REFERENCE" | translate }} </b> </div>
           <div class="panel-body">
-            <form class="panel-body" name="UpdateForm" ng-submit="ReferenceGroupCtrl.submit(UpdateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="UpdateForm" ng-submit="ReferenceGroupCtrl.submit(UpdateForm)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.reference_group.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.REFERENCE_GROUP" | translate }}</label>
                 <input type="text" class="form-control" name="reference_group" ng-maxlength="ReferenceGroupCtrl.referenceAbbrLength" ng-model="ReferenceGroupCtrl.referenceGroup.reference_group" required>
                 <div class="help-block" ng-messages="UpdateForm.reference_group.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
-            
+
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.text.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.LABEL" | translate }}</label>
                 <input type="text" class="form-control" name="text" ng-maxlength="ReferenceGroupCtrl.maxLength" ng-model="ReferenceGroupCtrl.referenceGroup.text" required>
                 <div class="help-block" ng-messages="UpdateForm.text.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <hr>
@@ -183,22 +183,22 @@
                 <input type="number" class="form-control"  min="0" name="position" ng-model="ReferenceGroupCtrl.referenceGroup.position" required>
                 <div class="help-block" ng-messages="UpdateForm.referenceGroup.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>               
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.section_bilan_id.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.BALANCE_SECTION" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="section_bilan_id" 
-                  ng-model="ReferenceGroupCtrl.referenceGroup.section_bilan_id" 
-                  id="section_bilan_id"  
+                <select
+                  class="form-control"
+                  name="section_bilan_id"
+                  ng-model="ReferenceGroupCtrl.referenceGroup.section_bilan_id"
+                  id="section_bilan_id"
                   ng-options="section.id as section.text for section in ReferenceGroupCtrl.sectionBilans" required>
                   <option value="" disabled> -- {{ "FORM.LABELS.BALANCE_SECTION" | translate }} -- </option>
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.section_bilan_id.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group">
@@ -209,12 +209,12 @@
                   {{ "FORM.BUTTONS.RESET" | translate }}
                 </button>
               </div>
-              
+
             </form>
-          </div>         
+          </div>
         </div>
 
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/references/references.html
+++ b/client/src/partials/references/references.html
@@ -41,8 +41,8 @@
               <tr ng-if="ReferenceCtrl.session.loading" class="text-center">
                 <td colspan="8"><loading-indicator></loading-indicator></td>
               </tr>
-              <tr 
-              ng-repeat="reference in ReferenceCtrl.references | orderBy:'number' | orderBy:'text' " 
+              <tr
+              ng-repeat="reference in ReferenceCtrl.references | orderBy:'number' | orderBy:'text' "
               ng-class="{'rowSelected' : ReferenceCtrl.reference.id === reference.id}" >
                 <td>{{$index + 1}}</td>
                 <td>{{ reference.ref }}</td>
@@ -55,7 +55,7 @@
               </tr>
               <tr ng-if="!ReferenceCtrl.references.length">
                 <td colspan="8">{{ "REFERENCE.NO_REFERENCES" | translate }}</td>
-              </tr> 
+              </tr>
             </tbody>
           </table>
         </div>
@@ -93,28 +93,28 @@
           <div class="alert alert-danger" id="delete_error">
             <h4>{{ ReferenceCtrl.HTTPError.data.code | translate }} </h4>
           </div>
-        </div>        
+        </div>
 
         <!-- Form for adding reference -->
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ "REFERENCE.NEW_REFERENCE" | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="ReferenceCtrl.submit(CreateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
-            
+            <form name="CreateForm" ng-submit="ReferenceCtrl.submit(CreateForm)" bh-form-defaults novalidate>
+
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.ref.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.REFERENCE" | translate }}</label>
                 <input type="text" class="form-control" name="ref" ng-maxlength="ReferenceCtrl.referenceAbbrLength" ng-model="ReferenceCtrl.reference.ref" required>
                 <div class="help-block" ng-messages="CreateForm.ref.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
-            
+
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.text.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.LABEL" | translate }}</label>
                 <input type="text" class="form-control" ng-maxlength="ReferenceCtrl.maxLength" name="text" ng-model="ReferenceCtrl.reference.text" required>
                 <div class="help-block" ng-messages="CreateForm.text.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.position.$invalid }">
@@ -122,27 +122,27 @@
                 <input type="number" class="form-control"  min="0" name="position" ng-model="ReferenceCtrl.reference.position" required>
                 <div class="help-block" ng-messages="CreateForm.position.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <hr>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.is_report.$invalid }">
                 <label class="control-label">
-                  <input type="checkbox"  name="is_report" id="is_report" ng-true-value="1" ng-false-value="0" 
+                  <input type="checkbox"  name="is_report" id="is_report" ng-true-value="1" ng-false-value="0"
                     ng-model="ReferenceCtrl.reference.is_report">  {{ 'FORM.LABELS.IS_REPORT' | translate }}
-                </label>  
-              </div> 
+                </label>
+              </div>
 
               <hr>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.reference_group_id.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.REFERENCE_GROUP" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="reference_group_id" 
-                  ng-model="ReferenceCtrl.reference.reference_group_id" 
-                  id="reference_group_id"  
+                <select
+                  class="form-control"
+                  name="reference_group_id"
+                  ng-model="ReferenceCtrl.reference.reference_group_id"
+                  id="reference_group_id"
                   ng-options="reference.id as reference.text for reference in ReferenceCtrl.referenceGroups"
                   >
                   <option value=""> -- {{ "FORM.SELECTS.SELECT_REFERENCE_GROUP" | translate }} -- </option>
@@ -151,11 +151,11 @@
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.section_resultat_id.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.RESULT_ACCOUNT_SCT" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="section_resultat_id" 
-                  ng-model="ReferenceCtrl.reference.section_resultat_id" 
-                  id="section_resultat_id"  
+                <select
+                  class="form-control"
+                  name="section_resultat_id"
+                  ng-model="ReferenceCtrl.reference.section_resultat_id"
+                  id="section_resultat_id"
                   ng-options="section.id as section.text for section in ReferenceCtrl.sectionResultats"
                   >
                   <option value=""> -- {{ "FORM.SELECTS.SELECT_RESULT_ACCOUNT_SCT" | translate }} -- </option>
@@ -171,29 +171,29 @@
                 </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
 
         <!-- Form for updating reference -->
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ "REFERENCE.UPD_REFERENCE" | translate }} </b> </div>
           <div class="panel-body">
-            <form class="panel-body" name="UpdateForm" ng-submit="ReferenceCtrl.submit(UpdateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="UpdateForm" ng-submit="ReferenceCtrl.submit(UpdateForm)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.ref.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.REFERENCE" | translate }}</label>
                 <input type="text" class="form-control" name="ref" ng-maxlength="ReferenceCtrl.referenceAbbrLength" ng-model="ReferenceCtrl.reference.ref" required>
                 <div class="help-block" ng-messages="UpdateForm.ref.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
-            
+
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.text.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.LABEL" | translate }}</label>
                 <input type="text" class="form-control" name="text" ng-maxlength="ReferenceCtrl.maxLength"  ng-model="ReferenceCtrl.reference.text" required>
                 <div class="help-block" ng-messages="UpdateForm.text.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                  
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.position.$invalid }">
@@ -201,27 +201,27 @@
                 <input type="number" class="form-control"  min="0" name="position" ng-model="ReferenceCtrl.reference.position" required>
                 <div class="help-block" ng-messages="UpdateForm.position.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                  
+                </div>
               </div>
 
               <hr>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.is_report.$invalid }">
                 <label class="control-label">
-                  <input type="checkbox"  name="is_report" id="is_report" ng-true-value="1" ng-false-value="0" 
+                  <input type="checkbox"  name="is_report" id="is_report" ng-true-value="1" ng-false-value="0"
                     ng-model="ReferenceCtrl.reference.is_report">  {{ 'FORM.LABELS.IS_REPORT' | translate }}
-                </label>  
-              </div> 
+                </label>
+              </div>
 
               <hr>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.reference_group_id.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.REFERENCE_GROUP" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="reference_group_id" 
-                  ng-model="ReferenceCtrl.reference.reference_group_id" 
-                  id="reference_group_id"  
+                <select
+                  class="form-control"
+                  name="reference_group_id"
+                  ng-model="ReferenceCtrl.reference.reference_group_id"
+                  id="reference_group_id"
                   ng-options="reference.id as reference.text for reference in ReferenceCtrl.referenceGroups"
                   >
                   <option value=""> -- {{ "FORM.SELECTS.SELECT_REFERENCE_GROUP" | translate }} -- </option>
@@ -230,11 +230,11 @@
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.section_resultat_id.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.RESULT_ACCOUNT_SCT" | translate }}</label>
-                <select 
-                  class="form-control" 
-                  name="section_resultat_id" 
-                  ng-model="ReferenceCtrl.reference.section_resultat_id" 
-                  id="section_resultat_id"  
+                <select
+                  class="form-control"
+                  name="section_resultat_id"
+                  ng-model="ReferenceCtrl.reference.section_resultat_id"
+                  id="section_resultat_id"
                   ng-options="section.id as section.text for section in ReferenceCtrl.sectionResultats"
                   >
                   <option value=""> -- {{ "FORM.SELECTS.SELECT_RESULT_ACCOUNT_SCT" | translate }} -- </option>
@@ -248,12 +248,12 @@
                   {{ "FORM.BUTTONS.CANCEL" | translate }}
                 </button>
               </div>
-              
+
             </form>
-          </div>         
+          </div>
         </div>
 
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/section_bilan/section_bilan.html
+++ b/client/src/partials/section_bilan/section_bilan.html
@@ -107,7 +107,7 @@
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ "SECTION_BILAN.NEW" | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="sectionBilanCtrl.submit(CreateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="CreateForm" ng-submit="sectionBilanCtrl.submit(CreateForm)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.text.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>
@@ -160,7 +160,7 @@
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ 'SECTION_BILAN.EDIT' | translate }} </b> </div>
           <div class="panel-body">
-            <form class="panel-body" name="UpdateForm" ng-submit="sectionBilanCtrl.submit(UpdateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="UpdateForm" ng-submit="sectionBilanCtrl.submit(UpdateForm)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.text.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>

--- a/client/src/partials/section_resultat/section_resultat.html
+++ b/client/src/partials/section_resultat/section_resultat.html
@@ -39,13 +39,13 @@
               <tr ng-if="sectionResultatCtrl.session.loading" class="text-center">
                 <td colspan="6"><loading-indicator></loading-indicator></td>
               </tr>
-              <tr 
-              ng-repeat="sectionResultat in sectionResultatCtrl.sectionResultats | orderBy:'number' | orderBy:'text' " 
+              <tr
+              ng-repeat="sectionResultat in sectionResultatCtrl.sectionResultats | orderBy:'number' | orderBy:'text' "
               ng-class="{'rowSelected' : sectionResultatCtrl.sectionResultat.id === sectionResultat.id}" >
                 <td>{{ $index+1 }}</td>
                 <td>{{ sectionResultat.text }}</td>
                 <td>{{sectionResultat.position}}</td>
-                <td>                  
+                <td>
                   <b ng-show="sectionResultat.is_charge">{{sectionResultatCtrl.doTranslate('TABLE.COLUMNS.CHARGE')}}</b>
                   <b ng-show="!sectionResultat.is_charge">{{sectionResultatCtrl.doTranslate('TABLE.COLUMNS.PROFIT')}}</b>
                 </td>
@@ -54,7 +54,7 @@
               </tr>
               <tr ng-if="!sectionResultatCtrl.sectionResultats.length">
                 <td colspan="6">{{ "SECTION_RESULTAT.NO_SECTION_RESULTAT" | translate }}</td>
-              </tr> 
+              </tr>
 
             </tbody>
           </table>
@@ -93,20 +93,20 @@
           <div class="alert alert-danger" id="delete_error">
             <h4>{{ sectionResultatCtrl.HTTPError.data.code | translate }} </h4>
           </div>
-        </div>        
+        </div>
 
         <!-- Form for adding sectionResultat -->
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ "SECTION_RESULTAT.NEW" | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="sectionResultatCtrl.submit(CreateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
-            
+            <form name="CreateForm" ng-submit="sectionResultatCtrl.submit(CreateForm)" bh-form-defaults novalidate>
+
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.text.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>
                 <input type="text" class="form-control" name="text" ng-maxlength="sectionResultatCtrl.maxLength" ng-model="sectionResultatCtrl.sectionResultat.text" required>
                 <div class="help-block" ng-messages="CreateForm.text.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.is_charge.$invalid }">
@@ -124,7 +124,7 @@
                 </div>
                 <div class="help-block" ng-messages="CreateForm.is_charge.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
               <hr>
 
@@ -133,7 +133,7 @@
                 <input type="number" class="form-control"  min="0" name="position" ng-model="sectionResultatCtrl.sectionResultat.position" required>
                 <div class="help-block" ng-messages="CreateForm.position.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group">
@@ -145,21 +145,21 @@
                 </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
 
         <!-- Form for updating sectionResultat -->
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ 'SECTION_RESULTAT.EDIT' | translate }} </b> </div>
           <div class="panel-body">
-            <form class="panel-body" name="UpdateForm" ng-submit="sectionResultatCtrl.submit(UpdateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="UpdateForm" ng-submit="sectionResultatCtrl.submit(UpdateForm)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.text.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>
                 <input type="text" class="form-control" name="text" ng-maxlength="sectionResultatCtrl.maxLength" ng-model="sectionResultatCtrl.sectionResultat.text" required>
                 <div class="help-block" ng-messages="UpdateForm.text.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.is_charge.$invalid }">
@@ -177,7 +177,7 @@
                 </div>
                 <div class="help-block" ng-messages="UpdateForm.is_charge.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
               <hr>
 
@@ -186,7 +186,7 @@
                 <input type="number" class="form-control"  min="0" name="position" ng-model="sectionResultatCtrl.sectionResultat.position" required>
                 <div class="help-block" ng-messages="UpdateForm.position.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group">
@@ -197,12 +197,12 @@
                   {{ "FORM.BUTTONS.RESET" | translate }}
                 </button>
               </div>
-              
+
             </form>
-          </div>         
+          </div>
         </div>
 
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/services/services.html
+++ b/client/src/partials/services/services.html
@@ -59,7 +59,7 @@
         <div ng-switch-default>
           <div class="alert alert-info" id="default">
             <h4>{{ 'SERVICE.TITLE' | translate}}</h4>
-            <p>{{ 'SERVICE.DESCRIPTION' | translate }}</p>           
+            <p>{{ 'SERVICE.DESCRIPTION' | translate }}</p>
           </div>
         </div>
 
@@ -94,14 +94,14 @@
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ 'SERVICE.ADDING_SERVICE' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="ServicesCtrl.submit(CreateForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form class="panel-body" name="CreateForm" ng-submit="ServicesCtrl.submit(CreateForm.$invalid)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.name.$invalid }">
                 <label class="control-label" for="bhima-service-name">{{ 'FORM.LABELS.NAME' | translate }}</label>
                 <input type="text" class="form-control" name="name" ng-maxlength="ServicesCtrl.maxLength" id="bhima-service-name" ng-model="ServicesCtrl.service.name" required>
                 <div class="help-block" ng-messages="CreateForm.name.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>  
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.enterprise_id.$invalid }">
@@ -111,7 +111,7 @@
                 </select>
                 <div class="help-block" ng-messages="CreateForm.enterprise_id.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                  
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.cost_center_id.$invalid }">
@@ -141,20 +141,20 @@
                 </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
 
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ 'SERVICE.EDITING_SERVICE' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="UpdateForm" ng-submit="ServicesCtrl.submit(UpdateForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form class="panel-body" name="UpdateForm" ng-submit="ServicesCtrl.submit(UpdateForm.$invalid)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.name.$invalid }">
                 <label class="control-label" for="bhima-service-name">{{ 'FORM.LABELS.NAME' | translate }}</label>
                 <input type="text" class="form-control" name="name" id="bhima-service-name" ng-maxlength="ServicesCtrl.maxLength" ng-model="ServicesCtrl.service.name" required>
                 <div class="help-block" ng-messages="UpdateForm.name.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.enterprise_id.$invalid }">
@@ -164,7 +164,7 @@
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.enterprise_id.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.cost_center_id.$invalid }">
@@ -194,7 +194,7 @@
                   </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
 
         <div class="panel panel-primary" ng-switch-when="more">
@@ -223,10 +223,10 @@
                 </tbody>
               </table>
             </div>
-          </div>        
+          </div>
         </div>
 
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/subsidies/subsidies.html
+++ b/client/src/partials/subsidies/subsidies.html
@@ -46,7 +46,7 @@
 
               <tr ng-if="!SubsidyCtrl.subsidies.length">
                 <td colspan="4">{{ "SUBSIDY.NO_SUBSIDY" | translate }}</td>
-              </tr>            
+              </tr>
             </tbody>
           </table>
         </div>
@@ -92,14 +92,14 @@
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ 'SUBSIDY.ADDING_SUBSIDY' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="SubsidyCtrl.submit(CreateForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="CreateForm" ng-submit="SubsidyCtrl.submit(CreateForm.$invalid)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.label.$invalid }">
                 <label class="control-label">{{ 'FORM.LABELS.NAME' | translate }}</label>
                 <input type="text" class="form-control" name="label" ng-maxlength="SubsidyCtrl.length250" ng-model="SubsidyCtrl.subsidy.label" required>
                 <div class="help-block" ng-messages="CreateForm.label.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.value.$invalid }">
@@ -107,7 +107,7 @@
                 <input type="number" class="form-control" name="value" ng-model="SubsidyCtrl.subsidy.value" required>
                 <div class="help-block" ng-messages="CreateForm.value.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.account_id.$invalid }">
@@ -117,7 +117,7 @@
                 </select>
                 <div class="help-block" ng-messages="CreateForm.account_id.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                 
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.description.$invalid }">
@@ -125,7 +125,7 @@
                 <textarea class="form-control" id="description" name="description" ng-maxlength="SubsidyCtrl.maxLength" ng-model="SubsidyCtrl.subsidy.description" rows="3"></textarea>
                 <div class="help-block" ng-messages="CreateForm.description.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                  
+                </div>
               </div>
 
               <div class="form-group">
@@ -137,20 +137,20 @@
                 </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
 
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ 'SUBSIDY.UPDATING_SUBSIDY' | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="UpdateForm" ng-submit="SubsidyCtrl.submit(UpdateForm.$invalid)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="UpdateForm" ng-submit="SubsidyCtrl.submit(UpdateForm.$invalid)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.label.$invalid }">
                 <label class="control-label">{{ 'FORM.LABELS.NAME' | translate }}</label>
                 <input type="text" class="form-control" name="label" ng-maxlength="SubsidyCtrl.length250" ng-model="SubsidyCtrl.subsidy.label" required>
                 <div class="help-block" ng-messages="UpdateForm.label.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.value.$invalid }">
@@ -158,7 +158,7 @@
                 <input type="number" class="form-control" name="value" ng-model="SubsidyCtrl.subsidy.value" required>
                 <div class="help-block" ng-messages="UpdateForm.value.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.account_id.$invalid }">
@@ -168,7 +168,7 @@
                 </select>
                 <div class="help-block" ng-messages="UpdateForm.account_id.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                                
+                </div>
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.description.$invalid }">
@@ -176,7 +176,7 @@
                 <textarea class="form-control" id="description" name="description" ng-maxlength="SubsidyCtrl.maxLength" ng-model="SubsidyCtrl.subsidy.description" rows="3"></textarea>
                 <div class="help-block" ng-messages="UpdateForm.description.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>                
+                </div>
               </div>
 
               <div class="form-group">
@@ -188,10 +188,10 @@
                 </button>
               </div>
             </form>
-          </div>        
+          </div>
         </div>
 
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/client/src/partials/suppliers/suppliers.html
+++ b/client/src/partials/suppliers/suppliers.html
@@ -81,7 +81,7 @@
         <div class="panel panel-primary" ng-switch-when="create">
           <div class="panel-heading">{{ "SUPPLIER.NEW_SUPPLIER" | translate }}</div>
           <div class="panel-body">
-            <form class="panel-body" name="CreateForm" ng-submit="SupplierCtrl.submit(CreateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="CreateForm" ng-submit="SupplierCtrl.submit(CreateForm)" bh-form-defaults novalidate>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.name.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>
@@ -182,7 +182,7 @@
         <div class="panel panel-primary" ng-switch-when="update">
           <div class="panel-heading">{{ 'SUPPLIER.EDIT_SUPPLIER' | translate }} </b> </div>
           <div class="panel-body">
-            <form class="panel-body" name="UpdateForm" ng-submit="SupplierCtrl.submit(UpdateForm)" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="UpdateForm" ng-submit="SupplierCtrl.submit(UpdateForm)" bh-form-defaults novalidate>
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.name.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>
                 <input type="text" class="form-control" name="name" ng-model="SupplierCtrl.supplier.name" required>

--- a/client/src/partials/templates/bhDateEditor.tmpl.html
+++ b/client/src/partials/templates/bhDateEditor.tmpl.html
@@ -9,7 +9,7 @@
   additional ng-message "date not in range" to deal with that particular case.
   It isn't ideal, but seems to be the only way to account for that scenario.
 -->
-<ng-form name="DateEditorForm" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+<ng-form name="DateEditorForm" bh-form-defaults novalidate>
   <div
     class="form-group"
     ng-class="{ 'has-error' : $ctrl.validationTrigger && DateEditorForm.$invalid } "

--- a/client/src/partials/templates/bhFindPatient.tmpl.html
+++ b/client/src/partials/templates/bhFindPatient.tmpl.html
@@ -5,13 +5,11 @@
     ng-switch-default
     ng-form="FindPatientForm"
     ng-class="{
-      'has-success': !$ctrl.showSearchView && $ctrl.loadStatus=='loaded',
-      'has-error': !$ctrl.showSearchView && $ctrl.loadStatus=='error'
-      }"
-    autocomplete="off"
-	autocapitalize="off"
-	autocorrect="off"
-	novalidate>
+    'has-success': !$ctrl.showSearchView && $ctrl.loadStatus=='loaded',
+    'has-error': !$ctrl.showSearchView && $ctrl.loadStatus=='error'
+    }"
+    bh-form-defaults
+    novalidate>
 
     <!-- inline input zone -->
     <div class="input-group" ng-if="$ctrl.showSearchView">
@@ -40,9 +38,6 @@
         type="text"
         class="form-control"
         placeholder="{{ $ctrl.selected.placeholder | translate }}...",
-        autocomplete="off"
-        autocorrect="off"
-        autocapitalize="off"
         ng-required="$ctrl.required">
 
       <!-- search by Name  -->
@@ -156,10 +151,7 @@
       <div class="form-group has-feedback"
         ng-class="{'has-success': $ctrl.loadStatus ==='loaded', 'has-error': $ctrl.loadStatus === 'error'}"
         ng-form="FindPatientForm"
-        autocomplete="off"
-		autocapitalize="off"
-		autocorrect="off"
-		novalidate>
+        novalidate>
 
         <!-- input zone -->
         <div class="input-group input-group-sm">
@@ -186,9 +178,6 @@
             name="idInput"
             type="text"
             class="form-control"
-            autocomplete="off"
-            autocorrect="off"
-            autocapitalize="off"
             placeholder="{{ $ctrl.selected.placeholder | translate }}"
             ng-required="$ctrl.required">
 
@@ -205,9 +194,6 @@
             typeahead-loading="$ctrl.loadingPatients"
             typeahead-template-url="/partials/templates/patientListe.tmpl.html"
             typeahead-on-select="$ctrl.selectPatient($item)"
-            autocomplete="off"
-            autocorrect="off"
-            autocapitalize="off"
             ng-required="$ctrl.required">
 
         </div>

--- a/client/src/partials/templates/bhFindSupplier.tmpl.html
+++ b/client/src/partials/templates/bhFindSupplier.tmpl.html
@@ -4,9 +4,7 @@
     'has-success': !$ctrl.showSearchView && $ctrl.loadStatus=='loaded',
     'has-error': !$ctrl.showSearchView && $ctrl.loadStatus=='error'
     }"
-  autocomplete="off" 
-  autocapitalize="off" 
-  autocorrect="off" 
+  bh-form-defaults
   novalidate>
 
   <!-- inline input zone -->

--- a/client/src/partials/templates/bhLocationSelect.tmpl.html
+++ b/client/src/partials/templates/bhLocationSelect.tmpl.html
@@ -12,10 +12,8 @@
 <fieldset
   ng-disabled="$ctrl.disable"
   ng-form="{{$ctrl.name}}"
-  autocomplete="off" 
-  autocapitalize="off" 
-  autocorrect="off" 
   novalidate
+  bh-form-defaults
   data-bh-location-select>
 
   <!-- allows a user to select a country -->

--- a/client/src/partials/templates/findDebtorGroup.tmpl.html
+++ b/client/src/partials/templates/findDebtorGroup.tmpl.html
@@ -1,9 +1,7 @@
 <div class="form-group has-feedback "
   ng-form="formFindDebtorGroup"
   ng-class="{'has-success' : $ctrl.state==1, 'has-error': $ctrl.noDebtorGroups}"
-  autocomplete="off" 
-  autocapitalize="off" 
-  autocorrect="off" 
+  bh-form-defaults
   novalidate>
 
   <div data-bh-find-debtorgroup-name>

--- a/client/src/partials/templates/modals/alert.modal.html
+++ b/client/src/partials/templates/modals/alert.modal.html
@@ -1,5 +1,5 @@
 <!-- leverage a form to get a loading indicator on the button -->
-<form name="AlertModalForm" ng-submit="AlertModalCtrl.submit()" data-confirm-modal autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+<form name="AlertModalForm" ng-submit="AlertModalCtrl.submit()" data-confirm-modal bh-form-defaults novalidate>
   <div class="modal-body">
 
     <!-- Error alert in case the server sends back an error -->

--- a/client/src/partials/templates/modals/confirm.modal.html
+++ b/client/src/partials/templates/modals/confirm.modal.html
@@ -1,5 +1,5 @@
 <!-- leverage a form to get a loading indicator on the button -->
-<form name="ConfirmModalForm" ng-submit="ConfirmModalCtrl.submit()" data-confirm-modal autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+<form name="ConfirmModalForm" ng-submit="ConfirmModalCtrl.submit()" data-confirm-modal bh-form-defaults novalidate>
   <div class="modal-header">
     <h4>{{ "FORM.LABELS.CONFIRMATION" | translate }}</h4>
   </div>

--- a/client/src/partials/templates/modals/findEntity.modal.html
+++ b/client/src/partials/templates/modals/findEntity.modal.html
@@ -1,9 +1,7 @@
 <ng-form
   name="EntityForm"
-  autocomplete="off"
-  autocorrect="off"
-  autocapitalize="off"
   data-modal="entity"
+  bh-form-defaults
   novalidate>
 
   <div class="modal-header">

--- a/client/src/partials/templates/modals/location.modal.html
+++ b/client/src/partials/templates/modals/location.modal.html
@@ -1,4 +1,4 @@
-<ng-form name="LocationModalForm" data-location-modal autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+<ng-form name="LocationModalForm" data-location-modal bh-form-defaults novalidate>
   <div class="modal-header">
     <h4>{{ "FORM.LABELS.CONFIRMATION" | translate }}</h4>
   </div>

--- a/client/src/partials/vouchers/complex.html
+++ b/client/src/partials/vouchers/complex.html
@@ -5,7 +5,7 @@
 
 <div class="flex-content">
   <div class="container-fluid">
-    <form name="ComplexVoucherForm" autocomplete="off" autocorrect="off" autocapitalize="off" novalidate>
+    <form name="ComplexVoucherForm" bh-form-defaults novalidate>
 
       <!-- description -->
       <div class="row">

--- a/client/src/partials/vouchers/simple.html
+++ b/client/src/partials/vouchers/simple.html
@@ -15,7 +15,7 @@
           </div>
 
           <div class="panel-body">
-            <form name="SimpleVoucherForm" bh-submit="SimpleVoucherCtrl.submit(SimpleVoucherForm)" autocomplete="off" autocomplete="off" autocapitalize="off" autocorrect="off" novalidate>
+            <form name="SimpleVoucherForm" bh-submit="SimpleVoucherCtrl.submit(SimpleVoucherForm)" bh-form-defaults novalidate>
 
               <bh-date-editor
                 date-value="SimpleVoucherCtrl.voucher.date"


### PR DESCRIPTION
This commit adds a new directive `bhFormDefaults` to automatically add attributes to any form element.  These attributes are:
1. `autocomplete`
2. `autocapitalize`
3. `autocorrect`

The directive turns them off by setting them to "none".  If a browser updates in the future to ignore the "none" directive, they can easily be updated.

Closes #502.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
