### PR TITLE
(fix) Resolve error on exactly paying invoice total

### DIFF
--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -633,7 +633,8 @@ BEGIN
     SET remainder = cashAmount - previousInvoiceBalances;
 
     -- check if we should round or not
-    IF (minMonentaryUnit > ABS(remainder)) THEN
+    -- if the remainder is 0 the invoice is payed without need for rounding
+    IF (minMonentaryUnit > ABS(remainder) && remainder <> 0) THEN
 
       /*
         A positive remainder means that the debtor overpaid slightly and we should debit


### PR DESCRIPTION
This pull request fixes an issue with the rounding logic in the PostCash stored procedure. 

It adds an additional check to make sure that the remainder is not 0 before implementing rounding logic, rounding does not need to take place if there is no remainder from currency conversion. 

**Current error behaviour**
![screenshot 2016-10-18 at 13 28 17](https://cloud.githubusercontent.com/assets/2844572/19477979/9c1eef5e-9538-11e6-8173-a313f0947e38.png)

**Factoring in exact payments**
![screenshot 2016-10-18 at 13 30 07](https://cloud.githubusercontent.com/assets/2844572/19477996/a75e0a62-9538-11e6-9c4e-491d38bef3cc.png)

This issue was identified by @lomamech and investigated by me here https://github.com/IMA-WorldHealth/bhima-2.X/pull/801#issuecomment-254488256. This pull request closes https://github.com/IMA-WorldHealth/bhima-2.X/pull/801. 

---

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.
