### PR TITLE
fix(invoice): do not submit invoice if items have no inventory sales_account

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -890,7 +890,12 @@
     "STAT_TOTAL_INVOICE" : "Total Invoices",
     "STAT_PAID"          : "Paid",
     "STAT_NOT_PAID"      : "Waiting Payment",
-    "SUCCESS"            : "Patient invoice successfully recorded."
+    "SUCCESS"            : "Patient invoice successfully recorded.",
+    "ERRORS"             : {
+      "INVALID_NUMBERS" : "The record contains negative, zero, or invalid numbers",
+      "MISSING_SALES_ACCOUNT" : "The record contains an inventory item missing a sales account.  You cannot make an invoice without a sales account.",
+      "NOT_CONFIGURED" : "The record is missing an inventory item. Please put in an inventory item or remove the row."
+    }
   },
   "PATIENT_RECORDS": {
     "TITLE"              : "Patients",

--- a/client/src/js/services/PatientInvoiceItemService.js
+++ b/client/src/js/services/PatientInvoiceItemService.js
@@ -64,12 +64,33 @@ function PatientInvoiceItemService(uuid) {
       item.quantity > 0 &&
       item.transaction_price >= 0;
 
+    // ensure the item has a sales account
+    var hasSalesAccount = angular.isDefined(item._salesAccount) &&
+      item._salesAccount !== null;
+
+    item._hasSalesAccount = hasSalesAccount;
+
     // the item is only initialised if it has an inventory item
     item._initialised = angular.isDefined(item.inventory_uuid);
 
     // alias both valid and invalid for easy reading
-    item._valid = item._initialised && hasValidNumbers;
+    item._valid = item._initialised && hasValidNumbers && hasSalesAccount;
     item._invalid = !item._valid;
+
+    item._message = '';
+
+    // if the item is invalid, bind the error reason to it.
+    if (item._invalid) {
+
+      // possible validation messages
+      if (!item._initialised) {
+        item._message = 'PATIENT_INVOICE.ERRORS.MISSING_SALES_ACCOUNT';
+      } else if (!hasSalesAccount) {
+        item._message = 'PATIENT_INVOICE.ERRORS.NOT_CONFIGURED';
+      } else {
+        item._message = 'PATIENT_INVOICE.ERRORS.INVALID_NUMBERS';
+      }
+    }
   };
 
   /**
@@ -91,6 +112,9 @@ function PatientInvoiceItemService(uuid) {
       this.transaction_price = inventoryItem.price;
       this.inventory_price = inventoryItem.price;
       this.inventory_uuid = inventoryItem.uuid;
+
+      // special binding to make sure inventory items have a sales_account
+      this._salesAccount = inventoryItem.sales_account;
     } catch (e) {}
 
     // reset the validation flags.

--- a/client/src/partials/patient_invoice/patientInvoice.html
+++ b/client/src/partials/patient_invoice/patientInvoice.html
@@ -111,6 +111,14 @@
       </div>
     </div>
 
+    <div ng-show="PatientInvoiceCtrl.Invoice._error" class="row">
+      <div class="col-xs-12">
+        <div class="alert alert-danger">
+          <i class="fa fa-warning"></i> {{ PatientInvoiceCtrl.Invoice._error | translate }}
+        </div>
+      </div>
+    </div>
+
     <!-- TODO Move padding to generic CSS class -->
     <div class="row" style="padding-bottom : 5px;">
       <div class="col-xs-12">

--- a/client/src/partials/patient_invoice/patientInvoice.js
+++ b/client/src/partials/patient_invoice/patientInvoice.js
@@ -67,7 +67,6 @@ function PatientInvoiceController(Patients, PatientInvoices, PatientInvoiceForm,
     Patients.read(uuid)
     .then(function (patient) {
       vm.Invoice.setPatient(patient);
-
       return Patients.balance(patient.debtor_uuid);
     })
     .then(function (balance) {
@@ -92,9 +91,9 @@ function PatientInvoiceController(Patients, PatientInvoices, PatientInvoiceForm,
     var invalidItems = vm.Invoice.validate(true);
 
     if (invalidItems.length) {
-      Notify.danger('PATIENT_INVOICE.INVALID_ITEMS');
 
       var firstInvalidItem = invalidItems[0];
+      Notify.danger(firstInvalidItem._message);
 
       // show the user where the error is
       vm.gridApi.core.scrollTo(firstInvalidItem);

--- a/client/src/partials/patient_invoice/templates/grid/code.tmpl.html
+++ b/client/src/partials/patient_invoice/templates/grid/code.tmpl.html
@@ -18,7 +18,6 @@
       popover-placement="right"
       popover-append-to-body="true"
       popover-trigger="mouseenter">
-
       <span class="fa fa-info-circle"></span>
     </span>
     <span>{{ row.entity.code }}</span>

--- a/client/src/partials/patient_invoice/templates/grid/status.tmpl.html
+++ b/client/src/partials/patient_invoice/templates/grid/status.tmpl.html
@@ -7,10 +7,10 @@
   class="ui-grid-cell-contents">
 
   <!-- warning state: invalid, but not initialised yet -->
-  <span ng-hide="row.entity._initialised" class="fa fa-circle-o"></span>
+  <span ng-hide="row.entity._initialised" class="fa fa-circle-o" uib-tooltip="{{ row.entity._message | translate }}" tooltip-placement="right" tooltip-append-to-body="true"></span>
 
   <!-- error state: invalid and initialised -->
-  <span ng-show="row.entity._initialised" class="fa fa-times-circle"></span>
+  <span ng-show="row.entity._initialised" class="fa fa-times-circle" uib-tooltip="{{ row.entity._message | translate }}" tooltip-placement="right" tooltip-append-to-body="true"></span>
 </div>
 
 <div ng-show="row.entity._valid" class="bg-success ui-grid-cell-contents">

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -114,7 +114,8 @@ function getItemsMetadata() {
   var sql =
     `SELECT BUID(i.uuid) as uuid, i.code, i.text AS label, i.price, iu.text AS unit,
       it.text AS type, ig.name AS groupName, BUID(ig.uuid) AS group_uuid, i.consumable, i.stock_min,
-      i.stock_max, i.origin_stamp AS timestamp, i.type_id, i.unit_id, i.unit_weight, i.unit_volume
+      i.stock_max, i.origin_stamp AS timestamp, i.type_id, i.unit_id, i.unit_weight, i.unit_volume,
+      ig.sales_account
     FROM inventory AS i JOIN inventory_type AS it
       JOIN inventory_unit AS iu JOIN inventory_group AS ig ON
       i.type_id = it.id AND i.group_uuid = ig.uuid AND
@@ -137,7 +138,8 @@ function getItemsMetadataById(uuid) {
   var sql =
     `SELECT BUID(i.uuid) as uuid, i.code, i.text AS label, i.price, iu.text AS unit,
       it.text AS type, ig.name AS groupName, BUID(ig.uuid) AS group_uuid, i.consumable, i.stock_min,
-      i.stock_max, i.origin_stamp AS timestamp, i.type_id, i.unit_id, i.unit_weight, i.unit_volume
+      i.stock_max, i.origin_stamp AS timestamp, i.type_id, i.unit_id, i.unit_weight, i.unit_volume,
+      ig.sales_account
     FROM inventory AS i JOIN inventory_type AS it
       JOIN inventory_unit AS iu JOIN inventory_group AS ig ON
       i.type_id = it.id AND i.group_uuid = ig.uuid AND


### PR DESCRIPTION
This commit ensures that the patient invoice page blocks invoices that
contain items missing sales account.  In production, this should only
occur if your database was improperly initialized.

Each item now is able to alert its own message as a tooltip when the
error state is hovered over.  Additionally, the grid itself displays a
large error when it detects items without a sales account.

![patientinvoicerowvalidation](https://cloud.githubusercontent.com/assets/896472/20709122/b2281f20-b633-11e6-8a71-81a79974db30.png)
_Fig 1: Row Validation with Tooltips_

![patientinvoiceglobalerrorvalidation](https://cloud.githubusercontent.com/assets/896472/20709123/b28f80ca-b633-11e6-81aa-907e20867230.png)
_Fig 2: Missing Sales Account Error Validation_


Partially addresses #980.

-----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!