### PR TITLE
Feature: delete archived report

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -117,7 +117,7 @@
       },
         "DEBTOR_INVOICES" : "Debtor Invoices",
         "RECEIPTS_TITLE"  : "Cash Payment Receipt",
-        "REPORT"          : "Rapport",
+        "REPORT"          : "Report",
         "SLIP"            : "Cash Voucher",
         "TITLE"           : "Cash Window",
         "SELECTED" : "Selected Invoices"
@@ -429,14 +429,14 @@
       "COST_CENTER"            : "Cost Center",
       "CONSUMABLE"             : "Consumable",
       "COUNTRY"                : "Country",
+      "CREATE"                 : "Create",
+      "CREATED"                : "Created",
       "CREDIT"                 : "Credit",
       "CREDITOR_GROUP"         : "Creditor Group",
       "CREDITOR_SUBCRIBED"     : "Subscribed Creditors",
       "CURRENCIES"             : "Currencies",
       "CURRENCY"               : "Currency",
       "CURRENT_LOCATION"       : "Current Location",
-      "CREATE"                 : "CREATE",
-      "CREATED"                : "Created",
       "DATE"                   : "Date",
       "DATE_CREATED"           : "Date Created",
       "DATE_FROM"              : "Start",
@@ -703,7 +703,7 @@
       "PROVINCE"           : "Select a Province",
       "REFERENCE"          : "Select a Reference",
       "REFERENCE_GROUP"    : "Select a Reference Group",
-      "REPORT_TYPE"        : "Select Report type",
+      "REPORT_TYPE"        : "Select a Report Type",
       "RESULT_ACCOUNT_SCT" : "Select a Result Account section",
       "ROOT_ACCOUNT"       : "Select a Root Account",
       "SECTOR"             : "Select a sector",
@@ -1392,7 +1392,7 @@
       "TITLE"              : "Simple Voucher",
       "TRANSFER"           : "Money Transfer"
     },
-    "REPORT": "Rapport"
+    "REPORT": "Report"
   },
   "GRAPHS" : {
     "PATIENT_REGISTRATIONS" : "Patient Registrations",

--- a/client/src/partials/reports/baseReports.service.js
+++ b/client/src/partials/reports/baseReports.service.js
@@ -10,6 +10,7 @@ function BaseReportService($http, Modal, util) {
   service.listSavedReports = listSavedReports;
   service.openConfiguration = openConfiguration;
   service.requestPDF = requestPDF;
+  service.deleteReport = deleteReport;
 
   function requestKey(key) {
     var url = '/reports/keys/';
@@ -73,5 +74,11 @@ function BaseReportService($http, Modal, util) {
     var options = angular.merge(reportOptions, pdfParams);
 
     return $http.get(url, { params : options });
+  }
+
+  function deleteReport(uuid) {
+    var url = '/reports/archive/'.concat(uuid);
+    return $http.delete(url)
+      .then(util.unwrapHttpResponse);
   }
 }

--- a/client/src/partials/reports/modals/accounts_chart.config.js
+++ b/client/src/partials/reports/modals/accounts_chart.config.js
@@ -1,7 +1,9 @@
 angular.module('bhima.controllers')
 .controller('accounts_chartController', AccountChartController);
 
-AccountChartController.$inject = [ '$state', '$uibModalInstance', 'NotifyService', 'LanguageService', 'BaseReportService', 'reportDetails' ];
+AccountChartController.$inject = [
+  '$state', '$uibModalInstance', 'NotifyService', 'LanguageService', 'BaseReportService', 'reportDetails'
+];
 
 function AccountChartController($state, ModalInstance, Notify, Languages, SavedReports, reportDetails) {
   var vm = this;
@@ -27,13 +29,12 @@ function AccountChartController($state, ModalInstance, Notify, Languages, SavedR
 
     SavedReports.requestPDF(url, report, options)
       .then(function (result) {
-        vm.$loading = false;
         ModalInstance.dismiss();
+        Notify.success('FORM.INFO.CREATE_SUCCESS');
         $state.reload();
        })
       .catch(function (error) {
         var INTERNAL_SERVER_ERROR = 500;
-        vm.$loading = false;
 
         if (error.status === INTERNAL_SERVER_ERROR) {
           ModalInstance.dismiss();
@@ -42,6 +43,9 @@ function AccountChartController($state, ModalInstance, Notify, Languages, SavedR
         Notify.handleError(error);
 
         throw error;
+      })
+      .finally(function () {
+        vm.$loading = false;
       });
   }
 }

--- a/client/src/partials/reports/modals/accounts_chart.modal.html
+++ b/client/src/partials/reports/modals/accounts_chart.modal.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <ol class="headercrumb">
-    <li class="static">{{ ReportConfigCtrl.reportTitleKey | translate }}</li>
+    <li class="static">{{ReportConfigCtrl.report.title_key | translate}}</li>
     <li class="title">{{ "FORM.LABELS.CREATE" | translate }}</li>
   </ol>
 </div>
@@ -10,7 +10,7 @@
   <div class="form-group"
     ng-class="{ 'has-error' : ConfigForm.$submitted && ConfigForm.label.$invalid }">
     <label class="control-label">{{ "FORM.LABELS.LABEL" | translate }}</label>
-    <input class="form-control" id="label" name="label" ng-model="ReportConfigCtrl.label" autocomplete="off" required />
+    <input class="form-control" id="label" name="label" ng-model="ReportConfigCtrl.label" required />
 
     <div class="help-block" ng-messages="ConfigForm.label.$error" ng-show="ConfigForm.$submitted">
       <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
@@ -28,11 +28,11 @@
     {{ "FORM.BUTTONS.CANCEL" | translate }}
   </button>
 
-  <!-- <div data-submit-area> -->
-    <bh-loading-button loading-state="ReportConfigCtrl.$loading"
-      ng-disabled="ConfigForm.$invalid">
-      {{ "FORM.BUTTONS.GENERATE" | translate }}
-    </bh-loading-button>
-  <!-- </div> -->
+  <bh-loading-button
+    loading-state="ReportConfigCtrl.$loading"
+    data-method="submit"
+    ng-disabled="ConfigForm.$invalid">
+    {{ "FORM.BUTTONS.GENERATE" | translate }}
+  </bh-loading-button>
 </div>
 </form>

--- a/client/src/partials/reports/reports.js
+++ b/client/src/partials/reports/reports.js
@@ -7,7 +7,9 @@ function ReportsController($state, SavedReports, Modal, Notify) {
   var vm = this;
   var keyTarget = $state.params.key;
 
+  // report configuratoion
   vm.report = {};
+
   vm.createReport = createReport;
   vm.deleteReport = deleteReport;
 

--- a/client/src/partials/templates/actionsDropdown.html
+++ b/client/src/partials/templates/actionsDropdown.html
@@ -5,8 +5,7 @@
     <ul class="dropdown-menu-right" uib-dropdown-menu>
       <li><a href="/reports/archive/{{row.entity.uuid}}" download><i class="fa fa-cloud-download"></i> {{ "REPORT.DOWNLOAD" | translate }}</a></li>
       <li><a href><span class="text-muted"><i class="fa fa-envelope"></i> {{ "TABLE.COLUMNS.EMAIL" | translate }}</span></a></li>
-      <li><a style="color : #a94442" href><i class="fa fa-trash"></i> {{ "REPORT.DELETE" | translate }}</a></li>
+      <li><a href ng-click="grid.appScope.deleteReport(row.entity.uuid)"><span class="text-danger"><i class="fa fa-trash"></i> {{ "REPORT.DELETE" | translate }}</span></a></li>
      </ul>
-
   </span>
 </div>

--- a/client/src/partials/templates/actionsDropdown.html
+++ b/client/src/partials/templates/actionsDropdown.html
@@ -5,7 +5,9 @@
     <ul class="dropdown-menu-right" uib-dropdown-menu>
       <li><a href="/reports/archive/{{row.entity.uuid}}" download><i class="fa fa-cloud-download"></i> {{ "REPORT.DOWNLOAD" | translate }}</a></li>
       <li><a href><span class="text-muted"><i class="fa fa-envelope"></i> {{ "TABLE.COLUMNS.EMAIL" | translate }}</span></a></li>
-      <li><a href ng-click="grid.appScope.deleteReport(row.entity.uuid)"><span class="text-danger"><i class="fa fa-trash"></i> {{ "REPORT.DELETE" | translate }}</span></a></li>
+      <li>
+        <a href ng-click="grid.appScope.deleteReport(row.entity.uuid)" data-action="delete"><span class="text-danger"><i class="fa fa-trash"></i> {{ "REPORT.DELETE" | translate }}</span></a>
+      </li>
      </ul>
   </span>
 </div>

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -368,7 +368,7 @@ exports.configure = function configure(app) {
   app.get('/reports/finance/income_expense', financeReports.incomeExpense.document);
   app.get('/reports/finance/balance', financeReports.balance.document);
   app.get('/reports/finance/account', financeReports.reportAccounts.document);
-
+  app.get('/reports/finance/journal', financeReports.journal.report);
 
   app.get('/reports/keys/:key', report.keys);
 
@@ -377,7 +377,7 @@ exports.configure = function configure(app) {
 
   // lookup saved report document
   app.get('/reports/archive/:uuid', report.sendArchived);
-  app.get('/reports/finance/journal', financeReports.journal.report);
+  app.delete('/reports/archive/:uuid', report.deleteArchived);
 
   // patient group routes
   app.get('/patients/groups', patientGroups.list);

--- a/server/lib/ReportManager.js
+++ b/server/lib/ReportManager.js
@@ -47,20 +47,7 @@ const defaults = {
 
 // Constants
 const SAVE_DIR = path.resolve(path.join(__dirname, '../reports/'));
-const DETAIL_SQL = `
-  SELECT r.uuid, r.label, r.type, r.parameters, r.link, r.timestamp, r.user_id
-  FROM report AS r WHERE r.uuid = ?;
-`;
-const LIST_SQL = `
-  SELECT r.uuid, r.label, r.type, r.parameters, r.link, r.timestamp, r.user_id
-  FROM report AS r WHERE r.type = ?;
-`;
-const DELETE_SQL = `
-  DELETE FROM report WHERE uuid = ?;
-`;
-const UPDATE_SQL = `
-   UPDATE report SET ? WHERE uuid = ?;
-`;
+
 const SAVE_SQL = `
   INSERT INTO saved_report SET ?;
 `;
@@ -147,7 +134,7 @@ class ReportManager {
       if (this.options.saveReport) {
         // FIXME This is not correctly deferred
         // FIXME PDF report is sent back to the client even though this is a save operation
-        // FIXME Errors are not propegated
+        // FIXME Errors are not propagated
         return this.save()
           .then(function (result) {
             return { headers: renderHeaders, report };
@@ -185,7 +172,7 @@ class ReportManager {
     const data = {
       uuid : db.bid(reportId),
       label : options.label,
-      link : reportId,
+      link : link,
       timestamp : new Date(),
       user_id : options.user.id,
       report_id : options.reportId
@@ -196,23 +183,11 @@ class ReportManager {
 
       db.exec(SAVE_SQL, data)
         .then(() => dfd.resolve({ uuid: reportId }))
-        .catch(dfd.reject);
+        .catch(dfd.reject)
+        .done();
     });
 
     return dfd.promise;
-  }
-
-  // crud operations on reports
-  list(type) {
-    return db.exec(LIST_SQL, [type]);
-  }
-
-  remove(uuid) {
-    return db.exec(DELETE_SQL, [uuid]);
-  }
-
-  update(uuid, data) {
-    return db.exec(UPDATE_SQL, [data, uuid]);
   }
 }
 

--- a/test/end-to-end/reports/chart/chart.spec.js
+++ b/test/end-to-end/reports/chart/chart.spec.js
@@ -1,0 +1,44 @@
+/* global browser, element, by */
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const helpers = require('../../shared/helpers');
+helpers.configure(chai);
+
+const FU = require('../../shared/FormUtils');
+const GU = require('../../shared/GridUtils');
+
+const components = require('../../shared/components');
+const ReportPage = require('../page.js');
+
+describe('Chart of Accounts Report Generation', () => {
+  'use strict';
+
+  let Page;
+  const key = 'accounts_chart';
+
+  before(() => {
+    helpers.navigate(`#/reports/${key}`);
+    Page = new ReportPage(key);
+  });
+
+  it('should be empty on start ', function () {
+    Page.expectPageToBeEmpty();
+  });
+
+  it('generates a new Chart of Accounts PDF report', function () {
+    Page.create({
+      'ReportConfigCtrl.label' : 'Generated Chart of Accounts'
+    });
+
+    components.notification.hasSuccess();
+  });
+
+  it('deletes the old Chart of Accounts PDF report', function () {
+    Page.delete(0);
+
+    components.notification.hasSuccess();
+  });
+
+});

--- a/test/end-to-end/reports/page.js
+++ b/test/end-to-end/reports/page.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const helpers = require('../shared/helpers');
+helpers.configure(chai);
+
+const _ = require('lodash');
+const FU = require('../shared/FormUtils');
+const GU = require('../shared/GridUtils');
+
+const gridId = 'report-grid';
+
+class ReportPage {
+  constructor(key) {
+    this.url = `/reports/${key}`;
+  }
+
+  // "form" is a JSON description of the ngModel mapped to a value
+  // @todo - this could be way more generic
+  create(form) {
+
+    // click the create button.
+    $('[data-method="create"]').click();
+
+    const modal = $('[uib-modal-window="modal-window"]');
+
+    // look through the form JSON description, setting
+    // ng-model keys to input values
+    _.forEach(form, (value, key) => {
+      FU.input(key, value, modal);
+    });
+
+    // click the generate button
+    modal.$('[data-method="submit"]').click();
+  }
+
+  // deletes an account from the grid
+  delete(row) {
+    let cell = GU.getCell(gridId, row, 5);
+
+    // open the dropdown menu
+    cell.$('[uib-dropdown-toggle]').click();
+
+    // click the "delete" link
+    $('[data-action="delete"]').click();
+  }
+
+  // asserts that there are no items in the grid
+  expectPageToBeEmpty() {
+    expect(GU.getRows(gridId).count()).to.eventually.equal(0);
+  }
+}
+
+module.exports = ReportPage;

--- a/test/end-to-end/vouchers/complex.page.js
+++ b/test/end-to-end/vouchers/complex.page.js
@@ -23,7 +23,7 @@ const GU = require('../shared/GridUtils');
  class Row {
    constructor(index) {
 
-     // store a reference of the row 
+     // store a reference of the row
      this._node = GU.getRow('voucherGridId', index);
    }
 


### PR DESCRIPTION
This PR implements the functionality to delete reports from the report page.

It cleans up the report server code, removing the old code in the ReportManager that will not be used for retrieving reports.  It correctly writes the document link via the ReportManager instead of putting in a `uuid` to the `link` field.

I've also written the beginning of an end-to-end test framework for the report page.  This covers both the creation (for chart of accounts) and deletion phases.  To make the framework generic, it needs a lot of work.  But I think it is a good first step.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!