### PR TITLE
Feature: filtering posting journal

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -798,3 +798,7 @@ growl-notification.fading.ng-leave.ng-leave-active {
   display: flex;
   justify-content: space-between;
 }
+
+.modal-tall {
+  max-height: 80vh;
+}

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -313,7 +313,6 @@
       "RETURN"                : "Return",
       "SAVE"                  : "Save",
       "SEARCH"                : "Search",
-      "SEE"                   : "See",
       "SELECT_INVOICES"       : "Select Invoices",
       "SUBMIT"                : "Submit",
       "SUBMIT_CHANGES"        : "Submit Changes",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -315,7 +315,6 @@
       "RETURN"                : "Retourne",
       "SAVE"                  : "Sauver",
       "SEARCH"                : "Rechercher",
-      "SEE"                   : "Voir",
       "SELECT_INVOICES"       : "Sélectionner la(les) Facture(s)",
       "SUBMIT"                : "Soumettre",
       "SUBMIT_CREDIT_NOTE"    : "Soumettre la note de crédit",

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -432,11 +432,19 @@ function compileConfig($compileProvider) {
   }
 }
 
+/**
+ * Configure global properties about ui-select
+ */
+function uiSelectConfig(uiSelectConfig) {
+  uiSelectConfig.theme = 'bootstrap';
+}
+
 bhima.constant('bhConstants', constantConfig());
 
 // configure services, providers, factories
 bhima.config(['$stateProvider', '$urlRouterProvider', '$urlMatcherFactoryProvider', bhimaConfig]);
 bhima.config(['$translateProvider', translateConfig]);
+bhima.config(['uiSelectConfig', uiSelectConfig]);
 bhima.config(['tmhDynamicLocaleProvider', localeConfig]);
 bhima.config(['$localStorageProvider', localStorageConfig]);
 bhima.config(['$httpProvider', httpConfig]);

--- a/client/src/js/components/bhDateInterval.js
+++ b/client/src/js/components/bhDateInterval.js
@@ -11,25 +11,25 @@
  * </bh-date-interval>
  * ```
  */
-angular.module('bhima.components').component('bhDateInterval', {
-  templateUrl : '/partials/templates/bhDateInterval.tmpl.html',
-  controller : bhDateInterval,
-  bindings : {
-    validationTrigger : '<', // validation trigger action
-    dateFrom : '=',          // date from
-    dateTo : '=',            // date to
-    required : '<',          // true or false
-    onChange : '<',          // on change action
-    mode : '@'               // the date mode (day|month|year)
-  }
-});
+angular.module('bhima.components')
+  .component('bhDateInterval', {
+    templateUrl : '/partials/templates/bhDateInterval.tmpl.html',
+    controller : bhDateInterval,
+    bindings : {
+      validationTrigger : '<', // validation trigger action
+      dateFrom : '=',          // date from
+      dateTo : '=',            // date to
+      required : '<',          // true or false
+      onChange : '<',          // on change action
+      mode : '@'               // the date mode (day|month|year)
+    }
+  });
 
 // dependencies injection
-bhDateInterval.$inject = ['DateService'];
+bhDateInterval.$inject = ['DateService', 'moment'];
 
 // controller definition
-function bhDateInterval(Dates) {
-  /* global moment */
+function bhDateInterval(Dates, moment) {
   var vm = this;
 
   vm.options = [
@@ -48,7 +48,7 @@ function bhDateInterval(Dates) {
   // start up the modal
   startup();
 
-  function search (selection) {
+  function search(selection) {
     vm.selected = selection.translateKey;
     selection.fn();
   }
@@ -74,11 +74,12 @@ function bhDateInterval(Dates) {
   }
 
   function clear() {
-    vm.dateFrom = null;
-    vm.dateTo = null;
+    delete vm.dateFrom;
+    delete vm.dateTo;
   }
 
   function startup() {
+
     // set today as default date plage value
     if (!vm.dateFrom && !vm.dateTo) {
       search(vm.options[0]);
@@ -96,7 +97,5 @@ function bhDateInterval(Dates) {
     if (vm.mode === 'clean') {
       clear();
     }
-
   }
-
 }

--- a/client/src/js/services/JournalConfig.service.js
+++ b/client/src/js/services/JournalConfig.service.js
@@ -8,6 +8,7 @@ function JournalConfigService(Modal) {
   var service = this;
 
   service.openColumnConfigModal = openColumnConfigModal;
+  service.openSearchModal = openSearchModal;
 
   function openColumnConfigModal(Columns) {
     return Modal.open({
@@ -18,6 +19,16 @@ function JournalConfigService(Modal) {
         Columns : function columnsProvider() { return Columns; }
       }
     });
+  }
+
+  function openSearchModal(options) {
+    return Modal.open({
+      templateUrl: 'partials/journal/modals/search.modal.html',
+      controller:  'JournalSearchModalController as ModalCtrl',
+      resolve : {
+        options : function () { return options; }
+      }
+    }).result;
   }
 
   return service;

--- a/client/src/js/services/JournalService.js
+++ b/client/src/js/services/JournalService.js
@@ -10,5 +10,49 @@ JournalService.$inject = ['PrototypeApiService'];
  */
 function JournalService(Api) {
   var service = new Api('/journal/');
+
+  service.formatFilterParameters = formatFilterParameters;
+
+  /**
+   * This function prepares the filters for the journal for display to the
+   * client via the bhFiltersApplied directive.
+   * @todo - this might be better in it's own service
+   */
+  function formatFilterParameters(params) {
+    var columns = [
+      { field: 'debit', displayName: 'FORM.LABELS.DEBIT' },
+      { field: 'credit', displayName: 'FORM.LABELS.CREDIT' },
+      { field: 'credit_equiv', displayName: 'FORM.LABELS.CREDIT' },
+      { field: 'debit_equiv', displayName: 'FORM.LABELS.DEBIT' },
+      { field: 'trans_id', displayName: 'FORM.LABELS.TRANS_ID' },
+      { field: 'reference', displayName: 'FORM.LABELS.REFERENCE' },
+      { field: 'user_id', displayName: 'FORM.LABELS.USER' },
+      { field: 'account_id', displayName: 'FORM.LABELS.ACCOUNT' },
+      { field: 'description', displayName: 'FORM.LABELS.DESCRIPTION', truncate: 8 },
+      { field: 'dateFrom', displayName: 'FORM.LABELS.DATE', comparitor: '>', ngFilter:'date' },
+      { field: 'dateTo', displayName: 'FORM.LABELS.DATE', comparitor: '<', ngFilter:'date' },
+    ];
+
+    // returns columns from filters
+    return columns.filter(function (column) {
+      var value = params[column.field];
+
+      if (angular.isDefined(value)) {
+
+        // this is to temporarily reduce the size of the description field
+        // @TODO - find a better way of doing this
+        if (column.truncate) {
+          column.value = String(value).substring(0, column.truncate) + '... ';
+        } else {
+          column.value = value;
+        }
+
+        return true;
+      } else {
+        return false;
+      }
+    });
+  }
+
   return service;
 }

--- a/client/src/js/services/PatientService.js
+++ b/client/src/js/services/PatientService.js
@@ -74,7 +74,7 @@ function PatientService($http, util, Session, $uibModal, Documents, Visits) {
   }
 
   /**
-   * This method accepts infromation recorded by a controllers form, formats it
+   * This method accepts information recorded by a controllers form, formats it
    * for submission and forwards it to the server /patients/create API. It can
    * be used for creating new patient records in the database.
    *

--- a/client/src/js/services/System.js
+++ b/client/src/js/services/System.js
@@ -44,12 +44,14 @@ function SystemService($http, util) {
     console.log('Connection was open.');
   }
 
+  /*
   // set up event stream
   var source = new EventSource(baseUrl.concat('/stream'));
 
   source.addEventListener('open', handleOpenEvent, false);
   source.addEventListener('message', handleServerSentEvent, false);
   source.addEventListener('error', handleErrorEvent, false);
+  */
 
   return service;
 }

--- a/client/src/partials/journal/journal.html
+++ b/client/src/partials/journal/journal.html
@@ -38,6 +38,24 @@
   </div>
 </div>
 
+<!-- @todo remove hardcoded styles -->
+<div class="flex-util" style="min-height : 35px; padding-top : 7px; max-height: initial" ng-if="JournalCtrl.filtersFmt.length > 0">
+  <bh-filters-applied
+    style="max-width:90%"
+    filters="JournalCtrl.filtersFmt"
+    on-remove-filter="JournalCtrl.onRemoveFilter(filter)">
+  </bh-filters-applied>
+
+  <a
+    href
+    ng-click="JournalCtrl.clearFilters()"
+    class="text-danger"
+    data-method="clear">
+    <i class="fa fa-ban text-danger"></i>
+    {{ "FORM.INFO.CLEAR_FILTERS" | translate }}
+  </a>
+</div>
+
 <div class="flex-content">
   <div class="container-fluid">
 
@@ -47,6 +65,7 @@
         <div
           id="journal-grid"
           class="grid-full-height"
+          ng-style="JournalCtrl.filterBarHeight"
           ui-grid="JournalCtrl.gridOptions"
           ui-grid-auto-resize
           ui-grid-resize-columns
@@ -61,7 +80,7 @@
             empty-state="JournalCtrl.gridOptions.data.length === 0"
             error-state="JournalCtrl.hasError"
           >
-        </bh-grid-loading-indicator>
+          </bh-grid-loading-indicator>
 
         </div>
       </div>

--- a/client/src/partials/journal/modals/search.modal.html
+++ b/client/src/partials/journal/modals/search.modal.html
@@ -1,0 +1,100 @@
+<form
+  name="ModalForm"
+  ng-submit="ModalCtrl.submit(ModalForm)"
+  data-modal="journal-search"
+  bh-form-defaults
+  novalidate>
+
+  <div class="modal-header">
+    <ol class="headercrumb">
+      <li class="static">{{ "TREE.POSTING_JOURNAL" | translate }}</li>
+      <li class="title">{{ "FORM.INFO.SEARCH" | translate }}</li>
+    </ol>
+  </div>
+
+  <div class="modal-body modal-tall">
+
+    <!-- date parameters -->
+    <bh-date-interval
+      date-from="ModalCtrl.options.dateFrom"
+      date-to="ModalCtrl.options.dateTo"
+      mode="clean"
+      validation-trigger="ModalForm.$submitted">
+    </bh-date-interval>
+
+    <!-- description fuzzy search -->
+    <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.description.$invalid }">
+      <label class="control-label">
+        {{ 'FORM.LABELS.DESCRIPTION' | translate }}
+      </label>
+      <span style="display:inline-block;" class="pull-right">
+        <a href ng-click="ModalCtrl.clear('description')" tabindex="-1">
+          <i class="fa fa-eraser"></i> {{ "FORM.BUTTONS.CLEAR" | translate }}
+        </a>
+      </span>
+      <textarea
+        class="form-control"
+        name="description"
+        ng-model="ModalCtrl.options.description"
+        rows="4">
+      </textarea>
+      <div class="help-block" ng-messages="ModalForm.description.$error" ng-show="ModalForm.$submitted">
+        <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+      </div>
+    </div>
+
+    <!-- users ui-select -->
+    <div class="form-group" ng-class="{'has-error' : ModalCtrl.user.$invalid && ModalForm.$submitted}">
+      <label class="control-label">
+        {{ 'FORM.LABELS.USER' | translate }}
+      </label>
+      <span style="display:inline-block;" class="pull-right">
+        <a href ng-click="ModalCtrl.clear('user_id')" tabindex="-1">
+          <i class="fa fa-eraser"></i> {{ "FORM.BUTTONS.CLEAR" | translate }}
+        </a>
+      </span>
+      <ui-select name="user" ng-model="ModalCtrl.options.user_id">
+        <ui-select-match placeholder="{{ 'FORM.SELECT.USER' | translate }}">{{$select.selected.display_name}}</span></ui-select-match>
+        <ui-select-choices ui-select-focus-patch repeat="user.id as user in ModalCtrl.users | filter:$select.search">
+          <span ng-bind-html="user.display_name | highlight:$select.search"></span>
+        </ui-select-choices>
+      </ui-select>
+
+      <div class="help-block" ng-messages="ModalForm.user.$error" ng-show="ModalForm.$submitted">
+        <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+      </div>
+    </div>
+
+    <!-- account ui-select -->
+    <div class="form-group" ng-class="{'has-error' : ModalCtrl.account.$invalid && ModalForm.$submitted}">
+      <label class="control-label">
+        {{ 'FORM.LABELS.ACCOUNT' | translate }}
+      </label>
+      <span style="display:inline-block;" class="pull-right">
+        <a href ng-click="ModalCtrl.clear('account_id')" tabindex="-1">
+          <i class="fa fa-eraser"></i> {{ "FORM.BUTTONS.CLEAR" | translate }}
+        </a>
+      </span>
+      <ui-select name="account" ng-model="ModalCtrl.options.account_id">
+        <ui-select-match placeholder="{{ 'FORM.SELECT.ACCOUNT' | translate }}"><strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span></ui-select-match>
+        <ui-select-choices ui-select-focus-patch repeat="account.id as account in ModalCtrl.accounts | filter:$select.search">
+          <span ng-bind-html="account.number | highlight:$select.search"></span>
+          <small ng-bind-html="account.label | highlight:$select.search"></small>
+        </ui-select-choices>
+      </ui-select>
+
+      <div class="help-block" ng-messages="ModalForm.account.$error" ng-show="ModalForm.$submitted">
+        <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal-footer">
+    <button type="button" class="btn btn-default" ng-click="ModalCtrl.cancel()" data-method="cancel">
+      {{ "FORM.BUTTONS.CLOSE" | translate }}
+    </button>
+    <button type="submit" class="btn btn-primary" data-method="submit">
+      {{ "FORM.BUTTONS.SUBMIT" | translate }}
+    </button>
+  </div>
+</form>

--- a/client/src/partials/journal/modals/search.modal.js
+++ b/client/src/partials/journal/modals/search.modal.js
@@ -1,0 +1,54 @@
+angular.module('bhima.controllers')
+  .controller('JournalSearchModalController', JournalSearchModalController);
+
+JournalSearchModalController.$inject = [
+  '$uibModalInstance', 'AccountService', 'UserService', 'ProjectService', 'NotifyService', 'options'
+];
+
+function JournalSearchModalController(Instance, Accounts, Users, Projects, Notify, options) {
+  var vm = this;
+
+  vm.options = options || {};
+
+  Accounts.read()
+    .then(function (accounts) {
+      vm.accounts = accounts;
+    })
+    .catch(Notify.handleError);
+
+  Users.read()
+    .then(function (users) {
+      vm.users = users;
+    })
+    .catch(Notify.handleError);
+
+  Projects.read()
+    .then(function (projects) {
+      vm.projects = projects;
+    })
+    .catch(Notify.handleError);
+
+  // deletes a filter from the options/parameters
+  vm.clear = function clear(key) {
+    delete vm.options[key];
+  };
+
+  vm.cancel = function cancel() {
+    Instance.dismiss();
+  };
+
+  // returns the filters to the journal to be used to refresh the page
+  vm.submit = function submit(form) {
+    if (form.$invalid) { return; }
+
+    // loop through and remove empty values from the json options
+    var keys = Object.keys(vm.options);
+    keys.forEach(function (key) {
+      var prop = vm.options[key];
+      if (!angular.isDefined(prop) || prop === '') { delete vm.options[key]; }
+    });
+
+    // return values to the JournalController
+    return Instance.close(vm.options);
+  };
+}

--- a/client/src/partials/journal/modals/trialBalanceMain.body.js
+++ b/client/src/partials/journal/modals/trialBalanceMain.body.js
@@ -39,7 +39,7 @@ function TrialBalanceMainBodyController(Session, trialBalanceService, Grouping, 
       headerCellFilter: 'translate',
       visible: true,
       enableCellEdit: false,
-      cellTemplate: '/partials/journal/templates/trial_balance_actions.cell.html',
+      cellTemplate: '/partials/journal/templates/error-link.cell.html',
       allowCellFocus: false
     }
   ];

--- a/client/src/partials/journal/templates/error-link.cell.html
+++ b/client/src/partials/journal/templates/error-link.cell.html
@@ -1,0 +1,5 @@
+<div class="ui-grid-cell-contents">
+  <a href data-method="detail" ng-click="grid.appScope.viewDetailByAccount(row.entity.account_id)" class="text-danger">
+    <i class="fa fa-warning"></i> {{ "FORM.BUTTONS.VIEW_ERRORS" | translate }}
+  </a>
+</div>

--- a/client/src/partials/journal/templates/trial_balance_actions.cell.html
+++ b/client/src/partials/journal/templates/trial_balance_actions.cell.html
@@ -1,5 +1,0 @@
-<div class="ui-grid-cell-contents">
-  <a href data-method="detail" ng-click="grid.appScope.viewDetailByAccount(row.entity.account_id)">
-    <span class="fa fa-eye"></span> {{ "FORM.BUTTONS.SEE" | translate }}
-  </a>
-</div>

--- a/client/src/partials/patients/registry/search.modal.html
+++ b/client/src/partials/patients/registry/search.modal.html
@@ -12,7 +12,7 @@
     </ol>
   </div>
 
-  <div class="modal-body" style="overflow: auto; max-height: 80vh;">
+  <div class="modal-body modal-tall" style="overflow: auto;">
     <fieldset>
       <legend>
         <i class="fa fa-calendar"></i> {{ "FORM.LABELS.DATE_REGISTRATION" | translate }}

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -3,25 +3,36 @@
  *
  * @module finance/journal/
  *
- * @description This module is responsible for handling CRUD operations
+ * @description
+ * This module is responsible for handling CRUD operations
  * against the `posting journal` table.
  *
+ * @requires q
+ * @requires lodash
+ * @requires node-uuid
  * @requires lib/db
+ * @requires lib/errors/NotFound
+ * @requires lib/errors/BadRequest
  */
 
 'use strict';
 
+// npm deps
+const q = require('q');
+const _ = require('lodash');
+const uuid = require('node-uuid');
+
 // module dependencies
 const db = require('../../../lib/db');
-const uuid = require('node-uuid');
-const NotFound   = require('../../../lib/errors/NotFound');
-const _ = require('lodash');
+const util = require('../../../lib/util');
+const NotFound  = require('../../../lib/errors/NotFound');
+const BadRequest = require('../../../lib/errors/BadRequest');
 
 // expose to the api
 exports.list = list;
 exports.getTransaction = getTransaction;
 exports.reverse = reverse;
-exports.journalEntryList = journalEntryList;
+exports.find = find;
 
 /**
  * Looks up a transaction by record_uuid.
@@ -49,7 +60,7 @@ function lookupTransaction(record_uuid) {
       JOIN user u ON u.id = p.user_id
     WHERE p.record_uuid = ?
     ORDER BY p.trans_date DESC;
-    `;
+  `;
 
   return db.exec(sql, [ db.bid(record_uuid) ])
     .then(function (rows) {
@@ -64,27 +75,31 @@ function lookupTransaction(record_uuid) {
 }
 
 /**
- * GET /journal
- * Getting data from the posting journal
+ * @function find
+ *
+ * @description
+ * This function filters the posting journal by query parameters passed in via
+ * the options object.  If no query parameters are provided, the method will
+ * return all items in the posting journal
  */
-function list(req, res, next) {
+function find(options) {
+  // remove the limit first thing, if it exists
+  let limit = Number(options.limit);
+  delete options.limit;
 
-  journalEntryList(req.query)
-    .then(rows => {
-      res.status(200).json(rows);
-    })
-    .catch(next);
-}
+  // support flexible queries by keeping a growing list of conditions and
+  // statements
+  let conditions = {
+    statements: [],
+    parameters: []
+  };
 
-/**
- * @method journalEntryList
- * @description return a list of journal entries
- */
-function journalEntryList(params) {
-  let uuids = [];
-  let conditions = [];
-  let whereTransactions;
-  let whereDates;
+  // if nothing is passed in as an option, throw an error
+  if (_.isEmpty(options)) {
+    return q.reject(
+      new BadRequest('The request requires at least one parameter.', 'ERRORS.PARAMETERS_REQUIRED')
+    );
+  }
 
   let sql = `
     SELECT BUID(p.uuid) AS uuid, p.project_id, p.fiscal_year_id, p.period_id,
@@ -105,47 +120,131 @@ function journalEntryList(params) {
       LEFT JOIN entity_map em ON em.uuid = p.entity_uuid
       LEFT JOIN document_map dm1 ON dm1.uuid = p.record_uuid
       LEFT JOIN document_map dm2 ON dm2.uuid = p.reference_uuid
+    WHERE
+      SQL_CONDITIONS
+    ORDER BY p.trans_date DESC
   `;
 
-  // get only transactions given
-  if (params && params.uuids && params.uuids.length) {
-    uuids = params.uuids.map(uuid => {
-      return db.bid(uuid);
-    });
-    whereTransactions = ' p.uuid IN (?) ';
+  // filter on a record uuid
+  if (options.record_uuid) {
+    const recordUuid = db.bid(options.record_uuid);
+    conditions.statements.push('p.record_uuid = ?');
+    conditions.parameters.push(recordUuid);
+    delete options.record_uuid;
   }
 
-  // dates given
-  if (params && params.dateFrom && params.dateTo) {
-    params.dateFrom = new Date(params.dateFrom);
-    params.dateTo = new Date(params.dateTo);
-    whereDates = ' DATE(p.trans_date) BETWEEN DATE(?) AND DATE(?) ';
+  // filter on reference uuid
+  if (options.reference_uuid) {
+    const referenceUuid = db.bid(options.reference_uuid);
+    conditions.statements.push('p.reference_uuid = ?');
+    conditions.parameters.push(referenceUuid);
+    delete options.reference_uuid;
   }
 
-  if (whereDates && whereTransactions) {
-    sql += ' WHERE ' + whereDates + ' AND ' + whereTransactions;
-    conditions.push(params.dateFrom, params.dateTo, uuids);
-
-  } else if (whereDates && !whereTransactions) {
-    sql += ' WHERE ' + whereDates;
-    conditions.push(params.dateFrom, params.dateTo);
-
-  } else if (!whereDates && whereTransactions) {
-    sql += ' WHERE ' + whereTransactions;
-    conditions.push(uuids);
+  // TODO - will this have SQL injection?
+  if (options.description) {
+    conditions.statements.push(`p.description LIKE "%${options.description}%"`);
+    delete options.description;
   }
 
-  sql += ' ORDER BY p.trans_date DESC;';
-  return db.exec(sql, conditions);
+  // filter on uuid
+  if (options.uuid) {
+    const id = db.bid(options.uuid);
+    conditions.statements.push('p.uuid = ?');
+    conditions.parameters.push(id);
+    delete options.uuid;
+  }
+
+  // filter on min date
+  if (options.dateFrom) {
+    conditions.statements.push('DATE(p.trans_date) >= ?');
+    conditions.parameters.push(new Date(options.dateFrom));
+    delete options.dateFrom;
+  }
+
+  // filter on max date
+  if (options.dateTo) {
+    conditions.statements.push('DATE(p.trans_date) <= ?');
+    conditions.parameters.push(new Date(options.dateTo));
+    delete options.dateTo;
+  }
+
+  if (options.comment) {
+    conditions.statements.push(`p.comment LIKE "%${options.comment}%"`);
+    delete options.comment;
+  }
+
+  // this accounts for currency_id, user_id, trans_id, account_id, etc ..
+
+  // assign query parameters as needed
+  let { statements, parameters } = util.parseQueryStringToSQL(options, 'p');
+  conditions.statements = _.concat(conditions.statements, statements);
+  conditions.parameters = _.concat(conditions.parameters, parameters);
+
+  sql = sql.replace('SQL_CONDITIONS', conditions.statements.join(' AND '));
+
+  // finally, apply the LIMIT query
+  if (!isNaN(limit)) {
+    sql += ' LIMIT ?;';
+    conditions.parameters.push(limit);
+  }
+
+  return db.exec(sql, conditions.parameters);
+}
+
+/**
+ * GET /journal
+ * Getting data from the posting journal
+ */
+function list(req, res, next) {
+
+  let promise;
+
+  // TODO - clean this up a bit.  We should only use a single column definition
+  // for both this and find()
+  if (_.isEmpty(req.query)) {
+    let sql = `
+      SELECT BUID(p.uuid) AS uuid, p.project_id, p.fiscal_year_id, p.period_id,
+        p.trans_id, p.trans_date, BUID(p.record_uuid) AS record_uuid,
+        dm1.text AS hrRecord, p.description, p.account_id, p.debit, p.credit,
+        p.debit_equiv, p.credit_equiv, p.currency_id, c.name AS currencyName,
+        BUID(p.entity_uuid) AS entity_uuid, em.text AS hrEntity,
+        BUID(p.reference_uuid) AS reference_uuid, dm2.text AS hrReference,
+        p.comment, p.origin_id, p.user_id, p.cc_id, p.pc_id, pro.abbr,
+        pro.name AS project_name, per.start_date AS period_start,
+        per.end_date AS period_end, a.number AS account_number, u.display_name
+      FROM posting_journal p
+        JOIN project pro ON pro.id = p.project_id
+        JOIN period per ON per.id = p.period_id
+        JOIN account a ON a.id = p.account_id
+        JOIN user u ON u.id = p.user_id
+        JOIN currency c ON c.id = p.currency_id
+        LEFT JOIN entity_map em ON em.uuid = p.entity_uuid
+        LEFT JOIN document_map dm1 ON dm1.uuid = p.record_uuid
+        LEFT JOIN document_map dm2 ON dm2.uuid = p.reference_uuid
+      ORDER BY p.trans_date DESC
+    `;
+
+    promise = db.exec(sql);
+  } else {
+    promise = find(req.query);
+  }
+
+  promise
+    .then(rows => {
+      res.status(200).json(rows);
+    })
+    .catch(next)
+    .done();
 }
 
 /**
  * GET /journal/:record_uuid
  * send back a set of lines which have the same record_uuid the which provided by the user
  */
-function getTransaction (req, res, next){
+function getTransaction (req, res, next) {
   lookupTransaction(req.params.record_uuid)
-    .then(function (transaction) {
+    .then(transaction => {
       res.status(200).json(transaction);
     })
     .catch(next)

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -177,9 +177,9 @@ function find(options) {
   // this accounts for currency_id, user_id, trans_id, account_id, etc ..
 
   // assign query parameters as needed
-  let { statements, parameters } = util.parseQueryStringToSQL(options, 'p');
-  conditions.statements = _.concat(conditions.statements, statements);
-  conditions.parameters = _.concat(conditions.parameters, parameters);
+  let destruct = util.parseQueryStringToSQL(options, 'p');
+  conditions.statements = _.concat(conditions.statements, destruct.statements);
+  conditions.parameters = _.concat(conditions.parameters, destruct.parameters);
 
   sql = sql.replace('SQL_CONDITIONS', conditions.statements.join(' AND '));
 

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -264,7 +264,7 @@ function lookupByDebtorUuid(debtorUuid) {
       p.father_name, p.mother_name, p.religion, p.marital_status, p.profession, p.employer, p.spouse,
       p.spouse_profession, p.spouse_employer, p.notes, p.avatar, proj.abbr, d.text,
       dg.account_id, BUID(dg.price_list_uuid) AS price_list_uuid, dg.is_convention, BUID(dg.uuid) as debtor_group_uuid,
-      dg.locked, dg.name as debtor_group_name, u.username, a.number 
+      dg.locked, dg.name as debtor_group_name, u.username, a.number
     FROM patient AS p JOIN project AS proj JOIN debtor AS d JOIN debtor_group AS dg JOIN user AS u JOIN account AS a
     ON p.debtor_uuid = d.uuid AND d.group_uuid = dg.uuid AND p.project_id = proj.id AND p.user_id = u.id AND a.id = dg.account_id
     WHERE p.debtor_uuid = ?;

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -14,6 +14,7 @@ const q = require('q');
 
 /** The query string conditions builder */
 module.exports.queryCondition = queryCondition;
+module.exports.parseQueryStringToSQL = parseQueryStringToSQL;
 module.exports.take = take;
 module.exports.isTrueString = isTrueString;
 module.exports.isFalsy = isFalsy;
@@ -66,6 +67,25 @@ function queryCondition(sql, params, excludeWhere, dateConditon) {
 
   sql += (excludeWhere ? '' : 'WHERE ') + criteria;
   return { query: sql, conditions : conditions };
+}
+
+// prefix is a string
+function parseQueryStringToSQL(options, tablePrefix) {
+  let conditions = {
+    statements: [],
+    parameters: []
+  };
+
+  tablePrefix = tablePrefix || '';
+
+  let escapedKeys = _.mapKeys(options, (value, key) => tablePrefix.concat('.', key));
+
+  _.forEach(escapedKeys, (value, key) => {
+    conditions.statements.push(`${key} = ?`);
+    conditions.parameters.push(value);
+  });
+
+  return conditions;
 }
 
 

--- a/server/models/test/data.sql
+++ b/server/models/test/data.sql
@@ -457,7 +457,7 @@ INSERT INTO `posting_journal` VALUES
   (HUID(UUID()),1,1,16,'TRANS4','2016-01-09 17:04:27',@second_voucher,'description x',3627,200.0000,0.0000,200.0000,0.0000,2,NULL,NULL,NULL,'Sample voucher data two',1,2,1,NULL),
   (HUID(UUID()),1,1,16,'TRANS4','2016-01-09 17:04:27',@second_voucher,'description x',3628,0.0000,200.0000,0.0000,200.0000,2,NULL,NULL,NULL,'Sample voucher data two',1,2,1,NULL),
   (HUID(UUID()),1,1,16,'TRANS5','2016-01-09 17:04:27',@third_voucher,'description x',3627,300.0000,0.0000,300.0000,0.0000,2,NULL,'D',NULL,'Sample voucher data three',1,2,1,NULL),
-  (HUID(UUID()),1,1,16,'TRANS5','2016-02-09 17:04:27',@third_voucher,'description x',3628,0.0000,300.0000,0.0000,300.0000,2,NULL,NULL,NULL,'Sample voucher data three',1,2,1,NULL);
+  (HUID(UUID()),1,1,16,'TRANS5','2016-02-09 17:04:27',@third_voucher,'unique',3628,0.0000,300.0000,0.0000,300.0000,2,NULL,NULL,NULL,'Sample voucher data three',1,2,1,NULL);
 
 -- zones des santes SNIS
 INSERT INTO `mod_snis_zs` VALUES

--- a/test/integration/journal.js
+++ b/test/integration/journal.js
@@ -9,15 +9,8 @@ const helpers = require('./helpers');
  */
 describe('(/journal) API endpoint', function () {
 
-  /**
-   * object containing different format of transaction to send to the
-   *server in order to get data
-   **/
-  var parameters = {
-    allRecords : {number : 8},
-    fetchingTransaction : {reference : 'a5a5f950-a4c9-47f0-9a9a-2bfc3123e534'},
-    unExistTransaction : {reference : 'a5a5f950-a4c9-47f0-9a9a-2bfc3123e635'}
-  };
+  const RECORD_UUID = 'a5a5f950-a4c9-47f0-9a9a-2bfc3123e534';
+  const MISSING_RECORD_UUID = 'a5a5f950-a4c9-47f0-9a9a-2bfc3123e635';
 
   const NUM_ROW_ALL_RECORDS = 13;
   const NUM_ROWS_FETCHING_TRANSACTION = 2;
@@ -31,7 +24,7 @@ describe('(/journal) API endpoint', function () {
   });
 
   it('GET /journal/:record_uuid : it returns a transaction which is an array of record', function () {
-    return agent.get('/journal/' + parameters.fetchingTransaction.reference)
+    return agent.get(`/journal/${RECORD_UUID}`)
       .then(function (res) {
         helpers.api.listed(res, NUM_ROWS_FETCHING_TRANSACTION);
       })
@@ -39,10 +32,49 @@ describe('(/journal) API endpoint', function () {
   });
 
   it('GET /journal/:record_id : it returns an error message and 404 code if the transaction does not exist ', function () {
-    return agent.get('/journal/' + parameters.unExistTransaction.reference)
+    return agent.get(`/journal/${MISSING_RECORD_UUID}`)
       .then(function (res) {
         helpers.api.errored(res, 404);
       })
       .catch(helpers.handler);
   });
+
+  describe('Searching', SearchTests);
 });
+
+function SearchTests() {
+
+  const description = 'unique';
+  const account_id = 3628;
+
+  it(`GET /journal?description=${description} should match one record`, function () {
+    const NUM_MATCHES = 1;
+    return agent.get('/journal')
+      .query({ description })
+      .then(function (res) {
+        helpers.api.listed(res, NUM_MATCHES);
+      })
+      .catch(helpers.handler);
+  });
+
+  it(`GET /journal filters should be additive`, function () {
+    const NUM_MATCHES = 1;
+    return agent.get('/journal')
+      .query({ description, account_id })
+      .then(function (res) {
+        helpers.api.listed(res, NUM_MATCHES);
+      })
+      .catch(helpers.handler);
+  });
+
+  it(`GET /journal filters should find items by account`, function () {
+    const NUM_MATCHES = 3;
+    return agent.get('/journal')
+      .query({ account_id })
+      .then(function (res) {
+        helpers.api.listed(res, NUM_MATCHES);
+      })
+      .catch(helpers.handler);
+  });
+
+}


### PR DESCRIPTION
This feature implements a few filters for the Posting Journal.  See the screenshot below:

![journalfilters](https://cloud.githubusercontent.com/assets/896472/20178313/d8764f36-a750-11e6-9f87-3d569d6ca21c.png)
_Fig 1: Posting Journal Filter Form_

When the filters are applied, they show up in the filter bar, which is hidden whenever no filtering is applied.  See below

![filterbar](https://cloud.githubusercontent.com/assets/896472/20178405/4ac56018-a751-11e6-8b62-aff377e2fe7c.png)
_Fig 2: Posting Journal Filter Bar_

In order to make these filters powerful, some more infrastructure needs to be implemented.  See #876 for one idea.

At the moment, the only implemented filters are 
 1. transaction date
 2. user_id
 3. account_id
 4. description (fuzzy search)

... on the client, although the server supports filtering on every column of the Posting Journal.

These provide good examples of how to implement the filters, and any other developer can add in a filter or two.

---
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!