### PR TITLE
refactor(build): rm old/unused build modules

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -534,6 +534,23 @@ function animateConfig($animateProvider) {
   $animateProvider.classNameFilter(/ng-animate-enabled/);
 }
 
+/**
+ * Configure the $compiler with performance enhancing variables
+ */
+function compileConfig($compileProvider) {
+
+  // switch this variable when going into production for an easy performance win.
+  var PRODUCTION = false;
+
+  if (PRODUCTION) {
+    $compileProvider.debugInfoEnabled(false);
+
+    // available in angular:1.6.x
+    //$compileProvider.commentDirectivesEnabled(false);
+    //$compileProvider.cssClassDirectivesEnabled(false);
+  }
+}
+
 bhima.constant('bhConstants', constantConfig());
 
 // configure services, providers, factories
@@ -543,6 +560,7 @@ bhima.config(['tmhDynamicLocaleProvider', localeConfig]);
 bhima.config(['$localStorageProvider', localStorageConfig]);
 bhima.config(['$httpProvider', httpConfig]);
 bhima.config(['$animateProvider', animateConfig]);
+bhima.config(['$compileProvider', compileConfig]);
 
 // run the application
 bhima.run(['$rootScope', '$state', '$uibModalStack', 'SessionService', 'amMoment', 'NotifyService', '$location', startupConfig]);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,3 @@
-/*jshint -W079 */
 /**
  * Build Script
  * @TODO
@@ -13,7 +12,6 @@ const uglify  = require('gulp-uglify');
 const cssnano = require('gulp-cssnano');
 const iife    = require('gulp-iife');
 const rimraf  = require('rimraf');
-const gutil   = require('gulp-util');
 const less    = require('gulp-less');
 
 // child process for custom scripts
@@ -29,7 +27,7 @@ const SERVER_FOLDER = './bin/server/';
 const CLIENT_FOLDER = './bin/client/';
 
 // resource paths
-var paths = {
+const paths = {
   client : {
     javascript : [
       'client/src/js/define.js',
@@ -91,9 +89,6 @@ var paths = {
 
       // ngStorage
       'client/vendor/ngstorage/ngStorage.min.js'
-    ],
-    e2etest    : [
-      'client/test/e2e/**/*.spec.js'
     ],
 
     // these must be globs ("**" syntax) to retain their folder structures
@@ -175,7 +170,7 @@ gulp.task('client-vendor-build-bootstrap', function () {
    * - compile with less
    * - copy CSS into static file folder
    */
-  var bhimaDefinition = 'client/src/less/bhima-bootstrap.less';
+  const bhimaDefinition = 'client/src/less/bhima-bootstrap.less';
 
   return gulp.src(bhimaDefinition)
     .pipe(gulp.dest('client/vendor/bootstrap/less'))
@@ -212,14 +207,9 @@ gulp.task('watch-client', function () {
   gulp.watch(paths.client.vendor, ['client-mv-vendor-style', 'client-compile-vendor']);
 });
 
-// TODO This message can be removed once the lint/build process has been transitioned
-gulp.task('notify-lint-process', function () {
-  gutil.log(gutil.colors.yellow('REMINDER: Please ensure you have run the command `gulp lint` before submitting a pull request to github'));
-});
-
 // builds the client with all the options available
 gulp.task('build-client', function () {
-  gulp.start('client-compile-js', 'client-compile-vendor', 'client-minify-css', 'client-mv-vendor-style', 'client-vendor-build-bootstrap', 'client-mv-static', 'notify-lint-process');
+  gulp.start('client-compile-js', 'client-compile-vendor', 'client-minify-css', 'client-mv-vendor-style', 'client-vendor-build-bootstrap', 'client-mv-static');
 });
 
 // Lint client code separately from build process
@@ -264,10 +254,6 @@ gulp.task('clean', function (cb) {
 
 gulp.task('build', ['clean'], function () {
   gulp.start('build-client', 'build-server');
-});
-
-gulp.task('test', ['build'], function () {
-  gulp.start('client-test-e2e');
 });
 
 // run the build-client and build-server tasks when no arguments


### PR DESCRIPTION
This commit removes old and unused build modules as recommended by the comments in the gulpfile.  It should lighten the load in `npm install` in the future.

It also introduces a PRODUCTION switch in the app.js file to make sure the app runs in production mode and not in development mode by turning off `$compileProvider` features.  Not all of these options are available yet, but soon will be.  Note that this will need more testing
before launch.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
