### PR TITLE
fix(tests): remove all e2e test warnings

### DIFF
--- a/client/src/js/services/receipts/modal/receiptModal.tmpl.html
+++ b/client/src/js/services/receipts/modal/receiptModal.tmpl.html
@@ -53,7 +53,7 @@
 </div>
 
 <div class="modal-footer">
-  <button type="button" class="btn btn-default btn-sm" ng-click="ReceiptCtrl.close()" data-action="close">
+  <button type="button" class="btn btn-default btn-sm" ng-click="ReceiptCtrl.close()" data-action="close" data-method="close">
     {{ "FORM.BUTTONS.CLOSE" | translate }}
   </button>
   <button class="btn btn-primary btn-sm" ng-click="ReceiptCtrl.print()" data-action="print">

--- a/client/src/partials/inventory/list/list.js
+++ b/client/src/partials/inventory/list/list.js
@@ -37,7 +37,7 @@ function InventoryListController ($translate, Inventory, Notify, uiGridConstants
   ];
 
   /** button Print */
-  vm.buttonPrint = { 
+  vm.buttonPrint = {
     pdfUrl: '/inventory/reports/metadata'
   };
 

--- a/client/src/partials/patient_invoice/registry/registry.js
+++ b/client/src/partials/patient_invoice/registry/registry.js
@@ -17,7 +17,7 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util,
 
   var invoiceActionsTemplate =
     '<div class="ui-grid-cell-contents">' +
-      '<a href ng-click="grid.appScope.openReceiptModal(row.entity.uuid)">' +
+      '<a href ng-click="grid.appScope.openReceiptModal(row.entity.uuid)" data-method="receipt">' +
         '<span class="fa fa-file-pdf-o"></span> {{ "TABLE.COLUMNS.RECEIPT" | translate }}' +
       '</a>' +
       '&nbsp;&nbsp;' +

--- a/test/end-to-end/accounts/accounts.page.js
+++ b/test/end-to-end/accounts/accounts.page.js
@@ -6,24 +6,14 @@ const expect = chai.expect;
 const helpers = require('../shared/helpers');
 helpers.configure(chai);
 
-const GU = require('../shared/gridTestUtils.spec.js');
+const GU = require('../shared/GridUtils.js');
 
 function AccountsPage() {
   const page = this;
-
   const gridId = 'account-grid';
-  const grid = GU.getGrid(gridId);
 
-  page.getRowCount = getRowCount;
-
-  function getRowCount() {
-    var rows = grid.element(by.css('.ui-grid-render-container-body'))
-        .all(by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index')).count();
-    return rows;
-  }
-
-  page.expectGridRows = function expectGridRows(rows) {
-    expect(getRowCount()).to.eventually.equal(rows);
+  page.expectGridRows = function expectGridRows(numRows) {
+    GU.expectRowCount(gridId, numRows);
   };
 
   page.toggleTitleRow = function toggleTitleRow(accountId) {

--- a/test/end-to-end/accounts/accounts.spec.js
+++ b/test/end-to-end/accounts/accounts.spec.js
@@ -16,7 +16,6 @@ describe('Account Management', function () {
   const path = '#/accounts';
   before(() => helpers.navigate(path));
 
-
   const INITIAL_ACCOUNTS = 14;
   let addedAccounts = 0;
 
@@ -63,7 +62,7 @@ describe('Account Management', function () {
 
     // relies on french translation
     FU.select('AccountEditCtrl.account.type_id', 'Titre').click();
-    FU.buttons.submit();
+    FU.modal.submit();
     addedAccounts += 1;
 
     components.notification.hasSuccess();
@@ -79,7 +78,7 @@ describe('Account Management', function () {
   it('updates an account title and parent', function () {
     FU.input('AccountEditCtrl.account.label', 'Updated inventory accounts');
     FU.uiSelect('AccountEditCtrl.account.parent', 'Test Income');
-    FU.buttons.submit();
+    FU.modal.submit();
 
     components.notification.hasSuccess();
   });
@@ -87,8 +86,8 @@ describe('Account Management', function () {
   const numberOfAccounts = 3;
 
   it('creates multiple accounts with the batch option selected', function () {
-    var parentNumber = 70000;
-    var mockAccount = {
+    const parentNumber = 70000;
+    const mockAccount = {
       number : parentNumber,
       label : 'End to End Test: '
     };
@@ -106,11 +105,12 @@ describe('Account Management', function () {
 
     select.element(by.css('[data-key="ACCOUNT.TYPES.TITLE"]')).click();
 
-    FU.buttons.submit();
+    FU.modal.submit();
     addedAccounts += 1;
 
     // set to this parent
     FU.uiSelect('AccountEditCtrl.account.parent', parentNumber);
+
     // set to income
     select.element(by.css('[data-key="ACCOUNT.TYPES.INCOME"]')).click();
 
@@ -128,13 +128,14 @@ describe('Account Management', function () {
 
   it('displays all created accounts with model refresh', function () {
     browser.refresh();
-    expect(page.getRowCount()).to.eventually.equal(INITIAL_ACCOUNTS + addedAccounts);
+    page.expectGridRows(INITIAL_ACCOUNTS + addedAccounts);
   });
 
+  // generic function to create an account in the modal
   function createAccount(account, index) {
     FU.input('AccountEditCtrl.account.number', account.number);
     FU.input('AccountEditCtrl.account.label', account.label.concat(index));
-    FU.buttons.submit();
+    FU.modal.submit();
     addedAccounts += 1;
   }
 });

--- a/test/end-to-end/inventory/configuration.spec.js
+++ b/test/end-to-end/inventory/configuration.spec.js
@@ -10,7 +10,7 @@ const components = require('../shared/components');
 
 helpers.configure(chai);
 
-describe('Inventory Configuration ::', () => {
+describe('Inventory Configuration', () => {
 
   // navigate to the page
   before(() => helpers.navigate('#/inventory/configuration'));
@@ -39,7 +39,7 @@ describe('Inventory Configuration ::', () => {
   const unit = { text : '[E2E] Inventory Unit' };
   const updateUnit = { text : '[E2E] Inventory Unit updated' };
 
-  describe('Groups ::', () => {
+  describe('Groups', () => {
     // navigate to the page
     before(() => helpers.navigate('#/inventory/configuration'));
 
@@ -68,7 +68,7 @@ describe('Inventory Configuration ::', () => {
   });
 
   // test inventory type
-  describe('Types ::', () => {
+  describe('Types', () => {
     // navigate to the page
     before(() => helpers.navigate('#/inventory/configuration'));
 
@@ -89,7 +89,7 @@ describe('Inventory Configuration ::', () => {
   });
 
   // test inventory unit
-  describe('Units ::', () => {
+  describe('Units', () => {
     // navigate to the page
     before(() => helpers.navigate('#/inventory/configuration'));
 

--- a/test/end-to-end/inventory/list.spec.js
+++ b/test/end-to-end/inventory/list.spec.js
@@ -11,7 +11,7 @@ const components = require('../shared/components');
 
 helpers.configure(chai);
 
-describe('Inventory List ::', () => {
+describe('Inventory List', () => {
 
   // navigate to the page
   before(() => helpers.navigate('#/inventory/list'));
@@ -42,7 +42,7 @@ describe('Inventory List ::', () => {
     unit_volume : 7
   };
 
-  it('Successfully creates a new inventory item (metadata)', () => {
+  it('successfully creates a new inventory item (metadata)', () => {
     FU.buttons.create();
     FU.input('$ctrl.session.label', metadata.text);
     FU.input('$ctrl.session.code', metadata.code);
@@ -53,16 +53,16 @@ describe('Inventory List ::', () => {
     FU.select('$ctrl.session.unit', metadata.unit);
     FU.input('$ctrl.session.unit_weight', metadata.unit_weight);
     FU.input('$ctrl.session.unit_volume', metadata.unit_volume);
-    FU.buttons.submit();
+    FU.modal.submit();
     components.notification.hasSuccess();
   });
 
-  it('Dont creates a new inventory item (metadata) for invalid data', () => {
+  it('dont creates a new inventory item (metadata) for invalid data', () => {
     FU.buttons.create();
     FU.input('$ctrl.session.label', metadata.text);
     FU.input('$ctrl.session.unit_weight', metadata.unit_weight);
     FU.input('$ctrl.session.unit_volume', metadata.unit_volume);
-    FU.buttons.submit();
+    FU.modal.submit();
 
     // check validations
     FU.validation.ok('$ctrl.session.label');
@@ -74,15 +74,13 @@ describe('Inventory List ::', () => {
     FU.validation.error('$ctrl.session.type');
     FU.validation.error('$ctrl.session.unit');
 
-    // be sure not success
-    expect(element(by.css('[data-notification-type="notification-success"]')).isPresent())
-      .to.eventually.equal(false);
+    //components.notification.hasDanger();
 
     FU.buttons.cancel();
   });
 
-  it('Successfully updates an existing inventory item (metadata)', () => {
-    element(by.css('[data-edit-metadata="' + metadata.code + '"]')).click();
+  it('successfully updates an existing inventory item (metadata)', () => {
+    element(by.css(`[data-edit-metadata="${metadata.code}"]`)).click();
     FU.input('$ctrl.session.label', metadataUpdate.text);
     FU.input('$ctrl.session.code', metadataUpdate.code);
     element(by.model('$ctrl.session.consumable')).click();
@@ -92,8 +90,8 @@ describe('Inventory List ::', () => {
     FU.select('$ctrl.session.unit', metadataUpdate.unit);
     FU.input('$ctrl.session.unit_weight', metadataUpdate.unit_weight);
     FU.input('$ctrl.session.unit_volume', metadataUpdate.unit_volume);
-    FU.buttons.submit();
+
+    FU.modal.submit();
     components.notification.hasSuccess();
   });
-
 });

--- a/test/end-to-end/patient/invoice/registry.page.js
+++ b/test/end-to-end/patient/invoice/registry.page.js
@@ -2,31 +2,28 @@
 /* global element, by, browser */
 
 const FU = require('../../shared/FormUtils');
+const GU = require('../../shared/GridUtils');
 
 function InvoiceRegistryPage() {
   const page = this;
 
-  //
-  const grid = element(by.id('invoice-registry'));
-  const gridRows = grid
-    .element(by.css('.ui-grid-render-container-body'))
-    .all( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index'));
+  const gridId = 'invoice-registry';
 
   function getInvoiceNumber() {
-    return gridRows.count();
+    return GU.getRows(gridId).count();
   }
 
   function showInvoiceProof(n) {
     const receiptColumnNumber = 6;
 
-    const row = grid
+    const row = GU.getGrid(gridId)
       .$('.ui-grid-render-container-body')
       .element(by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index').row(n));
 
     // click the <a> tag within the cell
     row
       .element(by.repeater('(colRenderIndex, col) in colContainer.renderedColumns track by col.uid').row(receiptColumnNumber))
-      .element(by.tagName('a'))
+      .element(by.css('[data-method="receipt"]'))
       .click();
   }
 

--- a/test/end-to-end/patient/invoice/registry.search.js
+++ b/test/end-to-end/patient/invoice/registry.search.js
@@ -14,7 +14,6 @@ function InvoiceRegistrySearch() {
   'use strict';
 
   const params = {
-    initialBillNumber : 4,
     monthBillNumber : 0,
     referenceValue : 'TPA2',
     serviceValue : 'Test Service',
@@ -38,17 +37,12 @@ function InvoiceRegistrySearch() {
     ).to.eventually.equal(number);
   }
 
-  it('displays all invoices loaded from database', () => {
-    expectNumberOfGridRows(params.initialBillNumber);
-    expectNumberOfFilters(0);
-  });
-
   it('filters invoices by clicking on date buttons', () => {
 
     // set the filters to month
     FU.buttons.search();
     $('[data-date-range="month"]').click();
-    FU.buttons.submit();
+    FU.modal.submit();
 
     expectNumberOfGridRows(params.monthBillNumber);
     expectNumberOfFilters(2);
@@ -62,7 +56,7 @@ function InvoiceRegistrySearch() {
     // set the date inputs manually
     FU.buttons.search();
     FU.input('ModalCtrl.params.billingDateTo', '2015-01-30');
-    FU.buttons.submit();
+    FU.modal.submit();
 
     expectNumberOfGridRows(0);
     expectNumberOfFilters(1);
@@ -74,7 +68,7 @@ function InvoiceRegistrySearch() {
   it('filters by radio buttons', () => {
     FU.buttons.search();
     element(by.id('no')).click();
-    FU.buttons.submit();
+    FU.modal.submit();
 
     expectNumberOfGridRows(0);
     expectNumberOfFilters(1);
@@ -86,7 +80,7 @@ function InvoiceRegistrySearch() {
   it('filters by reference should return a single result', () => {
     FU.buttons.search();
     FU.input('ModalCtrl.params.reference', 'TPA2');
-    FU.buttons.submit();
+    FU.modal.submit();
 
     expectNumberOfGridRows(1);
     expectNumberOfFilters(1);
@@ -99,7 +93,7 @@ function InvoiceRegistrySearch() {
     FU.buttons.search();
     FU.select('ModalCtrl.params.service_id', 'Test Service');
     FU.select('ModalCtrl.params.user_id', 'Super User');
-    FU.buttons.submit();
+    FU.modal.submit();
 
     expectNumberOfGridRows(4);
     expectNumberOfFilters(2);

--- a/test/end-to-end/patient/invoice/registry.spec.js
+++ b/test/end-to-end/patient/invoice/registry.spec.js
@@ -29,9 +29,7 @@ describe('Invoice Registry', () => {
   it('shows the proof of the invoice correctly', () => {
     page.showInvoiceProof(0);
     FU.exists(by.css('[data-modal="receipt"]'), true);
-
-    // close the modal
-    $('[data-action="close"]').click();
+    FU.modal.close();
   });
 
   describe('Searching', Search);
@@ -39,8 +37,7 @@ describe('Invoice Registry', () => {
   it('Credit Note for reverse any transaction in the posting_journal', () => {
     element(by.id('TPA1')).click();
     FU.input('ModalCtrl.creditNote.description', 'Credit Note Error');
-    FU.buttons.submit();
+    FU.modal.submit();
     components.notification.hasSuccess();
   });
-
 });

--- a/test/end-to-end/shared/FormUtils.js
+++ b/test/end-to-end/shared/FormUtils.js
@@ -1,4 +1,4 @@
-/* global browser, by, element, protractor */
+/* global browser, by, element */
 'use strict';
 
 const chai = require('chai');
@@ -22,7 +22,7 @@ const buttons =  {
 
 // This methods are for easily working with modals.  Works with the same custom
 // data tags used in form buttons.
-var modal = {
+const modal = {
   submit: function submit() { return $('[uib-modal-window] [data-method="submit"]').click(); },
   cancel: function cancel() { return $('[uib-modal-window] [data-method="cancel"]').click(); },
   close: function close() { return $('[uib-modal-window] [data-method="close"]').click(); },
@@ -30,7 +30,7 @@ var modal = {
 };
 
 // convenience methods to see if the form contains feedback text.  Returns locators.
-var feedback = {
+const feedback = {
   success: function success() { return by.css('[data-role="feedback"] > .text-success'); },
   error: function error() { return by.css('[data-role="feedback"] > .text-danger'); },
   warning: function warning() { return by.css('[data-role="feedback"] > .text-warning'); },
@@ -38,7 +38,7 @@ var feedback = {
 };
 
 // convenience methods to check form element validation states
-var validation = {
+const validation = {
 
   // an error state is present
   error : function error(model) {
@@ -205,7 +205,6 @@ module.exports = {
       `Expected locator ${locator.toString()} to contain "${text}".`
     ).to.eventually.equal(text);
   },
-
 
   // bind commonly used form buttons  These require specific data tags to be
   // leveraged effectively.

--- a/test/end-to-end/shared/GridUtils.js
+++ b/test/end-to-end/shared/GridUtils.js
@@ -1,5 +1,7 @@
 /* global element, by, browser */
 
+'use strict';
+
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -24,18 +26,18 @@ function getRows(gridId) {
 }
 
 function expectRowCount(gridId, number) {
-  var rows = getRows(gridId);
+  const rows = getRows(gridId);
   expect(rows.count()).to.eventually.equal(number);
 }
 
 function expectRowCountAbove(gridId, number) {
-  var rows = getRows(gridId);
+  const rows = getRows(gridId);
   expect(rows.count()).to.eventually.be.above(number);
 }
 
 // assert that the journal's column count is the number passed in
 function expectColumnCount(gridId, number) {
-  var columns = getColumns(gridId);
+  const columns = getColumns(gridId);
   expect(columns.count()).to.eventually.equal(number);
 }
 
@@ -49,8 +51,8 @@ function expectColumnCount(gridId, number) {
  *
  * @example
  * <pre>
- *   var row = gridUtils.getRow( 'myGrid', 0); //or internally
- *   var row = this.getRow( gridId, rowNum );
+ *   const row = gridUtils.getRow( 'myGrid', 0); //or internally
+ *   const row = this.getRow( gridId, rowNum );
  * </pre>
  */
 function getRow( gridId, rowNum ) {
@@ -87,16 +89,17 @@ function expectHeaderColumns(gridId, expectedColumns) {
  *
  * @example
  * <pre>
- *   var row = gridUtils.selectRow( 'myGrid', 0 );
+ *   const row = gridUtils.selectRow( 'myGrid', 0 );
  * </pre>
  */
 function selectRow( gridId, rowNum ) {
   // NOTE: Can't do .click() as it doesn't work when webdriving Firefox
-  var row = getRow( gridId, rowNum );
-  var btn = row.element( by.css('.ui-grid-selection-row-header-buttons') );
+  const row = getRow( gridId, rowNum );
+  const btn = row.element( by.css('.ui-grid-selection-row-header-buttons') );
   return browser.actions().mouseMove(btn).mouseDown(btn).mouseUp().perform();
 }
 
+exports.getGrid = getGrid;
 exports.getRows = getRows;
 exports.getColumns = getColumns;
 exports.expectRowCount = expectRowCount;


### PR DESCRIPTION
This commit cleans up the e2e tests so that they specify the exact elements they click.  It removes the "more than one element matching selector" errors.

The following tests are affected:
1. Accounts Management
2. Inventory Management
3. Invoice Registry/Search

The following utilities have been adjusted:
1. Grid Utils
2. Form Utils

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
