### PR TITLE
fix(trial balance): incorrect button text

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -325,12 +325,13 @@
       "UPDATE_PASSWORD"       : "Update Password",
       "UPDATE"                : "Update",
       "VALIDATE"              : "Validate",
-      "VIEW_ERRORS"           : "View Errors"
+      "VIEW_ERRORS"           : "View Errors",
+      "VIEW_DETAILS"          : "View Details"
     },
     "DIALOGS": {
-      "CONFIRM_ACTION"         : "Do you confirm this action ?",
+      "CONFIRM_ACTION"         : "Do you confirm this action?",
       "CONFIRM_DELETE"         : "You are about to delete a record.  This action is permanent and cannot be undone.  Click \"Confirm\" to accept or \"Cancel\" to halt this action.",
-      "CANNOT_UNDONE_ACTION"   : "This action CANNOT BE REVERSED, this action will be permanent. You must be sure that you want to do this action",
+      "CANNOT_UNDONE_ACTION"   : "This action CANNOT BE REVERSED, the action will be permanent. You must be sure that you want to do this action.",
       "NO_CORRESPONDANCY"      : "No correspondancy found for ",
       "PLEASE_TYPE_TEXT"       : "Please type {{value}} to confirm",
       "PLEASE_READ"            : "Unexpected bad things will happen if you don't read this!",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -327,7 +327,8 @@
       "UPDATE_PASSWORD"       : "Modifier mot de passe",
       "UPDATE"                : "Mettre à jour",
       "VALIDATE"              : "Valider",
-      "VIEW_ERRORS"           : "Voir erreurs"
+      "VIEW_ERRORS"           : "Voir Erreurs",
+      "VIEW_DETAILS"          : "Voir les Détails"
     },
     "DIALOGS": {
       "CONFIRM_ACTION"         : "Confirmez vous cette action ?",

--- a/client/src/partials/journal/modals/trialBalanceMain.body.js
+++ b/client/src/partials/journal/modals/trialBalanceMain.body.js
@@ -39,7 +39,7 @@ function TrialBalanceMainBodyController(Session, trialBalanceService, Grouping, 
       headerCellFilter: 'translate',
       visible: true,
       enableCellEdit: false,
-      cellTemplate: '/partials/journal/templates/error-link.cell.html',
+      cellTemplate: '/partials/journal/templates/details-link.cell.html',
       allowCellFocus: false
     }
   ];

--- a/client/src/partials/journal/templates/details-link.cell.html
+++ b/client/src/partials/journal/templates/details-link.cell.html
@@ -1,0 +1,5 @@
+<div class="ui-grid-cell-contents">
+  <a href data-method="detail" ng-click="grid.appScope.viewDetailByAccount(row.entity.account_id)" class="text-info">
+    <i class="fa fa-info-circle"></i> {{ "FORM.BUTTONS.VIEW_DETAILS" | translate }}
+  </a>
+</div>

--- a/client/src/partials/journal/templates/error-link.cell.html
+++ b/client/src/partials/journal/templates/error-link.cell.html
@@ -1,5 +1,0 @@
-<div class="ui-grid-cell-contents">
-  <a href data-method="detail" ng-click="grid.appScope.viewDetailByAccount(row.entity.account_id)" class="text-danger">
-    <i class="fa fa-warning"></i> {{ "FORM.BUTTONS.VIEW_ERRORS" | translate }}
-  </a>
-</div>


### PR DESCRIPTION
This commit fixes the incorrect button text on the trial balance
reported in #908.  The text reads "View Details" instead of "View
Errors", since it shows the details of each account hit instead of the
details of errors associated with the accounts.

Closes #908.

-----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!