### PR TITLE
fix(cashbox): allow ui-select to filter elements

### DIFF
--- a/client/src/js/services/AccountService.js
+++ b/client/src/js/services/AccountService.js
@@ -50,8 +50,6 @@ function AccountService($http, util, Session) {
           });
         }
 
-        /* @todo make this ordering work */
-        // return order(accounts);
         return accounts;
       });
   }
@@ -174,9 +172,8 @@ function AccountService($http, util, Session) {
   */
   function del(accountId){
     return $http.delete(baseUrl.concat(accountId))
-    .then(util.unwrapHttpResponse);    
+    .then(util.unwrapHttpResponse);
   }
-
 
   return service;
 }

--- a/client/src/partials/cash/cashboxes/configure_currency/modal.html
+++ b/client/src/partials/cash/cashboxes/configure_currency/modal.html
@@ -30,7 +30,7 @@
         <ui-select-choices
           ui-select-focus-patch
           ui-disable-choice="account.type_id === CashboxModalCtrl.bhConstants.accounts.TITLE"
-          repeat="account.id as account in ::CashboxModalCtrl.accounts | filter:$select.search">
+          repeat="account.id as account in CashboxModalCtrl.accounts | filter: { 'hrlabel' : $select.search }">
           <span ng-bind-html="account.number | highlight:$select.search"></span>
           <small ng-bind-html="account.label | highlight:$select.search"></small>
         </ui-select-choices>
@@ -49,7 +49,7 @@
         <ui-select-choices
           ui-select-focus-patch
           ui-disable-choice="account.type_id === CashboxModalCtrl.bhConstants.accounts.TITLE"
-          repeat="account.id as account in ::CashboxModalCtrl.accounts | filter:$select.search">
+          repeat="account.id as account in CashboxModalCtrl.accounts | filter: { 'hrlabel' : $select.search }">
           <span ng-bind-html="account.number | highlight:$select.search"></span>
           <small ng-bind-html="account.label | highlight:$select.search"></small>
         </ui-select-choices>

--- a/client/src/partials/cash/cashboxes/configure_currency/modal.js
+++ b/client/src/partials/cash/cashboxes/configure_currency/modal.js
@@ -1,9 +1,9 @@
 angular.module('bhima.controllers')
-.controller('CashboxCurrencyModalController', CashboxCurrencyModalController);
+  .controller('CashboxCurrencyModalController', CashboxCurrencyModalController);
 
 CashboxCurrencyModalController.$inject = [
   '$uibModalInstance', 'AccountService', 'CashboxService',
-  'currency', 'cashbox', 'data', 'bhConstants'
+  'currency', 'cashbox', 'data', 'bhConstants', 'NotifyService'
 ];
 
 /**
@@ -13,7 +13,7 @@ CashboxCurrencyModalController.$inject = [
  * cashboxes.  Each cashbox must have a currencied account defined for each currency
  * supported by the application.
  */
-function CashboxCurrencyModalController(ModalInstance, Accounts, Boxes, currency, cashbox, data, bhConstants) {
+function CashboxCurrencyModalController(ModalInstance, Accounts, Boxes, currency, cashbox, data, bhConstants, Notify) {
   var vm = this;
 
   // if a currency matches, we are updating.  Otherwise, we are creating.
@@ -40,21 +40,15 @@ function CashboxCurrencyModalController(ModalInstance, Accounts, Boxes, currency
 
   /* ------------------------------------------------------------------------ */
 
-  // generic error handling
-  function handler(error) {
-    vm.error = true;
-    console.log(error);
-  }
-
   // startup script for the controller
   function startup() {
 
-    // load accounts and properly formats their labels
-    Accounts.read()
+    // load accounts and properly order them
+    Accounts.read(null, { detailed : 1 })
       .then(function (accounts) {
-        vm.accounts = accounts;
+        vm.accounts = Accounts.order(accounts);
       })
-      .catch(handler);
+      .catch(Notify.handleError);
   }
 
   // return data to the
@@ -74,7 +68,7 @@ function CashboxCurrencyModalController(ModalInstance, Accounts, Boxes, currency
     // upon successful completion, close the modal or error out
   return promise
     .then(function () { ModalInstance.close(); })
-    .catch(handler);
+    .catch(Notify.handleError);
   }
 
   // startup the controller

--- a/client/src/partials/cash/cashboxes/update/edit.html
+++ b/client/src/partials/cash/cashboxes/update/edit.html
@@ -17,98 +17,99 @@
       <form
         name="UpdateForm"
         bh-submit="UpdateCtrl.submit(UpdateForm)"
+        bh-form-defaults
         novalidate>
 
-       <div>
          <div>
-            <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.label.$invalid }">
-              <label class="control-label">
-                {{ "FORM.LABELS.NAME" | translate }}
-              </label>
-              <input class="form-control" name="label" ng-model="UpdateCtrl.box.label" ng-maxlength="CashCtrl.maxLength" required>
-              <div class="help-block" ng-messages="UpdateForm.label.$error" ng-show="UpdateForm.$submitted">
-                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
-
-            <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.type.$invalid }">
-              <label class="control-label">
-                {{ "FORM.LABELS.TYPE" | translate }}
-              </label>
-              <div class="radio">
-                <label>
-                  <input type="radio" name="type" ng-model="UpdateCtrl.box.is_auxiliary" value="0" required>
-                  {{ "FORM.LABELS.PRINCIPAL" | translate }}
+           <div>
+              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.label.$invalid }">
+                <label class="control-label">
+                  {{ "FORM.LABELS.NAME" | translate }}
                 </label>
+                <input class="form-control" name="label" ng-model="UpdateCtrl.box.label" ng-maxlength="CashCtrl.maxLength" required>
+                <div class="help-block" ng-messages="UpdateForm.label.$error" ng-show="UpdateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
               </div>
 
-              <div class="radio">
-                <label>
-                  <input type="radio" name="type" ng-model="UpdateCtrl.box.is_auxiliary" value="1" required>
-                  {{ "FORM.LABELS.AUXILIARY" | translate }}
+              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.type.$invalid }">
+                <label class="control-label">
+                  {{ "FORM.LABELS.TYPE" | translate }}
                 </label>
-              </div>
-              <div class="help-block" ng-messages="UpdateForm.type.$error" ng-show="UpdateForm.$submitted">
-                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
+                <div class="radio">
+                  <label>
+                    <input type="radio" name="type" ng-model="UpdateCtrl.box.is_auxiliary" value="0" required>
+                    {{ "FORM.LABELS.PRINCIPAL" | translate }}
+                  </label>
+                </div>
 
-            <div class="form-group">
-              <label>{{ "FORM.LABELS.CURRENCIES" | translate }}</label>
-              <div ng-repeat="currency in UpdateCtrl.currencies | orderBy:currency.name track by currency.id">
-                <p ng-class="{ 'text-danger' : !currency.configured }">
-                  <i class="glyphicon glyphicon-alert" ng-if="!currency.configured"></i> {{ currency.name }} ({{ currency.symbol}})
-                  <a class="btn btn-xs btn-default" href="" ng-click="UpdateCtrl.configureCurrency(currency)" data-currency-id="{{ currency.id }}">
-                    <i class="fa fa-pencil-square-o"></i> {{ "FORM.BUTTONS.CONFIGURE" | translate }}
-                  </a>
-                </p>
-                <p ng-if="!currency.configured" class="help-block">
-                  {{ "FORM.INFO.NOT_CONFIGURED" | translate }}
-                </p>
+                <div class="radio">
+                  <label>
+                    <input type="radio" name="type" ng-model="UpdateCtrl.box.is_auxiliary" value="1" required>
+                    {{ "FORM.LABELS.AUXILIARY" | translate }}
+                  </label>
+                </div>
+                <div class="help-block" ng-messages="UpdateForm.type.$error" ng-show="UpdateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
               </div>
-            </div>
 
-            <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.project.$invalid }">
-              <label class="control-label">
-                {{ "FORM.LABELS.PROJECT" | translate }}
-              </label>
-              <select
-                class="form-control"
-                name="project"
-                ng-model="UpdateCtrl.box.project_id"
-                ng-options="project.id as project.name for project in CashCtrl.projects"
-                required>
-                <option value="" disabled>{{ "FORM.SELECT.PROJECT" | translate }}</option>
-              </select>
-              <div class="help-block" ng-messages="UpdateForm.project.$error" ng-show="UpdateForm.$submitted">
-                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              <div class="form-group">
+                <label>{{ "FORM.LABELS.CURRENCIES" | translate }}</label>
+                <div ng-repeat="currency in UpdateCtrl.currencies | orderBy:currency.name track by currency.id">
+                  <p ng-class="{ 'text-danger' : !currency.configured }">
+                    <i class="fa fa-alert" ng-if="!currency.configured"></i> {{ currency.name }} ({{ currency.symbol}})
+                    <a class="btn btn-xs btn-default" href="" ng-click="UpdateCtrl.configureCurrency(currency)" data-currency-id="{{ currency.id }}">
+                      <i class="fa fa-pencil-square-o"></i> {{ "FORM.BUTTONS.CONFIGURE" | translate }}
+                    </a>
+                  </p>
+                  <p ng-if="!currency.configured" class="help-block">
+                    {{ "FORM.INFO.NOT_CONFIGURED" | translate }}
+                  </p>
+                </div>
+              </div>
+
+              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.project.$invalid }">
+                <label class="control-label">
+                  {{ "FORM.LABELS.PROJECT" | translate }}
+                </label>
+                <select
+                  class="form-control"
+                  name="project"
+                  ng-model="UpdateCtrl.box.project_id"
+                  ng-options="project.id as project.name for project in CashCtrl.projects"
+                  required>
+                  <option value="" disabled>{{ "FORM.SELECT.PROJECT" | translate }}</option>
+                </select>
+                <div class="help-block" ng-messages="UpdateForm.project.$error" ng-show="UpdateForm.$submitted">
+                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+                </div>
               </div>
             </div>
           </div>
-        </div>
 
-        <div class="clearfix" style="margin-bottom : 5px">
-          <div class="pull-right" style="text-align : right">
-            <bh-loading-button loading-state="UpdateForm.$loading">
-              {{ "FORM.BUTTONS.SUBMIT" | translate }}
-            </bh-loading-button>
+          <div class="clearfix" style="margin-bottom : 5px">
+            <div class="pull-right" style="text-align : right">
+              <bh-loading-button loading-state="UpdateForm.$loading">
+                {{ "FORM.BUTTONS.SUBMIT" | translate }}
+              </bh-loading-button>
+            </div>
+          </div>
+        </form>
+      </div>
+
+      <div class="col-md-7">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <i class="fa fa-ellipsis-h"></i> {{ "CASHBOX.ACTIONS" | translate }}
+          </div>
+          <div class="panel-body">
+            <button class="btn btn-danger" type="button" ng-click="UpdateCtrl.remove(UpdateCtrl.box)" data-method="delete">
+              <i class="fa fa-trash-o"></i> {{ "FORM.BUTTONS.DELETE" | translate }} {{ "CASHBOX.CASHBOX" | translate }}
+            </button>
           </div>
         </div>
-      </form>
       </div>
-
-    <div class="col-md-7">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <i class="fa fa-ellipsis-h"></i> {{ "CASHBOX.ACTIONS" | translate }}
-        </div>
-        <div class="panel-body">
-          <button class="btn btn-danger" type="button" ng-click="UpdateCtrl.remove(UpdateCtrl.box)" data-method="delete">
-            <i class="fa fa-trash-o"></i> {{ "FORM.BUTTONS.DELETE" | translate }} {{ "CASHBOX.CASHBOX" | translate }}
-          </button>
-        </div>
-      </div>
-    </div>
 
     </div> <!-- Col -->
   </div> <!-- Row -->

--- a/server/controllers/finance/accounts/index.js
+++ b/server/controllers/finance/accounts/index.js
@@ -124,7 +124,7 @@ function remove(req, res, next) {
  */
 function list(req, res, next) {
   let sql =
-    'SELECT a.id, a.number, a.label, a.locked, a.type_id FROM account AS a';
+    'SELECT a.id, a.number, a.label, a.locked, a.type_id, a.parent FROM account AS a';
 
   let locked;
 


### PR DESCRIPTION
This commit removes the one-time binding on the cashbox ui-select to ensure that values are properly filtered.

It does three things:
 1. Orders accounts in the ui-select by their proper tree order.
 2. Disables the title accounts
 3. Makes sure that filtering is efficient on the `hrlabel` property.

This is a critical bug fix.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!