### PR TITLE
(Chore) Underline nav header to improve clarity

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -253,6 +253,9 @@
   width : 100%;
   overflow-y : auto;
   overflow-x : hidden;
+
+  /* underlines the nav header */
+  border-top : 1px solid #ccc;
 }
 
 .expanded .link-label {
@@ -356,6 +359,11 @@
 
 .flex-tree li {
   border-top: 1px solid #ccc;
+}
+
+/* remove border from the first child; this overlaps with the nav header */
+.flex-tree > ul > li:first-child {
+  border-top : none;
 }
 
 /* make sure the bottom node has a bottom border */


### PR DESCRIPTION
This commit adds two CSS rules that underline the navigation menu
header. When the navigation menu overflows without an underlined header
it can be difficult to distinguish the header from the menu.

![screenshot 2016-10-21 at 14 01 32](https://cloud.githubusercontent.com/assets/2844572/19768150/36d3a1b8-9c4e-11e6-8068-ce207b3d013c.png)

---

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.
