### PR TITLE
refactor(test): GridUtils for ui-grid e2e tests

### DIFF
--- a/client/test/e2e/journal/journal.config.js
+++ b/client/test/e2e/journal/journal.config.js
@@ -47,4 +47,3 @@ function JournalConfigurationModal() {
 }
 
 module.exports = JournalConfigurationModal;
-

--- a/client/test/e2e/journal/journal.page.js
+++ b/client/test/e2e/journal/journal.page.js
@@ -1,4 +1,4 @@
-/* global element, by, browser, protractor */
+/* global element, by, browser */
 
 const chai = require('chai');
 const expect = chai.expect;
@@ -7,46 +7,14 @@ const helpers = require('../shared/helpers');
 helpers.configure(chai);
 
 const FU = require('../shared/FormUtils');
+const GU = require('../shared/GridUtils');
 
 function JournalCorePage() {
   const page = this;
-
-  const grid = element(by.id('journal-grid'));
-  const gridRows = grid.element( by.css('.ui-grid-render-container-body')).all( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index') );
-  const gridColumns = grid.element( by.css('.ui-grid-render-container-body')).element( by.css('.ui-grid-header') ).all( by.repeater('col in colContainer.renderedColumns track by col.uid') );
+  const gridId = 'journal-grid';
 
   function openGridConfigurationModal() {
     return $('[data-method="configure"]').click();
-  }
-
-  // assert that the journal's column count is the number passed in
-  function expectColumnCount(number) {
-    expect(gridColumns.count()).to.eventually.equal(number);
-  }
-
-  // assert that the row count is the number provided
-  function expectRowCount(number) {
-    expect(gridRows.count()).to.eventually.equal(number);
-  }
-
-  // takes in an array of column texts and asserts they are the column headers
-  // @todo - migrate this to GridUtils
-  function expectHeaderColumns(expectedColumns) {
-    const headerColumns = grid
-      .element(by.css('.ui-grid-render-container-body'))
-      .element(by.css('.ui-grid-header'))
-      .all(by.repeater('col in colContainer.renderedColumns track by col.uid'))
-      .all(by.css('.ui-grid-header-cell-label'));
-
-    expect(headerColumns.count()).to.eventually.equal(expectedColumns.length);
-
-    headerColumns.getText().then(columnTexts => {
-      columnTexts = columnTexts.map(function trimText (text) {
-        return text.replace(/^\s+/, '').replace(/\s+$/, '');
-      });
-
-      expect(columnTexts).to.deep.equal(expectedColumns);
-    });
   }
 
   // polyfill for array.includes on lower node versions
@@ -84,13 +52,13 @@ function JournalCorePage() {
 
   // expose methods
   page.openGridConfigurationModal = openGridConfigurationModal;
-
-  page.expectColumnCount = expectColumnCount;
-  page.expectRowCount = expectRowCount;
-  page.expectHeaderColumns = expectHeaderColumns;
-
   page.setColumnCheckboxes = setColumnCheckboxes;
   page.setDefaultColumnCheckboxes = setDefaultColumnCheckboxes;
+
+  // custom wrappers for GU functionality
+  page.expectColumnCount = (number) => GU.expectColumnCount(gridId, number);
+  page.expectRowCount = (number) => GU.expectRowCount(gridId, number);
+  page.expectHeaderColumns = (headerColumns) => GU.expectHeaderColumns(gridId, headerColumns);
 }
 
 module.exports = JournalCorePage;

--- a/client/test/e2e/shared/GridUtils.js
+++ b/client/test/e2e/shared/GridUtils.js
@@ -1,0 +1,61 @@
+/* global element, by, browser */
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const helpers = require('./helpers');
+helpers.configure(chai);
+
+function getGrid(gridId) {
+  return element(by.id(gridId));
+}
+
+function getColumns(gridId) {
+  return getGrid(gridId)
+    .element(by.css('.ui-grid-render-container-body'))
+    .element( by.css('.ui-grid-header'))
+    .all(by.repeater('col in colContainer.renderedColumns track by col.uid'));
+}
+
+function getRows(gridId) {
+  return getGrid(gridId)
+    .element(by.css('.ui-grid-render-container-body'))
+    .all(by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index'));
+}
+
+function expectRowCount(gridId, number) {
+  var rows = getRows(gridId);
+  expect(rows.count()).to.eventually.equal(number);
+}
+
+// assert that the journal's column count is the number passed in
+function expectColumnCount(gridId, number) {
+  var columns = getColumns(gridId);
+  expect(columns.count()).to.eventually.equal(number);
+}
+
+// takes in an array of column texts and asserts they are the column headers
+// @todo - migrate this to GridUtils
+function expectHeaderColumns(gridId, expectedColumns) {
+  const columns = getColumns(gridId);
+  const headerColumns = columns
+    .all(by.css('.ui-grid-header-cell-label'));
+
+  expect(
+    headerColumns.count()
+  ).to.eventually.equal(expectedColumns.length);
+
+  headerColumns.getText().then(columnTexts => {
+    columnTexts = columnTexts.map(function trimText (text) {
+      return text.replace(/^\s+/, '').replace(/\s+$/, '');
+    });
+
+    expect(columnTexts).to.deep.equal(expectedColumns);
+  });
+}
+
+exports.getRows = getRows;
+exports.getColumns = getColumns;
+exports.expectRowCount = expectRowCount;
+exports.expectColumnCount = expectColumnCount;
+exports.expectHeaderColumns = expectHeaderColumns;


### PR DESCRIPTION
This commit implements a helper library for ui-grid end-to-end tests. The goal is to ensure uniform behavior between tests, increase ui-grid test development, and ensure that dangling DOM nodes are not queried after updates.  This is achieved by re-specifying the grid by ID each time an action is to be taken on the grid.

Closes #614.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
