### PR TITLE
fix(purchase): remove cellNav from purchase grid

### DIFF
--- a/client/src/partials/purchases/create/create.html
+++ b/client/src/partials/purchases/create/create.html
@@ -8,7 +8,7 @@
 </div>
 
 <div class="flex-content">
-  <div class="container-fluid">
+  <div class="container">
 
     <!--
       top note panel for the purchase order.details
@@ -24,15 +24,19 @@
                 <div class="form-group"
                   ng-class="{'has-error' : PurchaseOrderForm.$submitted && PurchaseOrderForm.supplier.$invalid }">
                   <label class="control-label">{{ "FORM.LABELS.SUPPLIER" | translate }}</label>
-                  <input
-                    class="form-control"
-                    ng-model="PurchaseCtrl.supplier"
-                    placeholder="{{ 'FORM.PLACEHOLDERS.SUPPLIER' | translate }}..."
+
+                  <ui-select
                     name="supplier"
-                    uib-typeahead="supplier as supplier.display_name for supplier in PurchaseCtrl.suppliers | filter:$viewValue | limitTo:10"
-                    typeahead-editable="false"
-                    typeahead-on-select="PurchaseCtrl.order.setSupplier(PurchaseCtrl.supplier)"
+                    ng-model="PurchaseCtrl.supplier"
+                    theme="bootstrap"
+                    on-select="PurchaseCtrl.order.setSupplier(PurchaseCtrl.supplier)"
                     required>
+                    <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.SUPPLIER' | translate }}"><span>{{$select.selected.display_name}}</span></ui-select-match>
+                    <ui-select-choices ui-select-focus-patch repeat="supplier in PurchaseCtrl.suppliers | filter:$select.search ">
+                      <span ng-bind-html="supplier.display_name| highlight:$select.search"></span>
+                    </ui-select-choices>
+                  </ui-select>
+
                   <div class="help-block" ng-messages="PurchaseOrderForm.supplier.$error" ng-show="PurchaseOrderForm.$submitted">
                     <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
                   </div>
@@ -128,7 +132,7 @@
           <span class="input-group-btn">
             <button
               id="btn-add-rows"
-              class="btn btn-default btn-sm"
+              class="btn btn-default"
               ng-disabled="!PurchaseCtrl.supplier"
               ng-click="PurchaseCtrl.addItems(PurchaseCtrl.itemIncrement)">
               <span class="fa fa-plus-circle"></span> {{ "FORM.BUTTONS.ADD" | translate }}
@@ -136,7 +140,7 @@
           </span>
           <input
             type="number"
-            class="form-control input-sm"
+            class="form-control"
             ng-model="PurchaseCtrl.itemIncrement"
             style="max-width : 40px;"
             ng-disabled="!PurchaseCtrl.supplier">
@@ -161,7 +165,7 @@
       </div>
     </div>
 
-    <div id="purchase-order-grid" ui-grid="PurchaseCtrl.gridOptions" style="height : {{ ::PurchaseCtrl.bhConstants.GRID_HEIGHT }}px; width : 100%;" ui-grid-auto-resize ui-grid-cellNav>
+    <div id="purchase-order-grid" ui-grid="PurchaseCtrl.gridOptions" style="height : {{ ::PurchaseCtrl.bhConstants.GRID_HEIGHT }}px; width : 100%;">
     </div>
 
     <div class="row" ng-if="PurchaseCtrl.supplier">

--- a/test/end-to-end/purchases/purchases.spec.js
+++ b/test/end-to-end/purchases/purchases.spec.js
@@ -21,10 +21,10 @@ describe('Purchase Orders', function () {
   beforeEach(() => helpers.navigate(path));
 
   it('supports single item purchase orders', () => {
-    var page = new PurchaseOrderPage();
+    let page = new PurchaseOrderPage();
 
     // prepare the page with default supplier, description, etc
-    FU.typeahead('PurchaseCtrl.supplier', 'Test Supplier');
+    FU.uiSelect('PurchaseCtrl.supplier', 'Test Supplier');
     FU.input('PurchaseCtrl.order.details.note', 'This is a brief description of what is going on');
     components.dateEditor.set(new Date('2016-03-03'));
 
@@ -45,10 +45,10 @@ describe('Purchase Orders', function () {
   });
 
   it('supports multi-item purchase orders', function () {
-    var page = new PurchaseOrderPage();
+    let page = new PurchaseOrderPage();
 
     // prepare the page with default supplier, description, etc
-    FU.typeahead('PurchaseCtrl.supplier', 'Test Supplier');
+    FU.uiSelect('PurchaseCtrl.supplier', 'Test Supplier');
     FU.input('PurchaseCtrl.order.details.note', 'We need more penicillin');
     components.dateEditor.set(new Date('2016-03-05'));
 
@@ -91,10 +91,8 @@ describe('Purchase Orders', function () {
   });
 
   it('blocks submission if no supplier is available', function () {
-    var page = new PurchaseOrderPage();
-
-    // no such supplier
-    FU.input('PurchaseCtrl.supplier', 'Harry Styles');
+    let page = new PurchaseOrderPage();
+    FU.input('PurchaseCtrl.order.details.note', 'We need more purchases.');
 
     // make sure the "add rows" button is still disabled
     expect(page.btns.add.isEnabled()).to.eventually.equal(false);
@@ -104,11 +102,11 @@ describe('Purchase Orders', function () {
   });
 
   it('blocks submission for an invalid grid', function () {
-    var page = new PurchaseOrderPage();
+    let page = new PurchaseOrderPage();
     page.btns.clear.click();
 
     // prepare the page with default supplier, description, etc
-    FU.typeahead('PurchaseCtrl.supplier', 'Test Supplier');
+    FU.uiSelect('PurchaseCtrl.supplier', 'Test Supplier');
     FU.input('PurchaseCtrl.order.details.note', 'We need more purchases.');
     components.dateEditor.set(new Date('2016-03-01'));
 


### PR DESCRIPTION
This commit removed the ui-grid-cellNav from the purchase grid.  It also uses a `ui-select` instead of a `typeahead` for the supplier search box.

Closes #726.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
