### PR TITLE
fix(invoices): pretty footer total values

### DIFF
--- a/client/src/js/components/bhNavigation.js
+++ b/client/src/js/components/bhNavigation.js
@@ -159,4 +159,6 @@ function NavigationController($location, $rootScope, Tree, AppCache, Notify) {
 
   // if the session is reloaded, download the new tree units
   $rootScope.$on('session:reload', loadTreeUnits);
+
+  loadTreeUnits();
 }

--- a/client/src/partials/patient_invoice/registry/registry.js
+++ b/client/src/partials/patient_invoice/registry/registry.js
@@ -50,16 +50,19 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util,
         headerCellFilter : 'translate',
         cellTemplate: '/partials/patient_invoice/registry/templates/cost.cell.tmpl.html',
         aggregationType: uiGridConstants.aggregationTypes.sum,
-        footerCellFilter: 'currency:grid.appScope.enterprise.currency_id'
+        aggregationHideLabel : true,
+        footerCellClass : 'text-right',
+        footerCellFilter: 'currency:' + Session.enterprise.currency_id
       },
       { field : 'serviceName', displayName : 'TABLE.COLUMNS.SERVICE', headerCellFilter : 'translate'  },
       { field : 'display_name', displayName : 'TABLE.COLUMNS.BY', headerCellFilter : 'translate' },
-      { name : 'receipt_action', displayName : '', cellTemplate : '/partials/patient_invoice/registry/templates/invoiceReceipt.action.tmpl.html' },
-      { name : 'credit_action', displayName : '', cellTemplate : '/partials/patient_invoice/registry/templates/creditNote.action.tmpl.html' }
+      { name : 'receipt_action', displayName : '', cellTemplate : '/partials/patient_invoice/registry/templates/invoiceReceipt.action.tmpl.html', enableSorting: false },
+      { name : 'credit_action', displayName : '', cellTemplate : '/partials/patient_invoice/registry/templates/creditNote.action.tmpl.html', enableSorting: false }
     ],
     enableSorting : true,
     rowTemplate : '/partials/patient_invoice/templates/grid.creditNote.tmpl.html'
   };
+
   vm.receiptOptions = {};
 
   // receiptOptions are used in the bh-print directive under the receipt-action template
@@ -99,7 +102,7 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, util,
       invoices.forEach(function (invoice) {
         invoice._backgroundColor =
           (invoice.type_id === bhConstants.transactionType.CREDIT_NOTE) ?  reversedBackgroundColor : regularBackgroundColor;
-      });   
+      });
 
       // put data in the grid
       vm.uiGridOptions.data = invoices;


### PR DESCRIPTION
This commit makes the invoice registry footer a bit nicer to look at -
the label is gone, and the currency is left aligned for easy reading.

Closes #1009.

Note: this PR also contains an important bug fix for the tree introduced in my merge of the Session PR.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!