### PR TITLE
fix(invoices): show the correct error text

### DIFF
--- a/client/src/js/services/PatientInvoiceItemService.js
+++ b/client/src/js/services/PatientInvoiceItemService.js
@@ -84,9 +84,9 @@ function PatientInvoiceItemService(uuid) {
 
       // possible validation messages
       if (!item._initialised) {
-        item._message = 'PATIENT_INVOICE.ERRORS.MISSING_SALES_ACCOUNT';
-      } else if (!hasSalesAccount) {
         item._message = 'PATIENT_INVOICE.ERRORS.NOT_CONFIGURED';
+      } else if (!hasSalesAccount) {
+        item._message = 'PATIENT_INVOICE.ERRORS.MISSING_SALES_ACCOUNT';
       } else {
         item._message = 'PATIENT_INVOICE.ERRORS.INVALID_NUMBERS';
       }


### PR DESCRIPTION
This commit fixes the error text on the invoice page so that it shows
the correct global error message for missing sales account.

Fixes #989.

---
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!