### PR TITLE
fix(vouchers): disable title accounts

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -1405,7 +1405,8 @@
       "USE_FINANCIAL_ACCOUNT" : "Use of cashes or banks accounts in this transaction",
       "RECEIPT" :  {
         "SUCCESS" : "Voucher Payment recorded successfully."
-      }
+      },
+      "ERROR_SAME_ACCOUNT" : "You cannot use the same account twice to in this transaction. Please select two different accounts."
     },
     "SIMPLE": {
       "CASH_PAYMENT"       : "Client Payment",

--- a/client/src/partials/vouchers/complex.js
+++ b/client/src/partials/vouchers/complex.js
@@ -24,6 +24,8 @@ ComplexJournalVoucherController.$inject = [
 function ComplexJournalVoucherController(Vouchers, $translate, Accounts, Currencies, Session, FindEntity, FindReference, Notify, Cashbox, Receipts, bhConstants) {
   var vm = this;
 
+  vm.bhConstants = bhConstants;
+
   // bread crumb paths
   vm.paths = [{
     label : $translate.instant('VOUCHERS.COMPLEX.TITLE'),

--- a/client/src/partials/vouchers/simple.html
+++ b/client/src/partials/vouchers/simple.html
@@ -80,12 +80,14 @@
                  <ui-select
                    name="fromAccount"
                    ng-model="SimpleVoucherCtrl.voucher.fromAccount"
-                   theme="bootstrap"
                    required>
                    <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
                      <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
                    </ui-select-match>
-                   <ui-select-choices ui-select-focus-patch repeat="account in SimpleVoucherCtrl.accounts | filter:$select.search">
+                   <ui-select-choices
+                     ui-select-focus-patch
+                     ui-disable-choice="account.type_id === SimpleVoucherCtrl.bhConstants.accounts.TITLE"
+                     repeat="account in SimpleVoucherCtrl.accounts | filter:$select.search">
                      <strong ng-bind-html="account.number | highlight:$select.search"></strong>
                      <span ng-bind-html="account.label | highlight:$select.search"></span>
                    </ui-select-choices>
@@ -105,12 +107,14 @@
                 <ui-select
                   name="toAccount"
                   ng-model="SimpleVoucherCtrl.voucher.toAccount"
-                  theme="bootstrap"
                   required>
                   <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
                     <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
                   </ui-select-match>
-                  <ui-select-choices ui-select-focus-patch repeat="account in SimpleVoucherCtrl.accounts | filter:$select.search">
+                     <ui-select-choices
+                       ui-select-focus-patch
+                       ui-disable-choice="account.type_id === SimpleVoucherCtrl.bhConstants.accounts.TITLE"
+                       repeat="account in SimpleVoucherCtrl.accounts | filter:$select.search">
                     <strong ng-bind-html="account.number | highlight:$select.search"></strong>
                     <span ng-bind-html="account.label | highlight:$select.search"></span>
                   </ui-select-choices>

--- a/client/src/partials/vouchers/simple.js
+++ b/client/src/partials/vouchers/simple.js
@@ -3,7 +3,7 @@ angular.module('bhima.controllers')
 
 SimpleJournalVoucherController.$inject = [
   'AppCache', 'VoucherService', 'AccountService', 'SessionService', 'util',
-  'NotifyService',  'ReceiptModal'
+  'NotifyService',  'ReceiptModal','bhConstants'
 ];
 
 /**
@@ -18,11 +18,13 @@ SimpleJournalVoucherController.$inject = [
  * @todo - Implement Voucher Templates to allow users to save pre-selected
  * forms (via AppCache and the breadcrumb component).
  */
-function SimpleJournalVoucherController(AppCache, Vouchers, Accounts, Session, util, Notify, Receipts) {
+function SimpleJournalVoucherController(AppCache, Vouchers, Accounts, Session, util, Notify, Receipts, bhConstants) {
   var vm = this;
 
   // cache to save work-in-progress data and pre-fabricated templates
   var cache = AppCache('JournalVouchers');
+
+  vm.bhConstants = bhConstants;
 
   // global variables
   vm.maxLength = util.maxTextLength;
@@ -74,6 +76,12 @@ function SimpleJournalVoucherController(AppCache, Vouchers, Accounts, Session, u
 
     // transfer type
     vm.voucher.type_id = vm.selectedType ? JSON.parse(vm.selectedType).id : null;
+
+    // make sure we are not using the same accounts for both fields
+    if (vm.voucher.toAccount.id === vm.voucher.fromAccount.id) {
+      Notify.danger('VOUCHERS.GLOBAL.ERROR_SAME_ACCOUNT');
+      return;
+    }
 
     // submit the voucher
     return Vouchers.createSimple(vm.voucher)

--- a/client/src/partials/vouchers/templates/account.grid.tmpl.html
+++ b/client/src/partials/vouchers/templates/account.grid.tmpl.html
@@ -3,14 +3,16 @@
    ng-model="row.entity.account"
    ng-change="grid.appScope.checkRowValidity(row.entity.index)"
    name="account"
-   theme="bootstrap"
    style="width:100%;"
    append-to-body="true"
    required>
    <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
      <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
    </ui-select-match>
-   <ui-select-choices ui-select-focus-patch repeat="account in grid.appScope.accounts | filter:$select.search">
+   <ui-select-choices
+     ui-select-focus-patch
+     ui-disable-choice="account.type_id === grid.appScope.bhConstants.accounts.TITLE"
+     repeat="account in grid.appScope.accounts | filter:$select.search">
      <strong ng-bind-html="account.number | highlight:$select.search"></strong>
      <span ng-bind-html="account.label | highlight:$select.search"></span>
    </ui-select-choices>

--- a/test/end-to-end/vouchers/complex.spec.js
+++ b/test/end-to-end/vouchers/complex.spec.js
@@ -25,7 +25,7 @@ describe('Complex Vouchers', function () {
         { account : 'Test Debtor Accounts1', debit: 18, credit: 0, entity : { type : 'D', name: 'Patient/2/Patient' }},
         { account : 'Test Capital One', debit: 0, credit: 8, reference : { type : 'voucher', index : 0 }},
         { account : 'Test Capital Two', debit: 0, credit: 5, reference : { type : 'voucher', index : 2 }},
-        { account : 'Test Balance Accounts', debit: 0, credit: 5, reference : { type : 'voucher', index : 1 }},
+        { account : 'First Test Item Account', debit: 0, credit: 5, reference : { type : 'voucher', index : 1 }},
         { account : 'Test Capital One', debit: 7, credit: 0, entity : { type : 'C', name : 'Fournisseur' }},
         { account : 'Test Capital Two', debit: 0, credit: 7, reference : { type : 'patient-invoice', index : 1 }}
       ]

--- a/test/end-to-end/vouchers/simple.spec.js
+++ b/test/end-to-end/vouchers/simple.spec.js
@@ -15,7 +15,7 @@ describe('Simple Vouchers', function () {
     date: yesterday,
     type: 'transfer',
     toAccount: 'Test Debtor Group Account',
-    fromAccount: 'Updated inventory accounts',
+    fromAccount: 'First Test Item Account',
     description: 'Awesome description',
     amount: 100.12
   };


### PR DESCRIPTION
This commit disables the title accounts on all voucher pages.  The title
accounts are still shown, but are disabled by checking the TITLE
bhConstant value.

It also does not allow a user to use the same account twice in a simple
voucher, as this would lead to an invalid transaction.

Closes #884.  Closes #896.

-----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!