### PR TITLE
fix(cash): modal does not close on ESC

### DIFF
--- a/client/src/js/services/receipts/ReceiptModal.js
+++ b/client/src/js/services/receipts/ReceiptModal.js
@@ -139,7 +139,8 @@ function ReceiptModal(Modal, Receipts) {
       resolve : {
         receipt       : function receiptProvider() { return { promise : cashRequest }; },
         options       : function optionsProvider() { return options; },
-      }
+      },
+      keyboard      : false
     };
 
     var configuration = angular.extend(modalConfiguration, reportProvider);


### PR DESCRIPTION
This commit prevents the cash modal from closing on the escape key.

Closes #869.

-----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!