### PR TITLE
fix(karma): do not use angular 1.6.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,7 @@
     "angular-ui-select": "^0.17.1"
   },
   "devDependencies": {
-    "angular-mocks": "^1.5.9"
+    "angular-mocks": "1.5.9"
   },
   "resolutions": {
     "angular": "1.5.9"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,9 +14,8 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'client/vendor/angular/angular.js',
-      'client/vendor/angular-mocks/angular-mocks.js',
       'bin/client/js/vendor.min.js',
+      'client/vendor/angular-mocks/angular-mocks.js',
       'bin/client/js/bhima.min.js',
       'bin/client/partials/**/*.html',
       'test/client-unit/**/*.spec.js'


### PR DESCRIPTION
This commit fixes the angular-mocks code to using the angular 1.5.x
branch of the codebase.  It also removes the double-call to angular in
the test output.

This is a critical bug fix.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!