### PR TITLE
(test): integration tests use global variables

### DIFF
--- a/client/test/e2e/inventory/inventory_configuration.spec.js
+++ b/client/test/e2e/inventory/inventory_configuration.spec.js
@@ -11,7 +11,6 @@ const components = require('../shared/components');
 helpers.configure(chai);
 
 describe('Inventory Configuration ::', () => {
-  'use strict';
 
   // navigate to the page
   before(() => helpers.navigate('#/inventory/configuration'));

--- a/server/test/api/accountTypes.js
+++ b/server/test/api/accountTypes.js
@@ -1,14 +1,9 @@
-/* jshint expr:true */
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 describe('(/accounts/types) Account Types', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
-
   var newAccountType = {
     type : 'Test Account Type 1'
   };

--- a/server/test/api/accounts.js
+++ b/server/test/api/accounts.js
@@ -1,21 +1,14 @@
+/* global expect, chai, agent */
 /* jshint expr : true */
-const chai = require('chai');
-const expect = chai.expect;
 
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 // cheeky method to duplicate an array
 function clone(array) {
-  return array.filter(function (element) { return 1; });
+  return array.filter(() => true);
 }
 
 describe('(/accounts) Accounts', function () {
-
-  // login before the test suite
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
-
   var newAccount = {
     type_id : 1,
     enterprise_id : 1,

--- a/server/test/api/billingServices.js
+++ b/server/test/api/billingServices.js
@@ -1,20 +1,13 @@
-/* jshint expr:true*/
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-// import test helpers
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /*
  * The /billing_services API endpoint
  */
 describe('(/billing_services) Billing Services API', function () {
   'use strict';
-
-  /* logs in at the beginning of the test suite */
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   const billingServiceA = {
     account_id:  3628,  // Test Capital Account Two

--- a/server/test/api/cash.js
+++ b/server/test/api/cash.js
@@ -1,15 +1,10 @@
-/* jshint expr:true*/
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 describe('(/cash) Cash Payments', function () {
   'use strict';
-
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   var CASHBOX_ID  = 1;   // Test Primary Cashbox A
   var CURRENCY_ID = 2;   // Congolese Francs

--- a/server/test/api/cashboxes.js
+++ b/server/test/api/cashboxes.js
@@ -1,18 +1,11 @@
-/* jshint expr:true */
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-/* import test helpers */
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /* The /cashboxes API endpoint */
 describe('(/cashboxes) The Cashboxes API endpoint', function () {
   'use strict';
-
-  /* login before the first request */
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   const numCashboxes = 3;
   const numAuxCashboxes = 2;

--- a/server/test/api/costCenter.js
+++ b/server/test/api/costCenter.js
@@ -1,8 +1,7 @@
-/* jshint expr:true */
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
+
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /*
  * @todo - there are some tests missing:
@@ -10,8 +9,6 @@ helpers.configure(chai);
  *  - 404s on PUTs
  */
 describe('(/cost_centers) The cost center API', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   const newCostCenter = {
     project_id : 1,

--- a/server/test/api/creditorGroups.js
+++ b/server/test/api/creditorGroups.js
@@ -1,9 +1,8 @@
-/* jshint expr:true*/
-const chai = require('chai');
-const expect = chai.expect;
-const uuid    = require('node-uuid');
+/* global expect, chai, agent */
+/* jshint expr : true */
+
 const helpers = require('./helpers');
-helpers.configure(chai);
+const uuid = require('node-uuid');
 
 /*
  * The /creditor_groups API endpoint
@@ -11,10 +10,6 @@ helpers.configure(chai);
  * This test suite implements full CRUD on the /creditor_groups HTTP API endpoint.
  */
 describe('(/creditor_groups) Creditor Groups', function () {
-
-  // login before each request
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   // creditor group we will add during this test suite.
   var creditorGroup = {

--- a/server/test/api/currencies.js
+++ b/server/test/api/currencies.js
@@ -1,14 +1,10 @@
-/* jshint expr:true */
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
+
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 describe('(/currencies) currencies API routes', function () {
   'use strict';
-
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   const currencyId = 1;
   const keys = [

--- a/server/test/api/debtorGroups.js
+++ b/server/test/api/debtorGroups.js
@@ -1,15 +1,10 @@
-/* jshint expr: true */
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-const uuid    = require('node-uuid');
-helpers.configure(chai);
+const uuid = require('node-uuid');
 
 describe('(/debtor_groups) The debtor groups API', function () {
-
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   var debtorGroup = {
     enterprise_id : 1,

--- a/server/test/api/debtors.js
+++ b/server/test/api/debtors.js
@@ -1,16 +1,11 @@
-const chai = require('chai');
-const uuid = require('node-uuid');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
+const uuid = require('node-uuid');
 
 describe('(/debtors) The /debtors API', function () {
   'use strict';
-
-  // Logs in before test suite
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   const debtorKeys = ['uuid', 'group_uuid', 'text'];
 

--- a/server/test/api/depots.js
+++ b/server/test/api/depots.js
@@ -1,19 +1,12 @@
-// jshint expr: true
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-// import test helpers
 const helpers = require('./helpers');
-const uuid    = require('node-uuid');
-helpers.configure(chai);
+const uuid = require('node-uuid');
 
 // The /depots API endpoint
-// @desc This test suit is about the crud operation with depots
 describe('(/depots) The depots API ', function () {
   'use strict';
-
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   // new depot object
   var newDepot = {

--- a/server/test/api/discounts.js
+++ b/server/test/api/discounts.js
@@ -1,15 +1,12 @@
-/* jshint expr:true*/
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
+
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /*
  * The /discounts API endpoint
  */
 describe('(/discounts) Discounts Interface', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   var ACCOUNT_ID = 3636;  // Test Inventory Account
   var INVENTORY_UUID = '289cc0a1-b90f-11e5-8c73-159fdc73ab02'; // INV1

--- a/server/test/api/employee.js
+++ b/server/test/api/employee.js
@@ -1,8 +1,7 @@
-/* jshint expr:true*/
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
+
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /*
  * The /employees API endpoint
@@ -11,9 +10,6 @@ helpers.configure(chai);
  */
 describe('(/employees) the employees API endpoint', function () {
   'use strict';
-
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   const numEmployees = 1;
 

--- a/server/test/api/enterprises.js
+++ b/server/test/api/enterprises.js
@@ -1,19 +1,13 @@
-/* jshint expr:true*/
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /*
  * The /enterprises API endpoint
  * This test suite implements full CRUD on the /enterprises HTTP API endpoint.
  */
 describe('(/enterprises) Enterprises API', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-
-  // ensure that the client is logged into the test suite
-  before(helpers.login(agent));
 
   var enterprise = {
     name : 'enterprises',

--- a/server/test/api/exchange.js
+++ b/server/test/api/exchange.js
@@ -1,15 +1,12 @@
-/* jshint expr: true */
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
+
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /*
  * The /exchange API endpoint
  */
 describe('(/exchange) The /exchange API endpoint', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   // constants
   const RATE = {

--- a/server/test/api/fiscalYear.js
+++ b/server/test/api/fiscalYear.js
@@ -1,12 +1,9 @@
-/* jshint expr:true*/
-var chai = require('chai');
-var expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-var helpers = require('./helpers');
-helpers.configure(chai);
+const helpers = require('./helpers');
 
 describe('(/fiscal) The Fiscal Years API', function () {
-  var agent = chai.request.agent(helpers.baseUrl);
 
   var newFiscalYear = {
     label : 'A new Fiscal Year 2017',
@@ -16,8 +13,6 @@ describe('(/fiscal) The Fiscal Years API', function () {
   };
 
   var responseKeys = ['id', 'enterprise_id', 'number_of_months', 'label', 'start_date', 'previous_fiscal_year_id', 'locked', 'note'];
-
-  before(helpers.login(agent));
 
   it('POST /fiscal adds a fiscal year', function () {
     return agent.post('/fiscal')

--- a/server/test/api/functions.js
+++ b/server/test/api/functions.js
@@ -1,17 +1,14 @@
-/* jshint expr:true*/
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
+
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /*
  * The /functions  API endpoint
  *
  * This test suite implements full CRUD on the /functions  HTTP API endpoint.
  */
-describe('The /functions  API endpoint', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
+describe('(/functions) The /functions  API endpoint', function () {
 
   // Function we will add during this test suite.
   const fonction = {

--- a/server/test/api/grades.js
+++ b/server/test/api/grades.js
@@ -1,10 +1,8 @@
-/* jshint expr:true*/
-const chai = require('chai');
-const expect = chai.expect;
-const uuid  = require('node-uuid');
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
+const uuid = require('node-uuid');
 
 /*
  * The /grades API endpoint
@@ -12,9 +10,6 @@ helpers.configure(chai);
  * This test suite implements full CRUD on the /grades   HTTP API endpoint.
  */
 describe('(/grades) API endpoint', function () {
-
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   // grade we will add during this test suite.
   var grade = {

--- a/server/test/api/helpers.js
+++ b/server/test/api/helpers.js
@@ -3,31 +3,6 @@
 
 // import plugins
 const expect = require('chai').expect;
-const chaiHttp = require('chai-http');
-const chaiDatetime =  require('chai-datetime');
-
-/*
- * Configure NodeJS/Mocha to continue working even with invalid TLS certs
- * This explicitly disables cert errors for the parent Node process, and
- * should only be done for testing cases.
- */
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
-
-// base URL for all tests
-const port = process.env.PORT || '8080';
-exports.baseUrl = 'https://localhost:' + port;
-
-// login using the base URL and user
-exports.login = function login(agent) {
-  // base user defined in test data
-  var user = { username : 'superuser', password : 'superuser', project: 1};
-
-  return function () {
-    return agent
-      .post('/login')
-      .send(user);
-  };
-};
 
 /**
  * Clones the object and removes the field, to test if the field is required
@@ -41,19 +16,6 @@ exports.mask = function mask(object, field) {
   var clone = JSON.parse(JSON.stringify(object));
   delete clone[field];
   return clone;
-};
-
-// generic configuration for chai
-exports.configure = function configure(chai) {
-  // workaround for low node versions
-  if (!global.Promise) {
-    var q = require('q');
-    chai.request.addPromises(q.Promise);
-  }
-
-  // attach plugins
-  chai.use(chaiHttp);
-  chai.use(chaiDatetime);
 };
 
 // generic error handler

--- a/server/test/api/inventory.js
+++ b/server/test/api/inventory.js
@@ -1,19 +1,11 @@
-/* jshint expr: true */
+/* global expect, chai, agent */
+/* jshint expr : true */
 'use strict';
-
-const chai = require('chai');
-const expect = chai.expect;
 
 const helpers = require('./helpers');
 const uuid    = require('node-uuid');
-helpers.configure(chai);
 
-describe('(/inventory) The inventory HTTP API :: ', () => {
-
-  // Logs in before each test
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
-
+describe('(/inventory) The Inventory HTTP API', () => {
   let inventoryList;
 
   let inventoryGroup = {
@@ -89,7 +81,7 @@ describe('(/inventory) The inventory HTTP API :: ', () => {
       .catch(helpers.handler);
   });
 
-  // detailS of inventory groups
+  // details of inventory groups
   it('GET /inventory/group returns details of an inventory group', () => {
     return agent.get('/inventory/groups/' + inventoryGroup.uuid)
       .then((res) => {
@@ -152,7 +144,7 @@ describe('(/inventory) The inventory HTTP API :: ', () => {
       .catch(helpers.handler);
   });
 
-  // detailS of inventory types
+  // details of inventory types
   it('GET /inventory/types returns details of an inventory type', () => {
     return agent.get('/inventory/types/' + inventoryType.id)
       .then((res) => {

--- a/server/test/api/invoiceReceipt.js
+++ b/server/test/api/invoiceReceipt.js
@@ -1,13 +1,9 @@
-/* jshint expr:true */
-var chai = require('chai');
-var expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-var helpers = require('./helpers');
-helpers.configure(chai);
+const helpers = require('./helpers');
 
 describe('/reports/invoices Receipts Interface', function () {
-  var agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   // known data for requests and assertions
   const validInvoice        = '957e4e79-a6bb-4b4d-a8f7-c42152b2c2f6';

--- a/server/test/api/locations.js
+++ b/server/test/api/locations.js
@@ -1,21 +1,14 @@
-/* jshint expr:true */
-const chai = require('chai');
-const expect = chai.expect;
-const uuid = require('node-uuid');
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-/* import test helpers */
 const helpers = require('./helpers');
-helpers.configure(chai);
+const uuid = require('node-uuid');
 
 
 /*
  * The /locations API endpoint
  */
 describe('(/locations) Locations Interface', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-
-  /* login before each request */
-  before(helpers.login(agent));
 
   /*
    * number of test villages, sectors, provinces, and countries in the test

--- a/server/test/api/login.js
+++ b/server/test/api/login.js
@@ -1,33 +1,31 @@
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent, baseUrl */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 describe('(/login) The login API', function () {
   'use strict';
 
-  var url = helpers.baseUrl;
+  const port = process.env.PORT || 8080;
+  const url = `https://localhost:${port}`;
 
   // set up valid user
-  var validUser = {
+  const validUser = {
     username : 'superuser',
     password : 'superuser',
     project: 1
   };
 
-  var invalidUser = {
+  const invalidUser = {
     username: 'unauthorized',
-    password : 'unauthorized'
+    password: 'unauthorized'
   };
 
   it('rejects access to non-existant routes', function () {
     return chai.request(url)
       .get('/non-existant')
       .then(function (res) {
-
         helpers.api.errored(res, 401);
-
         expect(res.body.code).to.equal('ERRORS.UNAUTHORIZED');
       })
       .catch(helpers.handler);
@@ -37,9 +35,7 @@ describe('(/login) The login API', function () {
     return chai.request(url)
       .get('/journal')
       .then(function (res) {
-
         helpers.api.errored(res, 401);
-
         expect(res.body.code).to.equal('ERRORS.UNAUTHORIZED');
       })
       .catch(helpers.handler);

--- a/server/test/api/patientCheckIn.js
+++ b/server/test/api/patientCheckIn.js
@@ -1,17 +1,12 @@
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 describe('(/patients/:uuid/visits) Patient Check In', () => {
   'use strict';
 
   const patientUuid = '81af634f-321a-40de-bc6f-ceb1167a9f65';
-
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
-
   it('GET /patients/:uuid/visits returns a list of all patient visits', () => {
     return agent.get(`/patients/${patientUuid}/visits`)
       .then(function (result) {

--- a/server/test/api/patientDocuments.js
+++ b/server/test/api/patientDocuments.js
@@ -1,17 +1,11 @@
-/* jshint expr:true */
-/* jshint -W079 */
-const chai = require('chai');
-const expect = chai.expect;
-const fs = require('fs');
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
+const fs = require('fs');
 
 describe('(patients/:uuid/documents) Patient Documents', () => {
   'use strict';
-
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   const patientUuid = '81af634f-321a-40de-bc6f-ceb1167a9f65';
   let docId = null;

--- a/server/test/api/patientGroups.js
+++ b/server/test/api/patientGroups.js
@@ -1,15 +1,9 @@
-/* jshint expr:true */
-var chai = require('chai');
-var expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-var helpers = require('./helpers');
-helpers.configure(chai);
+const helpers = require('./helpers');
 
 describe('(/patients/groups) Patient Group API', function () {
-
-  // log in before test suite
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   var newPatientGroup = {
     enterprise_id : 1,

--- a/server/test/api/patientInvoice.js
+++ b/server/test/api/patientInvoice.js
@@ -1,19 +1,12 @@
-/* jshint expr:true */
-const chai = require('chai');
-const expect = chai.expect;
-const uuid = require('node-uuid');
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-/* import test helpers */
+const uuid = require('node-uuid');
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /* The /invoices API endpoint */
 describe('The /invoices API', function () {
   'use strict';
-
-  // login at the start of the test */
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   /* total number of invoices in the database */
   const numInvoices = 2;
@@ -162,9 +155,6 @@ describe('The /invoices API', function () {
  */
 function BillingScenarios() {
   'use strict';
-
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   /*
    * A simple invoice that should be posted without issue.  This demonstrates

--- a/server/test/api/patientInvoiceCreditNote.js
+++ b/server/test/api/patientInvoiceCreditNote.js
@@ -1,16 +1,12 @@
+/* global chai, expect, agent */
 /* jshint expr:true*/
-var chai = require('chai');
-var expect = chai.expect;
 
-var helpers = require('./helpers');
-helpers.configure(chai);
+'use strict';
+const helpers = require('./helpers');
 
 describe('(/Journal) Credit notes to reverse invoice transactions', function () {
-  var agent = chai.request.agent(helpers.baseUrl);
-            
-  const fetchableInvoiceUuid = '957e4e79-a6bb-4b4d-a8f7-c42152b2c2f6';
 
-  before(helpers.login(agent));
+  const fetchableInvoiceUuid = '957e4e79-a6bb-4b4d-a8f7-c42152b2c2f6';
 
   it('PUT /journal/:uuid/reverse Cancel an Invoice', function () {
     return agent.post('/journal/' + fetchableInvoiceUuid + '/reverse')

--- a/server/test/api/patientPictures.js
+++ b/server/test/api/patientPictures.js
@@ -1,24 +1,16 @@
-/* jshint expr:true */
-/* jshint -W079 */
-const chai = require('chai');
-const expect = chai.expect;
-const fs = require('fs');
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
+const fs = require('fs');
 
 describe('(patients/:uuid/pictures) Patient Pictures', () => {
   'use strict';
 
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
-
   const patientUuid = '274c51ae-efcc-4238-98c6-f402bfb39866';
 
   it('POST /patients/:uuid/pictures should Set Picture to a patient', () => {
-    return agent
-      .post(`/patients/${patientUuid}/pictures`)
-
+    return agent.post(`/patients/${patientUuid}/pictures`)
       .attach('pictures', fs.createReadStream(`${__dirname}/data/patient.png`))
       .then(function (res) {
         expect(res).to.have.status(200);

--- a/server/test/api/patients.js
+++ b/server/test/api/patients.js
@@ -1,19 +1,13 @@
-/* jshint expr:true */
-const chai = require('chai');
-const expect = chai.expect;
-const q = require('q');
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
+const q = require('q');
 
 describe('(/patients) Patients', function () {
   'use strict';
 
-  // ensure the client is logged into before test suite
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
-
-  var patientUuid = '81af634f-321a-40de-bc6f-ceb1167a9f65';
+  const patientUuid = '81af634f-321a-40de-bc6f-ceb1167a9f65';
 
   // TODO Should this import UUID library and track mock patient throughout?
   var mockPatientUuid = '85bf7a85-16d9-4ae5-b5c0-1fec9748d2f9';
@@ -326,10 +320,6 @@ describe('(/patients) Patients', function () {
 function PatientGroups() {
   'use strict';
 
-  // get an agent
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
-
   // shared constants
   const patientUuid = '81af634f-321a-40de-bc6f-ceb1167a9f65';
   const totalPatientGroups = 4;
@@ -368,10 +358,7 @@ function PatientGroups() {
 
 // Tests for /patients/hospital_number/:id/exists
 function HospitalNumber() {
-
-  // get an agent
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
+  'use strict';
 
   const existingNumber = 100;
   const absentNumber = 3.3;

--- a/server/test/api/priceList.js
+++ b/server/test/api/priceList.js
@@ -1,18 +1,12 @@
-/* jshint expr:true*/
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-/* import test helpers */
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /*
  * The /prices API endpoint
  */
 describe('(/prices ) Price List', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
-
 
   // constants
   const emptyPriceList = {

--- a/server/test/api/profitCenter.js
+++ b/server/test/api/profitCenter.js
@@ -1,9 +1,7 @@
-/* jshint expr:true */
-const chai = require('chai');
-const expect = chai.expect;
-const helpers = require('./helpers');
-helpers.configure(chai);
+/* global expect, chai, agent */
+/* jshint expr : true */
 
+const helpers = require('./helpers');
 
 /*
  * @todo - there are some tests missing:
@@ -11,8 +9,6 @@ helpers.configure(chai);
  *  - 404s on PUTs
  */
 describe('(/profit_centers) Profit Center', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   var newProfitCenter = {
     project_id : 1,

--- a/server/test/api/projects.js
+++ b/server/test/api/projects.js
@@ -1,9 +1,7 @@
-/* jshint expr:true*/
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /*
  * The /projects API endpoint
@@ -11,7 +9,6 @@ helpers.configure(chai);
  * This test suite implements full CRUD on the /projects HTTP API endpoint.
  */
 describe('(/projects) The projects API endpoint', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
 
   // project we will add during this test suite.
   var project = {
@@ -28,9 +25,6 @@ describe('(/projects) The projects API endpoint', function () {
 
   /* number of projects defined in the database */
   const numProjects = 3;
-
-  // make sure the client is authenticated.
-  before(helpers.login(agent));
 
   it('GET /projects returns a list of projects', function () {
     return agent.get('/projects')

--- a/server/test/api/purchase.js
+++ b/server/test/api/purchase.js
@@ -1,9 +1,7 @@
-/* jshint expr:true */
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /*
  * The /purchases API endpoint
@@ -11,8 +9,6 @@ helpers.configure(chai);
  * This test suite implements full CRUD on the /purchases HTTP API endpoint.
  */
 describe('(/purchases) Purchases', () => {
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   // purchase order we will add during this test suite
   const purchaseOrder = {

--- a/server/test/api/referenceGroup.js
+++ b/server/test/api/referenceGroup.js
@@ -1,12 +1,9 @@
-/* jshint expr: true */
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
+
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 describe('(/reference_group) The Reference Group API', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-  beforeEach(helpers.login(agent));
 
   var newReferenceGroup = {
     reference_group   : 'AR',

--- a/server/test/api/references.js
+++ b/server/test/api/references.js
@@ -1,12 +1,9 @@
-/* jshint expr:true */
-const chai = require('chai');
-const expect = chai.expect;
-const helpers = require('./helpers');
-helpers.configure(chai);
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-describe('(/reference) The Reference API', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
+const helpers = require('./helpers');
+
+describe('(/references) The Reference API', function () {
 
   var newReference = {
     is_report : 0,

--- a/server/test/api/sectionBilan.js
+++ b/server/test/api/sectionBilan.js
@@ -1,12 +1,9 @@
-/* jshint expr:true*/
-var chai = require('chai');
-var expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-var helpers = require('./helpers');
-helpers.configure(chai);
+const helpers = require('./helpers');
 
-describe('(section_bilans) The section bilan API', function () {
-  var agent = chai.request.agent(helpers.baseUrl);
+describe('(/section_bilans) The section bilan API', function () {
 
   var newSectionBilan = {
     text : 'A new Section Bilan',
@@ -17,9 +14,6 @@ describe('(section_bilans) The section bilan API', function () {
   var responseKeys = [
     'id', 'text', 'position', 'is_actif'
   ];
-
-  // log in before the test suite executes
-  before(helpers.login(agent));
 
   it('POST /section_bilans adds a section bilan', function () {
     return agent.post('/section_bilans')

--- a/server/test/api/sectionResultat.js
+++ b/server/test/api/sectionResultat.js
@@ -1,15 +1,9 @@
-/* jshint expr:true */
-var chai = require('chai');
-var expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-var helpers = require('./helpers');
-helpers.configure(chai);
+const helpers = require('./helpers');
 
 describe('(/section_resultats) The section resultat API', function () {
-  var agent = chai.request.agent(helpers.baseUrl);
-
-  // log in before test suite
-  before(helpers.login(agent));
 
   var newSectionResultat = {
     text : 'A new Section Resultat',

--- a/server/test/api/services.js
+++ b/server/test/api/services.js
@@ -1,12 +1,9 @@
-/* jshint expr:true */
-var chai = require('chai');
-var expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
-var helpers = require('./helpers');
-helpers.configure(chai);
+const helpers = require('./helpers');
 
 describe('(/services) The Service API', function () {
-  var agent = chai.request.agent(helpers.baseUrl);
 
   var newService = {
     enterprise_id : 1,
@@ -35,8 +32,6 @@ describe('(/services) The Service API', function () {
   var responseKeys = [
     'id', 'cost_center_id', 'profit_center_id', 'name', 'enterprise_id'
   ];
-
-  before(helpers.login(agent));
 
   it('POST /services adds a services', function () {
     return agent.post('/services')

--- a/server/test/api/setup.js
+++ b/server/test/api/setup.js
@@ -1,0 +1,64 @@
+/**
+ * @overview setup
+ *
+ * @description
+ * This file runs before all other mocha tests, attaching global variables used in tests.
+ *
+ * @requires chai
+ * @requires q
+ * @requires chai-http
+ * @requires chai-datetime
+ *
+ */
+'use strict';
+
+// import plugins
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const chaiDatetime =  require('chai-datetime');
+
+/*
+ * Configure NodeJS/Mocha to continue working even with invalid TLS certs
+ * This explicitly disables cert errors for the parent Node process, and
+ * should only be done for testing cases.
+ */
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+
+// base URL for all tests
+const port = process.env.PORT || 8080;
+const baseUrl = `https://localhost:${port}`;
+global.baseUrl = baseUrl;
+
+// runs before any tests in the repository
+before(() => {
+  console.log('Setting up test suite...');
+
+  // workaround for low node versions
+  if (!global.Promise) {
+    const q = require('q');
+    chai.request.addPromises(q.Promise);
+  }
+
+  // attach plugins
+  chai.use(chaiHttp);
+  chai.use(chaiDatetime);
+
+  // set global variables
+  global.chai = chai;
+  global.expect = chai.expect;
+  global.agent = chai.request.agent(baseUrl);
+  const agent = global.agent;
+
+  // base user defined in test data
+  const user = { username : 'superuser', password : 'superuser', project: 1 };
+
+  // trigger login
+  return (() => agent.post('/login').send(user))();
+});
+
+// runs after all tests are completed
+after(() => {
+  console.log('Test suite completed.');
+});
+
+

--- a/server/test/api/subsidy.js
+++ b/server/test/api/subsidy.js
@@ -1,14 +1,9 @@
-/* jshint expr:true */
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 describe('(/subsidies) Subsidies', function () {
-
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   var newSubsidy = {
     account_id:  3626,

--- a/server/test/api/suppliers.js
+++ b/server/test/api/suppliers.js
@@ -1,10 +1,8 @@
-/* jshint expr:true*/
-const chai = require('chai');
-const expect = chai.expect;
-const uuid    = require('node-uuid');
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
+const uuid    = require('node-uuid');
 
 /*
  * The /supplier API endpoint
@@ -12,8 +10,6 @@ helpers.configure(chai);
  * This test suite implements full CRUD on the /supplier HTTP API endpoint.
  */
 describe('(/suppliers) The supplier API endpoint', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   // supplier we will add during this test suite.
   var supplier = {

--- a/server/test/api/system.js
+++ b/server/test/api/system.js
@@ -1,14 +1,9 @@
-/* jshint expr:true*/
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 describe('(/system) System Information', () => {
-
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   it('GET /system/events downloads a list of events', () => {
     agent.get('/system/events')

--- a/server/test/api/users.js
+++ b/server/test/api/users.js
@@ -1,9 +1,7 @@
-/* jshint expr:true */
-const chai = require('chai');
-const expect = chai.expect;
+/* global expect, chai, agent */
+/* jshint expr : true */
 
 const helpers = require('./helpers');
-helpers.configure(chai);
 
 /*
  * The /users API endpoint
@@ -11,8 +9,6 @@ helpers.configure(chai);
  * This test suite implements full CRUD on the /users HTTP API endpoint.
  */
 describe('(/users) Users and Permissions', function () {
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   var newUser = {
     username : 'newUser',

--- a/server/test/api/vouchers.js
+++ b/server/test/api/vouchers.js
@@ -1,9 +1,7 @@
-/* jshint expr: true */
-const chai = require('chai');
-const expect = chai.expect;
-const helpers = require('./helpers');
-helpers.configure(chai);
+/* global expect, chai, agent */
+/* jshint expr : true */
 
+const helpers = require('./helpers');
 const uuid = require('node-uuid');
 
 /*
@@ -13,9 +11,6 @@ const uuid = require('node-uuid');
  */
 describe('(/vouchers) The vouchers HTTP endpoint', function () {
   'use strict';
-
-  const agent = chai.request.agent(helpers.baseUrl);
-  before(helpers.login(agent));
 
   const date = new Date();
 


### PR DESCRIPTION
This commit removes the need for importing boilerplate modules into our integration tests. The following code is no longer needed in mocha integration tests:

``` js
const chai = require('chai');
const expect = chai.expect;
require('helpers').configure(chai);
```

These are automatically added to the global scope via a `setup.js` and can be used without import.  The setup file takes advantage of `mocha`'s `before()` method to run a function before any test has been executed.

It is also not necessary to login - this is automatically configured once for the entire test suite.  Instead, just use `agent` directly. The `before()` blocks in every single test have been eliminated.  This saves roughly 44 POST requests to the server, and about a second of test runtime.

**BREAKING CHANGES**
1. `helpers.baseUrl` no longer exists.
2. `helpers.login()` no longer exists.
3. `helpers.configure()` no longer exists.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
