### PR TITLE
fix(vouchers): print correct currency & user

### DIFF
--- a/server/controllers/finance/reports/vouchers/report.handlebars
+++ b/server/controllers/finance/reports/vouchers/report.handlebars
@@ -19,7 +19,7 @@
 
       <!-- list of data  -->
       <!-- voucher info  -->
-      <table class="table table-condensed">
+      <table class="table table-condensed table-bordered table-report">
         <thead>
           <tr>
             <th>{{translate 'FORM.LABELS.REFERENCE'}}</th>
@@ -35,8 +35,8 @@
               <td>{{reference}}</td>
               <td>{{date date}}</td>
               <td>{{description}}</td>
-              <td class="text-right">{{currency amount}}</td>
-              <td>{{user}}</td>
+              <td class="text-right">{{currency amount this.currency_id}}</td>
+              <td>{{this.display_name}}</td>
             </tr>
           {{/each}}
         </tbody>


### PR DESCRIPTION
This commit fixes the voucher registry so that it prints the correct
currency in the printed report.  It also ensures that the report prints
out the username in the user column.

Fixes https://github.com/Vanga-Hospital/bhima-2.X/issues/187.

Supercedes https://github.com/Vanga-Hospital/bhima-2.X/pull/258.

-----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
