### PR TITLE
(Chore) Refactor grid actions

### DIFF
--- a/client/src/partials/billing_services/index.js
+++ b/client/src/partials/billing_services/index.js
@@ -14,8 +14,11 @@ BillingServicesController.$inject = [
 function BillingServicesController($state, BillingServices, Accounts, Notify, bhConstants, $timeout) {
   var vm = this;
 
-  var actionsTemplate =
-    'partials/billing_services/templates/actions.link.html';
+  var editActionTemplate =
+    'partials/billing_services/templates/actions.edit.html';
+
+  var deleteActionTemplate =
+    'partials/billing_services/templates/actions.delete.html';
 
   vm.ROW_HIGHLIGHT_FLAG = bhConstants.grid.ROW_HIGHLIGHT_FLAG;
 
@@ -56,9 +59,13 @@ function BillingServicesController($state, BillingServices, Accounts, Notify, bh
       headerCellFilter: 'translate',
       cellFilter:'date',
     }, {
-      field : 'actions',
-      displayName: '...',
-      cellTemplate : actionsTemplate
+      field : 'edit_action',
+      displayName: '',
+      cellTemplate : editActionTemplate
+    }, {
+      field : 'delete_action',
+      displayName: '',
+      cellTemplate : deleteActionTemplate
     }]
   };
 

--- a/client/src/partials/billing_services/templates/actions.delete.html
+++ b/client/src/partials/billing_services/templates/actions.delete.html
@@ -1,15 +1,6 @@
 <div class="ui-grid-cell-contents">
   <a
     href
-    style="margin-right:1em;"
-    ui-sref="billingServices.update({id:row.entity.id})"
-    ui-sref-opts="{ notify: false }"
-    data-method="update">
-    <i class="fa fa-pencil-square-o"></i> {{ ::"FORM.BUTTONS.EDIT" | translate }}
-  </a>
-
-  <a
-    href
     class="text-danger"
     ui-sref="billingServices.delete({id:row.entity.id})"
     ui-sref-opts="{ notify: false }"

--- a/client/src/partials/billing_services/templates/actions.edit.html
+++ b/client/src/partials/billing_services/templates/actions.edit.html
@@ -1,0 +1,9 @@
+<div class="ui-grid-cell-contents">
+  <a
+    href
+    ui-sref="billingServices.update({id:row.entity.id})"
+    ui-sref-opts="{ notify: false }"
+    data-method="update">
+    <i class="fa fa-pencil-square-o"></i> {{ ::"FORM.BUTTONS.EDIT" | translate }}
+  </a>
+</div>

--- a/client/src/partials/inventory/list/list.js
+++ b/client/src/partials/inventory/list/list.js
@@ -39,21 +39,6 @@ function InventoryListController ($translate, Inventory, Notify, uiGridConstants
   /** button Print */
   vm.buttonPrint = { pdfUrl: '/reports/inventory/items' };
 
-
-  // edit button template
-  var editTemplate = '<div style="padding: 5px;">' +
-    '<a title="{{ \'FORM.LABELS.EDIT\' | translate }}" href="" ' +
-    'ng-click="grid.appScope.editInventoryItem(row.entity)" ' +
-    'data-edit-metadata="{{ row.entity.code }}">' +
-    '<i class="fa fa-edit"></i> ' +
-    '</a></div>';
-
-  // consumable icon template
-  var iconTemplate = '<div class="text-center">' +
-    '<i ng-show="row.entity.consumable === 1" class="text-success fa fa-check-circle-o fa-2x"></i>' +
-    '<i ng-show="row.entity.consumable === 0" class="text-warning fa fa-times-circle-o fa-2x"></i>' +
-    '</div>';
-
   // grid default options
   vm.gridOptions.appScopeProvider = vm;
   vm.gridOptions.enableFiltering  = vm.filterEnabled;
@@ -62,7 +47,7 @@ function InventoryListController ($translate, Inventory, Notify, uiGridConstants
       { field : 'code', displayName : 'FORM.LABELS.CODE', headerCellFilter : 'translate'
       },
       { field : 'consumable', displayName : 'FORM.LABELS.CONSUMABLE', headerCellFilter : 'translate',
-        cellTemplate : iconTemplate
+        cellTemplate : '/partials/inventory/list/templates/consumable.cell.tmpl.html'
       },
       { field : 'groupName', displayName : 'FORM.LABELS.GROUP', headerCellFilter : 'translate'},
       { field : 'label', displayName : 'FORM.LABELS.LABEL', headerCellFilter : 'translate'},
@@ -71,9 +56,8 @@ function InventoryListController ($translate, Inventory, Notify, uiGridConstants
       { field : 'unit', displayName : 'FORM.LABELS.UNIT', headerCellFilter : 'translate'},
       { field : 'unit_weight', displayName : 'FORM.LABELS.WEIGHT', headerCellFilter : 'translate'},
       { field : 'unit_volume', displayName : 'FORM.LABELS.VOLUME', headerCellFilter : 'translate'},
-      { field : 'action', displayName : '...',
-        width: 25,
-        cellTemplate: editTemplate,
+      { field : 'action', displayName : '',
+        cellTemplate: '/partials/inventory/list/templates/inventoryEdit.actions.tmpl.html',
         enableFiltering: false,
         enableColumnMenu: false
       }

--- a/client/src/partials/inventory/list/templates/consumable.cell.tmpl.html
+++ b/client/src/partials/inventory/list/templates/consumable.cell.tmpl.html
@@ -1,0 +1,4 @@
+<div class="ui-grid-cell-contents text-center">
+  <i ng-show="row.entity.consumable === 1" class="fa fa-check-circle-o"></i>
+  <i ng-show="row.entity.consumable === 0" class="fa fa-times-circle-o"></i>
+</div>';

--- a/client/src/partials/inventory/list/templates/inventoryEdit.actions.tmpl.html
+++ b/client/src/partials/inventory/list/templates/inventoryEdit.actions.tmpl.html
@@ -1,0 +1,9 @@
+<div class="ui-grid-cell-contents">
+  <a
+    title="{{ 'FORM.LABELS.EDIT' | translate }}"
+    href
+    ng-click="grid.appScope.editInventoryItem(row.entity)"
+    data-edit-metadata="{{ row.entity.code }}">
+    <i class="fa fa-edit"></i> {{ "FORM.BUTTONS.EDIT" | translate }}
+  </a>
+</div>

--- a/client/src/partials/patient_invoice/registry/registry.js
+++ b/client/src/partials/patient_invoice/registry/registry.js
@@ -17,22 +17,6 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util,
 
   var cache = AppCache('InvoiceRegistry');
 
-  var invoiceActionsTemplate =
-    '<div class="ui-grid-cell-contents">' +
-      '<a href ng-click="grid.appScope.openReceiptModal(row.entity.uuid)" data-method="receipt">' +
-        '<span class="fa fa-file-pdf-o"></span> {{ "TABLE.COLUMNS.RECEIPT" | translate }}' +
-      '</a>' +
-      '&nbsp;&nbsp;' +
-      '<a href id="{{row.entity.reference}}" ng-click="grid.appScope.creditNote(row.entity)" class="text-danger">' +
-        '<i class="fa fa-clone"></i> {{ "TABLE.COLUMNS.CREDIT_NOTE" | translate }}' +
-      '</a>' +
-    '</div>';
-
-  var costTemplate =
-    '<div class="ui-grid-cell-contents text-right">' +
-      '{{ row.entity.cost | currency: grid.appScope.enterprise.currency_id }}' +
-    '</div>';
-
   vm.search = search;
   vm.openReceiptModal = Receipt.invoice;
   vm.onRemoveFilter = onRemoveFilter;
@@ -60,13 +44,14 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util,
       { field : 'cost',
         displayName : 'TABLE.COLUMNS.COST',
         headerCellFilter : 'translate',
-        cellTemplate: costTemplate,
+        cellTemplate: '/partials/patient_invoice/registry/templates/cost.cell.tmpl.html',
         aggregationType: uiGridConstants.aggregationTypes.sum,
         footerCellFilter: 'currency:grid.appScope.enterprise.currency_id'
       },
       { field : 'serviceName', displayName : 'TABLE.COLUMNS.SERVICE', headerCellFilter : 'translate'  },
       { field : 'display_name', displayName : 'TABLE.COLUMNS.BY', headerCellFilter : 'translate' },
-      { name : 'Actions', displayName : '', cellTemplate : invoiceActionsTemplate }
+      { name : 'receipt_action', displayName : '', cellTemplate : '/partials/patient_invoice/registry/templates/invoiceReceipt.action.tmpl.html' },
+      { name : 'credit_action', displayName : '', cellTemplate : '/partials/patient_invoice/registry/templates/creditNote.action.tmpl.html' }
     ],
     enableSorting : true,
     rowTemplate : '/partials/patient_invoice/templates/grid.creditNote.tmpl.html'

--- a/client/src/partials/patient_invoice/registry/templates/cost.cell.tmpl.html
+++ b/client/src/partials/patient_invoice/registry/templates/cost.cell.tmpl.html
@@ -1,0 +1,3 @@
+<div class="ui-grid-cell-contents text-right">
+  {{ row.entity.cost | currency: grid.appscope.enterprise.currency_id }}
+</div>

--- a/client/src/partials/patient_invoice/registry/templates/creditNote.action.tmpl.html
+++ b/client/src/partials/patient_invoice/registry/templates/creditNote.action.tmpl.html
@@ -1,0 +1,5 @@
+<div class="ui-grid-cell-contents">
+  <a href id="{{row.entity.reference}}" ng-click="grid.appScope.creditNote(row.entity)" class="text-danger">
+    <i class="fa fa-clone"></i> {{ ::"TABLE.COLUMNS.CREDIT_NOTE" | translate }}
+  </a>
+</div>

--- a/client/src/partials/patient_invoice/registry/templates/invoiceReceipt.action.tmpl.html
+++ b/client/src/partials/patient_invoice/registry/templates/invoiceReceipt.action.tmpl.html
@@ -1,0 +1,5 @@
+<div class="ui-grid-cell-contents">
+  <a href ng-click="grid.appScope.openReceiptModal(row.entity.uuid)" data-method="receipt">
+    <i class="fa fa-file-pdf-o"></i> {{ "TABLE.COLUMNS.RECEIPT" | translate }}
+  </a>
+</div>


### PR DESCRIPTION
This pull request refactors a number of UI grids action cells to using the standard format. 
* Cell templates linked vs. hardcoded in the controller 
* Standard use of `<div class="ui-grid-cell-contents">`
* Action consisting of an icon and a text description
* One action per cell to allow the grid to collapse with individual icons showing

![screenshot 2016-11-02 at 12 41 41](https://cloud.githubusercontent.com/assets/2844572/19927853/ed1119cc-a0fb-11e6-85c9-acef4d56fad1.png)
![screenshot 2016-11-02 at 12 27 53](https://cloud.githubusercontent.com/assets/2844572/19927851/ec91df9a-a0fb-11e6-8837-880918523693.png)
![screenshot 2016-11-02 at 12 05 56](https://cloud.githubusercontent.com/assets/2844572/19927854/edc1a54e-a0fb-11e6-84ea-5017d2676eee.png)

---

 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.
