### PR TITLE
fix(vouchers): ui-select on small screen

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -836,3 +836,8 @@ growl-notification.fading.ng-leave.ng-leave-active {
 .progress-bar.ima-blue {
   background-color : #085484;
 }
+
+/* properly deal with ui-selects inside ui-grids */
+.ui-select-bootstrap > .ui-select-choices.ui-grid-ui-select {
+  width: initial;
+}

--- a/client/src/partials/vouchers/templates/account.grid.tmpl.html
+++ b/client/src/partials/vouchers/templates/account.grid.tmpl.html
@@ -11,6 +11,7 @@
    </ui-select-match>
    <ui-select-choices
      ui-select-focus-patch
+     class="ui-grid-ui-select"
      ui-disable-choice="account.type_id === grid.appScope.bhConstants.accounts.TITLE"
      repeat="account in grid.appScope.accounts | filter:$select.search">
      <strong ng-bind-html="account.number | highlight:$select.search"></strong>


### PR DESCRIPTION
This commit makes sure that the UI-select on the complex vouchers page
has plenty of room to select accounts via the css class
`ui-grid-ui-select` applied to the `ui-select-choices` element.

All other `ui-select` elements in grids can take advantage of this class
to display themselves better.

Closes #873.

![uigriduiselect](https://cloud.githubusercontent.com/assets/896472/20862204/185eaef2-b9a5-11e6-8d98-82c76fa354bd.png)
_Fig 1: The present implementation described._


----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!