### PR TITLE
(Fix) Account management UX

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -21,7 +21,7 @@
 }
 
 /**
- * IMA colors 
+ * IMA colors
  */
 .bg-ima-blue { background-color : #085484; color: #fff; }
 

--- a/client/src/partials/accounts/AccountGrid.js
+++ b/client/src/partials/accounts/AccountGrid.js
@@ -131,9 +131,5 @@ function AccountGridService(AccountStore, Accounts, Store, Notify) {
     this.data.splice(index, 0, account);
   };
 
-  AccountGrid.prototype.getAccount = function getAccount(id) {
-    return this._store.get(id);
-  }
-
   return AccountGrid;
 }

--- a/client/src/partials/accounts/AccountGrid.js
+++ b/client/src/partials/accounts/AccountGrid.js
@@ -67,6 +67,7 @@ function AccountGridService(AccountStore, Accounts, Store, Notify) {
     var insertedIndex;
 
     account.number = Number(account.number);
+    account.type_id = Number(account.type_id);
     account.hrlabel = Accounts.label(account);
 
     // update local store
@@ -81,17 +82,15 @@ function AccountGridService(AccountStore, Accounts, Store, Notify) {
 
 
   AccountGrid.prototype.updateViewDelete = function updateViewDelete(event, account) {
-    findAndRemove(this._store.data, 'id', account.id);
+    // findAndRemove(this._store.data, 'id', account.id);
 
-    function findAndRemove(array, property, value) {
-      array.forEach(function(result, index) {
-        if(result[property] === value) {
-          array.splice(index, 1);
-        }    
-      });
-    }
+    // Update the store for other modules accessing it
+    var removeIndex = this._store.index[account.id];
+    this._store.remove(account.id);
+    this.formatStore();
 
-    return this._store.data;
+    // Update this grid
+    this.data.splice(removeIndex, 1);
   };
 
 
@@ -131,6 +130,10 @@ function AccountGridService(AccountStore, Accounts, Store, Notify) {
   AccountGrid.prototype.insertDifference = function insertDifference(account, index) {
     this.data.splice(index, 0, account);
   };
+
+  AccountGrid.prototype.getAccount = function getAccount(id) {
+    return this._store.get(id);
+  }
 
   return AccountGrid;
 }

--- a/client/src/partials/accounts/accounts.html
+++ b/client/src/partials/accounts/accounts.html
@@ -8,6 +8,14 @@
    <div class="toolbar">
 
      <div class="toolbar-item">
+
+       <button
+         class="btn btn-default"
+         ng-class="{'btn-info' : AccountsCtrl.gridOptions.enableFiltering}"
+         data-method="filter" ng-click="AccountsCtrl.toggleInlineFilter()">
+        <i class="fa fa-filter"></i>
+       </button>
+
        <a class="btn btn-default" data-method="create" ui-sref="accounts.create">
          <i class="fa fa-plus-square"></i>
          {{ "ACCOUNT.CREATE" | translate }}

--- a/client/src/partials/accounts/accounts.html
+++ b/client/src/partials/accounts/accounts.html
@@ -33,13 +33,23 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-xs-12">
+        <!-- @todo Consider how the application is loaded and cached and make this functionality apply to the whole application -->
+        <!-- Hide broken UI-Grid on page load -->
+        <div ng-if="!AccountsCtrl.pageLoaded"><i class="fa fa-spin fa-circle-o-notch"></i></div>
         <div
           id="account-grid"
           style="height : calc(100vh - 65px)"
+          ng-show="AccountsCtrl.pageLoaded"
           ui-grid="AccountsCtrl.gridOptions"
           ui-grid-tree-view
           ui-grid-auto-resize
           ui-grid-resize-columns>
+
+          <bh-grid-loading-indicator
+            loading-state="AccountsCtrl.loading"
+            empty-state="AccountsCtrl.gridOptions.data.length===0"
+            error-state="AccountsCtrl.hasError">
+          </bh-grid-loading-indicator>
         </div>
       </div>
     </div>

--- a/client/src/partials/accounts/accounts.js
+++ b/client/src/partials/accounts/accounts.js
@@ -2,8 +2,8 @@ angular.module('bhima.controllers')
 .controller('AccountsController', AccountsController);
 
 AccountsController.$inject = [
-  '$rootScope', 'AccountGridService', 'NotifyService', 'bhConstants',
-  'LanguageService'
+  '$rootScope', '$timeout', 'AccountGridService', 'NotifyService', 'bhConstants',
+  'LanguageService', 'uiGridConstants'
 ];
 
 /**
@@ -15,7 +15,7 @@ AccountsController.$inject = [
  * This controller is responsible for configuring the Accounts Management UI grid
  * and connecting it with the Accounts data model.
  */
-function AccountsController($rootScope, AccountGrid, Notify, Constants, Language) {
+function AccountsController($rootScope, $timeout, AccountGrid, Notify, Constants, Language, uiGridConstants) {
 
   var vm = this;
   vm.Constants = Constants;
@@ -37,12 +37,13 @@ function AccountsController($rootScope, AccountGrid, Notify, Constants, Language
   var columns = [
     { field : 'number', displayName : '', cellClass : 'text-right', width : 70},
     { field : 'label', displayName : 'FORM.LABELS.ACCOUNT', cellTemplate : '/partials/accounts/templates/grid.indentCell.tmpl.html', headerCellFilter : 'translate' },
-    { name : 'actions', displayName : '', cellTemplate : '/partials/accounts/templates/grid.actionsCell.tmpl.html', headerCellFilter : 'translate', width : 140 }
+    { name : 'actions', enableFiltering : false, displayName : '', cellTemplate : '/partials/accounts/templates/grid.actionsCell.tmpl.html', headerCellFilter : 'translate', width : 140 }
   ];
 
   vm.gridOptions = {
     appScopeProvider : vm,
     enableSorting : false,
+    enableFiltering : false,
     showTreeExpandNoChildren : false,
     enableColumnMenus : false,
     rowTemplate : '/partials/accounts/templates/grid.leafRow.tmpl.html',
@@ -54,10 +55,11 @@ function AccountsController($rootScope, AccountGrid, Notify, Constants, Language
   // $parent $scope for the modal is $rootScope, it is impossible to inject the $scope of the
   // parent state into the onEnter callback. for this reason $rootScope is used for now
   $rootScope.$on('ACCOUNT_CREATED', vm.Accounts.updateViewInsert.bind(vm.Accounts));
-  $rootScope.$on('ACCOUNT_DELETED', handleDeletedAccount);
+  $rootScope.$on('ACCOUNT_DELETED', vm.Accounts.updateViewDelete.bind(vm.Accounts));
   $rootScope.$on('ACCOUNT_UPDATED', handleUpdatedAccount);
 
   function handleUpdatedAccount(event, account) {
+    var scrollDelay = 200;
 
     // check to see if the underlying accounts model requires a grid refresh
     // it will return true if it is required
@@ -66,21 +68,28 @@ function AccountsController($rootScope, AccountGrid, Notify, Constants, Language
     if (forceRefresh) {
       vm.initialDataSet = true;
       bindGridData();
+      $timeout(function () { scrollTo(account.id) }, scrollDelay);
     }
   }
 
-
-  function handleDeletedAccount(event, account) {
-
-    // check to see if the underlying accounts model requires a grid refresh
-    // it will return true if it is required
-    var accountsData = vm.Accounts.updateViewDelete(event, account);
-    vm.Accounts.data = accountsData;
-    bindGridData();
+  function scrollTo(accountId) {
+    vm.api.core.scrollTo(getDisplayAccount(accountId));
   }
 
+  function getDisplayAccount(id) {
+    var account;
+    vm.gridOptions.data.some(function (row) {
+      if (row.id === id) {
+        account = row;
+        return;
+      }
+      return false;
+    });
+    return account;
+  }
 
   function registerAccountEvents(api) {
+    vm.api = api;
     api.grid.registerDataChangeCallback(expandOnSetData);
   }
 
@@ -92,6 +101,13 @@ function AccountsController($rootScope, AccountGrid, Notify, Constants, Language
   }
 
   function bindGridData() {
+    console.log(vm.Accounts.data);
     vm.gridOptions.data = vm.Accounts.data;
   }
+
+  vm.toggleInlineFilter = function toggleInlineFilter() {
+    vm.gridOptions.enableFiltering = !vm.gridOptions.enableFiltering;
+    console.log(vm.gridOptions.enableFiltering);
+    vm.api.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
+  };
 }

--- a/client/src/partials/accounts/edit/accounts.edit.js
+++ b/client/src/partials/accounts/edit/accounts.edit.js
@@ -107,6 +107,9 @@ function AccountEditController($rootScope, $state, AccountStore, Accounts, Notif
     vm.account = angular.copy(account);
     accountParentId = vm.account.parent.id || vm.account.parent;
     vm.account.parent = accountStore.get(accountParentId);
+
+    // cast to string to match type options
+    vm.account.type_id = String(vm.account.type_id);
   }
 
   function defineNewAccount() {
@@ -129,7 +132,7 @@ function AccountEditController($rootScope, $state, AccountStore, Accounts, Notif
     }
 
     // default type
-    vm.account.type_id = cacheType || vm.types[0].id;
+    vm.account.type_id = cacheType || null;
   }
 
 

--- a/client/src/partials/accounts/edit/accounts.edit.js
+++ b/client/src/partials/accounts/edit/accounts.edit.js
@@ -192,16 +192,14 @@ function AccountEditController($rootScope, $state, AccountStore, Accounts, Notif
     .then(function (bool){
       // if the user clicked cancel, reset the view and return
       if (!bool) {
-        vm.view = 'default';
         return;
       }
 
       if (!account.id) {
         return;
       }
-      var accountId = account.id;
 
-      Accounts.delete(accountId)
+      Accounts.delete(account.id)
       .then(function (result){
         $rootScope.$broadcast('ACCOUNT_DELETED', account);
         Notify.success('ACCOUNT.DELETED');
@@ -209,7 +207,7 @@ function AccountEditController($rootScope, $state, AccountStore, Accounts, Notif
       })
       .catch(handleModalError);
     });
-    
+
   }
 
   function resetModal(accountForm) {

--- a/client/src/partials/accounts/edit/accounts.edit.modal.html
+++ b/client/src/partials/accounts/edit/accounts.edit.modal.html
@@ -45,15 +45,22 @@
       </div>
     </div>
 
-    <div ng-if="!AccountEditCtrl.isCreateState" class="form-group">
-      <label class="control-label">{{ "FORM.LABELS.ACCOUNT_TYPE" | translate }}</label>
-      <p class="form-control-static" ng-if="AccountEditCtrl.account" id="type-static">{{::AccountEditCtrl.getTypeTitle(AccountEditCtrl.account.type_id) | translate }}</p>
-    </div>
+    <!-- @TODO Re-disable account type edditing after accounts are stable -->
+    <!-- Account type read only -->
+    <!-- <div ng-if="!AccountEditCtrl.isCreateState" class="form-group"> -->
+      <!-- <label class="control-label">{{ "FORM.LABELS.ACCOUNT_TYPE" | translate }}</label> -->
+      <!-- <p class="form-control-static" ng-if="AccountEditCtrl.account" id="type-static">{{::AccountEditCtrl.getTypeTitle(AccountEditCtrl.account.type_id) | translate }}</p> -->
+    <!-- </div> -->
 
-    <div ng-if="AccountEditCtrl.isCreateState" class="form-group"
+    <div class="form-group"
          ng-class="{'has-error' : AccountForm.type_id.$invalid && AccountForm.$submitted}">
       <label class="control-label">{{ "FORM.LABELS.ACCOUNT_TYPE" | translate }}</label>
-      <select class="form-control" ng-model="AccountEditCtrl.account.type_id" name="type_id" required>
+      <select
+        class="form-control"
+        ng-model="AccountEditCtrl.account.type_id"
+        name="type_id"
+        required>
+        <option value="" disabled>{{ "FORM.SELECT.ACCOUNT_TYPE" | translate }}</option>
         <option ng-repeat="entry in AccountEditCtrl.types" value="{{entry.id}}" data-key="{{entry.translation_key}}">{{entry.translation_key | translate}}</option>
       </select>
       <div class="help-block" ng-messages="AccountForm.type_id.$error" ng-show="AccountForm.$submitted">

--- a/client/src/partials/accounts/edit/accounts.edit.modal.html
+++ b/client/src/partials/accounts/edit/accounts.edit.modal.html
@@ -69,10 +69,9 @@
       <ui-select
         name="parent"
         ng-model="AccountEditCtrl.account.parent"
-        theme="bootstrap"
         required>
         <ui-select-match placeholder="{{ 'ACCOUNT.SELECT_PARENT' | translate }}"><strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span></ui-select-match>
-        <ui-select-choices ui-select-focus-patch repeat="account in AccountEditCtrl.accounts | filter:$select.search | filter : { type_id : AccountEditCtrl.Constants.accounts.TITLE }">
+        <ui-select-choices ui-select-focus-patch repeat="account in AccountEditCtrl.accounts | filter:{ 'hrlabel' : $select.search} | filter : { type_id : AccountEditCtrl.Constants.accounts.TITLE }">
           <span ng-bind-html="account.number | highlight:$select.search"></span>
           <small ng-bind-html="account.label | highlight:$select.search"></small>
         </ui-select-choices>

--- a/client/src/partials/accounts/templates/grid.titleRow.tmpl.html
+++ b/client/src/partials/accounts/templates/grid.titleRow.tmpl.html
@@ -2,7 +2,7 @@
   ng-repeat="(colRenderIndex, col) in colContainer.renderedColumns track by col.uid"
   ui-grid-one-bind-id-grid="rowRenderIndex + '-' + col.uid + '-cell'"
   class="ui-grid-cell"
-  ng-class="{ 'ui-grid-row-header-cell': col.isRowHeader, 'text-uppercase text-bold' : row.entity.type === 'title' }"
+  ng-class="{ 'ui-grid-row-header-cell': col.isRowHeader, 'text-uppercase text-bold' : row.entity.type_id === grid.appScope.Constants.accounts.TITLE  }"
   data-vals="{{col.isRowHeader}}"
   role="{{col.isRowHeader ? 'rowheader' : 'gridcell'}}"
   ui-grid-cell>

--- a/test/end-to-end/accounts/accounts.spec.js
+++ b/test/end-to-end/accounts/accounts.spec.js
@@ -72,7 +72,9 @@ describe('Account Management', function () {
   it('edit state populates account data on clicking edit', function () {
     page.openEdit(account.id);
     expect(element(by.id('number-static')).getText()).to.eventually.equal(String(account.number));
-    expect(element(by.id('type-static')).getText()).to.eventually.equal(account.type);
+
+    // @todo removed to allow types to be updated - this should be reintroduced
+    // expect(element(by.id('type-static')).getText()).to.eventually.equal(account.type);
     expect(element(by.model('AccountEditCtrl.account.label')).getAttribute('value')).to.eventually.equal(account.label);
   });
 


### PR DESCRIPTION
This pull request refactor's the account management page, factoring feedback from module use during installation. 

**Filter Account Title/ Number**
_Filter disabled_
![filter_off](https://cloud.githubusercontent.com/assets/2844572/20687637/8ffea368-b5bd-11e6-8da5-dede78211c08.PNG)

_Filter enabled_
![filter_on](https://cloud.githubusercontent.com/assets/2844572/20687647/974e44e8-b5bd-11e6-9320-d701cda62569.PNG)

_Filter results - maintains structure of accounts_
![maintains_structure](https://cloud.githubusercontent.com/assets/2844572/20687657/a8ad51e8-b5bd-11e6-9fd3-08f73242adf3.PNG)

**Update account type**
Account types had been made read only in the edit view to ensure that account types were never changed during actual use of the application - however this proved very impractical for application installation. This feature should be developed further in the future (allowing disabling once complete or introducing disabling with a more stable build).
![edit_title](https://cloud.githubusercontent.com/assets/2844572/20687707/dcf5cbd8-b5bd-11e6-8062-325d89a727ad.PNG)

**Additional UX fixes**
* Account deletion simplified and updated - the grid is not forced to refresh on deletion and all bugs around this have been fixed
* Account update scrolls to the updated account - only if the parent account is updated is a grid redraw required (this allows movement of entire groups of accounts)
* Ensure title accounts that are created are displayed as title accounts (bold)
* Account selection UI-select correctly filters results on `hrlabel`


