### PR TITLE
feat(patient): implement patient barcodes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,8 @@
     "Chart.js": "^2.1.6",
     "angular-chart.js": "^1.0.1",
     "components-font-awesome": "^4.6.3",
-    "angular-ui-select": "^0.17.1"
+    "angular-ui-select": "^0.17.1",
+    "JsBarcode": "jsbarcode#^3.5.6"
   },
   "devDependencies": {
     "angular-mocks": "1.5.9"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,6 +42,8 @@ const paths = {
 
       // this is very cheeky
       'client/vendor/moment/moment.js',
+      'client/vendor/JsBarcode/dist/JsBarcode.all.min.js',
+
       '!client/vendor/**/src{,/**}',
       '!client/vendor/**/js{,/**}'
     ],

--- a/server/controllers/medical/reports/patient.receipt.handlebars
+++ b/server/controllers/medical/reports/patient.receipt.handlebars
@@ -33,4 +33,12 @@
       {{translate "TABLE.COLUMNS.REGISTERED_ON"}} {{date patient.registration_date }}<br />
     </div>
   </div>
+
+  <div class="row" style="margin-top: 2em;">
+    <div class="col-xs-12">
+      {{> barcode value=patient.uuid }}
+    </div>
+  </div>
+
+  <script>JsBarcode('.barcode').init();</script>
 </body>

--- a/server/lib/template/partials/barcode.handlebars
+++ b/server/lib/template/partials/barcode.handlebars
@@ -1,0 +1,9 @@
+<svg class="barcode"
+  jsbarcode-format="code128"
+  jsbarcode-value="{{value}}"
+  jsbarcode-width="1"
+  jsbarcode-height="50"
+  jsbarcode-displayvalue="false"
+  jsbarcode-margin="0"
+  jsbarcode-textmargin="0">
+</svg>

--- a/server/lib/template/partials/head.handlebars
+++ b/server/lib/template/partials/head.handlebars
@@ -3,6 +3,7 @@
   <title>{{translate title}}</title>
   <link href="{{absolutePath}}/css/bhima-bootstrap.css" rel="stylesheet">
   <link href="{{absolutePath}}/vendor/components-font-awesome/css/font-awesome.css" rel="stylesheet">
+  <script src="{{absolutePath}}/vendor/JsBarcode.all.min.js"></script>
   <style>
     @media print {
       table, tr, td, th, tbody, thead, tfoot {


### PR DESCRIPTION
This commit implements barcodes for any PDF rendered through
wkhtmltopdf using JsBarcode.  The barcodes can be easily assigned using
the barcode helper, as demonstrated on the patient card.

This feature was first attempted in #734.  It suffered from a lack of cross-platform support.

![patientbarcode](https://cloud.githubusercontent.com/assets/896472/21011540/12333c9a-bd52-11e6-92ef-25b1a1e6dcec.png)
_Fig 1: The rendered barcode_

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!