### PR TITLE
fix(cash): only allow auxiliary cashbox selection

### DIFF
--- a/client/src/partials/cash/cash.html
+++ b/client/src/partials/cash/cash.html
@@ -18,7 +18,7 @@
           <i class="fa fa-inbox"></i> {{ "CASH.VOUCHER.CASHBOXES.CHANGE_CASHBOX" | translate }}
         </button>
 
-        <button class="btn btn-primary btn-block" ui-sref="cash.transfer({ id: CashCtrl.cashbox.id })" data-perform-transfer>
+        <button style="margin-bottom: 1em;" class="btn btn-primary btn-block" ui-sref="cash.transfer({ id: CashCtrl.cashbox.id })" data-perform-transfer>
           <i class="fa fa-exchange"></i> {{ "CASH.VOUCHER.CASHBOXES.TRANSFER" | translate }}
         </button>
       </div>

--- a/client/src/partials/cash/modals/selectCashbox.modal.js
+++ b/client/src/partials/cash/modals/selectCashbox.modal.js
@@ -3,13 +3,13 @@ angular.module('bhima.controllers')
 
 SelectCashboxModalController.$inject = [
   'SessionService', '$uibModalInstance', 'CashboxService', '$stateParams',
-  'NotifyService', '$state'
+  'NotifyService'
 ];
 
 /**
  * This modal selects the active cashbox on the cash page
  */
-function SelectCashboxModalController(Session, Instance, Cashboxes, $stateParams, Notify, $state) {
+function SelectCashboxModalController(Session, Instance, Cashboxes, $stateParams, Notify) {
   var vm = this;
 
   vm.selectCashbox = selectCashbox;
@@ -23,17 +23,18 @@ function SelectCashboxModalController(Session, Instance, Cashboxes, $stateParams
     toggleLoadingIndicator();
 
     Cashboxes.read(undefined, {
-      project_id : Session.project.id
+      project_id : Session.project.id,
+      is_auxiliary : 1
     })
-    .then(function (cashboxes) {
-      vm.cashboxes = cashboxes;
+      .then(function (cashboxes) {
+        vm.cashboxes = cashboxes;
 
-      if (cashboxId) {
-        selectCashbox(cashboxId);
-      }
-    })
-    .catch(Notify.handleError)
-    .finally(toggleLoadingIndicator);
+        if (cashboxId) {
+          selectCashbox(cashboxId);
+        }
+      })
+      .catch(Notify.handleError)
+      .finally(toggleLoadingIndicator);
   }
 
   // fired when a user selects a cashbox from a list


### PR DESCRIPTION
This commit ensures that only is_auxiliary cashboxes are available for selection on the cash page.

Closes #746.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
