### PR TITLE
fix(build): build minifies using uglifyjs

### DIFF
--- a/client/src/js/services/PatientInvoiceService.js
+++ b/client/src/js/services/PatientInvoiceService.js
@@ -112,7 +112,7 @@ function PatientInvoiceService(Modal, util, Session, Api) {
 
     // returns columns from filters
     return columns.filter(function (column) {
-      let value = params[column.field];
+      var value = params[column.field];
 
       if (angular.isDefined(value)) {
         column.value = value;

--- a/client/src/js/services/PatientService.js
+++ b/client/src/js/services/PatientService.js
@@ -41,7 +41,7 @@ function PatientService($http, util, Session, $uibModal, Documents, Visits) {
   // document exposition definition
   service.Documents = Documents;
   service.Visits = Visits;
-  service.latest = latest;  
+  service.latest = latest;
 
   /**
    * This method returns information on a patient given the patients UUID. This
@@ -223,7 +223,7 @@ function PatientService($http, util, Session, $uibModal, Documents, Visits) {
 
     // returns columns from filters
     return columns.filter(function (column) {
-      let value = params[column.field];
+      var value = params[column.field];
 
       if (angular.isDefined(value)) {
         column.value = value;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ const concat  = require('gulp-concat');
 const uglify  = require('gulp-uglify');
 const cssnano = require('gulp-cssnano');
 const iife    = require('gulp-iife');
+const pump    = require('pump');
 const rimraf  = require('rimraf');
 const less    = require('gulp-less');
 
@@ -18,7 +19,7 @@ const less    = require('gulp-less');
 const exec = require('child_process').exec;
 
 // toggle client javascript minification
-const UGLIFY = false;
+const UGLIFY = (process.env.NODE_ENV === 'production');
 
 // the output folder for built server files
 const SERVER_FOLDER = './bin/server/';
@@ -128,12 +129,15 @@ const paths = {
 
 
 // minify the client javascript code via uglify writes output to bhima.min.js
-gulp.task('client-compile-js', function () {
-  return gulp.src(paths.client.javascript)
-    .pipe(gulpif(UGLIFY, uglify({ mangle: true })))
-    .pipe(concat('js/bhima.min.js'))
-    .pipe(iife())
-    .pipe(gulp.dest(CLIENT_FOLDER));
+gulp.task('client-compile-js', function (cb) {
+  pump([
+    gulp.src(paths.client.javascript),
+    gulpif(UGLIFY, uglify({ mangle: true })),
+    concat('js/bhima.min.js'),
+    iife(),
+    gulp.dest(CLIENT_FOLDER)
+  ], cb);
+
 });
 
 // minify the vendor JS code and compact into a vendor.min.js file.

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "mocha": "^3.0.0",
     "mochawesome-screenshots": "^1.4.1",
     "protractor": "^4.0.2",
+    "pump": "^1.0.1",
     "rimraf": "^2.5.4"
   },
   "homepage": "https://github.com/IMA-WorldHealth/bhima-2.X#readme",


### PR DESCRIPTION
This commit fixes a bug in which ECMAScript 6 features were used in the client, breaking `uglify`'s build.  These features have been removed in favor of their ES5 alternates.

The `pump` module has been added as a development dependency due to better gulp build errors.

Closes #704.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks.
