### PR TITLE
Implement accounts chart report using archive page

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -832,7 +832,7 @@
       "ACCOUNT"       : "Account Number",
       "DEBTOR_GROUP"  : "Debtor Group",
       "REPORT_TITLE"  : "Patient Financial Activity"
-    }    
+    }
   },
   "PATIENT_REG": {
     "PAGE_TITLE"           : "Patient Registration",
@@ -1004,6 +1004,7 @@
     },
     "CASH_EXPENSE"     : "Expenses",
     "CASH_INCOME"      : "Incomes",
+    "CHART_OF_ACCOUNTS" : "Chart of Accounts",
     "CLOSING_BALANCE"  : "Closing Balance",
     "CONFIGURATION"    : "Report Configuration",
     "GENERATED"        : "Generated Report",

--- a/client/src/partials/reports/modals/accounts_chart.config.js
+++ b/client/src/partials/reports/modals/accounts_chart.config.js
@@ -1,0 +1,50 @@
+angular.module('bhima.controllers')
+.controller('accounts_chartController', AccountChartController);
+
+AccountChartController.$inject = [ '$state', '$http', '$uibModalInstance', 'NotifyService', 'LanguageService' ];
+
+function AccountChartController($state, $http, ModalInstance, Notify, Languages) {
+  var vm = this;
+
+  // expose to the view
+  vm.generate = requestPDF;
+  vm.cancel = ModalInstance.dismiss;
+
+  // TODO This should be passed into the modal from the report controller
+  vm.reportId = 2;
+  vm.reportKey = 'accounts_chart';
+  vm.reportTitleKey = 'REPORT.CHART_OF_ACCOUNTS';
+
+  vm.$loading = false;
+
+  // TODO Move to service
+  function requestPDF() {
+    var url = 'reports/finance/accounts/chart';
+
+    if (!vm.label) { return ; }
+    vm.$loading = true;
+
+    // TODO Very specific parameters, API should be carefully designed
+    var pdfParams = {
+      reportId : vm.reportId,
+      label : vm.label,
+      lang: Languages.key,
+      renderer : 'pdf',
+      saveReport : true
+    };
+
+    $http.get(url, { params : pdfParams })
+      .then(function (result) {
+        vm.$loading = false;
+        ModalInstance.dismiss();
+        $state.reload();
+       })
+      .catch(function (error) {
+        vm.$loading = false;
+        throw error;
+      });
+  }
+
+}
+
+

--- a/client/src/partials/reports/modals/accounts_chart.modal.html
+++ b/client/src/partials/reports/modals/accounts_chart.modal.html
@@ -1,0 +1,38 @@
+<div class="modal-header">
+  <ol class="headercrumb">
+    <li class="static">{{ ReportConfigCtrl.reportTitleKey | translate }}</li>
+    <li class="title">{{ "FORM.LABELS.CREATE" | translate }}</li>
+  </ol>
+</div>
+
+<form name="ConfigForm" bh-submit="ReportConfigCtrl.generate()" bh-form-defaults novalidate>
+<div class="modal-body">
+  <div class="form-group"
+    ng-class="{ 'has-error' : ConfigForm.$submitted && ConfigForm.label.$invalid }">
+    <label class="control-label">{{ "FORM.LABELS.LABEL" | translate }}</label>
+    <input class="form-control" id="label" name="label" ng-model="ReportConfigCtrl.label" autocomplete="off" required />
+
+    <div class="help-block" ng-messages="ConfigForm.label.$error" ng-show="ConfigForm.$submitted">
+      <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+    </div>
+
+  </div>
+</div>
+
+<div class="modal-footer">
+  <button
+    type="button"
+    class="btn btn-default"
+    ng-click="ReportConfigCtrl.cancel()"
+    data-method="cancel">
+    {{ "FORM.BUTTONS.CANCEL" | translate }}
+  </button>
+
+  <!-- <div data-submit-area> -->
+    <bh-loading-button loading-state="ReportConfigCtrl.$loading"
+      ng-disabled="ConfigForm.$invalid">
+      {{ "FORM.BUTTONS.GENERATE" | translate }}
+    </bh-loading-button>
+  <!-- </div> -->
+</div>
+</form>

--- a/client/src/partials/reports/modals/cashflow.config.js
+++ b/client/src/partials/reports/modals/cashflow.config.js
@@ -68,15 +68,4 @@ function CashflowConfigController($state, $http, ModalInstance, Cashbox, Notify,
         throw error;
       });
   }
-
-  /** generate cashflow report */
-  function generate() {
-    if (!vm.cashbox || !vm.dateFrom || !vm.dateTo) { return ; }
-    var params = {
-      dateFrom : vm.dateFrom,
-      dateTo   : vm.dateTo,
-      cashbox  : vm.cashbox
-    };
-    $state.go('cashflow.report', params);
-  }
 }

--- a/server/controllers/finance/reports/accounts/chart.handlebars
+++ b/server/controllers/finance/reports/accounts/chart.handlebars
@@ -9,11 +9,13 @@
     {{translate 'ACCOUNT.ACCOUNT_CHART'}}
   </h1>
 
+  <br>
+
   <!-- content  -->
   <table class="table table-condensed table-striped table-bordered">
     <thead>
       <tr>
-        <th class="text-left" style="width: 15%;">{{translate 'ACCOUNT.NUMBER'}}</th>
+        <th class="text-left" style="width: 15%;"></th>
         <th>{{translate 'ACCOUNT.LABEL'}}</th>
         <th>{{translate 'FORM.LABELS.TYPE'}}</th>
         <th>{{translate 'ACCOUNT.COST_CENTER'}}</th>

--- a/server/controllers/finance/reports/accounts/index.js
+++ b/server/controllers/finance/reports/accounts/index.js
@@ -15,8 +15,11 @@ function chart(req, res, next) {
 
   let report;
 
+  let params = req.query;
+  params.user = req.session.user;
+
   try {
-    report = new ReportManager(TEMPLATE, req.session, req.query);
+    report = new ReportManager(TEMPLATE, req.session, params);
   } catch(e) {
     return next(e);
   }

--- a/server/lib/template/partials/header.handlebars
+++ b/server/lib/template/partials/header.handlebars
@@ -1,15 +1,15 @@
 <!-- this partial requires binding the variable 'metadata' -->
 <header class="row">
   <div class="col-xs-6">
-    <div><i class="fa fa-home"></i> {{metadata.enterprise.name}}</div>
+    <div>{{metadata.enterprise.name}}</div>
     <address style="margin-bottom: 0px;">
-       <i class="fa fa-map-marker"></i> {{metadata.enterprise.location}}
+      {{metadata.enterprise.location}}
     </address>
-    <div><i class="fa fa-envelope-o"></i> {{metadata.enterprise.email}}</div>
-    <div><i class="fa fa-phone"></i> {{metadata.enterprise.phone}}</div>
+    <div>{{metadata.enterprise.email}}</div>
+    <div>{{metadata.enterprise.phone}}</div>
   </div>
   <div class="col-xs-6 text-right">
-    <div><i class="fa fa-calendar"></i> {{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time></div>
-    <div><i class="fa fa-user"></i> {{translate "REPORT.PRODUCED_BY"}} {{metadata.user.username}}</div>
+    <div>{{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time></div>
+    <div>{{translate "REPORT.PRODUCED_BY"}} {{metadata.user.username}}</div>
   </div>
 </header>

--- a/server/models/test/data.sql
+++ b/server/models/test/data.sql
@@ -47,8 +47,9 @@ INSERT INTO unit VALUES
   (141, 'Vouchers Records', 'TREE.VOUCHER_REGISTRY', 'Vouchers registry module', 5, '/partials/vouchers/index', '/vouchers'),
   (142, 'Purchase Orders', 'TREE.PURCHASING', 'This module is responsible for creating purchase orders', 138, '/partials/purchases/create', '/purchases/create'),
   (143, 'Transaction Type Module', 'TREE.TRANSACTION_TYPE', 'This module is responsible for managing transaction type', 1, '/partials/admin/transaction_type', '/admin/transaction_type'),
-  (144, 'Reports (Finance)', 'TREE.REPORTS', 'A folder holding all finance reports', 5, '/partials/finance/reports', '/finance/reports'),
+  (144, 'Reports (Finance)', 'TREE.REPORTS', 'A folder holding all finance reports', 0, '/partials/finance/reports', '/finance/reports'),
   (145, 'Cashflow', 'TREE.CASHFLOW', 'The Cashflow Report', 144, '/partials/finance/cashflow', '/reports/cashflow'),
+  (148, 'Chart of Accounts', 'REPORT.CHART_OF_ACCOUNTS', 'The COA Report', 144, '/partials/finance/chart_of_accounts', '/reports/accounts_chart'),
   (146, 'Creditor Groups Management', 'TREE.CREDITOR_GROUP', 'Creditor Groups Management module', 1, '/partials/admin/creditor_groups/', '/admin/creditor_groups'),
   (147, 'Cash Payment Registry', 'TREE.CASH_PAYMENT_REGISTRY', 'Cash Payment Registry', 5, '/partials/finance/reports/cash_payemnt', '/finance/reports/cash_payment');
 
@@ -220,6 +221,8 @@ INSERT INTO permission (unit_id, user_id) VALUES
 
 -- inventory configuration module
 (140, 1),
+
+(148, 1),
 
 -- Voucher records
 (141, 1),
@@ -483,4 +486,5 @@ INSERT INTO `purchase_item` VALUES
 
  -- core BHIMA reports 
  INSERT INTO `report` (`id`, `report_key`, `title_key`) VALUES 
-  (1, 'cashflow', 'TREE.CASHFLOW');
+  (1, 'cashflow', 'TREE.CASHFLOW'), 
+  (2, 'accounts_chart', 'REPORT.CHART_OF_ACCOUNTS');


### PR DESCRIPTION
This report implements the archive page structure defined by the cashflow report https://github.com/IMA-WorldHealth/bhima-2.X/pull/832, allowing reports to be saved on the harddisk for later use.
- Registers a system report in the database
- Creates a conifguration modal for chart of accounts

Before submitting this pull request, please verify that you have:
- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
- [x] Run integration tests.
- [x] Run end-to-end tests.
- [x] Accurately described the changes your are making in this pull request.
