### PR TITLE
(Fix) Account - Block titles with children from having their types updated

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -47,7 +47,7 @@
     "SUBMIT_CREATE"  : "Create Account",
     "SUBMIT_DELETE"  : "Delete Account",
     "SUBMIT_UPDATE"  : "Update Account",
-
+    "TYPE_CHANGE_BLOCKED" : "You cannot change the type of a title account with children.",
     "TYPES" : {
       "INCOME" : "Income",
       "EXPENSE" : "Expense",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -47,12 +47,12 @@
     "TITLE"          : "Gestion des Comptes",
     "TITLE_ACCOUNT"  : "Comptes Titre",
     "UPDATED"        : "Modifié",
+    "TYPE_CHANGE_BLOCKED" : "Vous ne pouvez pas modifier le type d'un compte de titre qui a des sous-comptes.",
     "TYPES" : {
       "BALANCE" : "Balance",
       "EXPENSE" : "Frais",
       "TITLE" : "Titre",
       "INCOME" : "Produit",
-      "BALANCE" : "Balance",
       "EXPENSE" : "Charge"
     },
     "UPDATED"        : "Les données du compte ont été mis à jour"

--- a/client/src/partials/accounts/accounts.js
+++ b/client/src/partials/accounts/accounts.js
@@ -37,7 +37,7 @@ function AccountsController($rootScope, $timeout, AccountGrid, Notify, Constants
     .finally(toggleLoadingIndicator);
 
   var columns = [
-    { field : 'number', displayName : '', cellClass : 'text-right', width : 70},
+    { field : 'number', displayName : '', cellClass : 'text-right', width : 80},
     { field : 'label', displayName : 'FORM.LABELS.ACCOUNT', cellTemplate : '/partials/accounts/templates/grid.indentCell.tmpl.html', headerCellFilter : 'translate' },
     { name : 'actions', enableFiltering : false, displayName : '', cellTemplate : '/partials/accounts/templates/grid.actionsCell.tmpl.html', headerCellFilter : 'translate', width : 140 }
   ];

--- a/client/src/partials/accounts/edit/accounts.edit.js
+++ b/client/src/partials/accounts/edit/accounts.edit.js
@@ -136,6 +136,21 @@ function AccountEditController($rootScope, $state, AccountStore, Accounts, Notif
   }
 
 
+  vm.titleChangedValidation = titleChangedValidation;
+
+  // @todo form validation using validators on a component
+  function titleChangedValidation(newAccountType) {
+    var notTitleAccount = Number(newAccountType) !== Constants.accounts.TITLE;
+    var hasChildren = vm.account.children.length;
+
+    if (notTitleAccount && hasChildren) {
+      vm.invalidTitleAccount = true;
+    } else {
+      vm.invalidTitleAccount = false;
+    }
+  }
+
+
   /** @todo re-factor method - potentially these two actions should be split into two controllers */
   function updateAccount(accountForm) {
     // only require form to have changed if this is not the create state (no initial values)
@@ -146,6 +161,10 @@ function AccountEditController($rootScope, $state, AccountStore, Accounts, Notif
       return;
     }
     if (!accountForm.$dirty) {
+      return;
+    }
+
+    if (vm.invalidTitleAccount) {
       return;
     }
 
@@ -210,7 +229,6 @@ function AccountEditController($rootScope, $state, AccountStore, Accounts, Notif
       })
       .catch(handleModalError);
     });
-
   }
 
   function resetModal(accountForm) {

--- a/client/src/partials/accounts/edit/accounts.edit.modal.html
+++ b/client/src/partials/accounts/edit/accounts.edit.modal.html
@@ -52,17 +52,23 @@
       <!-- <p class="form-control-static" ng-if="AccountEditCtrl.account" id="type-static">{{::AccountEditCtrl.getTypeTitle(AccountEditCtrl.account.type_id) | translate }}</p> -->
     <!-- </div> -->
 
+
     <div class="form-group"
-         ng-class="{'has-error' : AccountForm.type_id.$invalid && AccountForm.$submitted}">
+         ng-class="{'has-error' : (AccountForm.type_id.$invalid && AccountForm.$submitted) || AccountEditCtrl.invalidTitleAccount}">
       <label class="control-label">{{ "FORM.LABELS.ACCOUNT_TYPE" | translate }}</label>
       <select
         class="form-control"
         ng-model="AccountEditCtrl.account.type_id"
+        ng-change="AccountEditCtrl.titleChangedValidation(AccountEditCtrl.account.type_id)"
         name="type_id"
         required>
         <option value="" disabled>{{ "FORM.SELECT.ACCOUNT_TYPE" | translate }}</option>
         <option ng-repeat="entry in AccountEditCtrl.types" value="{{entry.id}}" data-key="{{entry.translation_key}}">{{entry.translation_key | translate}}</option>
       </select>
+
+      <div class="help-block" ng-if="AccountEditCtrl.invalidTitleAccount">
+        {{ "ACCOUNT.TYPE_CHANGE_BLOCKED" | translate }}
+      </div>
       <div class="help-block" ng-messages="AccountForm.type_id.$error" ng-show="AccountForm.$submitted">
         <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
       </div>


### PR DESCRIPTION
This commit makes sure that a title account has no children before
it's type id can be changed. This ensures there are no other account
types with children on a well set up chart of accounts.

- [x] Requires French translation

@IMA-WorldHealth/bhima-core 
Can someone comment here with a good translation for:
```js
"TYPE_CHANGE_BLOCKED" : "You cannot change the type of a title account with children."
```
