### PR TITLE
refactor(exchange): restore old exchange route

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -30,6 +30,20 @@ function bhimaConfig($stateProvider, $urlMatcherFactoryProvider) {
       }
     }
   })
+  .state('exchange', {
+    abstract : true,
+    url : '/exchange',
+    templateUrl: 'partials/application/exchange.html'
+  })
+  .state('exchange.index', {
+    url : '',
+    views : {
+      'exchange@exchange' : {
+        templateUrl : 'partials/enterprises/exchange/exchange.html',
+        controller : 'ExchangeController as ExchangeCtrl'
+      }
+    }
+  })
   .state('login', {
     url : '/login',
     controller : 'LoginController as LoginCtrl',

--- a/client/src/partials/application/exchange.html
+++ b/client/src/partials/application/exchange.html
@@ -1,0 +1,22 @@
+<div class="flex-header">
+  <div class="bhima-title">
+    <ol class="headercrumb">
+      <li class="static" style="text-transform : uppercase">{{ "HOME.BHIMA" | translate }}</li>
+      <li class="title">{{ "EXCHANGE.TITLE" | translate }}</li>
+    </ol>
+  </div>
+</div>
+
+
+
+<div class="flex-content">
+  <div class="container-fluid">
+
+    <div class="row">
+      <div class="col-md-6">
+        <!-- embedded exchange rate -->
+        <div ui-view="exchange"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/client/src/partials/enterprises/exchange/exchange.modal.html
+++ b/client/src/partials/enterprises/exchange/exchange.modal.html
@@ -8,23 +8,17 @@
 
   <div class="modal-body">
 
-    <bh-date-editor
-      date-value="ModalCtrl.rate.date"
-      validation-trigger="ModalForm.$submitted"
-      max-date="ModalCtrl.timestamp">
-    </bh-date-editor>
-
     <div
       class="form-group"
-      ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.currency_id.$invalid }">
+      ng-show="ModalCtrl.hasMultipleCurrencies"
+      ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.currency.$invalid }">
       <label class="control-label">
         {{ "FORM.LABELS.CURRENCY" | translate }}
       </label>
 
       <ui-select
-        name="currency_id"
-        ng-model="ModalCtrl.rate.currency_id"
-        ng-disabled="ModalCtrl.currencies.length === 1"
+        name="currency"
+        ng-model="ModalCtrl.rate.currency"
         required>
         <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.CURRENCY' | translate }}">
           <span>{{ ModalCtrl.format($select.selected.id) }}</span>
@@ -36,16 +30,34 @@
         </ui-select-choices>
       </ui-select>
 
-      <div class="help-block" ng-messages="ModalForm.currency_id.$error" ng-show="ModalForm.$submitted">
+      <div class="help-block" ng-messages="ModalForm.currency.$error" ng-show="ModalForm.$submitted">
         <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
       </div>
     </div>
+
+    <bh-date-editor
+      date-value="ModalCtrl.rate.date"
+      validation-trigger="ModalForm.$submitted"
+      max-date="ModalCtrl.timestamp">
+    </bh-date-editor>
 
     <div class="form-group"
       ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.rate.$invalid }"
       >
       <label class="control-label">{{ "FORM.LABELS.EXCHANGE_RATE" | translate }}</label>
-      <input class="form-control" type="number" name="rate" ng-model="ModalCtrl.rate.rate" required>
+      <div class="row">
+        <div class="col-xs-2">
+          <p class="form-control-static text-right" ng-class="{ 'text-danger' : ModalForm.$submitted && ModalForm.rate.$invalid }">
+            {{ 1 | currency:ModalCtrl.enterprise.currency_id }} <b>=</b>
+          </p>
+        </div>
+        <div class="col-xs-10">
+          <div class="input-group">
+            <input class="form-control" type="number" name="rate" ng-model="ModalCtrl.rate.rate" required>
+            <span class="input-group-addon">{{ ModalCtrl.symbol(ModalCtrl.rate.currency.id) }}</span>
+          </div>
+        </div>
+      </div>
       <div class="help-block" ng-messages="ModalForm.rate.$error" ng-show="ModalForm.$submitted">
         <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
       </div>

--- a/client/src/partials/enterprises/exchange/exchange.modal.js
+++ b/client/src/partials/enterprises/exchange/exchange.modal.js
@@ -24,7 +24,11 @@ function ExchangeRateModalController(ModalInstance, Exchange, Currencies, Sessio
 
   vm.submit = submit;
   vm.format = Currencies.format;
+  vm.symbol = Currencies.symbol;
   vm.cancel = function () { ModalInstance.dismiss(); };
+
+  // this turns on and off the currency select input
+  vm.hasMultipleCurrencies = false;
 
   Currencies.read()
     .then(function (currencies) {
@@ -34,20 +38,29 @@ function ExchangeRateModalController(ModalInstance, Exchange, Currencies, Sessio
         });
 
       // use the first currency in the list
-      vm.rate.currency_id = vm.currencies[0];
+      vm.rate.currency = vm.currencies[0];
+
+      // if there are more than a single other currency (besides the enterprise currency)
+      // show the currency selection input
+      if (vm.currencies.length > 1) {
+        vm.hasMultipleCurrencies = true;
+      }
     })
     .catch(Notify.handleError);
 
   function submit(form) {
     if (form.$invalid) { return; }
 
-    vm.rate.enterprise_id = Session.enterprise.id;
+    // gather form data for submission
+    var data = angular.copy(vm.rate);
 
-    // TODO clean this up with proper Ui-select syntax when internet available
-    var currency = vm.rate.currency_id;
-    vm.rate.currency_id = currency.id;
+    data.enterprise_id = Session.enterprise.id;
 
-    return Exchange.create(vm.rate)
+    // TODO clean this up with proper ui-select syntax when internet available
+    var currency = vm.rate.currency;
+    data.currency_id = currency.id;
+
+    return Exchange.create(data)
       .then(function () {
         ModalInstance.close();
       });

--- a/client/src/partials/home/home.html
+++ b/client/src/partials/home/home.html
@@ -57,8 +57,8 @@
         <div class="panel panel-default segment">
           <div class="panel-body text-center">
             <div class="segment-title">{{ "TABLE.COLUMNS.EXCHANGE_RATE" | translate }}</div>
-            <div class="ui huge ima-blue statistic">
-              <div class="value">{{ HomeCtrl.primaryExchange.rate}}({{ HomeCtrl.primaryExchange.symbol }})</div>
+            <div class="ui huge ima-blue statistic" title="{{ HomeCtrl.primaryExchange.rate}} ({{ HomeCtrl.primaryExchange.symbol }})">
+              <div class="value">{{ HomeCtrl.primaryExchange.rate | limitTo:HomeCtrl.EXCHANGE_RATE_DISPLAY_SIZE }}({{ HomeCtrl.primaryExchange.symbol }})</div>
               <div class="uilabel">{{ "HOME.EXCHANGE_SET" | translate }} {{ HomeCtrl.primaryExchange.formattedDate }}</div>
             </div>
           </div>

--- a/client/src/partials/home/home.js
+++ b/client/src/partials/home/home.js
@@ -24,6 +24,9 @@ function HomeController(Currencies, Rates, Session, Notify, Fiscal, DashboardSer
 
   vm.primaryExchange = {};
 
+  // this limits the number of places that the page displays for the exchange rate
+  vm.EXCHANGE_RATE_DISPLAY_SIZE = 6;
+
   // bind the session information
   vm.project = Session.project;
   vm.user = Session.user;

--- a/server/models/test/data.sql
+++ b/server/models/test/data.sql
@@ -24,6 +24,7 @@ INSERT INTO unit VALUES
   (18,  'Cash Window','TREE.CASH_WINDOW','Cash payments against past or future invoices',5,'/partials/cash/','/cash'),
   (19,  'Register Supplier','TREE.REGISTER_SUPPLIER','',1,'/partials/suppliers/','/suppliers'),
   (21,  'Price List','TREE.PRICE_LIST','Configure price lists!',1,'/partials/price_list/','/prices'),
+  (22,  'Exchange Rate','TREE.EXCHANGE','Set todays exchange rate!',1,'/partials/exchange_rate/','/exchange'),
   (26,  'Location Manager','TREE.LOCATION','',1,'/partials/locations/locations.html','/locations'),
   (29,  'Patient Group','TREE.PATIENT_GRP','',1,'/partials/patients/groups/','/patients/groups'),
   (48,  'Service Management','TREE.SERVICE','',1,'partials/services/','/services'),
@@ -67,8 +68,7 @@ INSERT INTO `account_type` VALUES
 -- Languages
 INSERT INTO `language` VALUES
   (1,'Francais','fr', 'fr-be'),
-  (2,'English','en', 'en-us'),
-  (3,'Lingala','lg', 'fr-cd');
+  (2,'English','en', 'en-us');
 
 -- Currencies
 INSERT INTO `currency` (`id`, `name`, `format_key`, `symbol`, `note`, `min_monentary_unit`) VALUES
@@ -165,6 +165,9 @@ INSERT INTO permission (unit_id, user_id) VALUES
 
 -- Price list Management
 (21, 1),
+
+-- Exchange Rate
+(22, 1),
 
 -- Location Management
 (26,1),


### PR DESCRIPTION
This commit restores an exchange rate module in the tree.  It is located
under the classic `/exchange` route.

This commit clearly shows the value of the enterprise currency when
setting a new exchange rate.  It also hides the exchange rate select if
there is only a single currency to set a rate against.

This commit limits the size of the exchange rate displayed on the home
page dashboard.  For many decimal places, it only shows 4 places after
the decimal point.

Closes #957.

-----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!