### PR TITLE
feat(invoice): invoice caching on submit

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -411,7 +411,8 @@ function constantConfig() {
       maxTextLength : 1000
     },
     grid : {
-      ROW_HIGHLIGHT_FLAG : '_highlight'
+      ROW_HIGHLIGHT_FLAG : '_highlight',
+      ROW_ERROR_FLAG : '_error'
     },
     transactions : {
       ROW_EDIT_FLAG : '_edit',

--- a/client/src/js/services/PatientInvoiceItemService.js
+++ b/client/src/js/services/PatientInvoiceItemService.js
@@ -82,13 +82,18 @@ function PatientInvoiceItemService(uuid) {
    */
   PatientInvoiceItem.prototype.configure = function configure(inventoryItem) {
     this.quantity = 1;
-    this.code = inventoryItem.code;
-    this.description = inventoryItem.label;
-    this.transaction_price = inventoryItem.price;
-    this.inventory_price = inventoryItem.price;
-    this.inventory_uuid = inventoryItem.uuid;
 
-    // rest eh validation flags.
+    // when (empty) items are loaded from cache, not all of these codes are available.
+    // so we silently fail when there is an error.
+    try {
+      this.code = inventoryItem.code;
+      this.description = inventoryItem.label;
+      this.transaction_price = inventoryItem.price;
+      this.inventory_price = inventoryItem.price;
+      this.inventory_uuid = inventoryItem.uuid;
+    } catch (e) {}
+
+    // reset the validation flags.
     this.validate();
   };
 

--- a/client/src/less/bhima-bootstrap.less
+++ b/client/src/less/bhima-bootstrap.less
@@ -252,3 +252,14 @@ input[type=number] {-moz-appearance: textfield;}
   animation-name: highlight-flash;
   animation-duration: 1.5s;
 }
+
+/*  flash for error rows */
+@keyframes error-flash {
+  from { background: @btn-danger-bg; }
+  to { background: transparent; }
+}
+
+.ui-grid-row .ui-grid-cell.row-error {
+  animation-name: error-flash;
+  animation-duration: 2s;
+}

--- a/client/src/partials/patient_invoice/patientInvoice.html
+++ b/client/src/partials/patient_invoice/patientInvoice.html
@@ -105,13 +105,14 @@
       <div class="col-xs-12">
 
         <!-- "Recover Items" button -->
-        <div class="btn-group pull-right" role="group">
+        <div class="pull-right">
           <button
             class="btn btn-default"
-            ng-class="{'btn-primary' : PatientInvoiceCtrl.Invoice.hasCacheAvailable() && PatientInvoiceCtrl.Invoice.recipient }"
+            id="recover"
+            ng-class="{ 'btn-primary' : PatientInvoiceCtrl.Invoice.hasCacheAvailable() && PatientInvoiceCtrl.Invoice.recipient }"
             ng-click="PatientInvoiceCtrl.Invoice.readCache()"
-            ng-disabled="!PatientInvoiceCtrl.Invoice.hasCacheAvailable() || !PatientInvoiceCtrl.Invoice.recipient">
-            <span class="fa fa-recycle"></span> {{ "FORM.BUTTONS.RECOVER_ITEMS" | translate }}
+            ng-disabled="!PatientInvoiceCtrl.Invoice.hasCacheAvailable() || !PatientInvoiceCtrl.Invoice.recipient || PatientInvoiceCtrl.Invoice.hasRecoveredCache || detailsForm.$submitted">
+            <i class="fa fa-recycle"></i> {{ "FORM.BUTTONS.RECOVER_ITEMS" | translate }}
           </button>
         </div>
 
@@ -120,15 +121,15 @@
           <span class="input-group-btn">
             <button
               id="btn-add-rows"
-              class="btn btn-default btn-sm"
+              class="btn btn-default"
               ng-disabled="!PatientInvoiceCtrl.Invoice.recipient"
               ng-click="PatientInvoiceCtrl.addItems(PatientInvoiceCtrl.itemIncrement)">
-              <span class="fa fa-plus-circle"></span> {{ "FORM.BUTTONS.ADD" | translate }}
+              <i class="fa fa-plus-circle"></i> {{ "FORM.BUTTONS.ADD" | translate }}
             </button>
           </span>
           <input
             type="number"
-            class="form-control input-sm"
+            class="form-control"
             ng-model="PatientInvoiceCtrl.itemIncrement"
             style="max-width : 40px;"
             ng-disabled="!PatientInvoiceCtrl.Invoice.recipient">

--- a/client/src/partials/patient_invoice/templates/grid/actions.tmpl.html
+++ b/client/src/partials/patient_invoice/templates/grid/actions.tmpl.html
@@ -1,3 +1,5 @@
-<div style="padding : 5px;">
-  <a href="" ng-click="grid.appScope.Invoice.removeItem(row.entity)"><span class="fa fa-trash-o"></span></a>
+<div class="ui-grid-cell-contents">
+  <a href="" ng-click="grid.appScope.Invoice.removeItem(row.entity)" class="text-danger">
+    <i class="fa fa-trash-o"></i>
+  </a>
 </div>

--- a/client/src/partials/patient_invoice/templates/grid/status.tmpl.html
+++ b/client/src/partials/patient_invoice/templates/grid/status.tmpl.html
@@ -1,9 +1,10 @@
-<div ng-hide="row.entity._valid"
+<div
+  ng-hide="row.entity._valid"
   ng-class="{
-    'bg-warning text-warning' : !row.entity._initialised,
-    'bg-danger text-danger' : row.entity._initialised
+  'bg-warning text-warning' : !row.entity._initialised,
+  'bg-danger text-danger' : row.entity._initialised
   }"
-  style="padding: 5px;">
+  class="ui-grid-cell-contents">
 
   <!-- warning state: invalid, but not initialised yet -->
   <span ng-hide="row.entity._initialised" class="fa fa-circle-o"></span>
@@ -12,7 +13,7 @@
   <span ng-show="row.entity._initialised" class="fa fa-times-circle"></span>
 </div>
 
-<div ng-show="row.entity._valid" class="bg-success" style="padding: 5px;">
+<div ng-show="row.entity._valid" class="bg-success ui-grid-cell-contents">
   <!-- success state: valid and initialised -->
   <span class="text-success fa fa-check-circle"></span>
 </div>

--- a/client/src/partials/patient_invoice/templates/grid/unit.tmpl.html
+++ b/client/src/partials/patient_invoice/templates/grid/unit.tmpl.html
@@ -1,6 +1,6 @@
 <div style="padding : 5px;">
   <input
-    min="0"
+    min="0.0001"
     type="number"
     ng-disabled="!row.entity._initialised"
     class="form-control"

--- a/client/src/partials/templates/grid/error.row.html
+++ b/client/src/partials/templates/grid/error.row.html
@@ -3,7 +3,7 @@
   class="ui-grid-cell"
   ng-class="{
     'ui-grid-row-header-cell': col.isRowHeader,
-    'row-highlight': row[grid.appScope.ROW_HIGHLIGHT_FLAG]
+    'row-error': row.entity[grid.appScope.ROW_ERROR_FLAG]
   }"
   ui-grid-cell>
 </div>

--- a/server/controllers/finance/invoice/patientInvoice.create.js
+++ b/server/controllers/finance/invoice/patientInvoice.create.js
@@ -82,13 +82,20 @@ function processInvoice(invoiceUuid, invoice) {
   if (invoice.debtor_uuid) {
     invoice.debtor_uuid = db.bid(invoice.debtor_uuid);
   }
+
   invoice.uuid = invoiceUuid;
 
   // cleanup details not directly tied to invoice
   delete invoice.items;
   delete invoice.billingServices;
   delete invoice.subsidies;
-  return _.values(invoice);
+
+  const keys = [
+    'is_distributable', 'date', 'cost', 'description', 'service_id',
+    'debtor_uuid', 'project_id', 'user_id', 'uuid'
+  ];
+
+  return keys.map(key => invoice[key]);
 }
 
 /**

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -309,7 +309,7 @@ DROP TABLE IF EXISTS `consumption_service`;
 CREATE TABLE `consumption_service` (
   `uuid` BINARY(16) NOT NULL,
   `consumption_uuid` BINARY(16) NOT NULL,
-  `service_id` smallint(5) unsigned NOT NULL,
+  `service_id` SMALLINT(5) UNSIGNED NOT NULL,
   PRIMARY KEY (`uuid`),
   UNIQUE KEY `consumption_service_1` (`consumption_uuid`, `service_id`),
   KEY `consumption_uuid` (`consumption_uuid`),

--- a/test/end-to-end/patient/invoice/invoice.page.js
+++ b/test/end-to-end/patient/invoice/invoice.page.js
@@ -3,7 +3,8 @@
 'use strict';
 
 const FU = require('../../shared/FormUtils');
-const GU = require('../../shared/gridTestUtils.spec.js');
+const GU = require('../../shared/GridUtils');
+
 const findPatient = require('../../shared/components/bhFindPatient');
 const dateEditor = require('../../shared/components/bhDateEditor');
 
@@ -15,11 +16,11 @@ function PatientInvoicePage() {
     add : element(by.id('btn-add-rows')),
     distributable : element(by.id('distributable')),
     notDistributable : element(by.id('not-distributable')),
-    clear : element(by.id('clear'))
+    clear : element(by.id('clear')),
+    recover : element(by.id('recover'))
   };
 
   const gridId = page.gridId = 'invoice-grid';
-  const grid = GU.getGrid(gridId);
 
   // sets a patient to the id passed in
   page.patient = function patient(id) {
@@ -53,6 +54,11 @@ function PatientInvoicePage() {
     btns.submit.click();
   };
 
+  // click the "recover cache" button
+  page.recover = function recover() {
+    btns.recover.click();
+  };
+
   // adds n rows to the grid
   page.addRows = function addRows(n) {
     FU.input('PatientInvoiceCtrl.itemIncrement', n);
@@ -61,16 +67,19 @@ function PatientInvoicePage() {
 
   // returns n rows
   page.getRows = function getRows() {
-    var rows = grid.element(by.css('.ui-grid-render-container-body'))
-        .all(by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index'));
-    return rows;
+    return GU.getRows(gridId);
+  };
+
+  // expect row count to be equal to a number
+  page.expectRowCount = function expectRowCount(n) {
+    GU.expectRowCount(gridId, n);
   };
 
   // add an inventory item to the grid
   page.addInventoryItem = function addInvoiceItem(rowNumber, itemLabel) {
 
     // first column of the nth row
-    const itemCell = GU.dataCell(gridId, rowNumber, 1);
+    const itemCell = GU.getCell(gridId, rowNumber, 1);
 
     // enter data into the typeahead input.  We cannot use FU.typeahead because it is appended to the body.
     FU.input('row.entity.inventory_uuid', itemLabel, itemCell);
@@ -90,7 +99,7 @@ function PatientInvoicePage() {
   page.adjustItemPrice = function adjustItemPrice(rowNumber, price) {
 
     // fourth column of the last nth row
-    const priceCell = GU.dataCell(gridId, rowNumber, 4);
+    const priceCell = GU.getCell(gridId, rowNumber, 4);
     FU.input('row.entity.transaction_price', price, priceCell);
   };
 
@@ -105,7 +114,7 @@ function PatientInvoicePage() {
   page.adjustItemQuantity = function adjustItemQuantity(rowNumber, quantity) {
 
     // third column column of the nth row
-    const quantityCell = GU.dataCell(gridId, rowNumber, 3);
+    const quantityCell = GU.getCell(gridId, rowNumber, 3);
     FU.input('row.entity.quantity', quantity, quantityCell);
   };
 

--- a/test/end-to-end/patient/invoice/invoice.spec.js
+++ b/test/end-to-end/patient/invoice/invoice.spec.js
@@ -23,7 +23,7 @@ describe('Patient Invoice', function () {
   const path = '#/invoices/patient';
 
   // navigate to the patient invoice page
-  beforeEach(() => helpers.navigate(path));
+  before(() => helpers.navigate(path));
 
   it('invoices a patient for a single item', function () {
     var page = new PatientInvoicePage();
@@ -112,6 +112,53 @@ describe('Patient Invoice', function () {
 
     // there should be a danger notification
     components.notification.hasDanger();
+  });
+
+  it('saves and loads cached items correctly', function () {
+    var page = new PatientInvoicePage();
+    page.btns.clear.click();
+
+    page.prepare();
+
+    // add a two rows to the grid
+    page.addRows(1);
+
+    // add two inventory items to each row (0-indexing)
+    page.addInventoryItem(0, 'INV0');
+    page.addInventoryItem(1, 'INV2');
+
+    // change the required quantities
+    page.adjustItemQuantity(0, 1);
+    page.adjustItemQuantity(1, 2);
+
+    // change the prices
+    page.adjustItemPrice(0, 1.11);
+    page.adjustItemPrice(1, 2.22);
+
+    const description = element(by.model('PatientInvoiceCtrl.Invoice.details.description'));
+
+    // make the form invalid by clearing the description
+    description.clear();
+
+    // submit the form and clear the error message
+    page.submit();
+    components.notification.hasDanger();
+
+    // refresh the browser
+    browser.refresh();
+
+    // need to have a patient to recover data
+    page.patient('TPA1');
+
+    // click recover cache button
+    page.recover();
+
+    // make sure that information was correctly recovered
+    page.expectRowCount(2);
+
+    description.sendKeys('A real description!');
+    page.submit();
+    FU.exists(by.id('receipt-confirm-created'), true);
   });
 
   //it('can calculate totals correctly');

--- a/test/end-to-end/patient/invoice/registry.search.js
+++ b/test/end-to-end/patient/invoice/registry.search.js
@@ -89,13 +89,13 @@ function InvoiceRegistrySearch() {
     FU.buttons.clear();
   });
 
-  it('filters by <select> should return Four results', () => {
+  it('filters by <select> should return five results', () => {
     FU.buttons.search();
     FU.select('ModalCtrl.params.service_id', 'Test Service');
     FU.select('ModalCtrl.params.user_id', 'Super User');
     FU.modal.submit();
 
-    expectNumberOfGridRows(4);
+    expectNumberOfGridRows(5);
     expectNumberOfFilters(2);
 
     // make sure to clear the filters for the next test
@@ -103,5 +103,3 @@ function InvoiceRegistrySearch() {
   });
 
 }
-
-module.exports = InvoiceRegistrySearch;

--- a/test/end-to-end/patient/invoice/registry.spec.js
+++ b/test/end-to-end/patient/invoice/registry.spec.js
@@ -20,7 +20,7 @@ describe('Invoice Registry', () => {
   before(() => helpers.navigate(path));
 
   const page = new InvoiceRegistryPage();
-  const numInvoices = 4;
+  const numInvoices = 5;
 
   it('displays all invoices loaded from the database', () => {
     expect(page.getInvoiceNumber()).to.eventually.equal(numInvoices);

--- a/test/end-to-end/shared/GridUtils.js
+++ b/test/end-to-end/shared/GridUtils.js
@@ -29,7 +29,7 @@ function getCell(gridId, row, col) {
   return getGrid(gridId)
     .element(by.css('.ui-grid-render-container-body'))
     .element(by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index').row(row))
-    .element(by.repeater('(colRenderIndex, col) in colContainer.renderedColumns track by col.colDef.name').row(col));
+    .element(by.repeater('(colRenderIndex, col) in colContainer.renderedColumns track by col.uid').row(col));
 
 }
 


### PR DESCRIPTION
This commit implements caching of patient invoices on submit.  When an invoice is submitted, regardless of errors the form is cached in AppCache.  Once the user successfully submits the form, the cache is cleared.

The cache is only loaded once the user has chosen a patient.  The idea is that a patient should not be cached, only the form data.

Finally, I've introduced an error flash on invalid grid rows.  To prompt the error flash, one simply has to call `validate()` with the boolean `true`.

This PR also contains an important bug fix where the StageInvoice() call was passing in parameters in the correct order.  This has been fixed by forcing the order via a `keys.map()` statement to order the object keys in an array.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
