### PR TITLE
(Fix) Ensure rounding into gain account balances

### DIFF
--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -646,20 +646,11 @@ BEGIN
           actually debit them the additional amount. 
       */
       IF (remainder > 0) THEN
-
-        -- debit the debtor
-        INSERT INTO posting_journal (
-          uuid, project_id, fiscal_year_id, period_id, trans_id, trans_date,
-          record_uuid, description, account_id, debit, credit, debit_equiv,
-          credit_equiv, currency_id, user_id
-        ) SELECT
-          HUID(UUID()), cashProjectId, currentFiscalYearId, currentPeriodId, transactionId, c.date, c.uuid, c.description,
-          dg.account_id, remainder, 0, (remainder / currentExchangeRate), 0, c.currency_id, c.user_id
-        FROM cash AS c
-          JOIN debtor AS d ON c.debtor_uuid = d.uuid
-          JOIN debtor_group AS dg ON d.group_uuid = dg.uuid
-        WHERE c.uuid = cashUuid;
-
+  
+        -- The debtor is not debited in this transaction. They have already 
+        -- balanced the invoice and their debt according to the invoice (the 
+        -- exact amount). The additional payment can just be put in a gain account.
+        
         -- credit the rounding account
         INSERT INTO posting_journal (
           uuid, project_id, fiscal_year_id, period_id, trans_id, trans_date,


### PR DESCRIPTION
This commit removes the debit to the debtor after a gain on rounding to
the hospital. This debt is implicit in the gain to the hospital and
doesn't have to be recorded on the debtor's account - doing this causes
an unbalanced transaction to be recorded.

- [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.