### PR TITLE
fix(enterprise): account select sane defaults

### DIFF
--- a/client/src/partials/enterprises/enterprises.html
+++ b/client/src/partials/enterprises/enterprises.html
@@ -62,13 +62,16 @@
 
                 <ui-select
                   name="gain_account"
-                  ng-model="EnterpriseCtrl.enterprise.gain_account"
-                  theme="bootstrap"
+                  ng-model="EnterpriseCtrl.enterprise.gain_account_id"
+                  ng-model-options="{ 'debounce' : 250 }"
                   required>
                   <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
                     <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
                   </ui-select-match>
-                  <ui-select-choices ui-select-focus-patch repeat="account.id as account in  EnterpriseCtrl.accounts.data | filter:$select.search">
+                  <ui-select-choices
+                    ui-select-focus-patch
+                    ui-disable-choice="account.type_id === EnterpriseCtrl.bhConstants.accounts.TITLE"
+                    repeat="account.id as account in  EnterpriseCtrl.accounts | filter: { 'hrlabel': $select.search }">
                     <strong ng-bind-html="account.number | highlight:$select.search"></strong>
                     <span ng-bind-html="account.label | highlight:$select.search"></span>
                   </ui-select-choices>
@@ -87,13 +90,16 @@
 
                 <ui-select
                   name="loss_account"
-                  ng-model="EnterpriseCtrl.enterprise.loss_account"
-                  theme="bootstrap"
+                  ng-model="EnterpriseCtrl.enterprise.loss_account_id"
+                  ng-model-options="{ 'debounce' : 250 }"
                   required>
                   <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
                     <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
                   </ui-select-match>
-                  <ui-select-choices ui-select-focus-patch repeat="account.id as account in  EnterpriseCtrl.accounts.data | filter:$select.search">
+                  <ui-select-choices
+                    ui-select-focus-patch
+                    ui-disable-choice="account.type_id === EnterpriseCtrl.bhConstants.accounts.TITLE"
+                    repeat="account.id as account in  EnterpriseCtrl.accounts | filter:{'hrlabel' : $select.search}">
                     <strong ng-bind-html="account.number | highlight:$select.search"></strong>
                     <span ng-bind-html="account.label | highlight:$select.search"></span>
                   </ui-select-choices>

--- a/client/src/partials/enterprises/enterprises.js
+++ b/client/src/partials/enterprises/enterprises.js
@@ -1,16 +1,18 @@
 angular.module('bhima.controllers')
-.controller('EnterpriseController', EnterpriseController);
+  .controller('EnterpriseController', EnterpriseController);
 
 EnterpriseController.$inject = [
-  '$translate', 'EnterpriseService', 'CurrencyService', 'AccountStoreService',
-  'util', 'NotifyService', 'ProjectService', 'ModalService'
+  'EnterpriseService', 'CurrencyService', 'util', 'NotifyService',
+  'ProjectService', 'ModalService', 'AccountService', 'bhConstants'
 ];
 
 /**
  * Enterprise Controller
  */
-function EnterpriseController($translate, Enterprises, Currencies, Accounts, util, Notify, Projects, Modal) {
+function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, Modal, Accounts, bhConstants) {
   var vm = this;
+
+  vm.bhConstants = bhConstants;
 
   vm.enterprises = [];
   vm.enterprise = {};
@@ -29,45 +31,30 @@ function EnterpriseController($translate, Enterprises, Currencies, Accounts, uti
 
     // load enterprises
     Enterprises.read(null, { detailed : 1 })
-    .then(function (enterprises) {
-      vm.hasEnterprise = enterprises.length ? true : false;
-      vm.enterprises = vm.hasEnterprise ? enterprises : [];
+      .then(function (enterprises) {
+        vm.hasEnterprise = (enterprises.length > 0);
+        vm.enterprises = vm.hasEnterprise ? enterprises : [];
 
-      /**
-       * @note: set the enterprise to the first one
-       * this choice need the team point of view for to setting the default enterprise
-       */
-      vm.enterprise = vm.hasEnterprise ? vm.enterprises[0] : {};
-    })
-    .then(Accounts.accounts)
-    .then(function (list) {
-      vm.accounts = list;
+        /**
+         * @note: set the enterprise to the first one
+         * this choice need the team point of view for to setting the default enterprise
+         */
+        vm.enterprise = vm.hasEnterprise ? vm.enterprises[0] : {};
 
-      // gain account
-      vm.enterprise.gain_account = vm.accounts.get(vm.enterprise.gain_account_id);
-      // loss account
-      vm.enterprise.loss_account = vm.accounts.get(vm.enterprise.loss_account_id);
-    })
-    .then(refreshProjects)
-    .catch(Notify.handleError);
-
-    // load accounts
-    Accounts.accounts()
-    .then(function (list) {
-      vm.accounts = list;
-
-      // gain account
-      vm.enterprise.gain_account = vm.accounts.get(vm.enterprise.gain_account_id);
-      // loss account
-      vm.enterprise.loss_account = vm.accounts.get(vm.enterprise.loss_account_id);
-    })
-    .catch(Notify.handleError);
+        return Accounts.read();
+      })
+      .then(function (accounts) {
+        vm.accounts = Accounts.order(accounts);
+        return refreshProjects();
+      })
+      .catch(Notify.handleError);
 
     // load currencies
     Currencies.read()
-    .then(function (currencies) {
-      vm.currencies = currencies;
-    }).catch(Notify.handleError);
+      .then(function (currencies) {
+        vm.currencies = currencies;
+      })
+      .catch(Notify.handleError);
 
   }
 
@@ -104,8 +91,8 @@ function EnterpriseController($translate, Enterprises, Currencies, Accounts, uti
       location_id : enterprise.location_id,
       currency_id : enterprise.currency_id,
       po_box : enterprise.po_box,
-      gain_account_id : enterprise.gain_account.id,
-      loss_account_id : enterprise.loss_account.id
+      gain_account_id : enterprise.gain_account_id,
+      loss_account_id : enterprise.loss_account_id
     };
   }
 

--- a/test/end-to-end/enterprises/enterprises.spec.js
+++ b/test/end-to-end/enterprises/enterprises.spec.js
@@ -8,7 +8,7 @@ helpers.configure(chai);
 const FU = require('../shared/FormUtils');
 const components = require('../shared/components');
 
-describe('Enterprises ::', function () {
+describe('Enterprises', function () {
 
   const path = '#/enterprises';
   const enterpriseId = 1;
@@ -20,8 +20,8 @@ describe('Enterprises ::', function () {
     email : 'ima@imaworldhealth.com',
     po_box : 'POBOX USA 1',
     phone : '01500',
-    gain_account : 'Test Gain Account',
-    loss_account : 'Test Expense Accounts'
+    gain_account_id : 'Test Gain Account',
+    loss_account_id : 'Test Expense Accounts'
   };
 
   // default enterprise
@@ -31,8 +31,8 @@ describe('Enterprises ::', function () {
     email : 'enterprise@test.org',
     po_box : 'POBOX USA 1',
     phone : '243 81 504 0540',
-    gain_account : 'Test Gain Account',
-    loss_account : 'Test Expense Accounts'
+    gain_account_id : 'Test Gain Account',
+    loss_account_id : 'Test Expense Accounts'
   };
 
   // project
@@ -61,8 +61,8 @@ describe('Enterprises ::', function () {
     FU.input('EnterpriseCtrl.enterprise.name', enterprise.name);
     FU.input('EnterpriseCtrl.enterprise.abbr', enterprise.abbr);
 
-    FU.uiSelect('EnterpriseCtrl.enterprise.gain_account', enterprise.gain_account);
-    FU.uiSelect('EnterpriseCtrl.enterprise.loss_account', enterprise.loss_account);
+    FU.uiSelect('EnterpriseCtrl.enterprise.gain_account_id', enterprise.gain_account_id);
+    FU.uiSelect('EnterpriseCtrl.enterprise.loss_account_id', enterprise.loss_account_id);
 
     FU.input('EnterpriseCtrl.enterprise.po_box', enterprise.po_box);
     FU.input('EnterpriseCtrl.enterprise.email', enterprise.email);
@@ -105,8 +105,8 @@ describe('Enterprises ::', function () {
      FU.input('EnterpriseCtrl.enterprise.name', default_enterprise.name);
      FU.input('EnterpriseCtrl.enterprise.abbr', default_enterprise.abbr);
 
-     FU.uiSelect('EnterpriseCtrl.enterprise.gain_account', default_enterprise.gain_account);
-     FU.uiSelect('EnterpriseCtrl.enterprise.loss_account', default_enterprise.loss_account);
+     FU.uiSelect('EnterpriseCtrl.enterprise.gain_account_id', default_enterprise.gain_account_id);
+     FU.uiSelect('EnterpriseCtrl.enterprise.loss_account_id', default_enterprise.loss_account_id);
 
      FU.input('EnterpriseCtrl.enterprise.po_box', default_enterprise.po_box);
      FU.input('EnterpriseCtrl.enterprise.email', default_enterprise.email);


### PR DESCRIPTION
This commit disables the account ui-select on the enterprise page for
title accounts.  It also includes some minor code cleanup, including
ensuring accounts are properly ordered.

This also includes some performance improvements by debouncing the
ui-select search routine.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!