### PR TITLE
fix(cash): use patient name in description

### DIFF
--- a/client/src/js/services/CashService.js
+++ b/client/src/js/services/CashService.js
@@ -14,22 +14,21 @@ CashService.$inject = [
  */
 function CashService(Modal, Api, Exchange, Session, moment, $http, util) {
   var service     = new Api('/cash/');
-  var baseUrl     = '/cash/';
   var urlCheckin  = '/cash/checkin/';
 
-
   // templates for descriptions
-  var TRANSFER_DESCRIPTION = 'Transfer Voucher / :date / :user';
-  var PAYMENT_DESCRIPTION = 'Cash Payment/ :date / :user';
-  var CAUTION_DESCRIPTION = 'Caution Payment / :date / :user';
+  var TRANSFER_DESCRIPTION = 'Transfer Voucher / :date / :name';
+  var PAYMENT_DESCRIPTION = 'Cash Payment/ :date / :name';
+  var CAUTION_DESCRIPTION = 'Caution Payment / :date / :name';
 
   // custom methods
   service.create = create;
   service.getTransferRecord = getTransferRecord;
   service.calculateDisabledIds = calculateDisabledIds;
+  service.formatCashDescription = formatCashDescription;
   service.formatFilterParameters = formatFilterParameters;
   service.openCancelCashModal = openCancelCashModal;
-  service.checkCashPayment = checkCashPayment;  
+  service.checkCashPayment = checkCashPayment;
 
   /**
    * Cash Payments can be made to multiple invoices.  This function loops
@@ -75,8 +74,6 @@ function CashService(Modal, Api, Exchange, Session, moment, $http, util) {
       data.items = allocatePaymentAmounts(data);
     }
 
-    data.description = formatCashDescription(payment.date, payment.is_caution);
-
     // remove data.invoices property before submission to the server
     delete data.invoices;
 
@@ -87,12 +84,15 @@ function CashService(Modal, Api, Exchange, Session, moment, $http, util) {
   /*
    * Nicely format the cash payment description
    */
-  function formatCashDescription(date, isCaution) {
+  function formatCashDescription(patient, payment) {
+    var isCaution = payment.is_caution;
+    var date = payment.date;
+
     var tmpl = isCaution ? CAUTION_DESCRIPTION : PAYMENT_DESCRIPTION;
 
     return tmpl
       .replace(':date', moment(date).format('YYYY-MM-DD'))
-      .replace(':user', Session.user.display_name);
+      .replace(':name', patient.display_name);
   }
 
   /**

--- a/client/src/partials/cash/cash.js
+++ b/client/src/partials/cash/cash.js
@@ -95,13 +95,14 @@ function CashController(Cash, Cashboxes, AppCache, Currencies, Exchange, Session
     vm.patient = patient;
 
     Patient.balance(vm.patient.debtor_uuid)
-    .then(function (balance) {
-      /**
-       * balance < 0 means that enterprise must money to the patient (creditor balance)
-       * multiply by -1 means we want work with positive value if the patient has a creditor balance
-       */
-      vm.patientBalance = balance * -1;
-    });
+      .then(function (balance) {
+        /**
+         * balance < 0 means that enterprise must money to the patient (creditor balance)
+         * multiply by -1 means we want work with positive value if the patient has a creditor balance
+         */
+        vm.patientBalance = balance * -1;
+      })
+      .catch(Notify.handleError);
   }
 
   // caches the cashbox
@@ -158,6 +159,9 @@ function CashController(Cash, Cashboxes, AppCache, Currencies, Exchange, Session
     if (!isCaution && !hasInvoices) {
       return Notify.danger('CASH.VOUCHER.NO_INVOICES_ASSIGNED');
     }
+
+    // format the cash payment description
+    vm.payment.description = Cash.formatCashDescription(vm.patient, vm.payment);
 
     // submit the cash payment
     if (hasCaution) {


### PR DESCRIPTION
The cash payments module now uses the patient's name instead of the
username in the description. This allows the journal to filter on the
patient name instead of redundant data.

Closes #988.

----------

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!