### PR TITLE
refactor(cashboxes): migrate to account uiSelects

### DIFF
--- a/client/src/partials/cash/cashboxes/configure_currency/modal.html
+++ b/client/src/partials/cash/cashboxes/configure_currency/modal.html
@@ -20,28 +20,41 @@
 
     <div class="form-group" ng-class="{ 'has-error' : CashboxModalForm.$submitted && CashboxModalForm.account_id.$invalid }">
       <label class="control-label">{{ "FORM.LABELS.CASH_ACCOUNT" | translate }}</label>
-      <select
-        class="form-control"
+      <ui-select
         name="account_id"
         ng-model="CashboxModalCtrl.data.account_id"
-        ng-options="account.id as account.hrlabel disable when account.type === 'title' for account in ::CashboxModalCtrl.accounts"
         required>
-        <option value="" disabled>{{ "FORM.SELECT.ACCOUNT" | translate }}</option>
-      </select>
+        <ui-select-match placeholder="{{ 'FORM.SELECT.ACCOUNT' | translate }}">
+          <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
+        </ui-select-match>
+        <ui-select-choices
+          ui-select-focus-patch
+          ui-disable-choice="account.type_id === CashboxModalCtrl.bhConstants.accounts.TITLE"
+          repeat="account.id as account in ::CashboxModalCtrl.accounts | filter:$select.search">
+          <span ng-bind-html="account.number | highlight:$select.search"></span>
+          <small ng-bind-html="account.label | highlight:$select.search"></small>
+        </ui-select-choices>
+      </ui-select>
     </div>
 
     <div class="form-group" ng-class="{ 'has-error' : CashboxModalForm.$submitted && CashboxModalForm.transfer_account_id.$invalid }">
       <label class="control-label">{{ "FORM.LABELS.TRANSFER_ACCOUNT" | translate }}</label>
-      <select
-        class="form-control"
+      <ui-select
         name="transfer_account_id"
         ng-model="CashboxModalCtrl.data.transfer_account_id"
-        ng-options="account.id as account.hrlabel disable when account.type === 'title' for account in ::CashboxModalCtrl.accounts"
         required>
-        <option value="" disabled>{{ "FORM.SELECT.ACCOUNT" | translate }}</option>
-      </select>
+        <ui-select-match placeholder="{{ 'FORM.SELECT.ACCOUNT' | translate }}">
+          <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
+        </ui-select-match>
+        <ui-select-choices
+          ui-select-focus-patch
+          ui-disable-choice="account.type_id === CashboxModalCtrl.bhConstants.accounts.TITLE"
+          repeat="account.id as account in ::CashboxModalCtrl.accounts | filter:$select.search">
+          <span ng-bind-html="account.number | highlight:$select.search"></span>
+          <small ng-bind-html="account.label | highlight:$select.search"></small>
+        </ui-select-choices>
+      </ui-select>
     </div>
-
   </div>
 
   <div class="modal-footer">

--- a/client/src/partials/cash/cashboxes/configure_currency/modal.js
+++ b/client/src/partials/cash/cashboxes/configure_currency/modal.js
@@ -3,7 +3,7 @@ angular.module('bhima.controllers')
 
 CashboxCurrencyModalController.$inject = [
   '$uibModalInstance', 'AccountService', 'CashboxService',
-  'currency', 'cashbox', 'data'
+  'currency', 'cashbox', 'data', 'bhConstants'
 ];
 
 /**
@@ -13,13 +13,15 @@ CashboxCurrencyModalController.$inject = [
  * cashboxes.  Each cashbox must have a currencied account defined for each currency
  * supported by the application.
  */
-function CashboxCurrencyModalController(ModalInstance, Accounts, Boxes, currency, cashbox, data) {
+function CashboxCurrencyModalController(ModalInstance, Accounts, Boxes, currency, cashbox, data, bhConstants) {
   var vm = this;
 
   // if a currency matches, we are updating.  Otherwise, we are creating.
   var currencyIds = cashbox.currencies.map(function (row) {
     return row.currency_id;
   });
+
+  vm.bhConstants = bhConstants;
 
   // determine whether we will send a POST or a PUT request to the server
   var method = (currencyIds.indexOf(currency.id) > -1) ?

--- a/server/controllers/finance/accounts/index.js
+++ b/server/controllers/finance/accounts/index.js
@@ -124,7 +124,7 @@ function remove(req, res, next) {
  */
 function list(req, res, next) {
   let sql =
-    'SELECT a.id, a.number, a.label, a.locked FROM account AS a';
+    'SELECT a.id, a.number, a.label, a.locked, a.type_id FROM account AS a';
 
   let locked;
 

--- a/test/end-to-end/cashboxes/cashboxes.spec.js
+++ b/test/end-to-end/cashboxes/cashboxes.spec.js
@@ -38,9 +38,6 @@ describe('Cashboxes', function () {
 
     // make sure the success message shows
     components.notification.hasSuccess();
-
-    // click the cancel button
-    // FU.buttons.cancel();
   });
 
   it('successfully edits a cashbox', function () {
@@ -70,8 +67,8 @@ describe('Cashboxes', function () {
     FU.exists(by.css('[uib-modal-window]'), true);
     FU.exists(by.name('CashboxModalForm'), true);
 
-    FU.select('CashboxModalCtrl.data.account_id', 'Test Gain Account');
-    FU.select('CashboxModalCtrl.data.transfer_account_id', 'Test Loss Account');
+    FU.uiSelect('CashboxModalCtrl.data.account_id', 'Test Gain Account');
+    FU.uiSelect('CashboxModalCtrl.data.transfer_account_id', 'Test Loss Account');
 
     // submit the modal
     FU.modal.submit();
@@ -94,7 +91,7 @@ describe('Cashboxes', function () {
     // confirm that the modal appears
     FU.exists(by.css('[uib-modal-window]'), true);
 
-    FU.select('CashboxModalCtrl.data.account_id', 'First Test Item Account');
+    FU.uiSelect('CashboxModalCtrl.data.account_id', 'First Test Item Account');
 
     // submit the modal
     FU.modal.submit();
@@ -106,7 +103,7 @@ describe('Cashboxes', function () {
     FU.validation.ok('CashboxModalCtrl.data.account_id');
     FU.validation.error('CashboxModalCtrl.data.transfer_account_id');
 
-    FU.select('CashboxModalCtrl.data.transfer_account_id', 'Test Expense Accounts');
+    FU.uiSelect('CashboxModalCtrl.data.transfer_account_id', 'Test Debtor Group Account');
 
     // submit the modal
     FU.modal.submit();


### PR DESCRIPTION
This commit refactors the cashboxes currency modal to use uiSelects for the account selection instead of the original HTML select elements.  It also disables accounts with TITLE account ids from selection.

![disabledaccountuiselect](https://cloud.githubusercontent.com/assets/896472/20212398/44406816-a803-11e6-94ee-65bbaa8163fb.png)
_Fig 1: uiSelects for account selection with disabled title accounts_

This is the last piece of refactor for the cashboxes page.

Closes #780.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!