### PR TITLE
feature(journal): human-readable UUIDs via reference mapping

### DIFF
--- a/client/src/js/services/JournalService.js
+++ b/client/src/js/services/JournalService.js
@@ -2,25 +2,13 @@ angular.module('bhima.services')
 .service('JournalService', JournalService);
 
 // Dependencies injection
-JournalService.$inject = ['$http', 'util'];
+JournalService.$inject = ['PrototypeApiService'];
 
 /**
  * Journal Service
  * This service is responsible of all process with the posting journal
  */
-function JournalService($http, util) {
-  'use strict';
-
-  var service = this;
-
-  const baseUrl = '/journal/';
-
-  // expose the services method's
-  service.read = read;
-
-  /** Getting posting journal data */
-   function read() {
-     return $http.get(baseUrl)
-      .then(util.unwrapHttpResponse);
-   }
+function JournalService(Api) {
+  var service = new Api('/journal/');
+  return service;
 }

--- a/client/src/partials/journal/journal.js
+++ b/client/src/partials/journal/journal.js
@@ -119,6 +119,7 @@ function JournalController(Journal, Sorting, Grouping, Filtering, Columns, Confi
       editableCellTemplate: 'partials/journal/templates/date.edit.html',
       enableCellEdit: true
     },
+    { field : 'hrRecord', displayName : 'TABLE.COLUMNS.RECORD', headerCellFilter: 'translate', visible: true },
     { field : 'description', displayName : 'TABLE.COLUMNS.DESCRIPTION', headerCellFilter: 'translate' },
     { field : 'account_number', displayName : 'TABLE.COLUMNS.ACCOUNT', headerCellFilter: 'translate' },
     { field : 'debit_equiv', displayName : 'TABLE.COLUMNS.DEBIT', headerCellFilter: 'translate', cellTemplate : '/partials/templates/grid/debit_equiv.cell.html' },
@@ -138,8 +139,7 @@ function JournalController(Journal, Sorting, Grouping, Filtering, Columns, Confi
     // @todo this should be formatted showing the debtor/creditor
     { field : 'hrEntity', displayName : 'TABLE.COLUMNS.RECIPIENT', headerCellFilter: 'translate', visible: true},
 
-    { field : 'reference_uuid', displayName : 'TABLE.COLUMNS.REFERENCE', headerCellFilter: 'translate', visible: false },
-    { field : 'record_uuid', displayName : 'TABLE.COLUMNS.RECORD', headerCellFilter: 'translate', visible: false },
+    { field : 'hrReference', displayName : 'TABLE.COLUMNS.REFERENCE', headerCellFilter: 'translate', visible: true },
     { field : 'user', displayName : 'TABLE.COLUMNS.RESPONSIBLE', headerCellFilter: 'translate', visible: false, enableCellEdit: false },
     { field : 'actions', displayName : '', headerCellFilter: 'translate', visible: true, enableCellEdit: false, cellTemplate: '/partials/journal/templates/actions.cell.html', allowCellFocus: false }
   ];

--- a/client/src/partials/journal/journal.js
+++ b/client/src/partials/journal/journal.js
@@ -136,8 +136,7 @@ function JournalController(Journal, Sorting, Grouping, Filtering, Columns, Confi
     { field : 'currency_id', displayName : 'TABLE.COLUMNS.CURRENCY', headerCellFilter: 'translate', visible: false, enableCellEdit: false},
 
     // @todo this should be formatted showing the debtor/creditor
-    { field : 'entity_uuid', displayName : 'TABLE.COLUMNS.RECIPIENT', headerCellFilter: 'translate', visible: false },
-    { field : 'entity_type', displayName : 'TABLE.COLUMNS.RECIPIENT_TYPE', headerCellFilter: 'translate', visible: false },
+    { field : 'hrEntity', displayName : 'TABLE.COLUMNS.RECIPIENT', headerCellFilter: 'translate', visible: true},
 
     { field : 'reference_uuid', displayName : 'TABLE.COLUMNS.REFERENCE', headerCellFilter: 'translate', visible: false },
     { field : 'record_uuid', displayName : 'TABLE.COLUMNS.RECORD', headerCellFilter: 'translate', visible: false },

--- a/client/src/partials/journal/journal.js
+++ b/client/src/partials/journal/journal.js
@@ -132,13 +132,8 @@ function JournalController(Journal, Sorting, Grouping, Filtering, Columns, Confi
       enableCellEdit: false,
       allowCellFocus: false
     },
-
-    // @todo this should be formatted as a currency icon vs. an ID
-    { field : 'currency_id', displayName : 'TABLE.COLUMNS.CURRENCY', headerCellFilter: 'translate', visible: false, enableCellEdit: false},
-
-    // @todo this should be formatted showing the debtor/creditor
+    { field : 'currencyName', displayName : 'TABLE.COLUMNS.CURRENCY', headerCellFilter: 'translate', visible: false, enableCellEdit: false},
     { field : 'hrEntity', displayName : 'TABLE.COLUMNS.RECIPIENT', headerCellFilter: 'translate', visible: true},
-
     { field : 'hrReference', displayName : 'TABLE.COLUMNS.REFERENCE', headerCellFilter: 'translate', visible: true },
     { field : 'user', displayName : 'TABLE.COLUMNS.RESPONSIBLE', headerCellFilter: 'translate', visible: false, enableCellEdit: false },
     { field : 'actions', displayName : '', headerCellFilter: 'translate', visible: true, enableCellEdit: false, cellTemplate: '/partials/journal/templates/actions.cell.html', allowCellFocus: false }

--- a/server/controllers/admin/employees.js
+++ b/server/controllers/admin/employees.js
@@ -142,7 +142,7 @@ exports.checkOffday = function checkHoliday(req, res, next) {
  * @returns {Promise} - the result of the database query.
  */
 function lookupEmployee(id) {
-  let sql = `
+  const sql = `
     SELECT employee.id, employee.code AS code_employee, employee.display_name, employee.sexe, employee.dob, employee.date_embauche, employee.service_id,
       employee.nb_spouse, employee.nb_enfant, BUID(employee.grade_id) as grade_id,
       employee.locked, grade.text, grade.basic_salary,
@@ -162,14 +162,7 @@ function lookupEmployee(id) {
     WHERE employee.id = ?;
   `;
 
-  return db.exec(sql, [id])
-  .then(function (rows) {
-    if (rows.length === 0) {
-      throw new NotFound(`Could not find an employee with id ${id}.`);
-    }
-
-    return rows[0];
-  });
+  return db.one(sql, [id], id, 'employee');
 }
 
 /**
@@ -180,11 +173,11 @@ function lookupEmployee(id) {
  */
 function detail(req, res, next) {
   lookupEmployee(req.params.id)
-  .then(function (record) {
-    res.status(200).json(record);
-  })
-  .catch(next)
-  .done();
+    .then(function (record) {
+      res.status(200).json(record);
+    })
+    .catch(next)
+    .done();
 }
 
 /**
@@ -194,7 +187,7 @@ function detail(req, res, next) {
  * Update details of an employee referenced by an `id` in the database
  */
 function update(req, res, next) {
-  let employee = db.convert(req.body, [
+  const employee = db.convert(req.body, [
     'grade_id', 'debtor_group_uuid', 'creditor_group_uuid', 'creditor_uuid', 'debtor_uuid', 'location_id'
   ]);
 

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -72,7 +72,7 @@ function list(req, res, next) {
     SELECT BUID(p.uuid) AS uuid, p.project_id, p.fiscal_year_id, p.period_id,
       p.trans_id, p.trans_date, BUID(p.record_uuid) AS record_uuid,
       dm1.text AS hrRecord, p.description, p.account_id, p.debit, p.credit,
-      p.debit_equiv, p.credit_equiv, p.currency_id,
+      p.debit_equiv, p.credit_equiv, p.currency_id, c.name AS currencyName,
       BUID(p.entity_uuid) AS entity_uuid, em.text AS hrEntity,
       BUID(p.reference_uuid) AS reference_uuid, dm2.text AS hrReference,
       p.comment, p.origin_id, p.user_id, p.cc_id, p.pc_id, pro.abbr,
@@ -83,6 +83,7 @@ function list(req, res, next) {
       JOIN period per ON per.id = p.period_id
       JOIN account a ON a.id = p.account_id
       JOIN user u ON u.id = p.user_id
+      JOIN currency c ON c.id = p.currency_id
       LEFT JOIN entity_map em ON em.uuid = p.entity_uuid
       LEFT JOIN document_map dm1 ON dm1.uuid = p.record_uuid
       LEFT JOIN document_map dm2 ON dm2.uuid = p.reference_uuid
@@ -119,11 +120,6 @@ function getTransaction (req, res, next){
  * POST /journal/:uuid/reverse
  */
 function reverse(req, res, next) {
-<<<<<<< 3fa08c9a78e043908319ddaad1dc050257f02b0d
-=======
-  const uid = db.bid(req.params.uuid);
-  const userId = req.session.user.id;
->>>>>>> feat(entities): introduce entity_map
 
   const voucherUuid = uuid.v4();
   const params = [

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -1,13 +1,13 @@
 /**
-* The /journal HTTP API endpoint
-*
-* @module finance/journal/
-*
-* @description This module is responsible for handling CRUD operations
-* against the `posting journal` table.
-*
-* @requires lib/db
-*/
+ * The /journal HTTP API endpoint
+ *
+ * @module finance/journal/
+ *
+ * @description This module is responsible for handling CRUD operations
+ * against the `posting journal` table.
+ *
+ * @requires lib/db
+ */
 
 'use strict';
 
@@ -71,20 +71,21 @@ function list(req, res, next) {
   const sql = `
     SELECT BUID(p.uuid) AS uuid, p.project_id, p.fiscal_year_id, p.period_id,
       p.trans_id, p.trans_date, BUID(p.record_uuid) AS record_uuid,
-      p.description, p.account_id, p.debit, p.credit,
+      dm1.text AS hrRecord, p.description, p.account_id, p.debit, p.credit,
       p.debit_equiv, p.credit_equiv, p.currency_id,
       BUID(p.entity_uuid) AS entity_uuid, em.text AS hrEntity,
-      BUID(p.reference_uuid) AS reference_uuid, p.comment, p.origin_id,
-      p.user_id, p.cc_id, p.pc_id,
-      pro.abbr, pro.name AS project_name,
-      per.start_date AS period_start, per.end_date AS period_end,
-      a.number AS account_number, u.display_name
+      BUID(p.reference_uuid) AS reference_uuid, dm2.text AS hrReference,
+      p.comment, p.origin_id, p.user_id, p.cc_id, p.pc_id, pro.abbr,
+      pro.name AS project_name, per.start_date AS period_start,
+      per.end_date AS period_end, a.number AS account_number, u.display_name
     FROM posting_journal p
       JOIN project pro ON pro.id = p.project_id
       JOIN period per ON per.id = p.period_id
       JOIN account a ON a.id = p.account_id
       JOIN user u ON u.id = p.user_id
       LEFT JOIN entity_map em ON em.uuid = p.entity_uuid
+      LEFT JOIN document_map dm1 ON dm1.uuid = p.record_uuid
+      LEFT JOIN document_map dm2 ON dm2.uuid = p.reference_uuid
     ORDER BY p.trans_date DESC;
   `;
 

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -55,7 +55,7 @@ function lookupTransaction(record_uuid) {
 
       // if no records matching, throw a 404
       if (rows.length === 0) {
-        throw new NotFound(`could not find a transaction specified by the record`);
+        throw new NotFound(`Could not find a transaction with record_uuid ${record_uuid}.`);
       }
 
       return rows;
@@ -67,13 +67,13 @@ function lookupTransaction(record_uuid) {
  * Getting data from the posting journal
  */
 function list(req, res, next) {
-  // JOIN fiscal_year f ON f.id = p.fiscal_year_id
-  let sql = `
+
+  const sql = `
     SELECT BUID(p.uuid) AS uuid, p.project_id, p.fiscal_year_id, p.period_id,
       p.trans_id, p.trans_date, BUID(p.record_uuid) AS record_uuid,
       p.description, p.account_id, p.debit, p.credit,
       p.debit_equiv, p.credit_equiv, p.currency_id,
-      BUID(p.entity_uuid) AS entity_uuid, p.entity_type,
+      BUID(p.entity_uuid) AS entity_uuid, em.text AS hrEntity,
       BUID(p.reference_uuid) AS reference_uuid, p.comment, p.origin_id,
       p.user_id, p.cc_id, p.pc_id,
       pro.abbr, pro.name AS project_name,
@@ -84,25 +84,23 @@ function list(req, res, next) {
       JOIN period per ON per.id = p.period_id
       JOIN account a ON a.id = p.account_id
       JOIN user u ON u.id = p.user_id
+      LEFT JOIN entity_map em ON em.uuid = p.entity_uuid
     ORDER BY p.trans_date DESC;
   `;
 
   db.exec(sql)
-  .then(rows => {
-    res.status(200).json(rows);
-  })
-  .catch(next);
+    .then(rows => {
+      res.status(200).json(rows);
+    })
+    .catch(next);
 }
 
 /**
  * GET /journal/:record_uuid
  * send back a set of lines which have the same record_uuid the which provided by the user
  */
-function getTransaction(req, res, next) {
-
-  let record_uuid = req.params.record_uuid;
-
-  lookupTransaction(record_uuid)
+function getTransaction (req, res, next){
+  lookupTransaction(req.params.record_uuid)
     .then(function (transaction) {
       res.status(200).json(transaction);
     })
@@ -120,6 +118,11 @@ function getTransaction(req, res, next) {
  * POST /journal/:uuid/reverse
  */
 function reverse(req, res, next) {
+<<<<<<< 3fa08c9a78e043908319ddaad1dc050257f02b0d
+=======
+  const uid = db.bid(req.params.uuid);
+  const userId = req.session.user.id;
+>>>>>>> feat(entities): introduce entity_map
 
   const voucherUuid = uuid.v4();
   const params = [

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -85,13 +85,12 @@ exports.latestInvoice = latestInvoice;
 
 /** @todo Method handles too many operations */
 function create(req, res, next) {
-  let writeDebtorQuery, writePatientQuery;
-  var patientText;
+  let patientText;
 
-  var createRequestData = req.body;
+  const createRequestData = req.body;
 
-  var medical = createRequestData.medical;
-  var finance = createRequestData.finance;
+  let medical = createRequestData.medical;
+  let finance = createRequestData.finance;
 
   // Debtor group required for financial modelling
   let invalidParameters = !finance || !medical;
@@ -117,15 +116,12 @@ function create(req, res, next) {
     medical.registration_date = new Date(medical.registration_date);
   }
 
-
   finance = db.convert(finance, ['uuid', 'debtor_group_uuid']);
   medical = db.convert(medical, ['uuid', 'current_location_id', 'origin_location_id']);
   medical.debtor_uuid = finance.uuid;
 
-  writeDebtorQuery = 'INSERT INTO debtor (uuid, group_uuid, text) VALUES ' +
-    '(?, ?, ?)';
-
-  writePatientQuery = 'INSERT INTO patient SET ?';
+  let writeDebtorQuery = 'INSERT INTO debtor (uuid, group_uuid, text) VALUES (?, ?, ?)';
+  let writePatientQuery = 'INSERT INTO patient SET ?';
 
   let transaction = db.transaction();
 
@@ -179,15 +175,15 @@ function detail(req, res, next) {
  * Updates a patient group
  */
 function update(req, res, next) {
-  var updatePatientQuery;
-  var data = db.convert(req.body, ['debtor_uuid', 'current_location_id', 'origin_location_id']);
-  var patientUuid = req.params.uuid;
-  var buid = db.bid(patientUuid);
+  let data = db.convert(req.body, ['debtor_uuid', 'current_location_id', 'origin_location_id']);
+  let patientUuid = req.params.uuid;
+  let buid = db.bid(patientUuid);
 
   // prevent updating the patient's uuid
   delete data.uuid;
+  delete data.reference;
 
-  updatePatientQuery =
+  let updatePatientQuery =
     'UPDATE patient SET ? WHERE uuid = ?';
 
   db.exec(updatePatientQuery, [data, buid])

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -117,10 +117,6 @@ CREATE TABLE `cash` (
   FOREIGN KEY (`cashbox_id`) REFERENCES `cash_box` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- triggers to manage creation of references
-CREATE TRIGGER cash_before_insert BEFORE INSERT ON cash
-FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM cash WHERE cash.project_id = new.project_id);
-
 DROP TABLE IF EXISTS `cash_item`;
 CREATE TABLE `cash_item` (
   `uuid`            BINARY(16) NOT NULL,
@@ -442,10 +438,6 @@ CREATE TABLE `credit_note` (
   FOREIGN KEY (`invoice_uuid`) REFERENCES `invoice` (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- triggers to manage creation of references
-CREATE TRIGGER credit_note_before_insert BEFORE INSERT ON credit_note
-FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM credit_note WHERE credit_note.project_id = new.project_id);
-
 DROP TABLE IF EXISTS `creditor`;
 
 CREATE TABLE `creditor` (
@@ -641,7 +633,7 @@ CREATE TABLE `employee` (
   `service_id`    SMALLINT(5) UNSIGNED DEFAULT NULL,
   `location_id`   BINARY(16) NOT NULL,
   `creditor_uuid` BINARY(16) DEFAULT NULL,
-  `debtor_uuid`  BINARY(16) DEFAULT NULL,
+  `debtor_uuid`   BINARY(16) DEFAULT NULL,
   `locked`        TINYINT(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `employee_1` (`code`),
@@ -683,6 +675,13 @@ CREATE TABLE `enterprise` (
   FOREIGN KEY (`location_id`) REFERENCES `village` (`uuid`),
   FOREIGN KEY (`gain_account_id`) REFERENCES `account` (`id`),
   FOREIGN KEY (`loss_account_id`) REFERENCES `account` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+DROP TABLE IF EXISTS `entity_map`;
+CREATE TABLE `entity_map` (
+  `uuid`              BINARY(16) NOT NULL,
+  `text`              TEXT NOT NULL,
+  PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `event`;
@@ -1139,9 +1138,6 @@ CREATE TABLE `patient` (
   FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TRIGGER patient_reference BEFORE INSERT ON patient
-FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM patient WHERE patient.project_id = new.project_id);
-
 DROP TABLE IF EXISTS `patient_document`;
 
 CREATE TABLE `patient_document` (
@@ -1401,9 +1397,6 @@ CREATE TABLE `purchase` (
   FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TRIGGER purchase_reference BEFORE INSERT ON purchase
-FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM purchase WHERE purchase.project_id = new.project_id);
-
 DROP TABLE IF EXISTS `purchase_item`;
 
 CREATE TABLE `purchase_item` (
@@ -1519,9 +1512,6 @@ CREATE TABLE `invoice` (
   FOREIGN KEY (`service_id`) REFERENCES `service` (`id`),
   FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE TRIGGER invoice_reference BEFORE INSERT ON invoice
-FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM invoice WHERE invoice.project_id = new.project_id);
 
 DROP TABLE IF EXISTS invoice_billing_service;
 CREATE TABLE invoice_billing_service (
@@ -1657,17 +1647,18 @@ CREATE TABLE subsidy (
 
 DROP TABLE IF EXISTS `supplier`;
 CREATE TABLE `supplier` (
-  `uuid` BINARY(16) NOT NULL,
-  `creditor_uuid` BINARY(16) NOT NULL,
-  `display_name` varchar(45) NOT NULL,
-  `address_1` text,
-  `address_2` text,
-  `email` varchar(45) DEFAULT NULL,
-  `fax` varchar(45) DEFAULT NULL,
-  `note` text,
-  `phone` varchar(15) DEFAULT NULL,
-  `international` tinyint(1) NOT NULL DEFAULT 0,
-  `locked` tinyint(1) NOT NULL DEFAULT 0,
+  `uuid`            BINARY(16) NOT NULL,
+  `reference`       INT(10) UNSIGNED NOT NULL DEFAULT 0,
+  `creditor_uuid`   BINARY(16) NOT NULL,
+  `display_name`    VARCHAR(45) NOT NULL,
+  `address_1`       TEXT,
+  `address_2`       TEXT,
+  `email`           VARCHAR(45) DEFAULT NULL,
+  `fax`             VARCHAR(45) DEFAULT NULL,
+  `note`            TEXT,
+  `phone`           VARCHAR(15) DEFAULT NULL,
+  `international`   TINYINT(1) NOT NULL DEFAULT 0,
+  `locked`          TINYINT(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`uuid`),
   UNIQUE KEY `supplier_1` (`display_name`),
   KEY `creditor_uuid` (`creditor_uuid`),
@@ -1809,9 +1800,6 @@ CREATE TABLE IF NOT EXISTS `voucher` (
   UNIQUE KEY `voucher_1` (`project_id`, `reference`),
   PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE TRIGGER voucher_before_insert BEFORE INSERT ON voucher
-FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM voucher WHERE voucher.project_id = NEW.project_id);
 
 DROP TABLE IF EXISTS `voucher_item`;
 CREATE TABLE IF NOT EXISTS `voucher_item` (

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -594,8 +594,8 @@ CREATE TABLE `depot` (
   UNIQUE KEY `depot_1` (`text`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-DROP TABLE IF EXISTS discount;
 
+DROP TABLE IF EXISTS discount;
 CREATE TABLE discount (
   `id`                  SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
   `label`               VARCHAR(100) NOT NULL,
@@ -610,6 +610,14 @@ CREATE TABLE discount (
   KEY `account_id` (`account_id`),
   FOREIGN KEY (`inventory_uuid`) REFERENCES `inventory` (`uuid`) ON DELETE CASCADE ON UPDATE CASCADE,
   FOREIGN KEY (`account_id`) REFERENCES `account` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+DROP TABLE IF EXISTS `document_map`;
+CREATE TABLE `document_map` (
+  `uuid`              BINARY(16) NOT NULL,
+  `text`              TEXT NOT NULL,
+  PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `employee`;

--- a/server/models/test/data.sql
+++ b/server/models/test/data.sql
@@ -288,12 +288,10 @@ INSERT INTO `patient_group` VALUES
   (HUID('112a9fb5-847d-4c6a-9b20-710fa8b4da24'),1,NULL,'Test Patient Group 2','Test Patient Group 2 Note','2016-03-10 08:44:23'),
   (HUID('112a9fb5-847d-4c6a-9b20-710fa8b4da22'),1,NULL,'Test Patient Group 3','Test Patient Group 2 Note','2016-03-12 08:44:23');
 
-INSERT INTO `debtor` VALUES
+INSERT INTO `debtor` (uuid, group_uuid, text) VALUES
   (HUID('3be232f9-a4b9-4af6-984c-5d3f87d5c107'),HUID('4de0fe47-177f-4d30-b95f-cff8166400b4'),'Patient/2/Patient'),
   (HUID('a11e6b7f-fbbb-432e-ac2a-5312a66dccf4'),HUID('4de0fe47-177f-4d30-b95f-cff8166400b4'),'Patient/1/Patient'),
-  (HUID('be0096dd-2929-41d2-912e-fb2259356fb5'),HUID('4de0fe47-177f-4d30-b95f-cff8166400b4'),'Employee/Test Debtor'),
-  (HUID('1fa862d0-2d30-4550-8052-e9aa6dbc467e'),HUID('4de0fe47-177f-4d30-b95f-cff8166400b4'),'Anonymous/Test Debtor');
-
+  (HUID('be0096dd-2929-41d2-912e-fb2259356fb5'),HUID('4de0fe47-177f-4d30-b95f-cff8166400b4'),'Employee/Test Debtor');
 
 INSERT INTO `patient` VALUES
   (HUID('274c51ae-efcc-4238-98c6-f402bfb39866'),1,2,HUID('3be232f9-a4b9-4af6-984c-5d3f87d5c107'),'Test 2 Patient','1990-06-01 00:00:00',NULL,NULL,NULL,NULL,NULL,NULL,NULL,'M',NULL,NULL,NULL,NULL,NULL,NULL,0,HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'),HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'),'2015-11-14 07:04:49',NULL,NULL,'110', '', 1),
@@ -316,7 +314,6 @@ INSERT INTO `fonction` VALUES
 INSERT INTO `creditor_group` VALUES
   (1,HUID('8bedb6df-6b08-4dcf-97f7-0cfbb07cf9e2'),'Fournisseur [Creditor Group Test]',3630,0),
   (1,HUID('b0fa5ed2-04f9-4cb3-92f7-61d6404696e7'),'Personnel [Creditor Group Test]',3629,0);
-
 
 -- Creditor
 INSERT INTO `creditor` VALUES

--- a/server/models/triggers.sql
+++ b/server/models/triggers.sql
@@ -1,0 +1,74 @@
+
+DELIMITER $$
+
+-- Patient Triggers
+
+CREATE TRIGGER patient_reference BEFORE INSERT ON patient
+FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM patient WHERE patient.project_id = new.project_id)$$
+
+CREATE TRIGGER patient_entity_map AFTER INSERT ON patient
+FOR EACH ROW BEGIN
+
+  -- this writes a patient entity into the entity_map table
+  INSERT INTO entity_map
+    SELECT new.uuid, CONCAT_WS('.', 'P', project.abbr, new.reference) FROM project where project.id = new.project_id;
+
+  -- this writes a debtor entity into the entity_map table
+  -- NOTE: the debtor actually points to the patient entity for convienence
+  INSERT INTO entity_map
+    SELECT new.debtor_uuid, CONCAT_WS('.', 'P', project.abbr, new.reference) FROM project where project.id = new.project_id;
+END$$
+
+
+
+-- Purchase Triggers
+
+CREATE TRIGGER purchase_reference BEFORE INSERT ON purchase
+FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM purchase WHERE purchase.project_id = new.project_id)$$
+
+
+-- Invoice Triggers
+
+CREATE TRIGGER invoice_reference BEFORE INSERT ON invoice
+FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM invoice WHERE invoice.project_id = new.project_id)$$
+
+-- Cash Payment Triggers
+
+CREATE TRIGGER cash_before_insert BEFORE INSERT ON cash
+FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM cash WHERE cash.project_id = new.project_id)$$
+
+-- Credit Note Triggers
+-- @FIXME - why are we still using a credit note table?
+
+CREATE TRIGGER credit_note_before_insert BEFORE INSERT ON credit_note
+FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM credit_note WHERE credit_note.project_id = new.project_id)$$
+
+-- Voucher Triggers
+
+CREATE TRIGGER voucher_before_insert BEFORE INSERT ON voucher
+FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(reference) + 1, 1) FROM voucher WHERE voucher.project_id = NEW.project_id)$$
+
+-- Employee Triggers
+
+CREATE TRIGGER employee_entity_map AFTER INSERT ON employee
+FOR EACH ROW BEGIN
+
+  -- Since employees do not have UUIDs or project associations, we create their mapping by simply concatenating
+  -- the id with a prefix like this: E.{{employee.id}}.
+  INSERT INTO entity_map SELECT new.debtor_uuid, CONCAT_WS('.', 'E', new.id);
+END$$
+
+-- Supplier Triggers
+
+CREATE TRIGGER supplier_before_insert BEFORE INSERT ON supplier
+FOR EACH ROW SET NEW.reference = (SELECT IFNULL(MAX(supplier.reference) + 1, 1) FROM supplier)$$
+
+CREATE TRIGGER supplier_entity_map AFTER INSERT ON supplier
+FOR EACH ROW BEGIN
+
+  -- this writes the supplier's creditor into the entity_map, pointing to the supplier
+  INSERT INTO entity_map
+    SELECT new.creditor_uuid, CONCAT_WS('.', 'C', new.reference);
+END$$
+
+DELIMITER ;

--- a/sh/install.sh
+++ b/sh/install.sh
@@ -15,6 +15,7 @@ mysql -h $DB_HOST -u root -e "FLUSH PRIVILEGES;"
 mysql -h $DB_HOST -u root -e "DROP SCHEMA IF EXISTS $DB_NAME;"
 mysql -h $DB_HOST -u $DB_USER -p$DB_PASS -e "CREATE SCHEMA $DB_NAME CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
 mysql -h $DB_HOST -u $DB_USER -p$DB_PASS $DB_NAME < server/models/schema.sql
+mysql -h $DB_HOST -u $DB_USER -p$DB_PASS $DB_NAME < server/models/triggers.sql
 mysql -u $DB_USER -u $DB_USER -p$DB_PASS $DB_NAME < server/models/functions.sql
 mysql -u $DB_USER -u $DB_USER -p$DB_PASS $DB_NAME < server/models/procedures.sql
 mysql -u $DB_USER -u $DB_USER -p$DB_PASS $DB_NAME < server/models/debug.sql

--- a/sh/integration-tests.sh
+++ b/sh/integration-tests.sh
@@ -18,10 +18,16 @@ TIMEOUT=${BUILD_TIMEOUT:-8}
 # build the test database
 mysql -u $DB_USER -p$DB_PASS -e "DROP DATABASE IF EXISTS $DB_NAME ;"
 mysql -u $DB_USER -p$DB_PASS -e "CREATE DATABASE $DB_NAME CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
+
+echo "Building schema"
 mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/schema.sql
+echo "Building triggers"
+mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/triggers.sql
+echo "Building functions and procedures"
 mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/functions.sql
 mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/procedures.sql
-mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/debug.sql
+# mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/debug.sql
+echo "Building test database"
 mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/test/data.sql
 
 echo "Building server ...."

--- a/sh/test-ends.sh
+++ b/sh/test-ends.sh
@@ -19,6 +19,7 @@ TIMEOUT=${BUILD_TIMEOUT:-8}
 mysql -u $DB_USER -p$DB_PASS -e "DROP DATABASE bhima_test;"
 mysql -u $DB_USER -p$DB_PASS -e "CREATE DATABASE bhima_test;"
 mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/schema.sql
+mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/triggers.sql
 mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/functions.sql
 mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/procedures.sql
 mysql -u $DB_USER -p$DB_PASS $DB_NAME < server/models/test/data.sql

--- a/test/end-to-end/journal/journal.config.js
+++ b/test/end-to-end/journal/journal.config.js
@@ -12,11 +12,11 @@ const FU = require('../shared/FormUtils');
 function JournalConfigurationModal() {
   'use strict';
 
-  const defaultVisibleColumnCount = 7;
+  const defaultVisibleColumnCount = 10;
   const modifiedVisibleColumnCount = 3;
   const page = new JournalCorePage();
 
-  it('displays six visible columns by default', () => {
+  it(`displays ${defaultVisibleColumnCount} visible columns by default`, () => {
     page.expectColumnCount(defaultVisibleColumnCount);
   });
 

--- a/test/integration/debtors.js
+++ b/test/integration/debtors.js
@@ -8,7 +8,6 @@ describe('(/debtors) The /debtors API', function () {
   'use strict';
 
   const debtorKeys = ['uuid', 'group_uuid', 'text'];
-
   const debtorUuid = '3be232f9-a4b9-4af6-984c-5d3f87d5c107';
   const emptyDebtorUuid = 'a11e6b7f-fbbb-432e-ac2a-5312a66dccf4';
 
@@ -54,20 +53,19 @@ describe('(/debtors) The /debtors API', function () {
   it('GET /debtors should return a list of all debtors', function () {
     return agent.get('/debtors')
       .then(function (res) {
-        helpers.api.listed(res, 4);
+        helpers.api.listed(res, 3);
       })
       .catch(helpers.handler);
   });
 
   // FIXME - incredibly hard coded!!
   it('GET /debtors/:uuid should return detail of a specifying debtor', function () {
-    const debtorUuid = '1fa862d0-2d30-4550-8052-e9aa6dbc467e';
     return agent.get(`/debtors/${debtorUuid}`)
       .then(function (res) {
         expect(res.body).to.contain.all.keys(debtorKeys);
-        expect(res.body.uuid).to.be.equal('1fa862d0-2d30-4550-8052-e9aa6dbc467e');
+        expect(res.body.uuid).to.be.equal(debtorUuid);
         expect(res.body.group_uuid).to.be.equal('4de0fe47-177f-4d30-b95f-cff8166400b4');
-        expect(res.body.text).to.be.equal('Anonymous/Test Debtor');
+        expect(res.body.text).to.be.equal('Patient/2/Patient');
       })
       .catch(helpers.handler);
   });

--- a/test/integration/employee.js
+++ b/test/integration/employee.js
@@ -14,9 +14,9 @@ describe('(/employees) the employees API endpoint', function () {
   const numEmployees = 1;
 
   // custom dates
-  var embaucheDate  = new Date('2016-01-01'),
-      dob1 = new Date('1987-04-17'),
-      dob2 = new Date('1993-04-25');
+  let embaucheDate  = new Date('2016-01-01');
+  let dob1 = new Date('1987-04-17');
+  let dob2 = new Date('1993-04-25');
 
   // employee we will add during this test suite.
   var employee = {


### PR DESCRIPTION
This PR introduces human readable UUIDs to the posting journal by introducing reference mapping tables into the database.  These tables are updated whenever a record with a UUID is added via MySQL triggers.

Two tables are introduced:
1. `entity_map` which maps `entity_uuid`s to readable text
2. `document_map` which maps `record_uuid`s and `reference_uuid`s to readable text.

This creates a much nicer accounting user experience, since the records in the posting journal are suddenly meaningful.  See the image below to understand what the pull request does:

![journalreadableuuids](https://cloud.githubusercontent.com/assets/896472/18920523/86ba1a0c-8599-11e6-89ca-656a9cf73f74.png)
_Fig 1: Human Readable IDs_

Closes #629.  Closes #630.  Closes #753.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
