### PR TITLE
Fix error in the payment of the total amount of invoices

### DIFF
--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -639,7 +639,7 @@ BEGIN
         A positive remainder means that the debtor overpaid slightly and we should debit
         the difference to the debtor and credit the difference as a gain to the gain_account
       */
-      IF (remainder > 0) THEN
+      IF (remainder >= 0) THEN
 
         -- debit the debtor
         INSERT INTO posting_journal (


### PR DESCRIPTION
Fix error in the payment of the total amount of invoices
- Using the operator >= 0 instead > 0 for allow the paiment of the total amount of invoices
