### PR TITLE
fix(test): fix failing e2e patient uploads

### DIFF
--- a/client/test/e2e/patient/picture.spec.js
+++ b/client/test/e2e/patient/picture.spec.js
@@ -12,24 +12,22 @@ describe('Patient Record', function () {
   const root = '#/patients/';
   const id = '274c51ae-efcc-4238-98c6-f402bfb39866';
 
-
   const path = root.concat(id);
   before(() => helpers.navigate(path));
 
-  it('Upload a patient Picture', function () {
-    var fileToUpload = '../../../../server/test/api/data/patient.png',
-      absolutePath = paths.resolve(__dirname, fileToUpload);
-    
+  it('uploads a patient picture', function () {
+    const fileToUpload = '../../../../server/test/api/data/patient.png';
+    const absolutePath = paths.resolve(__dirname, fileToUpload);
+
     element.all(by.css('input[type=file]')).get(0).sendKeys(absolutePath);
     components.notification.hasSuccess();
   });
 
-  it('Unable to Upload a file who aren\'t a picture', function () {
-    var fileToUpload = '../../../../server/test/api/data/sample.pdf',
-      absolutePath = paths.resolve(__dirname, fileToUpload);
-    
+  it('unable to upload a file that is not a picture', function () {
+    const fileToUpload = '../../../../server/test/api/data/sample.pdf';
+    const absolutePath = paths.resolve(__dirname, fileToUpload);
+
     element.all(by.css('input[type=file]')).get(0).sendKeys(absolutePath);
     components.notification.hasDanger();
   });
-
 });

--- a/client/test/e2e/patient/record.spec.js
+++ b/client/test/e2e/patient/record.spec.js
@@ -28,12 +28,12 @@ describe('Patient Record', function () {
   before(() => helpers.navigate(url));
 
   it('downloads and correctly displays patient information', function () {
-    expect(element(by.id('name')).getText()).to.eventually.equal(patient.name);
-    expect(element(by.id('patientID')).getText()).to.eventually.equal(patient.id);
-    expect(element(by.id('hospitalNo')).getText()).to.eventually.equal(patient.hospital_no);
-    expect(element(by.id('age')).getText()).to.eventually.equal(patient.age);
-    expect(element(by.id('gender')).getText()).to.eventually.equal(patient.gender);
-  });
+    FU.hasText(by.id('name'), patient.name);
+    FU.hasText(by.id('patientID'), patient.id);
+    FU.hasText(by.id('hospitalNo'), patient.hospital_no);
+    FU.hasText(by.id('age'), patient.age);
+    FU.hasText(by.id('gender'), patient.gender);
+ });
 
   // sub unit tests - these can be moved to individual files if they become too large
   it('displays the correct number of check ins', function () {
@@ -49,60 +49,61 @@ describe('Patient Record', function () {
   });
 
   // Upload patient documents
-  it('Upload a valid image as document', () => {
+  it('upload a valid image as document', () => {
     let title = '[e2e] New Image As Document';
-    let fileToUpload = 'client/test/e2e/shared/upload/file.jpg';
-    let absolutePath = path.resolve(fileToUpload);
+    let fileToUpload = '../shared/upload/file.jpg';
+    let absolutePath = path.resolve(__dirname, fileToUpload);
 
     element(by.css('[data-document-action="add"]')).click();
-    element(by.model('$ctrl.title')).clear().sendKeys(title);
-    element(by.css('input[type="file"]')).sendKeys(absolutePath);
+
+    FU.input('$ctrl.title', title);
+    FU.input('$ctrl.file', absolutePath);
 
     FU.modal.submit();
     components.notification.hasSuccess();
   });
 
-  // Upload patient documents
-  it('Upload a PDF document', () => {
+  // upload patient documents
+  it('upload a PDF document', () => {
     let title = '[e2e] New Document';
-    let fileToUpload = 'client/test/e2e/shared/upload/file.pdf';
-    let absolutePath = path.resolve(fileToUpload);
+    let fileToUpload = '../shared/upload/file.pdf';
+    let absolutePath = path.resolve(__dirname, fileToUpload);
 
     element(by.css('[data-document-action="add"]')).click();
-    element(by.model('$ctrl.title')).clear().sendKeys(title);
-    element(by.css('input[type="file"]')).sendKeys(absolutePath);
+    FU.input('$ctrl.title', title);
+    FU.input('$ctrl.file', absolutePath);
 
     FU.modal.submit();
     components.notification.hasSuccess();
   });
 
   // test invalid file upload
-  it('Cannot upload invalid document', () => {
+  it('cannot upload invalid document', () => {
     let title = '[e2e] Invalid Document';
-    let fileToUpload = 'client/test/e2e/shared/upload/file.virus';
+    let fileToUpload = '../shared/upload/file.virus';
     let absolutePath = path.resolve(fileToUpload);
 
     element(by.css('[data-document-action="add"]')).click();
-    element(by.model('$ctrl.title')).clear().sendKeys(title);
-    element(by.css('input[type="file"]')).sendKeys(absolutePath);
-    element(by.css('[data-error-message]')).isPresent();
 
+    FU.input('$ctrl.title', title);
+    FU.input('$ctrl.file', absolutePath);
+
+    FU.exists(by.css('[data-error-message]'), true);
     FU.modal.close();
   });
 
   // change document view
-  it('Change document view', () => {
+  it('change document view', () => {
     element(by.css('[data-document-action="thumbnail"]')).click();
-    element(by.css('[data-view="thumbnail"]')).isPresent();
+    FU.exists(by.css('[data-view="thumbnail"]'), true);
 
     element(by.css('[data-document-action="list"]')).click();
-    element(by.css('[data-view="list"]')).isPresent();
+    FU.exists(by.css('[data-view="list"]'), true);
   });
 
   it('informs the user that there is no patient for invalid request', function () {
     helpers.navigate(root.concat('invalidid'));
     components.notification.hasError();
-    expect(element(by.id('nopatient')).isPresent()).to.eventually.equal(true);
+    FU.exists(by.id('nopatient'), true);
   });
-
 });

--- a/client/test/e2e/shared/FormUtils.js
+++ b/client/test/e2e/shared/FormUtils.js
@@ -159,6 +159,23 @@ module.exports = {
     return option.click();
   },
 
+  /**
+   * @method hasText
+   *
+   * @description
+   * Asserts that an element matching the locator contains the text passed
+   * in as a parameter.
+   *
+   * @param {Object} locator - a protractor web-driver locator
+   * @param {String} text - the text to search for within the element.
+   */
+  hasText: function hasText(locator, text) {
+    expect(
+      element(locator).getText(),
+      `Expected locator ${locator.toString()} to contain "${text}".`
+    ).to.eventually.equal(text);
+  },
+
 
   // bind commonly used form buttons  These require specific data tags to be
   // leveraged effectively.


### PR DESCRIPTION
This commit fixes the failing patient upload tests by making sure path resolution works locally on Linux.  It should work properly on windows systems as well.

It also implements FU.hasText() to check if an element contains given text.  This helps clean up the tests nicely.

Finally, it catches some invalid assertions (`element.isPresent()` without the expect) and ensures they are valid and pass.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.
