### PR TITLE
fix(invoices): only show item error if configured

### DIFF
--- a/client/src/js/services/PatientInvoiceForm.js
+++ b/client/src/js/services/PatientInvoiceForm.js
@@ -157,8 +157,9 @@ function PatientInvoiceFormService(Patients, PriceLists, Inventory, AppCache, St
     var invalidItems = this.store.data.filter(function (row) {
       row[ROW_ERROR_FLAG] = highlight ? row._invalid : false;
 
-      // this sets the global configuration error if a
-      if (!row._hasSalesAccount) {
+      // this sets the global configuration error if there is no sales account
+      // and the row has already been configured.
+      if (row._initialised && !row._hasSalesAccount) {
         globalConfigurationError = row._message;
       }
 


### PR DESCRIPTION

This commit ensures that the global error message is only shown if there
is no sales account _after_ the item has been configured.  Previously,
this resulted in showing large error messages during perfectly normal
operation.

Closes #1046.

![hiddenerrorswheninvoicenotconfigured](https://cloud.githubusercontent.com/assets/896472/21093452/3c4c8b00-c052-11e6-969a-06bd001ea407.png)
_Fig 1: Hidden Errors when Items not Configured_

![visibleerrorswheninvoiceconfigured](https://cloud.githubusercontent.com/assets/896472/21093451/3a421050-c052-11e6-9af7-00cca837018a.png)
_Fig 2: Visible Errors when Items missing Sales Account)_

------
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!