### PR TITLE
(FIX) Writing an invoice overwrites all costs

### DIFF
--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -158,7 +158,7 @@ BEGIN
 
   -- update relevant fields to represent final costs
   UPDATE invoice SET cost = total_subsidised_cost
-  WHERE uuid = uuid;
+  WHERE invoice.uuid = uuid;
 
   -- return information relevant to the final calculated and written bill
   select items_cost, billing_services_cost, total_cost_to_debtor, total_subsidy_cost, total_subsidised_cost;  


### PR DESCRIPTION
This commit updates the `WriteInvoice` procedure to check the invoice uuid provided with with the invoice table instead of against itself. 

(Removes tautology causing all invoice costs to be overwritten on every invoice created).

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/596

---

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.
