### PR TITLE
Display invoices in enterprise currency

### DIFF
--- a/server/controllers/finance/reports/financial.patient.handlebars
+++ b/server/controllers/finance/reports/financial.patient.handlebars
@@ -28,8 +28,8 @@
             <td>{{this.trans_id}}</td>
             <td>{{date this.date}}</td>
             <td>{{this.description}}</td>
-            <td>{{currency this.debit currency_id}}</td>
-            <td>{{currency this.credit currency_id}}</td>
+            <td>{{currency this.debit ../metadata.enterprise.currency_id}}</td>
+            <td>{{currency this.credit ../metadata.enterprise.currency_id}}</td>
           </tr>
         {{else}}       
           <tr>
@@ -42,11 +42,11 @@
       <tfoot>
         <tr>
           <td colspan="4">{{translate "FORM.LABELS.TOTAL" }}</td>
-          <td>{{currency sum.debit currency_id}}</td>
-          <td>{{currency sum.credit currency_id}}</td>
+          <td>{{currency sum.debit metadata.enterprise.currency_id}}</td>
+          <td>{{currency sum.credit metadata.enterprise.currency_id}}</td>
         </tr>       
         <tr>
-          <th colspan="6" class="text-right">{{translate "FORM.LABELS.BALANCE" }} {{currency sum.balance currency_id}}</th>
+          <th colspan="6" class="text-right">{{translate "FORM.LABELS.BALANCE" }} {{currency sum.balance metadata.enterprise.currency_id}}</th>
         </tr>
       </tfoot>
     </table>

--- a/server/controllers/finance/reports/invoices/receipt.handlebars
+++ b/server/controllers/finance/reports/invoices/receipt.handlebars
@@ -32,7 +32,7 @@
       </div>
       <div class="col-xs-6">
         <span class="text-capitalize">{{translate 'FORM.LABELS.INVOICE'}}</span>: <strong>{{reference}}</strong> <br>
-        <span class="text-capitalize">{{translate 'FORM.LABELS.AMOUNT'}}</span>: <strong>{{currency cost}}</strong> <br>
+        <span class="text-capitalize">{{translate 'FORM.LABELS.AMOUNT'}}</span>: <strong>{{currency cost metadata.enterprise.currency_id}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date date}} <br>
         <span class="text-capitalize">{{translate "REPORT.PRODUCED_BY"}}</span>: {{user.display_name}}
       </div>
@@ -65,14 +65,14 @@
       <tr>
         <td>{{this.code}}</td>
         <td>{{this.text}}</td>
-        <td class="text-right">{{currency this.transaction_price}}</td>
+        <td class="text-right">{{currency this.transaction_price ../metadata.enterprise.currency_id}}</td>
         <td class="text-right">{{quantity}}</td>
-        <td class="text-right">{{currency (multiply this.transaction_price quantity)}}</td>
+        <td class="text-right">{{currency (multiply this.transaction_price quantity) ../metadata.enterprise.currency_id}}</td>
       </tr>
       {{/each}}
       <tr>
         <td colspan="4" class="text-right">{{translate 'TABLE.COLUMNS.TOTAL'}}</td>
-        <td class="text-right">{{currency (sum items 'transaction_price' 'quantity')}}</td>
+        <td class="text-right">{{currency (sum items 'transaction_price' 'quantity') metadata.enterprise.currency_id}}</td>
       </tr>
     </tbody>
   </table>
@@ -91,16 +91,16 @@
               <td class="text-right">
                 ({{this.label}} {{this.billing_value}}%
                 {{translate 'FORM.LABELS.OF'}}
-                {{currency (sum ../items 'transaction_price' 'quantity')}}) =
+                {{currency (sum gitems 'transaction_price' 'quantity') ../metadata.enterprise.currency_id}}) =
               </td>
               <td class="text-right">
-                +{{currency this.value}}
+                +{{currency this.value ../metadata.enterprise.currency_id}}
               </td>
             </tr>
           {{/each}}
           <tr style="font-weight: bold;">
             <td class="text-right">{{translate 'FORM.LABELS.TOTAL'}} ({{translate 'FORM.LABELS.BILLING_SERVICES'}}) = </td>
-            <td class="text-right">+{{currency (sum billing 'value')}}</td>
+            <td class="text-right">+{{currency (sum billing 'value') ../metadata.enterprise.currency_id}}</td>
           </tr>
         </table>
       {{/if}}
@@ -113,7 +113,7 @@
               <h4><u>{{translate 'FORM.LABELS.SUBSIDIES'}}</u> ({{subsidy.length}}) :</h4>
             </td>
             <td class="text-right">
-              <b>-{{currency (sum subsidy 'value')}}</b>
+              <b>-{{currency (sum subsidy 'value') metadata.enterprise.currency_id}}</b>
             </td>
           </tr>
         </table>
@@ -126,7 +126,7 @@
             <h1>{{translate 'FORM.LABELS.TOTAL'}} : </h1>
           </td>
           <td class="text-right">
-            <h1><b>{{currency cost}}</b></h1>
+            <h1><b>{{currency cost metadata.enterprise.currency_id}}</b></h1>
           </td>
         </tr>
       </table>


### PR DESCRIPTION
This commit ensures that all invoice receipts that are provided to users reflect the correct enterprise currency.

Additional reports require updating to ensure they are displayed in the correct currency, however they are not generated as frequently and should be prioritised accordingly https://github.com/IMA-WorldHealth/bhima-2.X/issues/924.