### PR TITLE
(Fix) Handle no debtor information corner case

### DIFF
--- a/client/src/partials/home/units/debtors.js
+++ b/client/src/partials/home/units/debtors.js
@@ -30,6 +30,14 @@ function DashboardDebtorController(Dashboard) {
       vm.owedGraph.labels = debtorGroups.map(function (group) {
         return group.name;
       });
+
+      // server will not pass aggregates object if there have been no transactions
+      // (or if there are no debtor groups), this case is handled
+      if (!result.data.aggregates) {
+        vm.noDebt = true;
+        return;
+      }
+
       vm.noDebt = result.data.aggregates.total === 0;
     });
 }


### PR DESCRIPTION
This commit gracefully handles the server returning no information
on the aggregates of debtor groups. This is usually because there are
no transactions or even no debtor groups at all and should never occur
in a set up system.

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/960