### PR TITLE
fix(supplier): generate creditors from groups

### DIFF
--- a/client/src/js/services/CreditorGroupService.js
+++ b/client/src/js/services/CreditorGroupService.js
@@ -1,31 +1,14 @@
 angular.module('bhima.services')
-.service('CreditorGroupService', CreditorGroupService);
+  .service('CreditorGroupService', CreditorGroupService);
 
-CreditorGroupService.$inject = ['$http', 'util'];
+CreditorGroupService.$inject = ['PrototypeApiService'];
 
 /**
 * Creditor Group Service
 *
 * This service implements CRUD operations for the /creditor_groups API endpoint
 */
-function CreditorGroupService($http, util) {
-  var service = this;
-  var baseUrl = '/creditor_groups/';
-
-  /** Exposed method read */
-  service.read = read;
-
-  /**
-  * @method read
-  * @param {string} uuid The creditor group uuid
-  * @param {object} parameters The query string object
-  * @description This function is responsible for getting creditor groups
-  */
-  function read(uuid, parameters) {
-    var url = baseUrl.concat(uuid || '');
-    return $http.get(url, { params : parameters })
-    .then(util.unwrapHttpResponse);
-  }
-
+function CreditorGroupService(Api) {
+  var service = Api('/creditor_groups/');
   return service;
 }

--- a/client/src/partials/suppliers/suppliers.html
+++ b/client/src/partials/suppliers/suppliers.html
@@ -2,7 +2,7 @@
   <div class="bhima-title">
     <ol class="headercrumb">
       <li class="static">{{ "TREE.ADMIN" | translate }}</li>
-      <li class="active">{{ "SUPPLIER.TITLE" | translate }}</li>
+      <li class="title">{{ "SUPPLIER.TITLE" | translate }}</li>
     </ol>
 
     <div class="toolbar">
@@ -31,21 +31,23 @@
               <tr>
                 <th>{{ "TABLE.COLUMNS.NAME" | translate }}</th>
                 <th>{{ "TABLE.COLUMNS.PHONE" | translate }}</th>
-                <th><span class="glyphicon glyphicon-lock"></span></th>
                 <th>{{ "TABLE.COLUMNS.ACTION" | translate }}</th>
               </tr>
             </thead>
             <tbody>
-              <tr ng-if="SupplierCtrl.session.loading" class="text-center">
-                <td colspan="4"><loading-indicator></loading-indicator></td>
+              <tr ng-if="SupplierCtrl.loading" class="text-center">
+                <td colspan="3"><loading-indicator></loading-indicator></td>
               </tr>
-              <tr ng-repeat="supplier in SupplierCtrl.suppliers | orderBy:'display_name'">
-                <td>{{ supplier.display_name }}</td>
+              <tr ng-repeat="supplier in (SupplierCtrl.suppliers | orderBy:'display_name') track by supplier.uuid">
+                <td>{{ supplier.display_name }} <i class="fa fa-lock" ng-show="supplier.locked"></i></td>
                 <td>{{ supplier.phone | telephone }}</td>
-                <td><i class="fa fa-check" ng-show="supplier.locked"></i></td>
-                <td><a class="btn btn-xs btn-default" id="supplier-upd-{{$index+1}}" ng-click="SupplierCtrl.update(supplier)"><span class="glyphicon glyphicon-pencil"></span></a></td>
+                <td>
+                  <a id="supplier-upd-{{$index+1}}" ng-click="SupplierCtrl.update(supplier)" href>
+                    <i class="fa fa-pencil-square-o"></i> {{ "FORM.BUTTONS.UPDATE" | translate }}
+                  </a>
+                </td>
               </tr>
-              <tr ng-if="!SupplierCtrl.suppliers.length">
+              <tr ng-if="!SupplierCtrl.suppliers.length && !SupplierCtrl.loading">
                 <td colspan="5">{{ "SUPPLIER.NO_SUPPLIER" | translate }}</td>
               </tr>
             </tbody>
@@ -58,20 +60,6 @@
           <div class="alert alert-info">
             <h4>{{ "SUPPLIER.TITLE" | translate }}</h4>
             <p>{{ "SUPPLIER.INFO" | translate }}</p>
-          </div>
-        </div>
-
-        <!-- Success saving Feed Back -->
-        <div ng-switch-when="create_success">
-          <div class="alert alert-success" id="create_success">
-            <h4>{{ "FORM.INFO.SAVE_SUCCESS" | translate }}</h4>
-          </div>
-        </div>
-
-        <!-- Success updating feedBack -->
-        <div ng-switch-when="update_success">
-          <div class="alert alert-success" id="update_success">
-            <h4>{{ "FORM.INFO.UPDATE_SUCCESS" | translate }} </h4>
           </div>
         </div>
 
@@ -98,12 +86,12 @@
 
               <hr>
 
-              <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.creditor_uuid.$invalid }">
+              <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.creditor_group_uuid.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.GROUP" | translate }}</label>
-                <select class="form-control" name="creditor_uuid" ng-model="SupplierCtrl.supplier.creditor_uuid" ng-options="creditor.uuid as creditor.text for creditor in SupplierCtrl.creditors | orderBy:'name'" required>
-                  <option value="" disabled> -- {{ "FORM.SELECT.CREDITOR" | translate }} -- </option>
+                <select class="form-control" name="creditor_group_uuid" ng-model="SupplierCtrl.supplier.creditor_group_uuid" ng-options="group.uuid as group.name for group in SupplierCtrl.groups | orderBy:'name'" required>
+                  <option value="" disabled>{{ "FORM.SELECT.CREDITOR_GROUP" | translate }}</option>
                 </select>
-                <div class="help-block" ng-messages="CreateForm.creditor_uuid.$error" ng-show="CreateForm.$submitted">
+                <div class="help-block" ng-messages="CreateForm.creditor_group_uuid.$error" ng-show="CreateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
                 </div>
               </div>
@@ -135,43 +123,36 @@
                 </label>
               </div>
 
-              <hr>
-                <h3> {{ "FORM.LABELS.OPTIONAL_INFO" | translate }}  </h3>
-              <hr>
+              <fieldset>
+                <legend>{{ "FORM.LABELS.OPTIONAL_INFO" | translate }}</legend>
 
-              <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.address_2.$invalid }">
-                <label class="control-label">{{ "FORM.LABELS.ADDR_2" | translate }}</label>
-                <input type="address" class="form-control" name="address_2" ng-model="SupplierCtrl.supplier.address_2">
-              </div>
-
-              <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.fax.$invalid }">
-                <label class="control-label">{{ "FORM.LABELS.FAX" | translate }}</label>
-                <input type="text" class="form-control" name="fax" ng-model="SupplierCtrl.supplier.fax">
-              </div>
-
-              <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.note.$invalid }">
-                <label class="control-label" for="note">{{ "FORM.LABELS.NOTES" | translate }}</label>
-                <textarea class="form-control" name="note" ng-maxlength="SupplierCtrl.maxLength" ng-model="SupplierCtrl.supplier.note" rows="3"></textarea>
-                <div class="help-block" ng-messages="CreateForm.note.$error" ng-show="CreateForm.$submitted">
-                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.address_2.$invalid }">
+                  <label class="control-label">{{ "FORM.LABELS.ADDR_2" | translate }}</label>
+                  <input type="address" class="form-control" name="address_2" ng-model="SupplierCtrl.supplier.address_2">
                 </div>
-              </div>
+
+                <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.fax.$invalid }">
+                  <label class="control-label">{{ "FORM.LABELS.FAX" | translate }}</label>
+                  <input type="text" class="form-control" name="fax" ng-model="SupplierCtrl.supplier.fax">
+                </div>
+
+                <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.note.$invalid }">
+                  <label class="control-label" for="note">{{ "FORM.LABELS.NOTES" | translate }}</label>
+                  <textarea class="form-control" name="note" ng-maxlength="SupplierCtrl.maxLength" ng-model="SupplierCtrl.supplier.note" rows="3"></textarea>
+                  <div class="help-block" ng-messages="CreateForm.note.$error" ng-show="CreateForm.$submitted">
+                    <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                  </div>
+                </div>
+              </fieldset>
 
               <div class="form-group">
-                <button class="btn btn-default" id="submit-supplier" type="submit" data-method="submit">
+                <button class="btn btn-default" type="submit" data-method="submit">
                   {{ "FORM.BUTTONS.SAVE" | translate }}
                 </button>
                 <button class="btn btn-default" type="button" ng-click="SupplierCtrl.cancel()" data-method="cancel">
                   {{ "FORM.BUTTONS.RESET" | translate }}
                 </button>
               </div>
-
-              <!-- error feedback area -->
-              <div ng-if="SupplierCtrl.state.errored && CreateForm.$submitted"
-                class="text-danger" data-role="feedback" style="margin-top:10px;">
-                <i class="glyphicon glyphicon-remove-sign"></i> {{ "FORM.ERRORS.HAS_ERRORS" | translate }}
-              </div>
-
             </form>
           </div>
         </div>
@@ -189,21 +170,20 @@
                 </div>
               </div>
 
-              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.international.$invalid }">
-                <label class="control-label">
-                  <input type="checkbox"  name="international" ng-true-value="1" ng-false-value="0"
-                    ng-model="SupplierCtrl.supplier.international">  {{ "FORM.LABELS.INTL" | translate }}
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" name="international" ng-true-value="1" ng-false-value="0" ng-model="SupplierCtrl.supplier.international"> {{ "FORM.LABELS.INTL" | translate }}
                 </label>
               </div>
 
               <hr>
 
-              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.creditor_uuid.$invalid }">
+              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.creditor_group_uuid.$invalid }">
                 <label class="control-label">{{ "FORM.LABELS.GROUP" | translate }}</label>
-                <select class="form-control" name="creditor_uuid" ng-model="SupplierCtrl.supplier.creditor_uuid" ng-options="creditor.uuid as creditor.text for creditor in SupplierCtrl.creditors | orderBy:'name'" required>
-                  <option value="" disabled> -- {{ "FORM.SELECT.CREDITOR" | translate }} -- </option>
+                <select class="form-control" name="creditor_group_uuid" ng-model="SupplierCtrl.supplier.creditor_group_uuid" ng-options="group.uuid as group.name for group in SupplierCtrl.groups | orderBy:'name'" required>
+                  <option value="" disabled>{{ "FORM.SELECT.CREDITOR_GROUP" | translate }}</option>
                 </select>
-                <div class="help-block" ng-messages="UpdateForm.creditor_uuid.$error" ng-show="UpdateForm.$submitted">
+                <div class="help-block" ng-messages="UpdateForm.creditor_group_uuid.$error" ng-show="UpdateForm.$submitted">
                   <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
                 </div>
               </div>
@@ -228,53 +208,45 @@
                 </div>
               </div>
 
-              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.locked.$invalid }">
-                <label class="control-label">
-                  <input type="checkbox"  name="locked" ng-true-value="1" ng-false-value="0"
-                    ng-model="SupplierCtrl.supplier.locked">  {{ "FORM.LABELS.LOCKED" | translate }}
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" name="locked" ng-true-value="1" ng-false-value="0" ng-model="SupplierCtrl.supplier.locked">  {{ "FORM.LABELS.LOCKED" | translate }}
                 </label>
               </div>
 
-              <hr>
-                <h3> {{ "FORM.LABELS.OPTIONAL_INFO" | translate }}  </h3>
-              <hr>
+              <fieldset>
+                <legend>{{ "FORM.LABELS.OPTIONAL_INFO" | translate }}</legend>
 
-              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.address_2.$invalid }">
-                <label class="control-label">{{ "FORM.LABELS.ADDR_2" | translate }}</label>
-                <input type="address" class="form-control" name="address_2" ng-model="SupplierCtrl.supplier.address_2">
-              </div>
-
-              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.fax.$invalid }">
-                <label class="control-label">{{ "FORM.LABELS.FAX" | translate }}</label>
-                <input type="text" class="form-control" name="fax" ng-model="SupplierCtrl.supplier.fax">
-              </div>
-
-              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.note.$invalid }">
-                <label class="control-label" for="note">{{ "FORM.LABELS.NOTES" | translate }}</label>
-                <textarea class="form-control" name="note" ng-maxlength="SupplierCtrl.maxLength" ng-model="SupplierCtrl.supplier.note" rows="3"></textarea>
-                <div class="help-block" ng-messages="UpdateForm.note.$error" ng-show="UpdateForm.$submitted">
-                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.address_2.$invalid }">
+                  <label class="control-label">{{ "FORM.LABELS.ADDR_2" | translate }}</label>
+                  <input type="address" class="form-control" name="address_2" ng-model="SupplierCtrl.supplier.address_2">
                 </div>
-              </div>
 
+                <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.fax.$invalid }">
+                  <label class="control-label">{{ "FORM.LABELS.FAX" | translate }}</label>
+                  <input type="text" class="form-control" name="fax" ng-model="SupplierCtrl.supplier.fax">
+                </div>
+
+                <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.note.$invalid }">
+                  <label class="control-label" for="note">{{ "FORM.LABELS.NOTES" | translate }}</label>
+                  <textarea class="form-control" name="note" ng-maxlength="SupplierCtrl.maxLength" ng-model="SupplierCtrl.supplier.note" rows="3"></textarea>
+                  <div class="help-block" ng-messages="UpdateForm.note.$error" ng-show="UpdateForm.$submitted">
+                    <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                  </div>
+                </div>
+
+              </fieldset>
               <div class="form-group">
-                <button class="btn btn-default" id="change_supplier" type="submit" data-method="submit">
+                <button class="btn btn-default" type="submit" data-method="submit">
                   {{ "FORM.BUTTONS.SAVE" | translate }}
                 </button>
                 <button class="btn btn-default" type="button" ng-click="SupplierCtrl.cancel()" data-method="cancel">
                   {{ "FORM.BUTTONS.RESET" | translate }}
                 </button>
               </div>
-
-              <!-- error feedback area -->
-              <div ng-if="SupplierCtrl.state.errored && UpdateForm.$submitted"
-                class="text-danger" data-role="feedback" style="margin-top:10px;">
-                <i class="glyphicon glyphicon-remove-sign"></i> {{ "FORM.ERRORS.HAS_ERRORS" | translate }}
-              </div>
             </form>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/test/end-to-end/suppliers/suppliers.spec.js
+++ b/test/end-to-end/suppliers/suppliers.spec.js
@@ -6,6 +6,8 @@ const FU = require('../shared/FormUtils');
 const helpers = require('../shared/helpers');
 helpers.configure(chai);
 
+const components = require('../shared/components');
+
 describe('Suppliers', function () {
   'use strict';
 
@@ -32,7 +34,7 @@ describe('Suppliers', function () {
     element(by.model('SupplierCtrl.supplier.international')).click();
 
     // select an Creditor
-    FU.select('SupplierCtrl.supplier.creditor_uuid', 'Fournisseur');
+    FU.select('SupplierCtrl.supplier.creditor_group_uuid', 'Fournisseur');
 
     FU.input('SupplierCtrl.supplier.phone', supplier.phone);
     FU.input('SupplierCtrl.supplier.email', supplier.email);
@@ -43,7 +45,7 @@ describe('Suppliers', function () {
 
     // submit the page to the server
     FU.buttons.submit();
-    FU.exists(by.id('create_success'), true);
+    components.notification.hasSuccess();
   });
 
   it('edits an supplier', function () {
@@ -57,19 +59,19 @@ describe('Suppliers', function () {
     FU.input('SupplierCtrl.supplier.address_1', supplier.address_1);
 
     FU.buttons.submit();
-    FU.exists(by.id('update_success'), true);
+    components.notification.hasSuccess();
   });
 
   it('blocks invalid form submission with relevant error classes', function () {
     FU.buttons.create();
 
     // verify form has not been submitted
+    FU.buttons.submit();
     expect(helpers.getCurrentPath()).to.eventually.equal(path);
-    element(by.id('submit-supplier')).click();
 
     // the following fields should be required
     FU.validation.error('SupplierCtrl.supplier.display_name');
-    FU.validation.error('SupplierCtrl.supplier.creditor_uuid');
+    FU.validation.error('SupplierCtrl.supplier.creditor_group_uuid');
     FU.validation.error('SupplierCtrl.supplier.address_1');
 
     // the following fields are not required
@@ -79,5 +81,7 @@ describe('Suppliers', function () {
     FU.validation.ok('SupplierCtrl.supplier.address_2');
     FU.validation.ok('SupplierCtrl.supplier.fax');
     FU.validation.ok('SupplierCtrl.supplier.note');
+
+    components.notification.hasDanger();
   });
 });

--- a/test/integration/suppliers.js
+++ b/test/integration/suppliers.js
@@ -1,6 +1,8 @@
 /* global expect, chai, agent */
 /* jshint expr : true */
 
+'use strict';
+
 const helpers = require('./helpers');
 const uuid    = require('node-uuid');
 
@@ -12,9 +14,9 @@ const uuid    = require('node-uuid');
 describe('(/suppliers) The supplier API endpoint', function () {
 
   // supplier we will add during this test suite.
-  var supplier = {
+  let supplier = {
     uuid : uuid.v4(),
-    creditor_uuid : '7ac4e83c-65f2-45a1-8357-8b025003d794',
+    creditor_group_uuid : '8bedb6df-6b08-4dcf-97f7-0cfbb07cf9e2',
     display_name : 'SUPPLIER TEST A',
     address_1 : null,
     address_2 : null,
@@ -26,17 +28,17 @@ describe('(/suppliers) The supplier API endpoint', function () {
     locked : 0
   };
 
-  var responseKeys = [
+  let responseKeys = [
     'uuid', 'creditor_uuid', 'display_name', 'address_1', 'address_2',
     'email', 'fax', 'note', 'phone', 'international', 'locked'
   ];
 
-  var FILTER = {
+  let FILTER = {
     display_name : 'UPD',
     limit : 20
   };
 
-  var NOT_FOUND = {
+  let NOT_FOUND = {
     display_name : 'TEST',
     limit : 20
   };


### PR DESCRIPTION
This commit fixes a long-standing bug in the suppliers page.  The suppliers previously used Creditors instead of Creditor Groups which have no way to be created independently of the supplier.  The client
page has been refactored to choose creditor groups from a dropdown and the server now generates a new creditor UUID when creating a supplier.

Closes #754.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
