### PR TITLE
fix(prices): disable unique key on item labels

### DIFF
--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1088,7 +1088,7 @@ CREATE TABLE `price_list_item` (
   `is_percentage`       BOOLEAN NOT NULL DEFAULT 0,
   `created_at`          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`uuid`),
-  UNIQUE KEY `price_list_item_1` (`label`),
+  UNIQUE KEY `price_list_item_1` (`label`, `inventory_uuid`),
   UNIQUE KEY `price_list_item_2` (`price_list_uuid`, `inventory_uuid`),
   KEY `price_list_uuid` (`price_list_uuid`),
   KEY `inventory_uuid` (`inventory_uuid`),


### PR DESCRIPTION
This commit removes the unique key on inventory item labels.  This
causes problems when the same item is used in multiple price lists and
the user wants to give the item the same name.

Closes #1004.

Includes a new integration test as proof of work.

-----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!