### PR TITLE
chore(schema): make sure FKs cascade when needed

### DIFF
--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -125,7 +125,7 @@ CREATE TABLE `cash_item` (
   `invoice_uuid`    BINARY(16) DEFAULT NULL,
   PRIMARY KEY (`uuid`),
   KEY `cash_uuid` (`cash_uuid`),
-  FOREIGN KEY (`cash_uuid`) REFERENCES `cash` (`uuid`)
+  FOREIGN KEY (`cash_uuid`) REFERENCES `cash` (`uuid`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `cash_box`;
@@ -414,7 +414,6 @@ CREATE TABLE `country` (
 
 
 DROP TABLE IF EXISTS `credit_note`;
-
 CREATE TABLE `credit_note` (
   `uuid`            BINARY(16) NOT NULL,
   `project_id`      SMALLINT(5) UNSIGNED NOT NULL,
@@ -1530,7 +1529,7 @@ CREATE TABLE invoice_billing_service (
   UNIQUE KEY `invoice_billing_service_1` (`invoice_uuid`, `billing_service_id`),
   KEY `invoice_uuid` (`invoice_uuid`),
   KEY `billing_service_id` (`billing_service_id`),
-  FOREIGN KEY (`invoice_uuid`) REFERENCES `invoice` (`uuid`),
+  FOREIGN KEY (`invoice_uuid`) REFERENCES `invoice` (`uuid`) ON DELETE CASCADE,
   FOREIGN KEY (`billing_service_id`) REFERENCES `billing_service` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -1563,7 +1562,7 @@ CREATE TABLE `invoice_subsidy` (
   UNIQUE KEY `invoice_subsidy_1` (`invoice_uuid`, `subsidy_id`),
   KEY `invoice_uuid` (`invoice_uuid`),
   KEY `subsidy_id` (`subsidy_id`),
-  FOREIGN KEY (`invoice_uuid`) REFERENCES `invoice` (`uuid`),
+  FOREIGN KEY (`invoice_uuid`) REFERENCES `invoice` (`uuid`) ON DELETE CASCADE,
   FOREIGN KEY (`subsidy_id`) REFERENCES `subsidy` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -1822,7 +1821,7 @@ CREATE TABLE IF NOT EXISTS `voucher_item` (
   KEY `account_id` (`account_id`),
   KEY `voucher_uuid` (`voucher_uuid`),
   FOREIGN KEY (`account_id`) REFERENCES `account` (`id`),
-  FOREIGN KEY (`voucher_uuid`) REFERENCES `voucher` (`uuid`)
+  FOREIGN KEY (`voucher_uuid`) REFERENCES `voucher` (`uuid`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- a view to make SQL statements look nicer.


### PR DESCRIPTION
This commit makes sure that foreign keys relations are set to cascades between `table` and `table_item` tables.  This includes vouchers and billing services.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
