### PR TITLE
(refactor) patient invoice api

### DIFF
--- a/client/src/js/services/PatientInvoiceService.js
+++ b/client/src/js/services/PatientInvoiceService.js
@@ -2,7 +2,7 @@ angular.module('bhima.services')
   .service('PatientInvoiceService', PatientInvoiceService);
 
 PatientInvoiceService.$inject = [
-  '$http', '$uibModal', 'util', 'SessionService'
+  '$uibModal', 'util', 'SessionService', 'PrototypeApiService'
 ];
 
 /**
@@ -12,35 +12,13 @@ PatientInvoiceService.$inject = [
  * through the PatientService, but for queries not tied to particular patients,
  * this service is particularly useful.
  */
-function PatientInvoiceService($http, Modal, util, Session) {
-  var service = this;
-  var baseUrl = '/invoices/';
+function PatientInvoiceService(Modal, util, Session, Api) {
+  var service = new Api('/invoices/');
 
-  service.read = read;
   service.create = create;
-  service.search = search;
   service.openSearchModal = openSearchModal;
   service.formatFilterParameters = formatFilterParameters;
   service.openCreditNoteModal = openCreditNoteModal;
-
-  /**
-   * @method read
-   *
-   * @description
-   * Retrieves a particular invoice by UUID or a list of all invoices if no UUID is
-   * specified.
-   *
-   * @param {String} uuid (optional) - the uuid of the patient invoice to look
-   *   up in the database.
-   * @param {Object} options (optional) - options to be passed as query string
-   *   parameters to the http request
-   * @returns {Promise} promise - the result of the HTTP request
-   */
-  function read(uuid, options) {
-    var target = baseUrl.concat(uuid || '');
-    return $http.get(target)
-      .then(util.unwrapHttpResponse);
-  }
 
   /**
    * @method create
@@ -71,25 +49,7 @@ function PatientInvoiceService($http, Modal, util, Session) {
       return subsidy.subsidy_id;
     });
 
-    return $http.post(baseUrl, { invoice : invoice })
-      .then(util.unwrapHttpResponse);
-  }
-
-  /**
-   * @method search
-   *
-   * @description
-   * This method is responsible for searching for invoice(s) based on passed parameters
-   *
-   * @param {Object} options - query string parameters to be passed to $http for
-   *   serialization.
-   *
-   * @returns {Promise} - a promise resolving to the HTTP result.
-   */
-  function search (options) {
-    var target = baseUrl.concat('search');
-    return $http.get(target, { params : options })
-        .then(util.unwrapHttpResponse);
+    return Api.create.call(this, { invoice: invoice });
   }
 
   // utility methods

--- a/client/src/js/services/PatientInvoiceService.js
+++ b/client/src/js/services/PatientInvoiceService.js
@@ -21,7 +21,7 @@ function PatientInvoiceService($http, Modal, util, Session) {
   service.search = search;
   service.openSearchModal = openSearchModal;
   service.formatFilterParameters = formatFilterParameters;
-  service.openCreditNoteModal = openCreditNoteModal;  
+  service.openCreditNoteModal = openCreditNoteModal;
 
   /**
    * @method read
@@ -60,10 +60,16 @@ function PatientInvoiceService($http, Modal, util, Session) {
     billingServices = billingServices || [];
     subsidies = subsidies || [];
 
-    // concat into a single object to send back to the client
+    // concatenate into a single object to send back to the client
     invoice.items = invoiceItems.map(filterInventorySource);
-    invoice.billingServices = billingServices;
-    invoice.subsidies = subsidies;
+
+    invoice.billingServices = billingServices.map(function (billingService) {
+      return billingService.billing_service_id;
+    });
+
+    invoice.subsidies = subsidies.map(function (subsidy) {
+      return subsidy.subsidy_id;
+    });
 
     return $http.post(baseUrl, { invoice : invoice })
       .then(util.unwrapHttpResponse);
@@ -119,10 +125,8 @@ function PatientInvoiceService($http, Modal, util, Session) {
     return Modal.open({
       templateUrl : 'partials/patient_invoice/registry/modalCreditNote.html',
       resolve : {
-        data : {
-          invoice : invoice
-        }
-      },    
+        data : { invoice : invoice }
+      },
       size : 'md',
       animation : true,
       keyboard  : false,

--- a/server/controllers/finance/invoice/patientInvoice.create.js
+++ b/server/controllers/finance/invoice/patientInvoice.create.js
@@ -1,4 +1,5 @@
 'use strict';
+
 /**
  * Patient Invoice - Create State
  * @module controllers/finance/patientInvoice
@@ -90,15 +91,41 @@ function processInvoice(invoiceUuid, invoice) {
   return _.values(invoice);
 }
 
-/** @todo there is a proposal to transition this API to accept an array of billing service IDs, this method will have to updated in this re-factor */
+/**
+ * @method processBillingServices
+ *
+ * @description
+ * Maps an array of billing service ids into billing service ids and invoice
+ * UUID tuples.
+ *
+ * @param {Buffer} invoiceUuid - the binary invoice UUID
+ * @param {Array|Undefined} subsidiesDetails - an array of billing service ids
+ *   if they exist.
+ * @returns {Array} - a possibly empty array billing service ids and invoice UUID pairs.
+ *
+ * @private
+ */
 function processBillingServices(invoiceUuid, billingServiceDetails) {
   let billingServices = billingServiceDetails || [];
-  return billingServices.map(billingService => [billingService.billing_service_id, invoiceUuid]);
+  return billingServices.map(billingServiceId => [billingServiceId, invoiceUuid]);
 }
 
+/**
+ * @method processSubsidies
+ *
+ * @description
+ * Maps an array of subsidy ids into subsidy id and invoice uuid tuples
+ *
+ * @param {Buffer} invoiceUuid - the binary invoice uuid
+ * @param {Array|Undefined} subsidiesDetails - an array of subsidy ids if they
+ *   exist.
+ * @returns {Array} - a possibly empty array subsidy ids and invoice UUID pairs.
+ *
+ * @private
+ */
 function processSubsidies(invoiceUuid, subsidiesDetails) {
   let subsidies = subsidiesDetails || [];
-  return subsidies.map(subsidy => [subsidy.subsidy_id, invoiceUuid]);
+  return subsidies.map(subsidyId => [subsidyId, invoiceUuid]);
 }
 
 // process invoice items, transforming UUIDs into binary.
@@ -117,7 +144,7 @@ function processInvoiceItems(invoiceUuid, invoiceItems) {
     item.debit = 0;
   });
 
-  // create a filter to align invoice item columns to the sql columns
+  // create a filter to align invoice item columns to the SQL columns
   let filter =
     util.take('uuid', 'inventory_uuid', 'quantity', 'transaction_price', 'inventory_price', 'debit', 'credit', 'invoice_uuid');
 

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -1,14 +1,16 @@
 'use strict';
+
 /**
  * Patient Invoice API Controller
- *.@module controllers/finance/patientInvoice
+ *
+ *@module controllers/finance/patientInvoice
  *
  * @todo (required) major bug - Invoice items are entered based on order or attributes sent from client - this doesn't seem to be consistent as of 2.X
  * @todo GET /invoices/patient/:uuid - retrieve all patient invoices for a specific patient
  *    - should this be /patients/:uuid/invoices?
  * @todo Factor in subsidies, this depends on price lists and billing services infrastructure
- * @todo Credit note logic pending on clear design
  */
+
 const q    = require('q');
 const db   = require('../../lib/db');
 const uuid = require('node-uuid');
@@ -74,8 +76,9 @@ function list(req, res, next) {
 
 
 /**
- * lookupInvoice
+ * @method lookupInvoice
  *
+ * @description
  * Find an invoice by id in the database.
  *
  * @param {string} invoiceUuid - the uuid of the invoice in question
@@ -110,11 +113,12 @@ function lookupInvoice(invoiceUuid) {
     JOIN billing_service ON billing_service.id = invoice_billing_service.billing_service_id
     WHERE invoice_billing_service.invoice_uuid = ?`;
 
-  let invoiceSubsidyQuery =
-    `SELECT invoice_subsidy.value, subsidy.label, subsidy.value AS subsidy_value
+  let invoiceSubsidyQuery = `
+    SELECT invoice_subsidy.value, subsidy.label, subsidy.value AS subsidy_value
     FROM invoice_subsidy
     JOIN subsidy ON subsidy.id = invoice_subsidy.subsidy_id
-    WHERE invoice_subsidy.invoice_uuid = ?`;
+    WHERE invoice_subsidy.invoice_uuid = ?;
+  `;
 
   return db.exec(invoiceDetailQuery, [buid])
     .then(function (rows) {
@@ -128,7 +132,6 @@ function lookupInvoice(invoiceUuid) {
     })
     .then(function (rows) {
       record.items = rows;
-
       return db.exec(invoiceBillingQuery, [buid]);
     })
     .then(function (rows) {
@@ -138,7 +141,7 @@ function lookupInvoice(invoiceUuid) {
     })
     .then(function (rows) {
       record.subsidy = rows;
-      
+
       return record;
     });
 }
@@ -187,8 +190,8 @@ function find(options) {
   let sql =`
     SELECT BUID(invoice.uuid) as uuid, invoice.project_id, CONCAT(project.abbr, invoice.reference) AS reference,
       invoice.date, CONCAT(patient.first_name, ' - ',  patient.last_name) as patientNames, invoice.cost,
-       BUID(invoice.debtor_uuid) as debtor_uuid, invoice.user_id, invoice.is_distributable,
-        service.name as serviceName, CONCAT(user.first, ' - ', user.last) as createdBy, voucher.type_id
+      BUID(invoice.debtor_uuid) as debtor_uuid, invoice.user_id, invoice.is_distributable,
+      service.name as serviceName, CONCAT(user.first, ' - ', user.last) as createdBy, voucher.type_id
     FROM invoice
     LEFT JOIN patient ON invoice.debtor_uuid = patient.debtor_uuid
     LEFT JOIN voucher ON voucher.reference_uuid = invoice.uuid

--- a/server/test/api/patientInvoice.js
+++ b/server/test/api/patientInvoice.js
@@ -314,10 +314,7 @@ function BillingScenarios() {
       credit: 25
     }],
 
-    /* @todo - change this API to take in an array of billing service ids */
-    billingServices : [{
-      billing_service_id : 1
-    }]
+    billingServices : [ 1 ]
   };
 
   it('creates and posts a patient invoice (simple + 1 billing service)', () => {
@@ -379,10 +376,7 @@ function BillingScenarios() {
       credit: 40.95
     }],
 
-    /* @todo - change this API to take in an array of subsidy ids */
-    subsidies : [{
-      subsidy_id : 1
-    }]
+    subsidies : [ 1 ]
   };
 
   it('creates and posts a patient invoice (simple + 1 subsidy)', () => {


### PR DESCRIPTION
Closes #579.

This PR  refactors the patient invoice create API to only send back the numeric billing service and subsidies IDs when creating new records. Since all the information is already on the server, this was discarded upon arrival anyway.  The client now only sends an array of IDs instead of an array of objects.

Additionally, this PR changes the `PatientInvoiceService` to inherit from the `PrototypeApiService` and is able to recover ~25 lines of code because of it.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
