### PR TITLE
fix(report): use proper currency in income/expense

### DIFF
--- a/server/controllers/finance/reports/incomeExpense/report.handlebars
+++ b/server/controllers/finance/reports/incomeExpense/report.handlebars
@@ -36,9 +36,9 @@
             <tr>
               <td style="background-color: #ccc; font-weight: bold; text-align: center;" colspan="6">
                 {{ translate 'REPORT.CASH_INCOME' }}
-              </td>            
+              </td>
             </tr>
-          </thead>  
+          </thead>
 
             <!-- white line -->
           <tr>
@@ -54,14 +54,14 @@
               <td style="width: 10%"> {{ translate 'TABLE.COLUMNS.DATE'  }} </td>
               <td style="width: 10%"> {{ translate 'TABLE.COLUMNS.SOURCE'  }} </td>
               <td style="width: 10%"> {{ translate 'TABLE.COLUMNS.BY' }} </td>
-            </tr> 
+            </tr>
             {{/if}}
 
             {{#each incomeExpense.incomes}}
             <tr>
               <td class="text-left">{{ trans_id }}</td>
               <td class="text-left">{{ description }}</td>
-              <td class="text-right">{{ currency debit ../metadata.currency_id}}</td>
+              <td class="text-right">{{ currency debit ../metadata.enterprise.currency_id}}</td>
               <td class="text-left">{{ date trans_date }}</td>
               <td class="text-left">{{ translate transactionType }}</td>
               <td class="text-left">{{ username }}</td>
@@ -71,7 +71,7 @@
 
           <tfoot>
             <tr style="background-color: #efefef; font-weight: bold; ">
-              <td style="text-align: right;" colspan="6"> {{ translate 'TABLE.COLUMNS.TOTAL' }} :{{ currency incomeExpense.sumIncome ../metadata.currency_id}}</td>
+              <td style="text-align: right;" colspan="6"> {{ translate 'TABLE.COLUMNS.TOTAL' }} :{{ currency incomeExpense.sumIncome metadata.enterprise.currency_id}}</td>
             </tr>
           </tfoot>
         </table>
@@ -105,13 +105,13 @@
               <td style="width: 10%"> {{ translate 'TABLE.COLUMNS.SOURCE'  }} </td>
               <td style="width: 10%"> {{ translate 'TABLE.COLUMNS.BY' }} </td>
             </tr>
-            {{/if}} 
+            {{/if}}
 
             {{#each incomeExpense.expenses}}
             <tr>
               <td class="text-left">{{ trans_id }}</td>
               <td class="text-left">{{ description }}</td>
-              <td class="text-right">{{ currency credit ../metadata.currency_id}}</td>
+              <td class="text-right">{{ currency credit ../metadata.enterprise.currency_id}}</td>
               <td class="text-left">{{ date trans_date }}</td>
               <td class="text-left">{{ translate transactionType }}</td>
               <td class="text-left">{{ username }}</td>
@@ -121,7 +121,7 @@
 
           <tfoot>
             <tr style="background-color: #efefef; font-weight: bold; ">
-              <td style="text-align: right;" colspan="6"> {{ translate 'TABLE.COLUMNS.TOTAL' }} :{{ currency incomeExpense.sumExpense ../metadata.currency_id}}</td>
+              <td style="text-align: right;" colspan="6"> {{ translate 'TABLE.COLUMNS.TOTAL' }} :{{ currency incomeExpense.sumExpense metadata.enterprise.currency_id}}</td>
             </tr>
           </tfoot>
         </table>


### PR DESCRIPTION
This commit changes the income/expense report to use the enterprise
currency instead of rendering in dollars all the time.

Partially addresses #924.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!