### PR TITLE
feat(settings): implement bug report link

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -910,7 +910,9 @@
     "TITLE"               : "Service Management"
   },
   "SETTINGS": {
-    "TITLE" : "Settings"
+    "TITLE" : "Settings",
+    "BUG_LINK" : "Report an Issue",
+    "BUG_REPORT" : "Thank you for filing a bug! Please read the following message and replace the text surrounded by brackets ([[]]) with your report.\r\nWhere did the bug occur?\r\n\t\t[[ ENTER TEXT HERE ]]\r\nWhat task were you trying to accomplish?\r\n\t\t[[ ENTER TEXT HERE ]]\r\nWhat result did you expect?\r\n\t\t[[ ENTER TEXT HERE ]]\r\nAny other relevant information or comments?\r\n\t\t[[ ENTER TEXT HERE ]]\r\nMay we contact you for more information?\r\n\t\t[x] YES [ ] NO"
   },
   "SUBSIDY": {
     "ADDING_SUBSIDY"   : "Adding subsidy",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -888,7 +888,9 @@
     "TITLE"               : "Gestion des services"
   },
   "SETTINGS": {
-    "TITLE" : "Paramètres"
+    "TITLE" : "Paramètres",
+    "BUG_LINK" : "Signaler un Problème",
+    "BUG_REPORT" : "Thank you for filing a bug! Please read the following message and replace the text surrounded by brackets ([[]]) with your report.\r\nWhere did the bug occur?\r\n\t\t[[ ENTER TEXT HERE ]]\r\nWhat task were you trying to accomplish?\r\n\t\t[[ ENTER TEXT HERE ]]\r\nWhat result did you expect?\r\n\t\t[[ ENTER TEXT HERE ]]\r\nAny other relevant information or comments?\r\n\t\t[[ ENTER TEXT HERE ]]\r\nMay we contact you for more information?\r\n\t\t[x] YES [ ] NO"
   },
   "SUBSIDY": {
     "ADDING_SUBSIDY"   : "Ajout d'une subvention",

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -460,6 +460,9 @@ function constantConfig() {
     purchase : {
       GRID_HEIGHT: 200
     },
+    settings: {
+      CONTACT_EMAIL : 'developers@imaworldhealth.org'
+    },
     dates : {
       minDOB : new Date('1900-01-01'),
       maxDOB : new Date(),

--- a/client/src/partials/settings/settings.html
+++ b/client/src/partials/settings/settings.html
@@ -44,6 +44,12 @@
           data-logout-button>
           <span class="glyphicon glyphicon-log-out"></span> {{ "FORM.BUTTONS.LOGOUT" | translate }}
         </button>
+
+        <a ng-href="mailto:{{SettingsCtrl.bugLink}}" class="btn btn-default" data-bug-report-button>
+          <span class="text-danger">
+            <i class="fa fa-bug"></i> {{ "SETTINGS.BUG_LINK" | translate }}
+          </span>
+        </a>
       </div>
     </div>
   </div>

--- a/client/src/partials/settings/settings.js
+++ b/client/src/partials/settings/settings.js
@@ -1,8 +1,9 @@
 angular.module('bhima.controllers')
-.controller('settings', SettingsController);
+  .controller('settings', SettingsController);
 
 SettingsController.$inject = [
-  '$state', 'LanguageService', 'SessionService'
+  '$state', 'LanguageService', 'SessionService', 'bhConstants', '$translate',
+  'NotifyService'
 ];
 
 /**
@@ -13,7 +14,7 @@ SettingsController.$inject = [
  *
  * @constructor
  */
-function SettingsController($state, Languages, Session) {
+function SettingsController($state, Languages, Session, Constants, $translate, Notify) {
   var vm = this;
 
   // the url to return to (using the back button)
@@ -30,5 +31,25 @@ function SettingsController($state, Languages, Session) {
   Languages.read()
   .then(function (languages) {
     vm.languages = languages;
-  });
+  })
+  .catch(Notify.handleError);
+
+  // formatting or bug report
+  var emailAddress = Constants.settings.CONTACT_EMAIL;
+  var subject = '[BUG] ' + new Date().toLocaleDateString() + ' -  ' + Session.enterprise.name;
+
+  // get the translated bug report
+  $translate('SETTINGS.BUG_REPORT')
+    .then(function (body) {
+
+      var text =
+        Session.user.username + ' ' +
+        new Date().toLocaleDateString() + '\r\n\r\n' +
+        body;
+
+      // template in the bug link
+      vm.bugLink = encodeURI(emailAddress + '?subject=' + subject + '&body=' + text);
+    })
+    .catch(Notify.handleError);
+
 }


### PR DESCRIPTION
This commit implements a "Report an Issue" link on the settings page.  The link opens up the default email client of the user with a pre-made email, translated into their current language.  Only the English
translation exists, but it can be easily updated for French.

Closes #167.

This is what it looks like:
![bugreport](https://cloud.githubusercontent.com/assets/896472/17402870/2f916c2a-5a4d-11e6-87db-922c5a834eb9.png)
_Fig 1: Bug Report Button_

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
