### PR TITLE
(Chore) Default date sort on cash window invoices

### DIFF
--- a/client/src/partials/cash/modals/invoices.modal.js
+++ b/client/src/partials/cash/modals/invoices.modal.js
@@ -36,7 +36,13 @@ function CashInvoiceModalController(Debtors, debtorId, invoiceIds, ModalInstance
     columnDefs : [
       { name : 'reference'},
       { name : 'balance', cellFilter: 'currency:' + Session.enterprise.currencyId},
-      { name : 'date', cellFilter: 'date' }
+
+      // sort by date column by default
+      {
+        name : 'date',
+        cellFilter: 'date',
+        sort : { priority : 0, direction : 'desc' }
+      }
     ],
     minRowsToShow : 10
   };

--- a/client/src/partials/templates/modals/findReference.modal.js
+++ b/client/src/partials/templates/modals/findReference.modal.js
@@ -82,7 +82,14 @@ function FindReferenceModalController(Instance, Debtor, Creditor, Voucher, Cash,
 
       vm.gridOptions.columnDefs = [
         { field : 'reference', displayName : 'TABLE.COLUMNS.REFERENCE', headerCellFilter: 'translate' },
-        { field : 'date', cellFilter:'date', filter : { condition : filtering.byDate }, displayName : 'TABLE.COLUMNS.BILLING_DATE', headerCellFilter : 'translate' },
+        {
+          field : 'date',
+          cellFilter:'date',
+          filter : { condition : filtering.byDate },
+          displayName : 'TABLE.COLUMNS.BILLING_DATE',
+          headerCellFilter : 'translate',
+          sort : { priority : 0, direction : 'desc'}
+        },
         { field : 'patientNames', displayName : 'TABLE.COLUMNS.PATIENT', headerCellFilter : 'translate' },
         { field : 'cost', displayName : 'TABLE.COLUMNS.COST', headerCellFilter : 'translate', cellTemplate: costTemplate },
         { field : 'serviceName', displayName : 'TABLE.COLUMNS.SERVICE', headerCellFilter : 'translate'  },
@@ -103,7 +110,14 @@ function FindReferenceModalController(Instance, Debtor, Creditor, Voucher, Cash,
 
       vm.gridOptions.columnDefs = [
         { field : 'reference', displayName : 'TABLE.COLUMNS.REFERENCE', headerCellFilter: 'translate' },
-        { field : 'date', cellFilter:'date', filter : { condition : filtering.byDate }, displayName : 'TABLE.COLUMNS.BILLING_DATE', headerCellFilter : 'translate' },
+        {
+          field : 'date',
+          cellFilter:'date',
+          filter : { condition : filtering.byDate },
+          displayName : 'TABLE.COLUMNS.BILLING_DATE',
+          headerCellFilter : 'translate',
+          sort : { priority : 0, direction : 'desc'}
+        },
         { field : 'description', displayName : 'TABLE.COLUMNS.DESCRIPTION', headerCellFilter : 'translate' },
         { field : 'amount', displayName : 'TABLE.COLUMNS.COST', headerCellFilter : 'translate', cellTemplate: costTemplate }
       ];
@@ -122,7 +136,13 @@ function FindReferenceModalController(Instance, Debtor, Creditor, Voucher, Cash,
 
       vm.gridOptions.columnDefs  = [
         { field : 'reference', displayName : 'Reference'},
-        { field : 'date', displayName : 'Date', cellFilter : 'date:"mediumDate"', filter : { condition : filtering.byDate } },
+        {
+          field : 'date',
+          displayName : 'Date',
+          cellFilter : 'date:"mediumDate"',
+          filter : { condition : filtering.byDate },
+          sort : { priority : 0, direction : 'desc'}
+        },
         { field : 'description', displayName : 'Description'},
         { field : 'amount', displayName : 'Amount', cellTemplate: amountTemplate }
       ];


### PR DESCRIPTION
This commit changes the default behaviour of the cash window invoice
selection to show newest invoices first (Default sort priority, sort by
date DESC).

---

 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.