### PR TITLE
(Config) Disable TTL on redis server for development builds

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -36,11 +36,17 @@ exports.configure = function configure(app) {
   app.use(bodyParser.json({ limit : '8mb' }));
   app.use(bodyParser.urlencoded({ extended: false }));
 
+  // this will disable the session from expiring on the server (redis-session)
+  // during development
+  const disableTTL = !isProduction;
 
   // stores session in a file store so that server restarts do not interrupt
   // client sessions.
   const sess = {
-    store: new RedisStore({client: new Redis() }),
+    store: new RedisStore({
+      client: new Redis(),
+      disableTTL: disableTTL
+    }),
     secret: process.env.SESS_SECRET,
     resave: Boolean(process.env.SESS_RESAVE),
     saveUninitialized: Boolean(process.env.SESS_UNINITIALIZED),


### PR DESCRIPTION
This commit sets the `disableTTL` flag on the connection request to the
redis session server.
As this flag has not been set before the server has been using the
default TTL for redis sessions of 1 day. If the server is running in
production session expiry is still used as default.

---

 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request
