### PR TITLE
Confirm dialog modal implementation

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -271,10 +271,11 @@
       "VIEW_ERRORS"           : "View Errors"
     },
     "DIALOGS": {
+      "CONFIRM_ACTION"         : "Do you confirm this action ?",
       "CONFIRM_DELETE"         : "You are about to delete a record.  This action is permanent and cannot be done.  Click \"Confirm\" to accept or \"Cancel\" to halt this action.",
-      "CANNOT_UNDONE_DELETION" : "This action CANNOT BE REVERSED, the deletion will be permanent. You must be sure that you want to do this action",
-      "NO_CORRESPONDANCY"      : "No %ELEMENT% have the name ",
-      "PLEASE_TYPE_TEXT"       : "Please type in the %ELEMENT% name to confirm",
+      "CANNOT_UNDONE_ACTION"   : "This action CANNOT BE REVERSED, this action will be permanent. You must be sure that you want to do this action",
+      "NO_CORRESPONDANCY"      : "No correspondancy found for ",
+      "PLEASE_TYPE_TEXT"       : "Please type %ELEMENT% to confirm",
       "PLEASE_READ"            : "Unexpected bad things will happen if you don't read this!",
       "SURE_CONTINUE"          : "Are you ABSOLUTELY sure?",
       "UNDERSTAND_ACTION"      : "I accept the consequences of this action",
@@ -576,6 +577,11 @@
     "LEGENDS": {
       "CREATION" : "Creation",
       "EDITION"  : "Edition"
+    },
+    "PATTERNS": {
+      "DOCUMENT_NAME"    : "the document name",
+      "FISCAL_YEAR_NAME" : "the fiscal year name",
+      "PROJECT_NAME"     : "the project name"
     },
     "PLACEHOLDERS": {
       "ACCOUNT"      : "Enter account",

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -275,7 +275,7 @@
       "CONFIRM_DELETE"         : "You are about to delete a record.  This action is permanent and cannot be done.  Click \"Confirm\" to accept or \"Cancel\" to halt this action.",
       "CANNOT_UNDONE_ACTION"   : "This action CANNOT BE REVERSED, this action will be permanent. You must be sure that you want to do this action",
       "NO_CORRESPONDANCY"      : "No correspondancy found for ",
-      "PLEASE_TYPE_TEXT"       : "Please type %ELEMENT% to confirm",
+      "PLEASE_TYPE_TEXT"       : "Please type {{value}} to confirm",
       "PLEASE_READ"            : "Unexpected bad things will happen if you don't read this!",
       "SURE_CONTINUE"          : "Are you ABSOLUTELY sure?",
       "UNDERSTAND_ACTION"      : "I accept the consequences of this action",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -278,10 +278,11 @@
       "VIEW_ERRORS"           : "Voir erreurs"
     },
     "DIALOGS": {
+      "CONFIRM_ACTION"         : "Confirmez vous cette action ?",
       "CONFIRM_DELETE"         : "Confirmez vous la suppression ?",
-      "CANNOT_UNDONE_DELETION" : "Cette action NE POURRA PAS ETRE ANNULER, la suppression sera definitive. Vous devez etre sure que vous voulez vraiment effectuer cette operation",
-      "NO_CORRESPONDANCY"      : "Aucun %ELEMENT% n'a le nom ",
-      "PLEASE_TYPE_TEXT"       : "Veuillez taper le nom de %ELEMENT% pour confirmer ",
+      "CANNOT_UNDONE_ACTION"   : "Cette action NE POURRA PAS ETRE ANNULER, les consequences de cette action seront definitives. Vous devez etre sure que vous voulez vraiment effectuer cette action",
+      "NO_CORRESPONDANCY"      : "Aucune correspondance trouvée pour",
+      "PLEASE_TYPE_TEXT"       : "Veuillez saisir %ELEMENT% pour confirmer ",
       "PLEASE_READ"            : "Vous risquez de perdre des donnees importantes si vous ne lisez pas ce message!",
       "SURE_CONTINUE"          : "Etes-vous ABSOLUMENT sure ?",
       "UNDERSTAND_ACTION"      : "J'ACCEPTE les consequences de cette action"
@@ -584,6 +585,11 @@
     "LEGENDS": {
       "CREATION" : "Creation",
       "EDITION"  : "Edition"
+    },
+    "PATTERNS": {
+      "DOCUMENT_NAME"    : "le nom du document",
+      "FISCAL_YEAR_NAME" : "le nom de l'annee fiscale",
+      "PROJECT_NAME"     : "le nom du projet"
     },
     "PLACEHOLDERS": {
       "ACCOUNT"      : "Entrer le compte",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -282,7 +282,7 @@
       "CONFIRM_DELETE"         : "Confirmez vous la suppression ?",
       "CANNOT_UNDONE_ACTION"   : "Cette action NE POURRA PAS ETRE ANNULER, les consequences de cette action seront definitives. Vous devez etre sure que vous voulez vraiment effectuer cette action",
       "NO_CORRESPONDANCY"      : "Aucune correspondance trouvée pour",
-      "PLEASE_TYPE_TEXT"       : "Veuillez saisir %ELEMENT% pour confirmer ",
+      "PLEASE_TYPE_TEXT"       : "Veuillez saisir {{value}} pour confirmer ",
       "PLEASE_READ"            : "Vous risquez de perdre des donnees importantes si vous ne lisez pas ce message!",
       "SURE_CONTINUE"          : "Etes-vous ABSOLUMENT sure ?",
       "UNDERSTAND_ACTION"      : "J'ACCEPTE les consequences de cette action"

--- a/client/src/js/components/bhFindDocument.js
+++ b/client/src/js/components/bhFindDocument.js
@@ -58,9 +58,12 @@ function FindDocumentComponent(Patient, Modal, Document, Notify, User, $translat
 
   /** delete document */
   function deleteDocument(uuid, pattern) {
-    var request = { pattern: pattern, elementName: 'document'};
+    var request = {
+      pattern: pattern,
+      patternName: 'FORM.PATTERNS.DOCUMENT_NAME'
+    };
 
-    Modal.openConfirmDeletion(request)
+    Modal.openConfirmDialog(request)
     .then(function (ans) {
       if (!ans) { return; }
 

--- a/client/src/js/services/ModalService.js
+++ b/client/src/js/services/ModalService.js
@@ -56,7 +56,7 @@ function ModalService(Modal) {
   service.openDateInterval = openDateInterval;
 
   // confirm deletion modal
-  service.openConfirmDeletion = openConfirmDeletion;
+  service.openConfirmDialog = openConfirmDialog;
 
   // project actions : add or edit
   service.openProjectActions = openProjectActions;
@@ -304,11 +304,11 @@ function ModalService(Modal) {
      *   elementName: $translate.instant('FORM.LABELS.TRANSACTION')
      *  }
      */
-    function openConfirmDeletion(request) {
+    function openConfirmDialog(request) {
 
       var params = angular.extend(modalParameters, {
-        templateUrl  : 'partials/templates/modals/confirmDeletion.modal.html',
-        controller   : 'ConfirmDeletionModalController',
+        templateUrl  : 'partials/templates/modals/confirmDialog.modal.html',
+        controller   : 'ConfirmDialogModalController',
         controllerAs : '$ctrl',
         size         : 'xs',
         backdrop     : 'static',

--- a/client/src/partials/enterprises/enterprises.js
+++ b/client/src/partials/enterprises/enterprises.js
@@ -170,10 +170,10 @@ function EnterpriseController($translate, Enterprises, Currencies, Accounts, uti
   function deleteProject(id, pattern) {
     var params = {
       pattern: pattern,
-      elementName: $translate.instant('FORM.LABELS.PROJECT')
+      patternName: 'FORM.PATTERNS.PROJECT_NAME'
     };
 
-    Modal.openConfirmDeletion(params)
+    Modal.openConfirmDialog(params)
     .then(function (bool) {
       if (!bool) { return; }
 

--- a/client/src/partials/templates/modals/confirmDialog.modal.html
+++ b/client/src/partials/templates/modals/confirmDialog.modal.html
@@ -8,12 +8,12 @@
   </div>
 
   <div class="alert alert-warning">
-    {{ "FORM.DIALOGS.PLEASE_READ" | translate }}
+    <i class="fa fa-exclamation-triangle"></i> {{ "FORM.DIALOGS.PLEASE_READ" | translate }}
   </div>
 
   <div class="modal-body">
     <p>
-      {{ "FORM.DIALOGS.CANNOT_UNDONE_DELETION" | translate }}
+      {{ "FORM.DIALOGS.CANNOT_UNDONE_ACTION" | translate }}
     </p>
 
     <br>

--- a/client/src/partials/templates/modals/confirmDialog.modal.html
+++ b/client/src/partials/templates/modals/confirmDialog.modal.html
@@ -20,7 +20,7 @@
 
     <div class="form-group"
       ng-class="{ 'has-error' : $ctrl.hasErrorMessage, 'has-warning' : $ctrl.hasWarningMessage }">
-      <label class="control-label">{{ $ctrl.message }}</label>
+      <label class="control-label">{{ 'FORM.DIALOGS.PLEASE_TYPE_TEXT' | translate: $ctrl.patternValue }} </label>
       <input class="form-control" ng-model="$ctrl.text" ng-change="$ctrl.validate(ConfirmDeletion)" type="text" name="text" required>
       <div class="help-block" ng-show="ConfirmDeletion.$submitted">
         {{ $ctrl.noCorrespondancy }}

--- a/client/src/partials/templates/modals/confirmDialog.modal.js
+++ b/client/src/partials/templates/modals/confirmDialog.modal.js
@@ -36,11 +36,8 @@ function ConfirmDialogModalController (Instance, $translate, Data) {
       );
     }
 
-    // Confirmation name message
-    message = $translate.instant('FORM.DIALOGS.PLEASE_TYPE_TEXT');
-    pattern = $translate.instant(Data.patternName);
-
-    vm.message = message.replace('%ELEMENT%', pattern);
+    // value according context of the pattern 
+    vm.patternValue = { value: $translate.instant(Data.patternName) };
   }
 
   /** matching */

--- a/client/src/partials/templates/modals/confirmDialog.modal.js
+++ b/client/src/partials/templates/modals/confirmDialog.modal.js
@@ -1,16 +1,16 @@
 angular.module('bhima.controllers')
-.controller('ConfirmDeletionModalController', ConfirmDeletionModalController);
+.controller('ConfirmDialogModalController', ConfirmDialogModalController);
 
 // dependencies injection
-ConfirmDeletionModalController.$inject = ['$uibModalInstance', '$translate', 'data'];
+ConfirmDialogModalController.$inject = ['$uibModalInstance', '$translate', 'data'];
 
 /**
- * Confirm Deletion Controller
+ * Confirm Dialog Controller
  * This controller is responsible for check a match text given to continue
- * the deletion process
+ * with an action
  */
-function ConfirmDeletionModalController (Instance, $translate, Data) {
-  var vm = this, message;
+function ConfirmDialogModalController (Instance, $translate, Data) {
+  var vm = this;
 
   // expose to the view
   vm.accept = accept;
@@ -21,26 +21,26 @@ function ConfirmDeletionModalController (Instance, $translate, Data) {
 
   /** startup */
   function startup() {
+    var message, pattern;
 
     // Global objects
     vm.pattern = Data.pattern;
-    vm.elementName = Data.elementName;
+    vm.patternName = Data.patternName;
 
     // make sure the modal isn't accidentally called with empty values
-    if (!Data.pattern || !Data.elementName) {
+    if (!Data.pattern || !Data.patternName) {
       throw new Error(
-        'ConfirmDeletionModal requires both a pattern and an element name to be defined, but received:' +
+        'ConfirmDialogModal requires both a pattern and an element name to be defined, but received:' +
         'data.pattern = ' + Data.pattern + ' ' +
-        'data.elementName = ' + Data.elementName
+        'data.patternName = ' + Data.patternName
       );
     }
 
     // Confirmation name message
     message = $translate.instant('FORM.DIALOGS.PLEASE_TYPE_TEXT');
+    pattern = $translate.instant(Data.patternName);
 
-    vm.message = Data.elementName ?
-      message.replace('%ELEMENT%', Data.elementName) :
-      message.replace('%ELEMENT%', 'element');
+    vm.message = message.replace('%ELEMENT%', pattern);
   }
 
   /** matching */
@@ -64,8 +64,7 @@ function ConfirmDeletionModalController (Instance, $translate, Data) {
       Instance.close(result);
     } else if (!form.$invalid && !result) {
       vm.noCorrespondancy = $translate.instant('FORM.DIALOGS.NO_CORRESPONDANCY')
-        .replace('%ELEMENT%', vm.elementName)
-        .concat('"', vm.text, '"');
+        .concat(' "', vm.text, '"');
     } else {
       vm.noCorrespondancy = $translate.instant('FORM.ERRORS.REQUIRED');
     }


### PR DESCRIPTION
This PR :  
- Add a generic confirm dialog modal box,
- Remove de `confirmDeletion` modal and replace it with the `confirmDialog` modal
- Update the project deletion and the patient document deletion

![confirm dialog](https://cloud.githubusercontent.com/assets/5445251/19034842/bbd4ed14-891a-11e6-83d9-020c18d328d5.png)

close #759 
