### PR TITLE
fix(cash): alert when no invoices are selected

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -119,7 +119,8 @@
         "LINK"            : "Click here to add it.",
         "MISSING"         : "Don't see your cashbox?",
         "TRANSFER"        : "Transfer Funds",
-        "NO_CASHBOX_SELECTED" : "You have no selected a cashbox. Please select a cashbox to continue",
+        "NO_INVOICES_ASSIGNED" : "You have not assigned any invoices!  Please assign at least one invoice to the payment.",
+        "NO_CASHBOX_SELECTED" : "You have no selected a cashbox. Please select a cashbox to continue.",
         "SELECTED"        : "Selected cash"
       },
       "DEBTOR_INVOICES" : "Debtor Invoices",
@@ -127,7 +128,7 @@
       "REPORT"          : "Report",
       "SLIP"            : "Cash Voucher",
       "TITLE"           : "Cash Window",
-      "SELECTED" : "Selected Invoices"
+      "SELECTED"        : "Selected Invoices"
     }
   },
   "CASHBOX": {

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -125,7 +125,8 @@
         "CURRENT_CASHBOX" : "Caisse auxilliare courant",
         "LINK"            : "Cliquez ici pour l'ajouter.",
         "MISSING"         : "Vous ne trouvez pas votre caisse?",
-        "NO_CASHBOX_SELECTED" : "Vous avez pas sélectionné une caisse. S'il vous plaît choisir une caisse pour continuer",
+        "NO_INVOICES_ASSIGNED" : "Vous n'avez pas sélectionné des factures!  S'il vous plaît choisir des factures pour continuer.",
+        "NO_CASHBOX_SELECTED" : "Vous n'avez pas sélectionné une caisse. S'il vous plaît choisir une caisse pour continuer.",
         "SELECTED"        : "Selectionnée",
         "TRANSFER"        : "Transférer Fonds"
       },

--- a/client/src/partials/cash/cash.js
+++ b/client/src/partials/cash/cash.js
@@ -149,17 +149,24 @@ function CashController(Cash, Cashboxes, AppCache, Currencies, Exchange, Session
     vm.payment.cashbox_id = vm.cashbox.id;
 
     // patient invoices are covered by caution
-    var hascaution = vm.slip && vm.patientBalance > 0;
+    var hasCaution = vm.slip && vm.patientBalance > 0;
+    var isCaution = Number(vm.payment.is_caution);
+    var hasInvoices = vm.payment.invoices && vm.payment.invoices.length > 0;
+
+    // if the this is not a caution payment, but no invoices are selected,
+    // raise an error.
+    if (!isCaution && !hasInvoices) {
+      return Notify.danger('CASH.VOUCHER.NO_INVOICES_ASSIGNED');
+    }
 
     // submit the cash payment
-    if (hascaution) {
+    if (hasCaution) {
       return Modals.confirm('CASH.CONFIRM_PAYMENT_WHEN_CAUTION')
         .then(function (ans) {
           if (!ans) { return; }
           return submitPayment(form);
         })
         .catch(Notify.handleError);
-
     } else {
       return submitPayment(form);
     }

--- a/test/end-to-end/cash/cash.spec.js
+++ b/test/end-to-end/cash/cash.spec.js
@@ -138,6 +138,31 @@ describe('Cash Payments', function () {
       $('[data-action="close"]').click();
     });
 
+    it('should block invoice payments without invoices', function () {
+
+      // select the proper patient
+      components.findPatient.findByName(mockCautionPayment.patientName);
+
+      // we will leave the date input as default
+
+      // select the proper is caution type
+      var cautionOption = element(by.css('[data-caution-option="0"]'));
+      cautionOption.click();
+
+      // select the FC currency from the currency select
+      components.currencySelect.set(1);
+
+      // enter the amount to pay for a caution
+      components.currencyInput.set(mockCautionPayment.amount);
+
+      // click the submit button
+      FU.buttons.submit();
+
+      // expect a danger notification
+      components.notification.hasDanger();
+      components.findPatient.reset();
+    });
+
     it('should make a payment against previous invoices', function () {
       var gridId = 'debtorInvoicesGrid';
 

--- a/test/end-to-end/shared/components/bhCurrencyInput.js
+++ b/test/end-to-end/shared/components/bhCurrencyInput.js
@@ -15,7 +15,7 @@ module.exports = {
   // it might be clearer to do this in two steps.
     var root = element(id ? by.id(id) : by.css(this.selector));
     var elm  = root.element(by.model('$ctrl.model'));
-    elm.sendKeys(value);
+    elm.clear().sendKeys(value);
   },
 
   /**

--- a/test/end-to-end/shared/components/bhFindPatient.js
+++ b/test/end-to-end/shared/components/bhFindPatient.js
@@ -56,5 +56,9 @@ module.exports = {
     // submit the id to the server
     var submit = element(by.css('[data-find-patient-submit]'));
     submit.click();
+  },
+
+  reset : function reset() {
+    $('[ng-click="$ctrl.reset()"]').click();
   }
 };


### PR DESCRIPTION
This commit introduces a check to verify that invoices are being paid
against when a user submits the cash form.  If there are no invoices, a
danger notification is emitted telling the user to add some invoices and
no HTTP request is sent.

Previous, this would be validated on the server - the client no longer
even needs to make the HTTP request.

Closes #772.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!