### PR TITLE
(Feature) Current exchanged value presented on invoices

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -255,7 +255,11 @@
     "NEW_RATE"            : "New Exchange Rate",
     "RATE_SET"            : "Rate last set",
     "REVIEW_RATE"         : "Review the exchange rate",
-    "TITLE"               : "Exchange Rate Management"
+    "TITLE"               : "Exchange Rate Management",
+    "REVIEW"              : "Review Rates ",
+    "INVOICE_DISCLAIMER"  : "Exchange rate based on the latest enterprise exchange:",
+    "SET_AS"              : "Set as",
+    "ON"                  : "on"
   },
   "FISCAL": {
     "ALREADY_CLOSED"        : "Already closed",
@@ -812,7 +816,8 @@
     "LIST_UNIT"     : "Inventory Unit form"
   },
   "INVOICE_REGISTRY" : {
-    "TITLE" : "Invoice Registry"
+    "TITLE" : "Invoice Registry",
+    "RECEIPT_CURRENCY" : "Receipt Currency"
   },
   "LOCATION": {
     "DESCRIPTION"           : "Location Manager Configuration is used to create location and to store it in the system, locations are very importants when you register a patient and so one. Use this module to",

--- a/client/src/js/components/bhReceiptCurrency.js
+++ b/client/src/js/components/bhReceiptCurrency.js
@@ -1,0 +1,48 @@
+angular.module('bhima.components').component('bhReceiptCurrency', {
+  templateUrl : 'partials/templates/bhReceiptCurrency.tmpl.html',
+  controller : ReceiptCurrencyController,
+  bindings : {
+    onUpdate : '&'
+  }
+});
+
+ReceiptCurrencyController.$inject = ['CurrencyService', 'SessionService', 'AppCache', 'Store'];
+
+/**
+ * Receipt Currency Component
+ *
+ */
+function ReceiptCurrencyController(Currencies, Session, AppCache, Store) {
+  var ctrl = this;
+  var cache = new AppCache('ReceiptCurrencyComponent');
+
+  Currencies.read()
+    .then(function (currencies) {
+      ctrl.currencies = new Store();
+      ctrl.currencies.setData(currencies);
+      loadDefaultCurrency();
+    });
+
+  ctrl.update = function (currency) {
+    // update view with currency object (id and symbol)
+    ctrl.selectedCurrency = currency;
+
+    // update cache with id to select this currency object on next load
+    cache.selectedCurrencyId = currency.id;
+
+    // update bindings
+    ctrl.onUpdate({ currencyId : currency.id });
+  };
+
+  function loadDefaultCurrency() {
+    // if the cache exists - use that
+    var cached = cache.selectedCurrencyId;
+    if (cached) {
+      ctrl.update(ctrl.currencies.get(cached));
+      return;
+    }
+
+    // no cached value - use the enterprise currency
+    ctrl.update(ctrl.currencies.get(Session.enterprise.currency_id));
+  }
+}

--- a/client/src/js/services/receipts/ReceiptModal.js
+++ b/client/src/js/services/receipts/ReceiptModal.js
@@ -38,7 +38,7 @@ function ReceiptModal(Modal, Receipts) {
    * @param {String} uuid             Target invoice UUID
    * @param {Boolean} notifyCreated   Defines if a success message should be shown for entity creation
    */
-  function invoice(uuid, notifyCreated) {
+  function invoice(uuid, notifyCreated, userOptions) {
 
     /** @todo Discuss if these should be overridable from the controller or if the config should be set here */
     var options = {
@@ -49,7 +49,12 @@ function ReceiptModal(Modal, Receipts) {
       notifyCreated : notifyCreated
     };
 
-    var invoiceRequest = Receipts.invoice(uuid, { renderer : options.renderer });
+    var receiptOptions = {
+      renderer      : Receipts.renderers.PDF
+    };
+    angular.extend(receiptOptions, userOptions);
+
+    var invoiceRequest = Receipts.invoice(uuid, receiptOptions);
     var invoiceProvider = {
       resolve : {
         receipt       : function receiptProvider() { return { promise : invoiceRequest }; },

--- a/client/src/partials/patient_invoice/registry/registry.html
+++ b/client/src/partials/patient_invoice/registry/registry.html
@@ -23,15 +23,8 @@
 
 
       <div class="toolbar-item">
-        <div class="btn-group" uib-dropdown dropdown-append-to-body>
-          <button class="btn btn-default" uib-dropdown-toggle>{{ "INVOICE_REGISTRY.RECEIPT_CURRENCY" | translate }}</button>
-          <button style="min-width : 30px" class="btn btn-default">
-            <span>{{InvoiceRegistryCtrl.selectedCurrency.symbol}}</span>
-          </button>
-          <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-            <li ng-repeat="currency in InvoiceRegistryCtrl.currencies track by currency.id" role="menuitem"><a ng-click="InvoiceRegistryCtrl.setCurrency(currency)" href>{{currency.name}} (<b>{{currency.symbol}}</b>)</a></li>
-          </ul>
-        </div>
+        <bh-receipt-currency
+          on-update="InvoiceRegistryCtrl.setReceiptCurrency(currencyId)" />
       </div>
     </div>
   </div>

--- a/client/src/partials/patient_invoice/registry/registry.html
+++ b/client/src/partials/patient_invoice/registry/registry.html
@@ -20,6 +20,19 @@
         >
         </bh-pdf-print>
       </div>
+
+
+      <div class="toolbar-item">
+        <div class="btn-group" uib-dropdown dropdown-append-to-body>
+          <button class="btn btn-default" uib-dropdown-toggle>{{ "INVOICE_REGISTRY.RECEIPT_CURRENCY" | translate }}</button>
+          <button style="min-width : 30px" class="btn btn-default">
+            <span>{{InvoiceRegistryCtrl.selectedCurrency.symbol}}</span>
+          </button>
+          <ul class="dropdown-menu" uib-dropdown-menu role="menu">
+            <li ng-repeat="currency in InvoiceRegistryCtrl.currencies track by currency.id" role="menuitem"><a ng-click="InvoiceRegistryCtrl.setCurrency(currency)" href>{{currency.name}} (<b>{{currency.symbol}}</b>)</a></li>
+          </ul>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/client/src/partials/patient_invoice/registry/registry.js
+++ b/client/src/partials/patient_invoice/registry/registry.js
@@ -84,7 +84,6 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util,
 
   Currencies.read()
     .then(function (currencies) {
-      console.log('got currencies', currencies);
       vm.currencies = currencies;
     });
 

--- a/client/src/partials/patient_invoice/registry/registry.js
+++ b/client/src/partials/patient_invoice/registry/registry.js
@@ -4,7 +4,7 @@ angular.module('bhima.controllers')
 InvoiceRegistryController.$inject = [
   'PatientInvoiceService', 'bhConstants', 'NotifyService',
   'SessionService', 'util', 'ReceiptModal', 'appcache',
-  'uiGridConstants'
+  'uiGridConstants', 'CurrencyService'
 ];
 
 /**
@@ -12,13 +12,14 @@ InvoiceRegistryController.$inject = [
  *
  * This module is responsible for the management of Invoice Registry.
  */
-function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util, Receipt, AppCache, uiGridConstants) {
+function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util, Receipt, AppCache, uiGridConstants, Currencies) {
   var vm = this;
 
   var cache = AppCache('InvoiceRegistry');
 
   vm.search = search;
   vm.openReceiptModal = Receipt.invoice;
+  vm.setCurrency = setCurrency;
   vm.onRemoveFilter = onRemoveFilter;
   vm.clearFilters = clearFilters;
   vm.creditNote = creditNote;
@@ -57,6 +58,21 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util,
     rowTemplate : '/partials/patient_invoice/templates/grid.creditNote.tmpl.html'
   };
 
+  // receipt options
+  vm.selectedCurrency = {
+    id : vm.enterprise.currency_id,
+    symbol : vm.enterprise.currencySymbol
+  };
+
+  vm.receiptOptions = {
+    currency : vm.selectedCurrency.id
+  };
+
+  function setCurrency(currency) {
+    vm.selectedCurrency = currency;
+    vm.receiptOptions.currency = vm.selectedCurrency.id;
+  }
+
   function handler(error) {
     vm.hasError = true;
     Notify.handleError(error);
@@ -65,6 +81,12 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util,
   function toggleLoadingIndicator() {
     vm.loading = !vm.loading;
   }
+
+  Currencies.read()
+    .then(function (currencies) {
+      console.log('got currencies', currencies);
+      vm.currencies = currencies;
+    });
 
   // this function loads invoices from the database with search parameters
   // if passed in.
@@ -79,7 +101,7 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util,
     }
 
     // if we have search parameters, use search.  Otherwise, just read all
-    // invoices.    
+    // invoices.
     var request = angular.isDefined(parameters) ?
       Invoices.search(parameters) :
       Invoices.read();

--- a/client/src/partials/patient_invoice/registry/registry.js
+++ b/client/src/partials/patient_invoice/registry/registry.js
@@ -4,7 +4,7 @@ angular.module('bhima.controllers')
 InvoiceRegistryController.$inject = [
   'PatientInvoiceService', 'bhConstants', 'NotifyService',
   'SessionService', 'util', 'ReceiptModal', 'appcache',
-  'uiGridConstants', 'CurrencyService'
+  'uiGridConstants'
 ];
 
 /**
@@ -12,14 +12,13 @@ InvoiceRegistryController.$inject = [
  *
  * This module is responsible for the management of Invoice Registry.
  */
-function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util, Receipt, AppCache, uiGridConstants, Currencies) {
+function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util, Receipt, AppCache, uiGridConstants) {
   var vm = this;
 
   var cache = AppCache('InvoiceRegistry');
 
   vm.search = search;
   vm.openReceiptModal = Receipt.invoice;
-  vm.setCurrency = setCurrency;
   vm.onRemoveFilter = onRemoveFilter;
   vm.clearFilters = clearFilters;
   vm.creditNote = creditNote;
@@ -57,21 +56,12 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util,
     enableSorting : true,
     rowTemplate : '/partials/patient_invoice/templates/grid.creditNote.tmpl.html'
   };
+  vm.receiptOptions = {};
 
-  // receipt options
-  vm.selectedCurrency = {
-    id : vm.enterprise.currency_id,
-    symbol : vm.enterprise.currencySymbol
+  // receiptOptions are used in the bh-print directive under the receipt-action template
+  vm.setReceiptCurrency = function setReceiptCurrency(currencyId) {
+    vm.receiptOptions.currency = currencyId;
   };
-
-  vm.receiptOptions = {
-    currency : vm.selectedCurrency.id
-  };
-
-  function setCurrency(currency) {
-    vm.selectedCurrency = currency;
-    vm.receiptOptions.currency = vm.selectedCurrency.id;
-  }
 
   function handler(error) {
     vm.hasError = true;
@@ -81,11 +71,6 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util,
   function toggleLoadingIndicator() {
     vm.loading = !vm.loading;
   }
-
-  Currencies.read()
-    .then(function (currencies) {
-      vm.currencies = currencies;
-    });
 
   // this function loads invoices from the database with search parameters
   // if passed in.

--- a/client/src/partials/patient_invoice/registry/templates/invoiceReceipt.action.tmpl.html
+++ b/client/src/partials/patient_invoice/registry/templates/invoiceReceipt.action.tmpl.html
@@ -1,5 +1,5 @@
 <div class="ui-grid-cell-contents">
-  <a href ng-click="grid.appScope.openReceiptModal(row.entity.uuid)" data-method="receipt">
+  <a href ng-click="grid.appScope.openReceiptModal(row.entity.uuid, false, grid.appScope.receiptOptions)" data-method="receipt">
     <i class="fa fa-file-pdf-o"></i> {{ "TABLE.COLUMNS.RECEIPT" | translate }}
   </a>
 </div>

--- a/client/src/partials/templates/bhFindPatient.tmpl.html
+++ b/client/src/partials/templates/bhFindPatient.tmpl.html
@@ -33,7 +33,8 @@
         ng-model-options="{ 'debounce' : { 'default' : 150, 'blur' : 0 }}"
         ng-if="$ctrl.selected == $ctrl.options.findById"
         ng-keypress="$ctrl.onKeyPress($event)"
-        placeholder="{{ $ctrl.selected.placeholder | translate }}...",
+        placeholder="{{ $ctrl.selected.placeholder | translate }}..."
+        autocomplete="off"
         ng-required="$ctrl.required">
 
       <!-- search by Name  -->
@@ -51,6 +52,7 @@
         typeahead-template-url="/partials/templates/patientList.tmpl.html"
         typeahead-on-select="$ctrl.selectPatient($item)"
         placeholder="{{ $ctrl.selected.placeholder | translate }}..."
+        autocomplete="off"
         ng-required="$ctrl.required">
 
       <!-- submit button for search by ID -->

--- a/client/src/partials/templates/bhReceiptCurrency.tmpl.html
+++ b/client/src/partials/templates/bhReceiptCurrency.tmpl.html
@@ -1,0 +1,11 @@
+<div class="btn-group" uib-dropdown dropdown-append-to-body>
+  <button class="btn btn-default" uib-dropdown-toggle>{{ "INVOICE_REGISTRY.RECEIPT_CURRENCY" | translate }}</button>
+  <button style="min-width : 30px" class="btn btn-default">
+    <span>{{$ctrl.selectedCurrency.symbol || '-'}}</span>
+  </button>
+  <ul class="dropdown-menu" uib-dropdown-menu role="menu">
+    <li ng-repeat="currency in $ctrl.currencies.data track by currency.id" role="menuitem">
+      <a ng-click="$ctrl.update(currency)" href>{{currency.name}} (<b>{{currency.symbol}}</b>)</a>
+    </li>
+  </ul>
+</div>

--- a/server/controllers/finance/reports/invoices/receipt.handlebars
+++ b/server/controllers/finance/reports/invoices/receipt.handlebars
@@ -131,11 +131,20 @@
         </tr>
 
         <!-- Bill exchange -->
-        <!-- <tr -->
-          <!-- td class="text-right">Exchange</td -->
-          <!-- td>Value</td -->
-        <!-- /tr -->
-
+        {{#if exchange}}
+          <tr>
+            <td colspan="2">{{{translate 'EXCHANGE.INVOICE_DISCLAIMER'}}}</td>
+          </tr>
+          <tr>
+            <td colspan="2">{{{translate 'EXCHANGE.SET_AS'}}} 1:{{exchange}} {{{translate 'EXCHANGE.ON'}}} {{dateFormat}}</td>
+          </tr>
+          <tr>
+            <td></td>
+            <td class="text-right">
+              <h1><b>{{{currency exchangedTotal receiptCurrency}}}</b></h1>
+            </td>
+          </tr>
+        {{/if}}
       </table>
 
     </div>

--- a/server/controllers/finance/reports/invoices/receipt.handlebars
+++ b/server/controllers/finance/reports/invoices/receipt.handlebars
@@ -65,7 +65,7 @@
       <tr>
         <td>{{this.code}}</td>
         <td>{{this.text}}</td>
-        <td class="text-right">{{currency this.transaction_price ../metadata.enterprise.currency_id}}</td>
+        <td class="text-right">{{this.transaction_price}}</td>
         <td class="text-right">{{quantity}}</td>
         <td class="text-right">{{currency (multiply this.transaction_price quantity) ../metadata.enterprise.currency_id}}</td>
       </tr>
@@ -129,6 +129,13 @@
             <h1><b>{{currency cost metadata.enterprise.currency_id}}</b></h1>
           </td>
         </tr>
+
+        <!-- Bill exchange -->
+        <!-- <tr -->
+          <!-- td class="text-right">Exchange</td -->
+          <!-- td>Value</td -->
+        <!-- /tr -->
+
       </table>
 
     </div>

--- a/server/lib/template/helpers/finance.js
+++ b/server/lib/template/helpers/finance.js
@@ -16,10 +16,9 @@ const FC_FMT = {
 
 /** @todo use the currency filter fork written for the client to perform the same behaviour here */
 function currency(value, currencyId) {
-
   // if currencyId is not defined, defaults to USD.
   // @TODO - super-hardcoded values for the moment.  Can we do better?
-  const fmt = (currencyId === 1) ? FC_FMT : USD_FMT;
+  const fmt = (Number(currencyId) === 1) ? FC_FMT : USD_FMT;
   return accountingjs.formatMoney(value || 0, fmt);
 }
 


### PR DESCRIPTION
This pull requests adds a value in the selected currency to patient invoices. It uses the valid exchange rate at the time of invoice. 

If the enterprise currency is selected no exchange information is displayed.

**Receipt currency selection (Invoice registry module)**
![screenshot 2016-11-18 at 12 43 02](https://cloud.githubusercontent.com/assets/2844572/20429358/8cf8ef34-ad8e-11e6-8ddc-601d5db33752.png)

**Receipt displaying converted $:FC amount**
![screenshot 2016-11-18 at 12 43 27](https://cloud.githubusercontent.com/assets/2844572/20429423/cbcdd788-ad8e-11e6-8a87-8cb857ee7c1d.png)

The primary functionality is included in this pull request. Ideally to complete: 
- [x] Wrap currency selection from patient invoice registry module in a component (handles downloading of currencies etc.) 
- ~~Add receipt currency selection component to patient invoice module to allow receipts to be fetched in FC as they are made~~ To be designed

Future questions
* What is the best user experience for selecting the currency of an invoice or bill
* Should the entire invoice be displayed as FC - as the conversion happens on the lump sum (the total cost of the invoice) this could result in very inaccurate totals without hacks to prevent this

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/888
Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/902

 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.
