### PR TITLE
(Chore) Re-factor action cells to use ui-class

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -212,7 +212,7 @@
       "DELETE"                : "Delete",
       "DISMISS"               : "Dismiss",
       "EDIT"                  : "Edit",
-      "EDIT_PERMISSIONS"      : "Edit Permission",
+      "EDIT_PERMISSIONS"      : "Permission",
       "ENTER_FULL_DATE"       : "Enter Full Date",
       "ENTITY"                : "Entity",
       "FILTER"                : "Filter",

--- a/client/src/partials/patient_invoice/registry/registry.js
+++ b/client/src/partials/patient_invoice/registry/registry.js
@@ -16,13 +16,16 @@ function InvoiceRegistryController(Invoices, Notify, util, Receipt) {
     var vm = this;
 
     var invoiceActionsTemplate =
-        '<div style="padding : 5px"><a ng-click="grid.appScope.showBill(row.entity.uuid)">' +
-        '<span class="glyphicon glyphicon-list-alt"></span> {{ "TABLE.COLUMNS.BILL" | translate }}</a></div>';
+      '<div class="ui-grid-cell-contents">' +
+      '<a href ng-click="grid.appScope.showBill(row.entity.uuid)">' +
+      '<span class="fa fa-file-pdf-o"></span> {{ "TABLE.COLUMNS.RECEIPT" | translate }}' +
+      '</a>' +
+      '</div>';
 
 
     vm.search = search;
     vm.showBill = showBill;
-    vm.momentAge = util.getMomentAge;    
+    vm.momentAge = util.getMomentAge;
 
     // track if module is making a HTTP request for invoices
     vm.loading = false;

--- a/client/src/partials/patients/registry/registry.js
+++ b/client/src/partials/patients/registry/registry.js
@@ -15,13 +15,17 @@ function PatientRegistryController(Patients, Notify, moment, Receipt, AppCache, 
 
   var cache = AppCache('PatientRegistry');
 
-  var patientActionsTemplate =
-      '<div style="padding : 5px"> ' +
+  var patientDetailActionTemplate =
+      '<div class="ui-grid-cell-contents"> ' +
         '<a ui-sref="patientRecord.details({patientID : row.entity.uuid})"> ' +
-          '<span class="glyphicon glyphicon-list-alt"></span> {{ "PATIENT_REGISTRY.RECORD" | translate }} ' +
+          '<span class="fa fa-book"></span> {{ "PATIENT_REGISTRY.RECORD" | translate }} ' +
         '</a>' +
+      '</div>';
+
+  var patientEditActionTemplate =
+      '<div class="ui-grid-cell-contents"> ' +
         '<a ui-sref="patientEdit({uuid : row.entity.uuid})"> ' +
-          '<span class="glyphicon glyphicon-edit"></span> {{ "TABLE.COLUMNS.EDIT" | translate }} ' +
+          '<span class="fa fa-edit"></span> {{ "TABLE.COLUMNS.EDIT" | translate }} ' +
         '</a> ' +
       '</div>';
 
@@ -48,7 +52,8 @@ function PatientRegistryController(Patients, Notify, moment, Receipt, AppCache, 
       { field : 'registration_date', cellFilter:'date', displayName : 'TABLE.COLUMNS.DATE_REGISTERED', headerCellFilter : 'translate' },
       { field : 'last_visit', cellFilter:'date', displayName : 'TABLE.COLUMNS.LAST_VISIT', headerCellFilter : 'translate' },
       { field : 'dob', cellFilter:'date', displayName : 'TABLE.COLUMNS.DOB', headerCellFilter : 'translate' },
-      { name : 'Actions', displayName : '', cellTemplate : patientActionsTemplate }
+      { name : 'actionsDetail', displayName : '', cellTemplate : patientDetailActionTemplate },
+      { name : 'actionsEdit', displayName : '', cellTemplate : patientEditActionTemplate }
     ],
     enableSorting : true
   };

--- a/client/src/partials/permissions/permissions.js
+++ b/client/src/partials/permissions/permissions.js
@@ -6,9 +6,9 @@ PermissionsController.$inject = [
   'ProjectService', 'NodeTreeService'
 ];
 
-/** 
- * Users and Permission Controller 
- * 
+/**
+ * Users and Permission Controller
+ *
  * This module is responsible for handling the creation
  * of users and assigning permissions to existing modules.
  *
@@ -18,10 +18,10 @@ function PermissionsController($window, $translate, $http, $uibModal, util, Sess
   var vm = this;
 
   var editTemplate =
-    '<div style="margin: 0px 5px 5px 5px;"><a class="btn btn-sm btn-default btn-block" ng-click="grid.appScope.edit(row.entity)">{{ "FORM.BUTTONS.EDIT" | translate }}</a></div>';
-  
-  var permissionTemplate = 
-    '<div style="margin: 0px 5px 5px 5px;"><a class="btn btn-sm btn-default btn-block" ng-click="grid.appScope.editPermissions(row.entity)">{{ "FORM.BUTTONS.EDIT_PERMISSIONS" | translate }}</a></div>';
+    '<div class="ui-grid-cell-contents"><a href ng-click="grid.appScope.edit(row.entity)"><i class="fa fa-edit"></i> {{ "FORM.BUTTONS.EDIT" | translate }}</a></div>';
+
+  var permissionTemplate =
+    '<div class="ui-grid-cell-contents"><a href ng-click="grid.appScope.editPermissions(row.entity)"><i class="fa fa-key"></i> {{ "FORM.BUTTONS.EDIT_PERMISSIONS" | translate }}</a></div>';
 
   // options for the UI grid
   vm.uiGridOptions = {
@@ -56,7 +56,7 @@ function PermissionsController($window, $translate, $http, $uibModal, util, Sess
 
   vm.maxLength = util.maxTextLength;
   vm.userName = 80;
-  vm.length100 = util.length100;  
+  vm.length100 = util.length100;
 
   var isDefined = angular.isDefined;
   /* ------------------------------------------------------------------------ */
@@ -244,18 +244,18 @@ function PermissionsController($window, $translate, $http, $uibModal, util, Sess
 
       if (parent[0].parent) {
         vm.toggleParents(parent);
-      } 
-    } 
+      }
+    }
   }
 
   // toggle the selection all child nodes
-  function toggleUnitChildren(unit, children) { 
+  function toggleUnitChildren(unit, children) {
     if (!unit.checked) { vm.super = false; }
 
     if(unit.parent !== 0){
-      vm.toggleParents(unit); // traverse upwards, toggling parents  
+      vm.toggleParents(unit); // traverse upwards, toggling parents
     }
-    
+
     children.forEach(function (node) {
       node.checked = unit.checked;
       if (node.children) {

--- a/client/test/e2e/patient_invoice/invoiceRegistry.page.js
+++ b/client/test/e2e/patient_invoice/invoiceRegistry.page.js
@@ -1,4 +1,3 @@
-
 function InvoiceRegistryPage() {
   var page = this;
 
@@ -18,7 +17,9 @@ function InvoiceRegistryPage() {
 
   function showInvoiceProof(line) {
       var row = grid.element( by.css('.ui-grid-render-container-body')).element( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index').row( line ) );
-      row.element( by.repeater('(colRenderIndex, col) in colContainer.renderedColumns track by col.uid').row(6)).click();
+
+      // click the <a> tag within the cell
+      row.element( by.repeater('(colRenderIndex, col) in colContainer.renderedColumns track by col.uid').row(6)).element( by.tagName('a')).click();
   }
 
   function isInvoiceProofPresent() {

--- a/client/test/e2e/patient_invoice/invoiceRegsitry.spec.js
+++ b/client/test/e2e/patient_invoice/invoiceRegsitry.spec.js
@@ -10,8 +10,6 @@ const InvoiceRegistryPage = require('./invoiceRegistry.page.js');
 const modalPage = require('./modal.page.js');
 const ReceiptModalPage = require('../receipt_modal/receiptModal.page.js');
 
-
-
 describe('Invoice Registry page', function () {
   'use strict';
 
@@ -30,7 +28,6 @@ describe('Invoice Registry page', function () {
         noDistributableInvoiceNumber : 0
     };
 
-
   // This will be run before every single test ('it') - navigating the browser to the correct page.
   before(() => helpers.navigate(path));
 
@@ -42,7 +39,7 @@ describe('Invoice Registry page', function () {
     it('filters invoices of today correctly', function () {
         var invoiceRegistry = new InvoiceRegistryPage();
         var filterModal = new modalPage();
-        
+
         invoiceRegistry.showFilterDialog();
         filterModal.setRange('today');
         filterModal.submit();


### PR DESCRIPTION
This commit replaces various different UI Grid action cell templates
with a standardised template using the `ui-grid-cell-contents-class`.
It also enforces one action per cell to ensure overflow does not break
the page.

**Previous Behaviour** 
Overflow 
_Edit action overflows hidden underneath - unusable_
![screenshot 2016-06-28 at 14 15 00](https://cloud.githubusercontent.com/assets/2844572/16416551/bcbf531c-3d3a-11e6-9ef1-f47973b8650a.png)

**Revised Behaviour**
Standardised Action Cell 
_Recommended one cell per action_
![screenshot 2016-06-28 at 13 48 05](https://cloud.githubusercontent.com/assets/2844572/16416578/da739aa8-3d3a-11e6-8c4b-133f0d1d0b48.png)

Overflow 
_All actions still usable_
![screenshot 2016-06-28 at 13 48 33](https://cloud.githubusercontent.com/assets/2844572/16416607/ff0e84b8-3d3a-11e6-8de9-d1b8f8f97d94.png)

Completely Collapsed 
_Icons usable with text wrapped with ..._
![screenshot 2016-06-28 at 13 48 59](https://cloud.githubusercontent.com/assets/2844572/16416665/4282da50-3d3b-11e6-864f-414c9e91eb29.png)

---

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.
