### PR TITLE
fix(journal): ensure col aggregates are displayed

### DIFF
--- a/client/src/js/components/bhInfo.js
+++ b/client/src/js/components/bhInfo.js
@@ -6,7 +6,7 @@ angular.module('bhima.components')
       '  uib-popover-template="$ctrl.template" ' +
       '  popover-placement="right" ' +
       '  popover-append-to-body="true" ' +
-      '  popover-trigger="mouseenter"> ' +
+      '  popover-trigger="\'mouseenter\'"> ' +
       '</span> ',
     bindings : {
       template: '@',

--- a/client/src/js/services/grid/GridGrouping.js
+++ b/client/src/js/services/grid/GridGrouping.js
@@ -20,12 +20,15 @@ function GridGroupingService(uiGridGroupingConstants, $filter, Session, $timeout
   // cache the currency filter for later lookup
   var $currency = $filter('currency');
 
+  // alias copy
+  var copy = angular.copy;
+
   /** @const renders any currencied amount */
   var DEFAULT_COST_AGGREGATOR = {
 
     // used to render amounts in the aggregate columns
     // TODO - this should render the currency from the row set.
-    customTreeAggregationFinalizerFn : function amountRenderer(aggregation) {
+    customTreeAggregationFinalizerFn : function (aggregation) {
       aggregation.rendered = $currency(aggregation.value, currencyId);
     },
 
@@ -33,17 +36,29 @@ function GridGroupingService(uiGridGroupingConstants, $filter, Session, $timeout
   };
 
   /** @const aggregates quantities as needed */
-  var DEFAULT_QUANTITY_AGGREGATOR= {
+  var DEFAULT_QUANTITY_AGGREGATOR = {
     treeAggregationType : uiGridGroupingConstants.aggregation.SUM,
+  };
+
+  /** @const aggregates by choosing a single item to display */
+  /** @todo - this currently defaults to MAX, should be implemented as its own custom aggregator */
+  var DEFAULT_SINGLE_AGGREGATOR = {
+    treeAggregationType: uiGridGroupingConstants.aggregation.MAX,
+    customTreeAggregationFinalizerFn: function (aggregation) {
+      aggregation.rendered = aggregation.value;
+    }
   };
 
   /** @const aggregators assigned by column ids */
   var DEFAULT_AGGREGATORS = {
-    'debit_equiv' : DEFAULT_COST_AGGREGATOR,
-    'credit_equiv' : DEFAULT_COST_AGGREGATOR,
-    'cost' : DEFAULT_COST_AGGREGATOR,
-    'quantity' : DEFAULT_QUANTITY_AGGREGATOR,
-    'amount' : DEFAULT_QUANTITY_AGGREGATOR
+    'debit_equiv' : copy(DEFAULT_COST_AGGREGATOR),
+    'credit_equiv' : copy(DEFAULT_COST_AGGREGATOR),
+    'cost' : copy(DEFAULT_COST_AGGREGATOR),
+    'quantity' : copy(DEFAULT_QUANTITY_AGGREGATOR),
+    'amount' : copy(DEFAULT_QUANTITY_AGGREGATOR),
+    'description' : copy(DEFAULT_SINGLE_AGGREGATOR),
+    'date' : copy(DEFAULT_SINGLE_AGGREGATOR),
+    'trans_date' : copy(DEFAULT_SINGLE_AGGREGATOR), // TODO - eliminate this in favor of "date"
   };
 
   /**

--- a/client/src/partials/journal/templates/credit.cell.html
+++ b/client/src/partials/journal/templates/credit.cell.html
@@ -1,3 +1,7 @@
-<div class="ui-grid-cell-contents">
-  {{ row.entity.credit_equiv | currency:row.entity.currency_id }}
+<div class="ui-grid-cell-contents" title="TOOLTIP" ng-if="!row.groupHeader">
+  {{ row.entity.credit | currency:row.entity.currency_id }}
+</div>
+
+<div class="ui-grid-cell-contents" title="TOOLTIP" ng-if="row.groupHeader">
+  {{ COL_FIELD CUSTOM_FILTERS }}
 </div>

--- a/client/src/partials/journal/templates/credit_equiv.cell.html
+++ b/client/src/partials/journal/templates/credit_equiv.cell.html
@@ -1,3 +1,7 @@
-<div class="ui-grid-cell-contents">
+<div class="ui-grid-cell-contents" title="TOOLTIP" ng-if="!row.groupHeader">
   {{ row.entity.credit_equiv | currency:grid.appScope.enterprise.currency_id }}
+</div>
+
+<div class="ui-grid-cell-contents" title="TOOLTIP" ng-if="row.groupHeader">
+  {{ COL_FIELD CUSTOM_FILTERS }}
 </div>

--- a/client/src/partials/journal/templates/debit.cell.html
+++ b/client/src/partials/journal/templates/debit.cell.html
@@ -1,3 +1,9 @@
-<div class="ui-grid-cell-contents">
-  {{ row.entity.debit_equiv | currency:row.entity.currency_id }}
+<div class="ui-grid-cell-contents"  title="TOOLTIP" ng-if="!row.groupHeader">
+  {{ row.entity.debit | currency:row.entity.currency_id }}
 </div>
+
+<div class="ui-grid-cell-contents" title="TOOLTIP" ng-if="row.groupHeader">
+  {{COL_FIELD CUSTOM_FILTERS}}
+</div>
+
+

--- a/client/src/partials/journal/templates/debit_equiv.cell.html
+++ b/client/src/partials/journal/templates/debit_equiv.cell.html
@@ -1,3 +1,7 @@
-<div class="ui-grid-cell-contents">
+<div class="ui-grid-cell-contents" title="TOOLTIP" ng-if="!row.groupHeader">
   {{ row.entity.debit_equiv | currency:grid.appScope.enterprise.currency_id }}
+</div>
+
+<div class="ui-grid-cell-contents" title="TOOLTIP" ng-if="row.groupHeader">
+  {{ COL_FIELD CUSTOM_FILTERS }}
 </div>


### PR DESCRIPTION
This commit ensures that the column aggregates for debits, credits, descriptions, and dates are shown on the grid group headers.  Because of careless cell template design, these values were not substituted into the templates in a previous iteration.

Closes #626.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
