### PR TITLE
(Feature) Debtor Group -> Billing Services, Subsidy Subscriptions

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -190,7 +190,9 @@
     },
     "TITLE"          : "Debtor Group Management",
     "SUBSCRIBED"     : "Debtors subscribed",
-    "UPDATED"        : "Debtor group record updated"
+    "UPDATED"        : "Debtor group record updated",
+    "LOADING"        : "Fetching Debtor Group",
+    "SUBSCRIPTIONS"  : "Subscriptions"
   },
   "DEPOT": {
     "ADD_DEPOT"   : "Add a Depot",

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -175,7 +175,9 @@
       "SUBSIDIES" : {
         "TITLE" : "Subsidies",
         "INFO"  : "With this configuration unchecked no member of this debtor group will qualify for any subsidies",
-        "LABEL" : "This group qualifies for subsidies"
+        "LABEL" : "This group qualifies for subsidies",
+        "UPDATE" : "Update Subsidies",
+        "EMPTY" : "This debtor group is not subscribed to any subsidies"
       },
       "DISCOUNTS" : {
         "TITLE" : "Discounts",
@@ -185,7 +187,9 @@
       "BILLING_SERVICES" : {
         "TITLE" : "Billing Services",
         "INFO" : "With this configuration option checked all members of this debtor group will be exempt from paying automatically applied billing services",
-        "LABEL" : "This group is exempt from paying billing services"
+        "LABEL" : "This group is exempt from paying billing services",
+        "UPDATE" : "Update Billing Services",
+        "EMPTY" : "This debtor group is not subscribed to any billing services"
       }
     },
     "TITLE"          : "Debtor Group Management",

--- a/client/src/js/services/DebtorGroupService.js
+++ b/client/src/js/services/DebtorGroupService.js
@@ -75,8 +75,10 @@ function DebtorGroupService($http, Modal, util, SessionService) {
    *                                    debtor group will now be subscribed to
    */
   function updateBillingServices(debtorGroupUuid, subscriptions) {
-    var path = baseUrl.concat('groups/debtor_group_billing_services/', debtorGroupUuid);
-    return $http.post(path, subscriptions)
+    var path = '/groups/debtor_group_billing_service/'.concat(debtorGroupUuid);
+    var options = { subscriptions : subscriptions };
+    console.log('sub', options);
+    return $http.post(path, options)
       .then(util.unwrapHttpResponse);
   }
 

--- a/client/src/js/services/DebtorGroupService.js
+++ b/client/src/js/services/DebtorGroupService.js
@@ -17,9 +17,10 @@ function DebtorGroupService($http, Modal, util, SessionService) {
   service.create = create;
   service.update = update;
   service.updateBillingServices = updateBillingServices;
+  service.updateSubsidies = updateSubsidies;
 
-  service.manageSubscriptions = manageSubscriptions;
-
+  service.manageBillingServices = manageBillingServices;
+  service.manageSubsidies = manageSubsidies;
   /**
   * @method read
   * @param {string} uuid The debtor group uuid
@@ -81,11 +82,33 @@ function DebtorGroupService($http, Modal, util, SessionService) {
       .then(util.unwrapHttpResponse);
   }
 
-  function manageSubscriptions(debtorGroup, subscriptions) {
+  function updateSubsidies(debtorGroupUuid, subscriptions) {
+    var path = '/groups/debtor_group_subsidy/'.concat(debtorGroupUuid);
+    var options = { subscriptions : subscriptions };
+    return $http.post(path, options)
+      .then(util.unwrapHttpResponse);
+  }
 
+  function manageBillingServices(debtorGroup, subscriptions) {
     return Modal.open({
       templateUrl : '/partials/debtors/subscriptions.modal.html',
-      controller : 'ChargeSubscriptions as SubCtrl',
+      controller : 'BillingServiceSubscriptions as SubCtrl',
+      size : 'md',
+      resolve : {
+        Subscriptions : function Subscriptions() {
+          return subscriptions;
+        },
+        DebtorGroup : function DebtorGroup() {
+          return debtorGroup;
+        }
+      }
+    });
+  }
+
+  function manageSubsidies(debtorGroup, subscriptions) {
+    return Modal.open({
+      templateUrl : '/partials/debtors/subscriptions.modal.html',
+      controller : 'SubsidySubscriptions as SubCtrl',
       size : 'md',
       resolve : {
         Subscriptions : function Subscriptions() {

--- a/client/src/js/services/DebtorGroupService.js
+++ b/client/src/js/services/DebtorGroupService.js
@@ -16,6 +16,7 @@ function DebtorGroupService($http, Modal, util, SessionService) {
   service.read = read;
   service.create = create;
   service.update = update;
+  service.updateBillingServices = updateBillingServices;
 
   service.manageSubscriptions = manageSubscriptions;
 
@@ -60,6 +61,23 @@ function DebtorGroupService($http, Modal, util, SessionService) {
 
     return $http.put(url, debtorGroup)
     .then(util.unwrapHttpResponse);
+  }
+
+  /**
+   * @function updateBillingServices
+   *
+   * @description
+   * Replaces a debtor groups billing services subscriptions with a provided
+   * set of billing service IDs
+   *
+   * @param {string}  debtorGroupUuid   UUID of debtor group that will be updated
+   * @param {Array}   subscriptions     Array of billing service ids that this
+   *                                    debtor group will now be subscribed to
+   */
+  function updateBillingServices(debtorGroupUuid, subscriptions) {
+    var path = baseUrl.concat('groups/debtor_group_billing_services/', debtorGroupUuid);
+    return $http.post(path, subscriptions)
+      .then(util.unwrapHttpResponse);
   }
 
   function manageSubscriptions(debtorGroup, subscriptions) {

--- a/client/src/js/services/DebtorGroupService.js
+++ b/client/src/js/services/DebtorGroupService.js
@@ -1,14 +1,14 @@
 angular.module('bhima.services')
 .service('DebtorGroupService', DebtorGroupService);
 
-DebtorGroupService.$inject = ['$http', 'util', 'SessionService'];
+DebtorGroupService.$inject = ['$http', '$uibModal', 'util', 'SessionService'];
 
 /**
 * Debtor Group Service
 *
 * This service implements CRUD operations for the /debtor_groups API endpoint
 */
-function DebtorGroupService($http, util, SessionService) {
+function DebtorGroupService($http, Modal, util, SessionService) {
   var service = this;
   var baseUrl = '/debtor_groups/';
 
@@ -16,6 +16,8 @@ function DebtorGroupService($http, util, SessionService) {
   service.read = read;
   service.create = create;
   service.update = update;
+
+  service.manageSubscriptions = manageSubscriptions;
 
   /**
   * @method read
@@ -58,6 +60,23 @@ function DebtorGroupService($http, util, SessionService) {
 
     return $http.put(url, debtorGroup)
     .then(util.unwrapHttpResponse);
+  }
+
+  function manageSubscriptions(debtorGroup, subscriptions) {
+
+    return Modal.open({
+      templateUrl : '/partials/debtors/subscriptions.modal.html',
+      controller : 'ChargeSubscriptions as SubCtrl',
+      size : 'md',
+      resolve : {
+        Subscriptions : function Subscriptions() {
+          return subscriptions;
+        },
+        DebtorGroup : function DebtorGroup() {
+          return debtorGroup;
+        }
+      }
+    });
   }
 
   return service;

--- a/client/src/js/services/DebtorGroupService.js
+++ b/client/src/js/services/DebtorGroupService.js
@@ -77,7 +77,6 @@ function DebtorGroupService($http, Modal, util, SessionService) {
   function updateBillingServices(debtorGroupUuid, subscriptions) {
     var path = '/groups/debtor_group_billing_service/'.concat(debtorGroupUuid);
     var options = { subscriptions : subscriptions };
-    console.log('sub', options);
     return $http.post(path, options)
       .then(util.unwrapHttpResponse);
   }

--- a/client/src/partials/debtors/billingServiceSubscriptions.js
+++ b/client/src/partials/debtors/billingServiceSubscriptions.js
@@ -1,25 +1,25 @@
 angular.module('bhima.controllers')
-.controller('ChargeSubscriptions', ChargeSubscriptions);
+.controller('BillingServiceSubscriptions', BillingServiceSubscriptions);
 
-ChargeSubscriptions.$inject = ['$uibModalInstance', 'DebtorGroup', 'BillingServicesService', 'DebtorGroupService', 'NotifyService'];
+BillingServiceSubscriptions.$inject = ['$uibModalInstance', 'DebtorGroup', 'BillingServicesService', 'DebtorGroupService', 'NotifyService'];
 
-function ChargeSubscriptions(ModalInstance, DebtorGroup, BillingServices, DebtorGroups, Notify) {
+function BillingServiceSubscriptions(ModalInstance, DebtorGroup, BillingServices, DebtorGroups, Notify) {
   var vm = this;
 
   vm.close = ModalInstance.dismiss;
   vm.confirmSubscription = confirmSubscription;
 
   vm.group = DebtorGroup;
-
+  vm.entityKey = 'DEBTOR_GROUP.POLICIES.BILLING_SERVICES.TITLE';
   vm.subscriptions = {};
+  vm.billingServices = [];
 
   initialiseSubscriptions();
-
-  vm.billingServices = [];
 
   BillingServices.read()
     .then(function (result) {
       vm.billingServices = result;
+      vm.entities = vm.billingServices;
     });
 
   function confirmSubscription(subscriptionForm) {

--- a/client/src/partials/debtors/groups.create.js
+++ b/client/src/partials/debtors/groups.create.js
@@ -23,20 +23,25 @@ function DebtorGroupCreateController($state, ScrollTo, SessionService, DebtorGro
     billingServices : false
   };
 
+  vm.$loading = true;
+  vm.$loaded = false;
+
   /* @todo This should be handled by the accounts directive - this controller should not be concerned with accounts */
   Accounts.read()
     .then(function (accounts) {
       vm.accounts = accounts;
+      return Prices.read();
     })
-    .catch(Notify.handleError);
-
   /* @todo This controller should not be concerned about individual price lists */
   /* @todo All read/ list API methods should be uniform on the client */
-  Prices.read()
     .then(function (priceLists) {
       vm.priceLists = priceLists;
+      vm.$loaded = true;
     })
-    .catch(Notify.handleError);
+    .catch(Notify.handleError)
+    .finally(function () {
+      vm.$loading = false;
+    });
 
   // expose state for optional view elements
   vm.state = $state;

--- a/client/src/partials/debtors/groups.edit.html
+++ b/client/src/partials/debtors/groups.edit.html
@@ -1,213 +1,231 @@
 <div class="container-fluid" ng-form="debtorGroup" bh-form-defaults novalidate>
-
-  <div class="row">
+  <div class="row" ng-if="GroupEditCtrl.$loading">
     <div class="col-xs-12">
-      <p>
-        <a ng-href="#/debtors/groups">
-          <span class="fa fa-arrow-circle-left" aria-hidden="true"></span>
-          {{ "DEBTOR_GROUP.BACK" | translate }}
-        </a>
-      </p>
+      <i class="fa fa-circle-o-notch fa-spin"></i> {{ "DEBTOR_GROUP.LOADING" | translate }}
     </div>
   </div>
-
-  <div class="row">
-    <div class="col-md-5">
-      <!-- Debtor group details form elements -->
-      <div>
-        <div
-          class="form-group has-feedback"
-          ng-class="{'has-error' : debtorGroup.name.$invalid && debtorGroup.$submitted}">
-
-
-          <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>
-          <input name="name" ng-model="GroupEditCtrl.group.name" class="form-control" required>
-
-          <div class="help-block" ng-messages="debtorGroup.name.$error" ng-show="debtorGroup.$submitted">
-            <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-          </div>
-        </div>
-
-        <!-- @todo this should be a directive - this controller should not have to consider accounts -->
-        <div
-          class="form-group has-feedback"
-          ng-class="{'has-error' : debtorGroup.account_id.$invalid && debtorGroup.$submitted}">
-
-          <label class="control-label">{{ "TABLE.COLUMNS.ACCOUNT" | translate }}</label>
-          <ui-select
-            name="account_id"
-            ng-model="GroupEditCtrl.group.account_id"
-            theme="bootstrap">
-            <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
-              <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
-            </ui-select-match>
-            <ui-select-choices ui-select-focus-patch repeat="account.id as account in  GroupEditCtrl.accounts | filter:$select.search">
-              <strong ng-bind-html="account.number | highlight:$select.search"></strong>
-              <span ng-bind-html="account.label | highlight:$select.search"></span>
-            </ui-select-choices>
-          </ui-select>
-
-          <div class="help-block" ng-messages="debtorGroup.account_id.$error" ng-show="debtorGroup.$submitted">
-            <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-          </div>
-        </div>
-
-        <!-- @todo The UI should show an option that allows you apply a price list, if this is checked then you can select an option -->
-        <div
-          class="form-group has-feedback"
-          ng-class="{'has-error' : debtorGroup.price_list.$invalid && debtorGroup.$submitted}">
-
-          <label class="control-label">{{ "TABLE.COLUMNS.PRICE_LIST" | translate }}</label>
-          <select
-            name="price_list_uuid"
-            ng-model="GroupEditCtrl.group.price_list_uuid"
-            ng-options="priceList.uuid as priceList.label for priceList in GroupEditCtrl.priceLists"
-            class="form-control">
-            <option value="">{{ "PRICE_LIST.NONE" | translate }}</option>
-          </select>
-
-          <div class="help-block" ng-messages="debtorGroup.price_list.$error" ng-show="debtorGroup.$submitted">
-            <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-          </div>
-        </div>
-
-        <div
-          class="form-group has-feedback"
-          ng-class="{'has-error' : debtorGroup.max_credit.$invalid && debtorGroup.$submitted}">
-
-          <label class="control-label">{{ "FORM.LABELS.MAX_CREDIT" | translate }}</label>
-          <p class="text-info"><span class="fa fa-info-circle" aria-hidden="true"></span> {{ "FORM.LABELS.MAX_CREDIT_INFO" | translate }}</p>
-          <input type="number" ng-model="GroupEditCtrl.group.max_credit" name="max_credit" class="form-control" bh-integer required>
-
-          <div class="help-block" ng-messages="debtorGroup.max_credit.$error" ng-show="debtorGroup.$submitted">
-            <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-          </div>
-        </div>
-
-        <div class="form-group" ng-class="{ 'has-error' : debtorGroup.$submitted && debtorGroup.note.$invalid }">
-          <label class="control-label">{{ "FORM.LABELS.NOTES" | translate }}</label>
-          <textarea class="form-control" ng-model="GroupEditCtrl.group.note" name="note"></textarea>
-        </div>
-
-        <div class="form-group">
-          <label class="control-label">{{ "FORM.LABELS.PHONE" | translate }}</label>
-          <input name="phone" ng-model="GroupEditCtrl.group.phone" class="form-control">
-        </div>
-
-        <div
-          class="form-group"
-          ng-class="{'has-error' : debtorGroup.email.$invalid && debtorGroup.$submitted}">
-          <label class="control-label">{{ "FORM.LABELS.EMAIL" | translate }}</label>
-          <input name="email" ng-model="GroupEditCtrl.group.email" type="email" class="form-control">
-
-          <div class="help-block" ng-messages="debtorGroup.email.$error" ng-show="debtorGroup.$submitted">
-            <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-          </div>
-
-        </div>
-
-        <div class="form-group">
-          <!-- required -->
-          <bh-location-select
-            id="location"
-            name="location_id"
-            validation-trigger="debtorGroup.$submitted"
-            location-uuid="GroupEditCtrl.group.location_id"
-            required></bh-location-select>
-        </div>
-      </div>
-
-      <!-- @todo remove temporary style hack -->
-      <div class="clearfix" style="margin-bottom : 5px">
-        <div class="pull-right" style="text-align : right">
-
-          <!-- @todo remove temporary style hack -->
-          <div ng-if="GroupEditCtrl.state.current.name==='debtorGroups.create'" class="checkbox" style="display : inline-block; padding-right : 5px;">
-            <label>
-              <input type="checkbox" ng-model="GroupEditCtrl.resetOnCompletion">
-              {{ "DEBTOR_GROUP.CREATE_ANOTHER" | translate }}
-            </label>
-          </div>
-
-          <!-- <button class="btn btn-default">Cancel</button> -->
-          <button data-method="submit" type="submit" ng-click="GroupEditCtrl.submit(debtorGroup)" class="btn btn-primary">
-            {{ "FORM.BUTTONS.SUBMIT" | translate }}
-          </button>
-        </div>
+  <div ng-if="GroupEditCtrl.$loaded">
+    <div class="row">
+      <div class="col-xs-12">
+        <p>
+          <a ng-href="#/debtors/groups">
+            <span class="fa fa-arrow-circle-left" aria-hidden="true"></span>
+            {{ "DEBTOR_GROUP.BACK" | translate }}
+          </a>
+        </p>
       </div>
     </div>
 
-    <div class="col-md-7">
+    <div class="row">
+      <div class="col-md-5">
+        <!-- Debtor group details form elements -->
+        <div>
+          <div
+            class="form-group has-feedback"
+            ng-class="{'has-error' : debtorGroup.name.$invalid && debtorGroup.$submitted}">
 
-      <hr class="visible-sm"></hr>
 
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <span class="fa fa-book" aria-hidden="true"></span>
-          {{ "DEBTOR_GROUP.POLICIES.TITLE" | translate }}
+            <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>
+            <input name="name" ng-model="GroupEditCtrl.group.name" class="form-control" required>
+
+            <div class="help-block" ng-messages="debtorGroup.name.$error" ng-show="debtorGroup.$submitted">
+              <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+            </div>
+          </div>
+
+          <!-- @todo this should be a directive - this controller should not have to consider accounts -->
+          <div
+            class="form-group has-feedback"
+            ng-class="{'has-error' : debtorGroup.account_id.$invalid && debtorGroup.$submitted}">
+
+            <label class="control-label">{{ "TABLE.COLUMNS.ACCOUNT" | translate }}</label>
+            <ui-select
+              name="account_id"
+              ng-model="GroupEditCtrl.group.account_id"
+              theme="bootstrap">
+              <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
+                <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
+              </ui-select-match>
+              <ui-select-choices ui-select-focus-patch repeat="account.id as account in  GroupEditCtrl.accounts | filter:$select.search">
+                <strong ng-bind-html="account.number | highlight:$select.search"></strong>
+                <span ng-bind-html="account.label | highlight:$select.search"></span>
+              </ui-select-choices>
+            </ui-select>
+
+            <div class="help-block" ng-messages="debtorGroup.account_id.$error" ng-show="debtorGroup.$submitted">
+              <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+            </div>
+          </div>
+
+          <!-- @todo The UI should show an option that allows you apply a price list, if this is checked then you can select an option -->
+          <div
+            class="form-group has-feedback"
+            ng-class="{'has-error' : debtorGroup.price_list.$invalid && debtorGroup.$submitted}">
+
+            <label class="control-label">{{ "TABLE.COLUMNS.PRICE_LIST" | translate }}</label>
+            <select
+              name="price_list_uuid"
+              ng-model="GroupEditCtrl.group.price_list_uuid"
+              ng-options="priceList.uuid as priceList.label for priceList in GroupEditCtrl.priceLists"
+              class="form-control">
+              <option value="">{{ "PRICE_LIST.NONE" | translate }}</option>
+            </select>
+
+            <div class="help-block" ng-messages="debtorGroup.price_list.$error" ng-show="debtorGroup.$submitted">
+              <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+            </div>
+          </div>
+
+          <div
+            class="form-group has-feedback"
+            ng-class="{'has-error' : debtorGroup.max_credit.$invalid && debtorGroup.$submitted}">
+
+            <label class="control-label">{{ "FORM.LABELS.MAX_CREDIT" | translate }}</label>
+            <p class="text-info"><span class="fa fa-info-circle" aria-hidden="true"></span> {{ "FORM.LABELS.MAX_CREDIT_INFO" | translate }}</p>
+            <input type="number" ng-model="GroupEditCtrl.group.max_credit" name="max_credit" class="form-control" bh-integer required>
+
+            <div class="help-block" ng-messages="debtorGroup.max_credit.$error" ng-show="debtorGroup.$submitted">
+              <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+            </div>
+          </div>
+
+          <div class="form-group" ng-class="{ 'has-error' : debtorGroup.$submitted && debtorGroup.note.$invalid }">
+            <label class="control-label">{{ "FORM.LABELS.NOTES" | translate }}</label>
+            <textarea class="form-control" ng-model="GroupEditCtrl.group.note" name="note"></textarea>
+          </div>
+
+          <div class="form-group">
+            <label class="control-label">{{ "FORM.LABELS.PHONE" | translate }}</label>
+            <input name="phone" ng-model="GroupEditCtrl.group.phone" class="form-control">
+          </div>
+
+          <div
+            class="form-group"
+            ng-class="{'has-error' : debtorGroup.email.$invalid && debtorGroup.$submitted}">
+            <label class="control-label">{{ "FORM.LABELS.EMAIL" | translate }}</label>
+            <input name="email" ng-model="GroupEditCtrl.group.email" type="email" class="form-control">
+
+            <div class="help-block" ng-messages="debtorGroup.email.$error" ng-show="debtorGroup.$submitted">
+              <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+            </div>
+
+          </div>
+
+          <div class="form-group">
+            <!-- required -->
+            <bh-location-select
+              id="location"
+              name="location_id"
+              validation-trigger="debtorGroup.$submitted"
+              location-uuid="GroupEditCtrl.group.location_id"
+              required></bh-location-select>
+          </div>
         </div>
-        <div class="panel panel-body">
 
-          <div class="row">
-            <div class="col-md-12">
-              <h5><b>{{ "DEBTOR_GROUP.POLICIES.SUBSIDIES.TITLE" | translate }}</b></h5>
+        <!-- @todo remove temporary style hack -->
+        <div class="clearfix" style="margin-bottom : 5px">
+          <div class="pull-right" style="text-align : right">
 
-              <!-- Only show if the subsidies option is unchecked -->
-              <p ng-if="GroupEditCtrl.group.apply_subsidies===false" class="text-info">
-                <span class="glyphicon glyphicon-info-sign"></span> {{ "DEBTOR_GROUP.POLICIES.SUBSIDIES.INFO" | translate }}
-              </p>
-              <div class="checkbox">
-                <label>
-                  <input ng-model="GroupEditCtrl.group.apply_subsidies" name="apply_subsidies" type="checkbox">
-                  {{"DEBTOR_GROUP.POLICIES.SUBSIDIES.LABEL" | translate }}
-                </label>
+            <!-- @todo remove temporary style hack -->
+            <div ng-if="GroupEditCtrl.state.current.name==='debtorGroups.create'" class="checkbox" style="display : inline-block; padding-right : 5px;">
+              <label>
+                <input type="checkbox" ng-model="GroupEditCtrl.resetOnCompletion">
+                {{ "DEBTOR_GROUP.CREATE_ANOTHER" | translate }}
+              </label>
+            </div>
+
+            <!-- <button class="btn btn-default">Cancel</button> -->
+            <button data-method="submit" type="submit" ng-click="GroupEditCtrl.submit(debtorGroup)" class="btn btn-primary">
+              {{ "FORM.BUTTONS.SUBMIT" | translate }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="col-md-7">
+
+        <hr class="visible-sm"></hr>
+
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <span class="fa fa-book" aria-hidden="true"></span>
+            {{ "DEBTOR_GROUP.POLICIES.TITLE" | translate }}
+          </div>
+          <div class="panel panel-body">
+
+            <div class="row">
+              <div class="col-md-12">
+                <h5><b>{{ "DEBTOR_GROUP.POLICIES.SUBSIDIES.TITLE" | translate }}</b></h5>
+
+                <!-- Only show if the subsidies option is unchecked -->
+                <p ng-if="GroupEditCtrl.group.apply_subsidies===false" class="text-info">
+                  <span class="glyphicon glyphicon-info-sign"></span> {{ "DEBTOR_GROUP.POLICIES.SUBSIDIES.INFO" | translate }}
+                </p>
+                <div class="checkbox">
+                  <label>
+                    <input ng-model="GroupEditCtrl.group.apply_subsidies" name="apply_subsidies" type="checkbox">
+                    {{"DEBTOR_GROUP.POLICIES.SUBSIDIES.LABEL" | translate }}
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-12">
+                <h5><b>{{"DEBTOR_GROUP.POLICIES.DISCOUNTS.TITLE" | translate }}</b></h5>
+                <p ng-if="GroupEditCtrl.group.apply_discounts===false" class="text-info">
+                  <span class="fa fa-info-circle" aria-hidden="true"></span> {{"DEBTOR_GROUP.POLICIES.DISCOUNTS.INFO" | translate }}
+                </p>
+                <div class="checkbox">
+                  <label>
+                    <input ng-model="GroupEditCtrl.group.apply_discounts" name="apply_discounts" type="checkbox">
+                    {{"DEBTOR_GROUP.POLICIES.DISCOUNTS.LABEL" | translate }}
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-12">
+                <h5><b>{{ "DEBTOR_GROUP.POLICIES.BILLING_SERVICES.TITLE" | translate }}</b></h5>
+                <p ng-if="GroupEditCtrl.group.apply_billing_services===false" class="text-info">
+                  <span class="fa fa-info-circle" aria-hidden="true"></span> {{ "DEBTOR_GROUP.POLICIES.BILLING_SERVICES.INFO" | translate }}
+                </p>
+                <div class="checkbox">
+                  <label>
+                    <input ng-model="GroupEditCtrl.group.apply_billing_services" name="apply_billing_services" ng-true-value="false" ng-false-value="true" type="checkbox">
+                    {{ "DEBTOR_GROUP.POLICIES.BILLING_SERVICES.LABEL" | translate }}
+                  </label>
+                </div>
+              </div>
+            </div>
+            <!-- These operations should be hidden for a new account -->
+            <div class="row">
+              <div class="col-md-12">
+                <!-- @todo -->
+                <!-- Placeholder - these features are not yet supported in 2.x -->
+                <!--
+                <hr>
+
+                <button class="btn btn-default">
+                  <span class="glyphicon glyphicon-lock"></span>
+                  Lock Debtor Group
+                </button>
+
+                <button class="btn btn-danger"><span class="glyphicon glyphicon-trash"></span> Delete Debtor Group</button>
+                -->
               </div>
             </div>
           </div>
-          <div class="row">
-            <div class="col-md-12">
-              <h5><b>{{"DEBTOR_GROUP.POLICIES.DISCOUNTS.TITLE" | translate }}</b></h5>
-              <p ng-if="GroupEditCtrl.group.apply_discounts===false" class="text-info">
-                <span class="fa fa-info-circle" aria-hidden="true"></span> {{"DEBTOR_GROUP.POLICIES.DISCOUNTS.INFO" | translate }}
-              </p>
-              <div class="checkbox">
-                <label>
-                  <input ng-model="GroupEditCtrl.group.apply_discounts" name="apply_discounts" type="checkbox">
-                  {{"DEBTOR_GROUP.POLICIES.DISCOUNTS.LABEL" | translate }}
-                </label>
-              </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-12">
-              <h5><b>{{ "DEBTOR_GROUP.POLICIES.BILLING_SERVICES.TITLE" | translate }}</b></h5>
-              <p ng-if="GroupEditCtrl.group.apply_billing_services===false" class="text-info">
-                <span class="fa fa-info-circle" aria-hidden="true"></span> {{ "DEBTOR_GROUP.POLICIES.BILLING_SERVICES.INFO" | translate }}
-              </p>
-              <div class="checkbox">
-                <label>
-                  <input ng-model="GroupEditCtrl.group.apply_billing_services" name="apply_billing_services" ng-true-value="false" ng-false-value="true" type="checkbox">
-                  {{ "DEBTOR_GROUP.POLICIES.BILLING_SERVICES.LABEL" | translate }}
-                </label>
-              </div>
-            </div>
-          </div>
-          <!-- These operations should be hidden for a new account -->
-          <div class="row">
-            <div class="col-md-12">
-              <!-- @todo -->
-              <!-- Placeholder - these features are not yet supported in 2.x -->
-              <!--
-              <hr>
+        </div>
 
-              <button class="btn btn-default">
-                <span class="glyphicon glyphicon-lock"></span>
-                Lock Debtor Group
-              </button>
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            {{ "DEBTOR_GROUP.SUBSCRIPTIONS" | translate }}
+          </div>
 
-              <button class="btn btn-danger"><span class="glyphicon glyphicon-trash"></span> Delete Debtor Group</button>
-              -->
-            </div>
+          <div class="panel-body">
+            <label>Billing Services</label>
+
+            <label>Subsidies</label>
           </div>
         </div>
       </div>

--- a/client/src/partials/debtors/groups.edit.html
+++ b/client/src/partials/debtors/groups.edit.html
@@ -217,7 +217,7 @@
           </div>
         </div>
 
-        <div class="panel panel-default">
+        <div class="panel panel-default" ng-if="GroupEditCtrl.state.current.name==='debtorGroups.update'">
           <div class="panel-heading">
             <i class="fa fa-list-alt"></i>
             {{ "DEBTOR_GROUP.SUBSCRIPTIONS" | translate }}
@@ -225,10 +225,10 @@
 
           <div class="panel-body">
             <div class="form-group">
-              <label>Billing Services</label>
+              <label>{{ "DEBTOR_GROUP.BILLING_SERVICES.TITLE" | translate }}</label>
 
               <p class="text-info form-control-static" ng-if="GroupEditCtrl.group.billingServices.length === 0">
-                <i class="fa fa-info-circle"></i> This debtor group is not subscribed to any billing services
+                <i class="fa fa-info-circle"></i>  {{ "DEBTOR_GROUP.POLICIES.BILLING_SERVICES.EMPTY" | translate }}
               </p>
               <ul>
                 <li
@@ -238,15 +238,15 @@
                 </li>
               </ul>
 
-              <button class="btn btn-block btn-warning" ng-click="GroupEditCtrl.subscriptions()">
-                Update Billing Services
+              <button class="btn btn-block btn-warning" ng-click="GroupEditCtrl.billingServiceSubscriptions()">
+                {{ "DEBTOR_GROUP.POLICIES.SUBSIDIES.UPDATE" | translate }}
               </button>
             </div>
             <div class="form-group">
-              <label>Subsidies</label>
+              <label>{{ "DEBTOR_GROUP.SUBSIDIES.TITLE" | translate }}</label>
 
               <p class="text-info form-control-static" ng-if="GroupEditCtrl.group.subsidies.length === 0">
-                <i class="fa fa-info-circle"></i> This debtor group is not subscribed to any subsidies
+              <i class="fa fa-info-circle"></i> {{ "DEBTOR_GROUP.POLICIES.SUBSIDIES.EMPTY" | translate }}
               </p>
               <ul>
                 <li
@@ -255,8 +255,8 @@
                   {{ subsidy.label }}
                 </li>
               </ul>
-              <button class="btn btn-block btn-warning">
-                Update Subsidies
+              <button class="btn btn-block btn-warning" ng-click="GroupEditCtrl.subsidySubscriptions()">
+                {{ "DEBTOR_GROUP.POLICIES.BILLING_SERVICES.UPDATE" | translate }}
               </button>
 
             </div>

--- a/client/src/partials/debtors/groups.edit.html
+++ b/client/src/partials/debtors/groups.edit.html
@@ -23,8 +23,6 @@
           <div
             class="form-group has-feedback"
             ng-class="{'has-error' : debtorGroup.name.$invalid && debtorGroup.$submitted}">
-
-
             <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>
             <input name="name" ng-model="GroupEditCtrl.group.name" class="form-control" required>
 
@@ -225,7 +223,7 @@
 
           <div class="panel-body">
             <div class="form-group">
-              <label>{{ "DEBTOR_GROUP.BILLING_SERVICES.TITLE" | translate }}</label>
+              <label>{{ "DEBTOR_GROUP.POLICIES.BILLING_SERVICES.TITLE" | translate }}</label>
 
               <p class="text-info form-control-static" ng-if="GroupEditCtrl.group.billingServices.length === 0">
                 <i class="fa fa-info-circle"></i>  {{ "DEBTOR_GROUP.POLICIES.BILLING_SERVICES.EMPTY" | translate }}
@@ -238,12 +236,12 @@
                 </li>
               </ul>
 
-              <button class="btn btn-block btn-warning" ng-click="GroupEditCtrl.billingServiceSubscriptions()">
+              <button id="subsidySubscription" class="btn btn-block btn-warning" ng-click="GroupEditCtrl.billingServiceSubscriptions()">
                 {{ "DEBTOR_GROUP.POLICIES.SUBSIDIES.UPDATE" | translate }}
               </button>
             </div>
             <div class="form-group">
-              <label>{{ "DEBTOR_GROUP.SUBSIDIES.TITLE" | translate }}</label>
+              <label>{{ "DEBTOR_GROUP.POLICIES.SUBSIDIES.TITLE" | translate }}</label>
 
               <p class="text-info form-control-static" ng-if="GroupEditCtrl.group.subsidies.length === 0">
               <i class="fa fa-info-circle"></i> {{ "DEBTOR_GROUP.POLICIES.SUBSIDIES.EMPTY" | translate }}
@@ -255,7 +253,7 @@
                   {{ subsidy.label }}
                 </li>
               </ul>
-              <button class="btn btn-block btn-warning" ng-click="GroupEditCtrl.subsidySubscriptions()">
+              <button id="billingServiceSubscription" class="btn btn-block btn-warning" ng-click="GroupEditCtrl.subsidySubscriptions()">
                 {{ "DEBTOR_GROUP.POLICIES.BILLING_SERVICES.UPDATE" | translate }}
               </button>
 

--- a/client/src/partials/debtors/groups.edit.html
+++ b/client/src/partials/debtors/groups.edit.html
@@ -219,13 +219,47 @@
 
         <div class="panel panel-default">
           <div class="panel-heading">
+            <i class="fa fa-list-alt"></i>
             {{ "DEBTOR_GROUP.SUBSCRIPTIONS" | translate }}
           </div>
 
           <div class="panel-body">
-            <label>Billing Services</label>
+            <div class="form-group">
+              <label>Billing Services</label>
 
-            <label>Subsidies</label>
+              <p class="text-info form-control-static" ng-if="GroupEditCtrl.group.billingServices.length === 0">
+                <i class="fa fa-info-circle"></i> This debtor group is not subscribed to any billing services
+              </p>
+              <ul>
+                <li
+                  ng-repeat="billingService in GroupEditCtrl.group.billingServices | orderBy:'label'"
+                  class="form-control-static">
+                  {{ billingService.label }}
+                </li>
+              </ul>
+
+              <button class="btn btn-block btn-warning">
+                Update Billing Services
+              </button>
+            </div>
+            <div class="form-group">
+              <label>Subsidies</label>
+
+              <p class="text-info form-control-static" ng-if="GroupEditCtrl.group.subsidies.length === 0">
+                <i class="fa fa-info-circle"></i> This debtor group is not subscribed to any subsidies
+              </p>
+              <ul>
+                <li
+                  ng-repeat="subsidy in GroupEditCtrl.group.subsidies | orderBy:'label'"
+                  class="form-control-static">
+                  {{ subsidy.label }}
+                </li>
+              </ul>
+              <button class="btn btn-block btn-warning">
+                Update Subsidies
+              </button>
+
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/partials/debtors/groups.edit.html
+++ b/client/src/partials/debtors/groups.edit.html
@@ -238,7 +238,7 @@
                 </li>
               </ul>
 
-              <button class="btn btn-block btn-warning">
+              <button class="btn btn-block btn-warning" ng-click="GroupEditCtrl.subscriptions()">
                 Update Billing Services
               </button>
             </div>

--- a/client/src/partials/debtors/groups.html
+++ b/client/src/partials/debtors/groups.html
@@ -3,8 +3,11 @@
 
     <ol class="headercrumb">
       <li class="static">{{ "TREE.FINANCE" | translate }}</li>
-      <li class="title">{{ "DEBTOR_GROUP.TITLE" | translate }}</li>
-      <span class="label label-warning">{{GroupCtrl.state.current.data.label | translate}}</span>
+
+      <li ng-class="{'static' : GroupCtrl.state.current.name==='debtorGroups.update', 'title' : GroupCtrl.state.current.name!=='debtorGroups.update'}">{{ "DEBTOR_GROUP.TITLE" | translate }}</li>
+      <li class="title" ng-if="!GroupCtrl.state.current.data.label && GroupCtrl.state.current.name==='debtorGroups.update'"><i class="fa fa-spin fa-circle-o-notch"></i></li>
+      <li class="title" ng-if="GroupCtrl.state.current.data.label">{{GroupCtrl.state.current.data.label | translate}}</li>
+      <!-- <span class="label label-warning">{{GroupCtrl.state.current.data.label | translate}}</span> -->
     </ol>
 
 

--- a/client/src/partials/debtors/groups.update.js
+++ b/client/src/partials/debtors/groups.update.js
@@ -80,6 +80,15 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
   }
 
   function subscriptions() {
-    DebtorGroups.manageSubscriptions(vm.group);
+    var modal = DebtorGroups.manageSubscriptions(vm.group)
+    modal.result
+      .then(function (results) {
+
+        console.log('results', results);
+        // update UI
+        vm.group.billingServices = results;
+
+        console.log('group', vm.group);
+      });
   }
 }

--- a/client/src/partials/debtors/groups.update.js
+++ b/client/src/partials/debtors/groups.update.js
@@ -15,9 +15,12 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
 
   vm.submit = submit;
   vm.state = $state;
+  vm.subscriptions = subscriptions;
 
   vm.$loading = true;
   vm.$loaded = false;
+
+  console.log('state', $state);
 
   // reset name attribute to ensure no UI glitch
   $state.current.data.label = null;
@@ -74,5 +77,9 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
         $state.go('debtorGroups.list', null, {reload : true});
       })
       .catch(Notify.handleError);
+  }
+
+  function subscriptions() {
+    DebtorGroups.manageSubscriptions(vm.group);
   }
 }

--- a/client/src/partials/debtors/groups.update.js
+++ b/client/src/partials/debtors/groups.update.js
@@ -16,7 +16,7 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
   vm.submit = submit;
   vm.state = $state;
 
-  vm.$loading = false;
+  vm.$loading = true;
   vm.$loaded = false;
 
   // reset name attribute to ensure no UI glitch
@@ -25,11 +25,8 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
   Prices.read()
     .then(function (priceLists) {
       vm.priceLists = priceLists;
-    });
-
-  vm.$loading = true;
-
-  Accounts.read()
+      return Accounts.read();
+    })
     .then(function (accounts) {
       vm.accounts = accounts;
       return DebtorGroups.read(target);
@@ -37,9 +34,9 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
     .then(function (result) {
       vm.group = result;
       vm.$loaded = true;
-      console.log(vm.group);
       $state.current.data.label = vm.group.name;
 
+      console.log(vm.group);
       /** @todo work around for checkboxes (use value='' instead) */
       vm.group.apply_billing_services = Boolean(vm.group.apply_billing_services);
       vm.group.apply_subsidies = Boolean(vm.group.apply_subsidies);

--- a/client/src/partials/debtors/groups.update.js
+++ b/client/src/partials/debtors/groups.update.js
@@ -1,3 +1,7 @@
+/**
+ * @todo complex page should require loading resolve before displaying, a lot of
+ *       data is fetched per page load
+ */
 angular.module('bhima.controllers')
 .controller('DebtorGroupUpdateController', DebtorGroupsUpdateController);
 
@@ -12,6 +16,9 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
   vm.submit = submit;
   vm.state = $state;
 
+  vm.$loading = false;
+  vm.$loaded = false;
+
   // reset name attribute to ensure no UI glitch
   $state.current.data.label = null;
 
@@ -20,6 +27,8 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
       vm.priceLists = priceLists;
     });
 
+  vm.$loading = true;
+
   Accounts.read()
     .then(function (accounts) {
       vm.accounts = accounts;
@@ -27,7 +36,8 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
     })
     .then(function (result) {
       vm.group = result;
-
+      vm.$loaded = true;
+      console.log(vm.group);
       $state.current.data.label = vm.group.name;
 
       /** @todo work around for checkboxes (use value='' instead) */
@@ -35,7 +45,12 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
       vm.group.apply_subsidies = Boolean(vm.group.apply_subsidies);
       vm.group.apply_discounts = Boolean(vm.group.apply_discounts);
     })
-    .catch(Notify.handleError);
+    .catch(Notify.handleError)
+    .finally(function () {
+      vm.$loading = false;
+    })
+
+
 
   function submit(debtorGroupForm) {
     var submitDebtorGroup;

--- a/client/src/partials/debtors/groups.update.js
+++ b/client/src/partials/debtors/groups.update.js
@@ -15,7 +15,8 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
 
   vm.submit = submit;
   vm.state = $state;
-  vm.subscriptions = subscriptions;
+  vm.billingServiceSubscriptions = billingServiceSubscriptions;
+  vm.subsidySubscriptions = subsidySubscriptions;
 
   vm.$loading = true;
   vm.$loaded = false;
@@ -79,16 +80,21 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
       .catch(Notify.handleError);
   }
 
-  function subscriptions() {
-    var modal = DebtorGroups.manageSubscriptions(vm.group)
+  function billingServiceSubscriptions() {
+    var modal = DebtorGroups.manageBillingServices(vm.group)
     modal.result
       .then(function (results) {
-
-        console.log('results', results);
         // update UI
         vm.group.billingServices = results;
+      });
+  }
 
-        console.log('group', vm.group);
+  function subsidySubscriptions() {
+    var modal = DebtorGroups.manageSubsidies(vm.group);
+    modal.result
+      .then(function (results) {
+        // update UI
+        vm.group.subsidies = results;
       });
   }
 }

--- a/client/src/partials/debtors/groups.update.js
+++ b/client/src/partials/debtors/groups.update.js
@@ -21,8 +21,6 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
   vm.$loading = true;
   vm.$loaded = false;
 
-  console.log('state', $state);
-
   // reset name attribute to ensure no UI glitch
   $state.current.data.label = null;
 
@@ -40,7 +38,6 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
       vm.$loaded = true;
       $state.current.data.label = vm.group.name;
 
-      console.log(vm.group);
       /** @todo work around for checkboxes (use value='' instead) */
       vm.group.apply_billing_services = Boolean(vm.group.apply_billing_services);
       vm.group.apply_subsidies = Boolean(vm.group.apply_subsidies);
@@ -49,9 +46,7 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
     .catch(Notify.handleError)
     .finally(function () {
       vm.$loading = false;
-    })
-
-
+    });
 
   function submit(debtorGroupForm) {
     var submitDebtorGroup;
@@ -81,11 +76,12 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
   }
 
   function billingServiceSubscriptions() {
-    var modal = DebtorGroups.manageBillingServices(vm.group)
+    var modal = DebtorGroups.manageBillingServices(vm.group);
     modal.result
       .then(function (results) {
         // update UI
         vm.group.billingServices = results;
+        Notify.success('FORM.INFO.UPDATE_SUCCESS');
       });
   }
 
@@ -95,6 +91,7 @@ function DebtorGroupsUpdateController($state, DebtorGroups, Accounts, Prices, Sc
       .then(function (results) {
         // update UI
         vm.group.subsidies = results;
+        Notify.success('FORM.INFO.UPDATE_SUCCESS');
       });
   }
 }

--- a/client/src/partials/debtors/subscriptions.js
+++ b/client/src/partials/debtors/subscriptions.js
@@ -1,9 +1,9 @@
 angular.module('bhima.controllers')
 .controller('ChargeSubscriptions', ChargeSubscriptions);
 
-ChargeSubscriptions.$inject = ['$uibModalInstance', 'DebtorGroup', 'BillingServicesService'];
+ChargeSubscriptions.$inject = ['$uibModalInstance', 'DebtorGroup', 'BillingServicesService', 'DebtorGroupService'];
 
-function ChargeSubscriptions(ModalInstance, DebtorGroup, BillingServices) {
+function ChargeSubscriptions(ModalInstance, DebtorGroup, BillingServices, DebtorGroups) {
   var vm = this;
 
   vm.close = ModalInstance.dismiss;
@@ -29,15 +29,15 @@ function ChargeSubscriptions(ModalInstance, DebtorGroup, BillingServices) {
 
   function confirmSubscription(subscriptionForm) {
 
-    console.log(vm.group.uuid, vm.subscriptions, subscriptionForm);
     if (subscriptionForm.$pristine) {
       ModalInstance.dismiss();
       return;
     }
 
-    DebtorGroup.updateBillingservice(vm.group.uuid, vm.subscriptions)
-      .then(function () {
-
+    DebtorGroups.updateBillingServices(vm.group.uuid, vm.subscriptions)
+      .then(function (results) {
+        console.log('received');
+        console.log(results);
       });
   }
 

--- a/client/src/partials/debtors/subscriptions.js
+++ b/client/src/partials/debtors/subscriptions.js
@@ -1,14 +1,22 @@
 angular.module('bhima.controllers')
 .controller('ChargeSubscriptions', ChargeSubscriptions);
 
-ChargeSubscriptions.$inject = ['DebtorGroup', 'BillingServicesService'];
+ChargeSubscriptions.$inject = ['$uibModalInstance', 'DebtorGroup', 'BillingServicesService'];
 
-function ChargeSubscriptions(DebtorGroup, BillingServices) {
+function ChargeSubscriptions(ModalInstance, DebtorGroup, BillingServices) {
   var vm = this;
 
+  vm.close = ModalInstance.dismiss;
+  vm.confirmSubscription = confirmSubscription;
+
   vm.group = DebtorGroup;
+  vm.subscriptions = {};
+
+  initialiseSubscriptions();
 
   vm.billingServices = [];
+
+  console.log('vm.group', vm.group);
 
   BillingServices.read()
     .then(function (result) {
@@ -19,6 +27,32 @@ function ChargeSubscriptions(DebtorGroup, BillingServices) {
 
   console.log(vm.group);
 
+  function confirmSubscription(subscriptionForm) {
+
+    console.log(vm.group.uuid, vm.subscriptions, subscriptionForm);
+    if (subscriptionForm.$pristine) {
+      ModalInstance.dismiss();
+      return;
+    }
+
+    DebtorGroup.updateBillingservice(vm.group.uuid, vm.subscriptions)
+      .then(function () {
+
+      });
+  }
+
+  /**
+   * @function initialiseSubscriptions
+   *
+   * @description
+   * Iterate through debtor group billing services and pre-populate
+   * the binary flags for current subscriptions
+   */
+  function initialiseSubscriptions() {
+    vm.group.billingServices.forEach(function (billingService) {
+      vm.subscriptions[billingService.billing_service_id] = true;
+    });
+  }
 
   console.log('charge subscriptions fired');
 }

--- a/client/src/partials/debtors/subscriptions.js
+++ b/client/src/partials/debtors/subscriptions.js
@@ -1,0 +1,24 @@
+angular.module('bhima.controllers')
+.controller('ChargeSubscriptions', ChargeSubscriptions);
+
+ChargeSubscriptions.$inject = ['DebtorGroup', 'BillingServicesService'];
+
+function ChargeSubscriptions(DebtorGroup, BillingServices) {
+  var vm = this;
+
+  vm.group = DebtorGroup;
+
+  vm.billingServices = [];
+
+  BillingServices.read()
+    .then(function (result) {
+      console.log(result);
+
+      vm.billingServices = result;
+    });
+
+  console.log(vm.group);
+
+
+  console.log('charge subscriptions fired');
+}

--- a/client/src/partials/debtors/subscriptions.modal.html
+++ b/client/src/partials/debtors/subscriptions.modal.html
@@ -6,20 +6,22 @@
 </div>
 
 <div class="modal-body">
-  <div class="form-group">
+  <form name="subscriptionForm">
+    <div class="form-group">
 
-    <label class="control-label">Billing Services</label>
-    {{SubCtrl.subscriptions}}
-    <div class="checkbox" ng-repeat="billingService in SubCtrl.billingServices | orderBy:'label'">
-      <label>
-        <input data-group-option type="checkbox" ng-model="SubCtrl.subscriptions[billingService.id]">
-        {{billingService.label}}
-      </label>
+      <label class="control-label">Billing Services</label>
+      {{SubCtrl.subscriptions}}
+      <div class="checkbox" ng-repeat="billingService in SubCtrl.billingServices | orderBy:'label'">
+        <label>
+          <input data-group-option type="checkbox" ng-model="SubCtrl.subscriptions[billingService.id]">
+          {{billingService.label}}
+        </label>
+      </div>
     </div>
-  </div>
+  </form>
 </div>
 
 <div class="modal-footer">
-  <button class="btn btn-default">Cancel</button>
-  <button class="btn btn-primary">Confirm</button>
+  <button ng-click="SubCtrl.close()" class="btn btn-default">Cancel</button>
+  <button ng-click="SubCtrl.confirmSubscription(subscriptionForm)" class="btn btn-primary">Confirm</button>
 </div>

--- a/client/src/partials/debtors/subscriptions.modal.html
+++ b/client/src/partials/debtors/subscriptions.modal.html
@@ -1,0 +1,25 @@
+<div class="modal-header">
+  <ol class="headercrumb">
+    <li class="static">{{ SubCtrl.group.name }}</li>
+    <li class="title">{{ "DEBTOR_GROUP.SUBSCRIPTIONS" | translate }}</li>
+  </div>
+</div>
+
+<div class="modal-body">
+  <div class="form-group">
+
+    <label class="control-label">Billing Services</label>
+    {{SubCtrl.subscriptions}}
+    <div class="checkbox" ng-repeat="billingService in SubCtrl.billingServices | orderBy:'label'">
+      <label>
+        <input data-group-option type="checkbox" ng-model="SubCtrl.subscriptions[billingService.id]">
+        {{billingService.label}}
+      </label>
+    </div>
+  </div>
+</div>
+
+<div class="modal-footer">
+  <button class="btn btn-default">Cancel</button>
+  <button class="btn btn-primary">Confirm</button>
+</div>

--- a/client/src/partials/debtors/subscriptions.modal.html
+++ b/client/src/partials/debtors/subscriptions.modal.html
@@ -21,5 +21,5 @@
 
 <div class="modal-footer">
   <button ng-click="SubCtrl.close()" class="btn btn-default">{{ "FORM.BUTTONS.CANCEL" | translate }}</button>
-  <button ng-click="SubCtrl.confirmSubscription(subscriptionForm)" class="btn btn-primary">{{ "FORM.BUTTONS.CONFIRM" | translate }}</button>
+  <button data-method="submit" ng-click="SubCtrl.confirmSubscription(subscriptionForm)" class="btn btn-primary">{{ "FORM.BUTTONS.CONFIRM" | translate }}</button>
 </div>

--- a/client/src/partials/debtors/subscriptions.modal.html
+++ b/client/src/partials/debtors/subscriptions.modal.html
@@ -10,7 +10,6 @@
     <div class="form-group">
 
       <label class="control-label">Billing Services</label>
-      {{SubCtrl.subscriptions}}
       <div class="checkbox" ng-repeat="billingService in SubCtrl.billingServices | orderBy:'label'">
         <label>
           <input data-group-option type="checkbox" ng-model="SubCtrl.subscriptions[billingService.id]">

--- a/client/src/partials/debtors/subscriptions.modal.html
+++ b/client/src/partials/debtors/subscriptions.modal.html
@@ -8,12 +8,11 @@
 <div class="modal-body">
   <form name="subscriptionForm">
     <div class="form-group">
-
-      <label class="control-label">Billing Services</label>
-      <div class="checkbox" ng-repeat="billingService in SubCtrl.billingServices | orderBy:'label'">
+      <label class="control-label">{{ SubCtrl.entityKey | translate }}</label>
+      <div class="checkbox" ng-repeat="entity in SubCtrl.entities | orderBy:'label'">
         <label>
-          <input data-group-option type="checkbox" ng-model="SubCtrl.subscriptions[billingService.id]">
-          {{billingService.label}}
+          <input data-group-option type="checkbox" ng-model="SubCtrl.subscriptions[entity.id]">
+          {{entity.label}}
         </label>
       </div>
     </div>
@@ -21,6 +20,6 @@
 </div>
 
 <div class="modal-footer">
-  <button ng-click="SubCtrl.close()" class="btn btn-default">Cancel</button>
-  <button ng-click="SubCtrl.confirmSubscription(subscriptionForm)" class="btn btn-primary">Confirm</button>
+  <button ng-click="SubCtrl.close()" class="btn btn-default">{{ "FORM.BUTTONS.CANCEL" | translate }}</button>
+  <button ng-click="SubCtrl.confirmSubscription(subscriptionForm)" class="btn btn-primary">{{ "FORM.BUTTONS.CONFIRM" | translate }}</button>
 </div>

--- a/client/src/partials/debtors/subsidySubscriptions.js
+++ b/client/src/partials/debtors/subsidySubscriptions.js
@@ -1,0 +1,77 @@
+angular.module('bhima.controllers')
+.controller('SubsidySubscriptions', SubsidySubscriptions);
+
+SubsidySubscriptions.$inject = ['$uibModalInstance', 'DebtorGroup', 'SubsidyService', 'DebtorGroupService', 'NotifyService'];
+
+function SubsidySubscriptions(ModalInstance, DebtorGroup, Subsidies, DebtorGroups, Notify) {
+  var vm = this;
+
+  vm.close = ModalInstance.dismiss;
+  vm.confirmSubscription = confirmSubscription;
+
+  vm.group = DebtorGroup;
+
+  vm.entityKey = 'DEBTOR_GROUP.POLICIES.SUBSIDIES.TITLE';
+  vm.subscriptions = {};
+  vm.subsidies = [];
+
+  initialiseSubscriptions();
+
+  Subsidies.read()
+    .then(function (result) {
+      vm.subsidies = result;
+
+      // mirror for generic view
+      vm.entities = vm.subsidies;
+    });
+
+  function confirmSubscription(subscriptionForm) {
+
+    if (subscriptionForm.$pristine) {
+      ModalInstance.dismiss();
+      return;
+    }
+
+    DebtorGroups.updateSubsidies(vm.group.uuid, vm.subscriptions)
+      .then(function (results) {
+        ModalInstance.close(formatSelection());
+      })
+      .catch(Notify.handleError);
+  }
+
+  /**
+   * @function formatSelection
+   *
+   * @description
+   * This function formats the newly selected/ subscribed subsidies to
+   * update the parent states view.
+   */
+  function formatSelection() {
+    return vm.subsidies
+      .filter(function (subsidy) {
+        var selectedOption = vm.subscriptions[subsidy.id];
+
+        if (selectedOption) {
+          return subsidy;
+        }
+      })
+      .map(function (subsidy) {
+        // transform id to subsidy specifically; routes could be updated to use id
+        subsidy.subsidy_id = subsidy.id;
+        return subsidy;
+      });
+  }
+
+  /**
+   * @function initialiseSubscriptions
+   *
+   * @description
+   * Iterate through debtor group subsidies and pre-populate
+   * the binary flags for current subscriptions
+   */
+  function initialiseSubscriptions() {
+    vm.group.subsidies.forEach(function (subsidy) {
+      vm.subscriptions[subsidy.subsidy_id] = true;
+    });
+  }
+}

--- a/client/src/partials/patients/edit/edit.html
+++ b/client/src/partials/patients/edit/edit.html
@@ -45,10 +45,12 @@
                 <label class="control-label">{{ "FORM.LABELS.GROUPS_PATIENT_TITLE" | translate }}</label>
 
                 <!-- Iterate through patient groups -->
-                 <ul
-                 class="form-control-static"
-                 ng-repeat="group in PatientEditCtrl.finance.patientGroups | orderBy:'name'">
-                 <li>{{group.name}}</li>
+                 <ul>
+                  <li
+                    class="form-control-static"
+                    ng-repeat="group in PatientEditCtrl.finance.patientGroups | orderBy:'name'">
+                    {{group.name}}
+                  </li>
                  </ul>
 
                  <p class="text-info form-control-static" ng-if="PatientEditCtrl.finance.patientGroups.length === 0">

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -35,6 +35,7 @@ const functions    = require('../controllers/admin/functions');
 const grades       = require('../controllers/admin/grades');
 const languages    = require('../controllers/admin/languages');
 const locations    = require('../controllers/admin/locations');
+const groups       = require('../controllers/groups');
 
 // medical routes
 const patients       = require('../controllers/medical/patients');
@@ -123,6 +124,8 @@ exports.configure = function configure(app) {
   app.put('/locations/sectors/:uuid', locations.update.sector);
   app.put('/locations/provinces/:uuid', locations.update.province);
   app.put('/locations/countries/:uuid', locations.update.country);
+
+  app.post('/groups/:key/:id', groups.updateSubscriptions);
 
   // API for account type routes CRUD
   app.get('/accounts/types', accounts.types.list);

--- a/server/controllers/finance/debtors/groups/index.js
+++ b/server/controllers/finance/debtors/groups/index.js
@@ -72,8 +72,9 @@ function lookupDebtorGroup(uid) {
 
 function lookupBillingServices(uid) {
   const sql = `
-    SELECT id, billing_service_id, created_at
+    SELECT billing_service_id, label, debtor_group_billing_service.created_at
     FROM debtor_group_billing_service
+    LEFT JOIN billing_service ON debtor_group_billing_service.billing_service_id = billing_service.id
     WHERE debtor_group_uuid = ?
   `;
 
@@ -82,8 +83,9 @@ function lookupBillingServices(uid) {
 
 function lookupSubsidies(uid) {
   const sql = `
-    SELECT id, subsidy_id, created_at
+    SELECT label, subsidy_id, debtor_group_subsidy.created_at
     FROM debtor_group_subsidy
+    LEFT JOIN subsidy ON debtor_group_subsidy.subsidy_id = subsidy.id
     WHERE debtor_group_uuid = ?
   `;
 

--- a/server/controllers/finance/debtors/groups/index.js
+++ b/server/controllers/finance/debtors/groups/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
 * The Debtor Groups Controllers
 *

--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -1,0 +1,27 @@
+const db          = require('../../lib/db');
+const BadRequest  = require('../../lib/errors/BadRequest');
+
+const subscriptions = {
+  debtor_billing_service : {
+    entity  : 'debtor_group_uuid',
+    map     : 'billing_service_id'
+  }
+};
+
+function updateSubscription(req, res, next) {
+  // TODO remove the concept of ids or uuids on linking tables
+  const id = req.params.id;
+  const subscriptionKey = req.params.key;
+  const subscriptionDetails = subscriptions[key];
+  const subscriptions = req.body.subscriptions;
+
+  if (!subscriptionDetails) {
+    throw new BadRequest(`Cannot find details for ${key} subscription`, 'ERROR.ERR_MISSING_INFO');
+  }
+  if (!subscriptions) {
+    throw new BadRequest(`Request must specify a "subscriptions" object containing an array of entity ids`, 'ERROR.ERR_MISSING_INFO');
+  }
+
+
+
+}

--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -7,6 +7,10 @@ let subscriptions = {
   debtor_group_billing_service : {
     entity  : 'debtor_group_uuid',
     map     : 'billing_service_id'
+  },
+  debtor_group_subsidy : {
+    entity  : 'debtor_group_uuid',
+    map     : 'subsidy_id '
   }
 };
 

--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -1,3 +1,4 @@
+'use strict';
 const _           = require('lodash');
 
 const db          = require('../lib/db');

--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -1,27 +1,110 @@
-const db          = require('../../lib/db');
-const BadRequest  = require('../../lib/errors/BadRequest');
+const _           = require('lodash');
 
-const subscriptions = {
-  debtor_billing_service : {
+const db          = require('../lib/db');
+const BadRequest  = require('../lib/errors/BadRequest');
+
+let subscriptions = {
+  debtor_group_billing_service : {
     entity  : 'debtor_group_uuid',
     map     : 'billing_service_id'
   }
 };
 
-function updateSubscription(req, res, next) {
+exports.updateSubscriptions = updateSubscriptions;
+
+prepareQueries();
+
+/**
+ * @function updateSubscriptions
+ *
+ * @description
+ * :key - subscription relationship table
+ * :id - UUID of entity to update subscriptions for
+ */
+function updateSubscriptions(req, res, next) {
   // TODO remove the concept of ids or uuids on linking tables
   const id = req.params.id;
   const subscriptionKey = req.params.key;
-  const subscriptionDetails = subscriptions[key];
-  const subscriptions = req.body.subscriptions;
+  const subscriptionDetails = subscriptions[subscriptionKey];
+  const groupSubscriptions = req.body.subscriptions;
 
   if (!subscriptionDetails) {
-    throw new BadRequest(`Cannot find details for ${key} subscription`, 'ERROR.ERR_MISSING_INFO');
+    throw new BadRequest(`Cannot find details for ${subscriptionKey} subscription`, 'ERROR.INVALID_REQUEST');
   }
-  if (!subscriptions) {
+  if (!groupSubscriptions) {
     throw new BadRequest(`Request must specify a "subscriptions" object containing an array of entity ids`, 'ERROR.ERR_MISSING_INFO');
   }
 
+  let transaction = db.transaction();
+  let binaryId = db.bid(id);
+  let formattedSubscriptions = parseFormMap(groupSubscriptions, binaryId);
 
+  // remove all relationships for the entity ID provided
+  transaction.addQuery(subscriptionDetails.removeAssignmentsQuery, [binaryId]);
 
+  // add relationships for all subscription IDs specified
+  if (formattedSubscriptions.length) {
+    transaction.addQuery(subscriptionDetails.createAssignmentsQuery, [formattedSubscriptions]);
+  }
+
+  transaction.execute()
+    .then(function (result) {
+      res.status(200).json(result);
+    })
+    .catch(next)
+    .done();
+}
+
+/**
+ * @function prepareQueries
+ *
+ * @description
+ * This method is run once on server startup.
+ * Iterate through all valid server subscriptions and template in table names
+ * and entity ids - these prepared statements can then be run to update subscriptions
+ */
+function prepareQueries() {
+  // accept a subscription definition object and append two attributes
+  // * removeAssignmentsQuery - remove all assignements with this entity
+  // * createAssigmentsQuery - insert assignments into table name
+  subscriptions = _.mapValues(subscriptions, function (subscription, key) {
+    subscription.removeAssignmentsQuery =
+      `DELETE FROM ${key} WHERE ${subscription.entity} = ?`;
+    subscription.createAssignmentsQuery =
+      `INSERT INTO ${key} (${subscription.entity}, ${subscription.map}) VALUES ?`;
+    return subscription;
+  });
+  return subscriptions;
+}
+
+/**
+ * @function parseFormMap
+ *
+ * @description
+ * This method parses an object directly sent from a clients form elements. It
+ * converts an object key : value map into an array that can be inserted using
+ * the INSERT INTO VALUES ? syntax
+ *
+ * @example
+ * {
+ *  '1' : true,
+ *  '2' : false,
+ *  '3' : true
+ * }
+ *
+ * returns
+ *
+ * [
+ *  [${subscription_uuid}, 1],
+ *  [${subscription_uuid}, 3]
+ * ]
+ */
+function parseFormMap(groupSubscriptions, entityId) {
+  let formattedGroups = [];
+
+  formattedGroups = _.chain(groupSubscriptions)
+    .pickBy(isGroupSubscribed => isGroupSubscribed)
+    .map((isGroupSubscribed, key) => [entityId, key])
+    .value();
+  return formattedGroups;
 }

--- a/test/end-to-end/debtors/debtorgroups.spec.js
+++ b/test/end-to-end/debtors/debtorgroups.spec.js
@@ -50,4 +50,21 @@ describe('Debtor Groups Management', function () {
 
     components.notification.hasSuccess();
   });
+
+  it('updates debtor group billing service subscriptions', function () {
+    let updateGroup = element.all(by.css('[data-group-entry]'));
+    updateGroup.all(by.css('[data-method="update"]')).first().click();
+
+    element(by.css('#billingServiceSubscription')).click();
+    element.all(by.css('[data-group-option]')).get(1).click();
+    FU.modal.submit();
+    components.notification.hasSuccess();
+  });
+
+  it('updates debtor group subsidy subscriptions', function () {
+    element(by.css('#subsidySubscription')).click();
+    element.all(by.css('[data-group-option]')).get(1).click();
+    FU.modal.submit();
+    components.notification.hasSuccess();
+  });
 });

--- a/test/integration/debtorGroups.js
+++ b/test/integration/debtorGroups.js
@@ -285,6 +285,11 @@ describe('(/debtor_groups) The debtor groups API', function () {
     .send(updateGroup)
     .then(function (res) {
       updateGroup.uuid = debtorGroup.uuid;
+
+      // data provided by the server; always blank for new debtor groups
+      updateGroup.billingServices = [];
+      updateGroup.subsidies = [];
+
       expect(res).to.have.status(200);
       expect(res.body).to.be.an('object');
       expect(res.body).to.have.deep.equal(updateGroup);

--- a/test/integration/groups.js
+++ b/test/integration/groups.js
@@ -1,0 +1,53 @@
+/* global expect, chai, agent */
+/* jshint expr : true */
+
+const helpers = require('./helpers');
+
+describe.only('(/groups) Group subscriptions API', function () {
+
+  let invalidKey = 'notakey';
+  let validKey = 'debtor_group_billing_service';
+
+  // debtor group id
+  let validEntity = '4de0fe47-177f-4d30-b95f-cff8166400b4';
+
+  // billing service ids
+  let validSubscriptions = {
+    1 : true,
+    2 : true
+  };
+
+  it('POST /groups/:key/:id rejects an invalid key', function () {
+    return agent.post(`/groups/${invalidKey}/id`)
+      .send(validSubscriptions)
+      .then(function (result) {
+        helpers.api.errored(result, 400, 'ERROR.INVALID_REQUEST');
+      });
+  });
+
+  it('POST /groups/:key/:id rejects a requst with valid key and no subscriptions', function () {
+    return agent.post(`/groups/${validKey}/${validEntity}`)
+      .send({})
+      .then(function (result) {
+        helpers.api.errored(result, 400, 'ERROR.ERR_MISSING_INFO');
+      });
+  });
+
+  it('POST /groups/:key/:id updates group subscriptions with valid request', function () {
+    // determine how many subscriptions should be affected
+    let trueSubscriptions = [];
+    Object.keys(validSubscriptions).forEach(function (key) {
+      if (validSubscriptions[key]) { trueSubscriptions.push(key); }
+    });
+
+    return agent.post(`/groups/${validKey}/${validEntity}`)
+      .send({ subscriptions : validSubscriptions })
+      .then(function (result) {
+        expect(result).to.have.status(200);
+        expect(result.body).to.not.be.empty;
+        expect(result.body[1].affectedRows).to.equal(trueSubscriptions.length);
+      });
+  });
+});
+
+

--- a/test/integration/groups.js
+++ b/test/integration/groups.js
@@ -3,7 +3,8 @@
 
 const helpers = require('./helpers');
 
-describe.only('(/groups) Group subscriptions API', function () {
+describe('(/groups) Group subscriptions API', function () {
+  'use strict';
 
   let invalidKey = 'notakey';
   let validKey = 'debtor_group_billing_service';

--- a/test/integration/patients.js
+++ b/test/integration/patients.js
@@ -387,7 +387,7 @@ function billingServices() {
   'use strict';
 
   const patientUuid = '85bf7a85-16d9-4ae5-b5c0-1fec9748d2f9';
-  const billingServiceAttached = 1;
+  const billingServiceAttached = 2;
 
   it('GET /patients/:uuid/services will return a list of the patients billing services', function () {
     return agent.get(`/patients/${patientUuid}/services`)

--- a/test/integration/reports/rendering.js
+++ b/test/integration/reports/rendering.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global expect, chai, agent */
 /* jshint expr : true */
 


### PR DESCRIPTION
This pull request adds the ability to link debtor groups with billing services and subsidies. This is essential for being able to correctly bill patients according to their group assignments. 

Subscriptions are shown when managing a debtor group through the debtor group management module.

* Server controllers for listing debtor group billing services and subsidies 
* Modal for updating entity subscriptions
* Generic group subscription controller - this will be used to reduce duplicated code on the server as the number of 'subscription' relationships increases 
  * Debtor groups -> Billing services
  * Debtor groups -> Subsidies 
  * Patient groups -> Billing services 
  * Patient groups -> Subsidies 
  * Patients -> Patient groups 
* Integration tests for generic group subscription route
* End to end tests for debtor group subscription update

**Debtor Group Subscription unit**
![screenshot 2016-11-04 at 15 20 38](https://cloud.githubusercontent.com/assets/2844572/20009368/898853a2-a2a4-11e6-9f4e-f5480e54a391.png)

**Update modal**
![screenshot 2016-11-04 at 15 25 11](https://cloud.githubusercontent.com/assets/2844572/20008980/f2e9d994-a2a2-11e6-95ed-70dd8b6892e1.png)

**Updated/ assigned subscriptions**
![screenshot 2016-11-04 at 15 25 30](https://cloud.githubusercontent.com/assets/2844572/20008978/f2c77c32-a2a2-11e6-8af9-aa546c25826a.png)

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/818

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull requests