### PR TITLE
refactor(users): ensure loading indicators on POST

### DIFF
--- a/client/src/js/services/UserService.js
+++ b/client/src/js/services/UserService.js
@@ -20,6 +20,7 @@ function UserService($http, util) {
   service.projects = projects;
   service.updatePassword = updatePassword;
   service.updatePermissions = updatePermissions;
+  service.validatePassword = validatePassword;
 
   /* ------------------------------------------------------------------------ */
 
@@ -78,5 +79,20 @@ function UserService($http, util) {
   function updatePassword(id, data) {
     return $http.put('/users/' + id + '/password', data)
     .then(util.unwrapHttpResponse);
+  }
+
+  /**
+   * @function validatePassword
+   *
+   * @param {String} passwordA - a user password
+   * @param {String} passwordB - a challenge password
+   *
+   * @description
+   * This function exists to validate password inputs where two passwords are
+   * required and must be equal.  This is involved in updating/creating a user
+   * password to ensure that the password is correctly memorized by the user..
+   */
+  function validatePassword(passwordA, passwordB) {
+    return passwordA && passwordA.length && passwordA === passwordB;
   }
 }

--- a/client/src/partials/users/UserEditPasswordModal.js
+++ b/client/src/partials/users/UserEditPasswordModal.js
@@ -19,7 +19,7 @@ function UsersPasswordModalController($state, Users, Notify) {
 
   // checks if a valid password exists
   function validPassword() {
-    return vm.user.password && vm.user.password.length && vm.user.password === vm.user.passwordVerify;
+    return Users.validatePassword(vm.user.password, vm.user.passwordVerify);
   }
 
   // submits the password form
@@ -28,16 +28,16 @@ function UsersPasswordModalController($state, Users, Notify) {
     if (!passwordForm.$dirty || !validPassword()) { return; }
 
     // try to update the user's password
-    Users.updatePassword(vm.user.id, { password : vm.user.password })
+    return Users.updatePassword(vm.user.id, { password : vm.user.password })
       .then(function () {
         Notify.success('USERS.UPDATED');
-        $state.go('users.edit', {id : vm.user.id, creating : false}, {reload : false});
+        $state.go('users.edit', {id : vm.user.id, creating : false});
       })
       .catch(Notify.handleError);
   }
 
   function cancel() {
-    $state.go('users.edit', {id : vm.user.id, creating : false}, {reload : false});
+    $state.go('users.edit', {id : vm.user.id, creating : false});
   }
 
   Users.read($state.params.id)

--- a/client/src/partials/users/user.modal.js
+++ b/client/src/partials/users/user.modal.js
@@ -40,10 +40,9 @@ function UserModalController($state, Projects, Users, Notify) {
     if (userForm.$invalid) { return; }
     if (!userForm.$dirty) { return; }
 
-
     promise = (vm.isCreating) ? Users.create(vm.user) : Users.update(vm.user.id, vm.user);
 
-    promise
+    return promise
       .then(function () {
         var translateKey = (vm.isCreating) ?  'USERS.CREATED' : 'USERS.UPDATED';
         Notify.success(translateKey);
@@ -58,7 +57,7 @@ function UserModalController($state, Projects, Users, Notify) {
 
   // make sure that the passwords exist and match.
   function validPassword() {
-    return vm.user.password && vm.user.password.length && vm.user.password === vm.user.passwordVerify;
+    return Users.validatePassword(vm.user.password, vm.user.passwordVerify);
   }
 
   // opens a new modal to let the user set a password

--- a/client/src/partials/users/userPermission.modal.js
+++ b/client/src/partials/users/userPermission.modal.js
@@ -117,7 +117,7 @@ function UserPermissionModalController($translate, $http, $state, util, Users, N
         return u.id;
       });
 
-    Users.updatePermissions(vm.user.id, permissions)
+    return Users.updatePermissions(vm.user.id, permissions)
       .then(function () {
         Notify.success('USERS.UPDATED');
         $state.go('users.list', null, {reload : true});
@@ -126,7 +126,7 @@ function UserPermissionModalController($translate, $http, $state, util, Users, N
   }
 
   function closeModal (){
-    $state.go('users.list', null, {reload : false});
+    $state.go('users.list');
   }
 
   Users.read($state.params.id)


### PR DESCRIPTION
This commit hooks up the `bhSubmit` and `bhLoadingButtons` to properly
show a loading indicator when data is POSTed on the users and permission
page.

-----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!