### PR TITLE
(Feature) Add optional flag to use the combined ledger; debtor debt

### DIFF
--- a/client/src/partials/templates/grid/debit_equiv.cell.html
+++ b/client/src/partials/templates/grid/debit_equiv.cell.html
@@ -1,7 +1,7 @@
-<div class="ui-grid-cell-contents" title="TOOLTIP" ng-if="!row.groupHeader">
+<div class="ui-grid-cell-contents" title="TOOLTIP" ng-if="::!row.groupHeader">
   {{row.entity.debit_equiv}}
 </div>
 
-<div class="ui-grid-cell-contents" title="TOOLTIP" ng-if="row.groupHeader">
+<div class="ui-grid-cell-contents" title="TOOLTIP" ng-if="::row.groupHeader">
   {{ COL_FIELD CUSTOM_FILTERS }}
 </div>

--- a/server/controllers/dashboard/debtorGroups.js
+++ b/server/controllers/dashboard/debtorGroups.js
@@ -22,7 +22,9 @@ function getReport(req, res, next) {
   }
 
   // the cache has expired or has never been created - calculate the report
-  report.context()
+  // ensure the lastest data from both the posting journal and the general ledger
+  // is used
+  report.context({combinedLedger : 1})
     .then(function (result) {
       timestamp = new moment();
       cachedReport = result;

--- a/server/controllers/finance/debtors/groups/index.js
+++ b/server/controllers/finance/debtors/groups/index.js
@@ -270,7 +270,7 @@ function loadInvoices(params) {
     `SELECT BUID(i.uuid) as uuid, i.date, CONCAT(project.abbr, i.reference) as reference,
       debit, credit, (debit - credit) as balance, BUID(entity_uuid) as entity_uuid
     FROM (
-      SELECT record_uuid as uuid, combined_ledger.date, SUM(debit) as debit, SUM(credit) as credit,
+      SELECT record_uuid as uuid, combined_ledger.trans_date as date, SUM(debit_equiv) as debit, SUM(credit_equiv) as credit,
         entity_uuid, invoice.reference, invoice.project_id
       FROM combined_ledger
       JOIN invoice ON combined_ledger.record_uuid = invoice.uuid OR combined_ledger.reference_uuid = invoice.uuid

--- a/server/controllers/finance/debtors/index.js
+++ b/server/controllers/finance/debtors/index.js
@@ -161,11 +161,11 @@ function invoices(req, res, next) {
         FROM (
           SELECT uuid, SUM(debit) AS debit, SUM(credit) AS credit, SUM(debit-credit) AS balance, entity_uuid
           FROM (
-            SELECT record_uuid AS uuid, debit, credit, entity_uuid
+            SELECT record_uuid AS uuid, debit_equiv as debit, credit_equiv as credit, entity_uuid
             FROM combined_ledger
             WHERE record_uuid IN (?) AND entity_uuid = ?
           UNION ALL
-            SELECT reference_uuid AS uuid, debit, credit, entity_uuid
+            SELECT reference_uuid AS uuid, debit_equiv as debit, credit_equiv as credit, entity_uuid
             FROM  combined_ledger
             WHERE reference_uuid IN (?) AND entity_uuid = ?
           ) AS ledger
@@ -222,7 +222,7 @@ function balance(req, res, next) {
     sql =
       `SELECT COUNT(*) AS count, SUM(credit - debit) AS balance, BUID(entity_uuid) as entity_uuid
       FROM (
-        SELECT record_uuid as uuid, debit, credit
+        SELECT record_uuid as uuid, debit_equiv as debit, credit_equiv as credit
         FROM combined_ledger
         WHERE entity_uuid = ?
       ) AS ledger

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -610,11 +610,11 @@ function loadLatestInvoice (latestInvoice){
       FROM (
         SELECT uuid, SUM(debit) as debit, SUM(credit) as credit, entity_uuid
         FROM (
-          SELECT record_uuid as uuid, debit, credit, entity_uuid
+          SELECT record_uuid as uuid, debit_equiv as debit, credit_equiv as credit, entity_uuid
           FROM combined_ledger
           WHERE record_uuid IN (?) AND entity_uuid = ?
         UNION ALL
-          SELECT reference_uuid as uuid, debit, credit, entity_uuid
+          SELECT reference_uuid as uuid, debit_equiv as debit, credit_equiv as credit, entity_uuid
           FROM  combined_ledger
           WHERE reference_uuid IN (?) AND entity_uuid = ?
         ) AS ledger
@@ -627,11 +627,11 @@ function loadLatestInvoice (latestInvoice){
       FROM (
         SELECT uuid,  debit, credit, entity_uuid
         FROM (
-          SELECT record_uuid as uuid, debit, credit, entity_uuid
+          SELECT record_uuid as uuid, debit_equiv as debit, credit_equiv as credit, entity_uuid
           FROM combined_ledger
           WHERE record_uuid IN (?) AND entity_uuid = ? AND debit = 0
         UNION ALL
-          SELECT reference_uuid as uuid, debit, credit, entity_uuid
+          SELECT reference_uuid as uuid, debit_equiv as debit, credit_equiv as credit, entity_uuid
           FROM  combined_ledger
           WHERE reference_uuid IN (?) AND entity_uuid = ? AND debit = 0
         ) AS ledger

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -629,11 +629,11 @@ function loadLatestInvoice (latestInvoice){
         FROM (
           SELECT record_uuid as uuid, debit_equiv as debit, credit_equiv as credit, entity_uuid
           FROM combined_ledger
-          WHERE record_uuid IN (?) AND entity_uuid = ? AND debit = 0
+          WHERE record_uuid IN (?) AND entity_uuid = ? AND debit_equiv = 0
         UNION ALL
           SELECT reference_uuid as uuid, debit_equiv as debit, credit_equiv as credit, entity_uuid
           FROM  combined_ledger
-          WHERE reference_uuid IN (?) AND entity_uuid = ? AND debit = 0
+          WHERE reference_uuid IN (?) AND entity_uuid = ? AND debit_equiv = 0
         ) AS ledger
       ) AS i JOIN invoice ON i.uuid = invoice.uuid
       JOIN project ON invoice.project_id = project.id `;

--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -820,14 +820,14 @@ BEGIN
   );
 
   INSERT INTO stage_cash_records
-    SELECT cl.record_uuid AS uuid, cl.debit, cl.credit, cl.entity_uuid, cl.date
+    SELECT cl.record_uuid AS uuid, cl.debit_equiv as debit, cl.credit_equiv as credit, cl.entity_uuid, cl.trans_date as date
     FROM combined_ledger AS cl
     WHERE cl.record_uuid IN (
       SELECT ci.invoice_uuid FROM stage_cash_item AS ci WHERE ci.cash_uuid = cashUuid
     ) AND cl.entity_uuid = cashDebtorUuid;
 
   INSERT INTO stage_cash_references
-    SELECT cl.reference_uuid AS uuid, cl.debit, cl.credit, cl.entity_uuid, cl.date
+    SELECT cl.reference_uuid AS uuid, cl.debit_equiv as debit, cl.credit_equiv as credit, cl.entity_uuid, cl.trans_date as date
     FROM combined_ledger AS cl
     WHERE cl.reference_uuid IN (
       SELECT ci.invoice_uuid FROM stage_cash_item AS ci WHERE ci.cash_uuid = cashUuid

--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -318,12 +318,12 @@ BEGIN
  -- cursor for debtor's cautions
   DECLARE curse CURSOR FOR
     SELECT c.id, c.date, c.description, SUM(c.credit - c.debit) AS balance FROM (
-        SELECT debit, credit, combined_ledger.date, combined_ledger.description, record_uuid AS id
+        SELECT debit_equiv as debit, credit_equiv as credit, combined_ledger.trans_date as date, combined_ledger.description, record_uuid AS id
         FROM combined_ledger JOIN cash
           ON cash.uuid = combined_ledger.record_uuid
         WHERE reference_uuid IS NULL AND entity_uuid = ientityId AND cash.is_caution = 0
       UNION
-        SELECT debit, credit, combined_ledger.date, combined_ledger.description, reference_uuid AS id
+        SELECT debit_equiv as debit, credit_equiv as credit, combined_ledger.trans_date as date, combined_ledger.description, reference_uuid AS id
         FROM combined_ledger JOIN cash
           ON cash.uuid = combined_ledger.reference_uuid
         WHERE entity_uuid = ientityId AND cash.is_caution = 0

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1840,11 +1840,11 @@ CREATE TABLE IF NOT EXISTS `voucher_item` (
 
 -- a view to make SQL statements look nicer.
 CREATE VIEW combined_ledger AS
-  SELECT record_uuid, trans_id, trans_date AS date, account_id, credit_equiv AS credit, debit_equiv as debit,
+  SELECT record_uuid, trans_id, trans_date, account_id, credit_equiv, debit_equiv,
     reference_uuid, description, entity_uuid
   FROM posting_journal
   UNION ALL
-  SELECT record_uuid, trans_id, trans_date AS date, account_id, credit_equiv AS credit, debit_equiv as debit,
+  SELECT record_uuid, trans_id, trans_date, account_id, credit_equiv, debit_equiv,
     reference_uuid, description, entity_uuid
   FROM general_ledger;
 


### PR DESCRIPTION
This commit adds the `combinedLedger` flag to the aged debtor debt
report. This changes the 'source' of the debt query, using the
`general_ledger` by default and using the `combined_ledger` if the
flag is set.

It also updates the combined ledger to use the same column names as
the general ledger, querries can alias this after it is requested
if required.