### PR TITLE
feat(bhInfo): popovers made simple

### DIFF
--- a/client/src/js/components/bhInfo.js
+++ b/client/src/js/components/bhInfo.js
@@ -1,0 +1,15 @@
+angular.module('bhima.components')
+  .component('bhInfo', {
+    template :
+      '<span ' +
+      '  class="text-info fa fa-info-circle" ' +
+      '  uib-popover-template="$ctrl.template" ' +
+      '  popover-placement="right" ' +
+      '  popover-append-to-body="true" ' +
+      '  popover-trigger="mouseenter"> ' +
+      '</span> ',
+    bindings : {
+      template: '@',
+      direction: '@'
+    }
+  });

--- a/client/src/partials/patient_invoice/patientInvoice.html
+++ b/client/src/partials/patient_invoice/patientInvoice.html
@@ -46,13 +46,7 @@
 
                 <label class="control-label">
                   {{ "FORM.LABELS.TYPE" | translate }}
-                  <span
-                    class="text-info fa fa-info-circle"
-                    uib-popover-template="'typePopover.tmpl.html'"
-                    popover-placement="right"
-                    popover-append-to-body="true"
-                    popover-trigger="mouseenter">
-                  </span>
+                  <bh-info template="typePopover.tmpl.html" direction="right"></bh-info>
                 </label>
 
                 <!-- TODO distributable vs. non distributable sales or invoices should be designed/reviewed carefully -->
@@ -189,29 +183,27 @@
 
             <h4>
               {{ "FORM.LABELS.BILLING_SERVICES" | translate }}
-
-              <!-- popover template definitions temporarily at the base of this file -->
               <span
-                class="text-info"
+                class="text-info fa fa-info-circle"
                 ng-show="PatientInvoiceCtrl.Invoice.billingServices.length > 0"
                 uib-popover-template="'billingServicesPopover.tmpl.html'"
                 popover-placement="right"
                 popover-append-to-body="true"
-                popover-trigger="mouseenter">
-                <span class="fa fa-info-circle"></span>
+                popover-trigger="mouseenter"
+                >
               </span>
             </h4>
 
             <h4>
               {{ "FORM.LABELS.SUBSIDIES" | translate }}
               <span
-                class="text-info"
+                class="text-info fa fa-info-circle"
                 ng-show="PatientInvoiceCtrl.Invoice.subsidies.length > 0"
                 uib-popover-template="'subsidiesPopover.tmpl.html'"
                 popover-placement="right"
                 popover-append-to-body="true"
-                popover-trigger="mouseenter">
-                <span class="fa fa-info-circle"></span>
+                popover-trigger="mouseenter"
+                >
               </span>
             </h4>
 


### PR DESCRIPTION
This commit creates a bhInfo component that is simply a wrapper for popovers.  Since this is a component, these popovers cannot have any knowledge of their parent scope.  This component is ideal for informational popovers that only contain `$translate` filters.

The API is described in #525.  For reference, here is an example usage:

``` html
<bh-info template="typePopover.tmpl.html" direction="right"></bh-info>
```

Closes #525.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
