### PR TITLE
fix(accounts): remove unique label key

### DIFF
--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -25,7 +25,6 @@ CREATE TABLE `account` (
   `is_charge` TINYINT(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `account_1` (`number`),
-  UNIQUE KEY `account_2` (`label`),
   KEY `type_id` (`type_id`),
   KEY `enterprise_id` (`enterprise_id`),
   KEY `cc_id` (`cc_id`),


### PR DESCRIPTION
This commit removes the unique label restriction from the account table
in the database.  Given that the approved chart of accounts from the
Ministry of Health has duplicate labels, we are removing this
restriction.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!