### PR TITLE
(Fix) Ensure totals digest is called on invoice item delete

### DIFF
--- a/client/src/js/services/PatientInvoiceForm.js
+++ b/client/src/js/services/PatientInvoiceForm.js
@@ -330,6 +330,7 @@ function PatientInvoiceFormService(Patients, PriceLists, Inventory, AppCache, St
     if (item.inventory_uuid) {
       this.inventory.release(item.inventory_uuid);
     }
+    this.digest();
   };
 
   /**

--- a/client/src/partials/patient_invoice/patientInvoice.html
+++ b/client/src/partials/patient_invoice/patientInvoice.html
@@ -259,11 +259,6 @@
           ng-click="PatientInvoiceCtrl.clear(detailsForm)">
           {{ "FORM.BUTTONS.CLEAR" | translate }}
         </button>
-        <p
-          class="text-danger"
-          ng-show="PatientInvoiceCtrl.Invoice._invalid && detailsForm.$submitted">
-          <span class="fa fa-exclamation-circle"></span> {{ "FORM.INFO.INVALID_ITEMS" | translate }}
-        </p>
       </div>
     </div>
   </div>

--- a/client/src/partials/patient_invoice/patientInvoice.js
+++ b/client/src/partials/patient_invoice/patientInvoice.js
@@ -82,6 +82,12 @@ function PatientInvoiceController(Patients, PatientInvoices, PatientInvoiceForm,
     // update value for form validation
     detailsForm.$setSubmitted();
 
+    // make sure there are actually items to validate
+    if (vm.Invoice.store.data.length === 0) {
+      Notify.danger('PATIENT_INVOICE.INVALID_ITEMS');
+      return;
+    }
+
     // ask service items to validate themselves - if anything is returned it is invalid
     var invalidItems = vm.Invoice.validate(true);
 


### PR DESCRIPTION
This commit call `this.digest()` when an invoice item is removed from
the invoice item service. This ensures that totals are calculated and kept
up to date. It also adds a check case for empty invoices which previously
send a `400 BAD REQUEST` to the server.

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/939

---

 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.