### PR TITLE
refactor(settings): update to 2.x standards

### DIFF
--- a/client/src/partials/settings/settings.html
+++ b/client/src/partials/settings/settings.html
@@ -31,18 +31,17 @@
         </div>
 
         <button
-          ng-if="SettingsCtrl.previous"
           class="btn btn-default"
-          ui-sref="{{ SettingsCtrl.previous }}"
+          ng-click="SettingsCtrl.back()"
           data-back-button>
-          <span class="glyphicon glyphicon-circle-arrow-left"></span> {{ "FORM.BUTTONS.BACK" | translate }}
+          <i class="fa fa-arrow-left"></i> {{ "FORM.BUTTONS.BACK" | translate }}
         </button>
 
         <button
           class="btn btn-default"
           ng-click="SettingsCtrl.logout()"
           data-logout-button>
-          <span class="glyphicon glyphicon-log-out"></span> {{ "FORM.BUTTONS.LOGOUT" | translate }}
+          <i class="fa fa-sign-out"></i> {{ "FORM.BUTTONS.LOGOUT" | translate }}
         </button>
 
         <a ng-href="mailto:{{SettingsCtrl.bugLink}}" class="btn btn-default" data-bug-report-button>

--- a/client/src/partials/settings/settings.js
+++ b/client/src/partials/settings/settings.js
@@ -2,8 +2,8 @@ angular.module('bhima.controllers')
   .controller('settings', SettingsController);
 
 SettingsController.$inject = [
-  '$state', 'LanguageService', 'SessionService', 'bhConstants', '$translate',
-  'NotifyService'
+  'LanguageService', 'SessionService', 'bhConstants', '$translate',
+  'NotifyService', '$window'
 ];
 
 /**
@@ -14,11 +14,10 @@ SettingsController.$inject = [
  *
  * @constructor
  */
-function SettingsController($state, Languages, Session, Constants, $translate, Notify) {
+function SettingsController(Languages, Session, Constants, $translate, Notify, $window) {
   var vm = this;
 
-  // the url to return to (using the back button)
-  vm.previous = $state.params.previous;
+  vm.back = function () { $window.history.back(); };
 
   // load settings from services
   vm.settings = { language : Languages.key };
@@ -51,5 +50,4 @@ function SettingsController($state, Languages, Session, Constants, $translate, N
       vm.bugLink = encodeURI(emailAddress + '?subject=' + subject + '&body=' + text);
     })
     .catch(Notify.handleError);
-
 }

--- a/test/end-to-end/settings/settings.spec.js
+++ b/test/end-to-end/settings/settings.spec.js
@@ -16,25 +16,23 @@ describe('Settings', function () {
     // ideally, we should check that the language changed, but this
     // test should only confirm that things are open.
     FU.select('SettingsCtrl.settings.language', 'Fr');
-
-    // make sure that the "back" button doesn't exist
-    FU.exists(by.css('[data-back-button]'), false);
   });
 
   it('uses the back button to return to previous state', function () {
+    const start = '#/';
+    const btn = by.css('[data-back-button]');
 
     // load the settings page w/o backwards navigation
-    helpers.navigate('#/settings?previous=index');
-
-    var btn = '[data-back-button]';
-
-    // make sure that the "back" button doesn't exist
-    FU.exists(by.css(btn), true);
-
-    // click the back button
-    element(by.css(btn)).click();
+    helpers.navigate(start);
+    helpers.navigate('#/settings');
 
     // ensure we navigate back to the main page.
-    expect(helpers.getCurrentPath()).to.eventually.equal('#/');
+    expect(helpers.getCurrentPath()).to.eventually.equal('#/settings');
+
+    // click the back button
+    element(btn).click();
+
+    // ensure we navigate back to the main page.
+    expect(helpers.getCurrentPath()).to.eventually.equal(start);
   });
 });


### PR DESCRIPTION
This commit updates the settings page to standards.  After this update, settings can be considered as completed.
1. Use font-awesome instead of glyphicons
2. Use the history API instead of query string hacks to navigate back

The whole purpose of this PR is to remove the `querystring` pollution caused by using URL or `$state`-based solutions.  The [history API](https://developer.mozilla.org/en/docs/Web/API/History) is [widely available](http://caniuse.com/#feat=history).

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
