### PR TITLE
Fix: limit csv renderer output with filters

### DIFF
--- a/client/src/js/components/bhRendererDropdown.js
+++ b/client/src/js/components/bhRendererDropdown.js
@@ -21,7 +21,6 @@ function bhRendererController(AppCache) {
 
   $ctrl.$onInit = function () {
     $ctrl.options = [
-      { icon : 'file-code-o', key : 'DOWNLOADS.JSON', parameters : { renderer: 'json'}, type : 'application/json' },
       { icon : 'file-excel-o', key : 'DOWNLOADS.CSV', parameters : { renderer: 'csv'}, type : 'application/csv' },
       { icon : 'file-pdf-o', key : 'DOWNLOADS.PDF', parameters : { renderer: 'pdf'}, type : 'application/pdf' }
     ];
@@ -36,6 +35,12 @@ function bhRendererController(AppCache) {
   $ctrl.select = function (option) {
     $ctrl.selection = cache.selection = option;
   };
+
+  /*
+  $ctrl.$onChanges = function (changes) {
+    console.log('changes:', changes);
+  };
+  */
 
   /**
    * @method toggleLoading

--- a/client/src/js/components/bhRendererDropdown.js
+++ b/client/src/js/components/bhRendererDropdown.js
@@ -8,15 +8,16 @@ angular.module('bhima.components')
     controller : bhRendererController
   });
 
-bhRendererController.$inject = [ 'appcache' ];
+bhRendererController.$inject = [ 'appcache', '$httpParamSerializer' ];
 
-function bhRendererController(AppCache) {
+function bhRendererController(AppCache, $httpParamSerializer) {
   var $ctrl = this;
 
   var cache = new AppCache('bhRendererComponent');
 
   // delay between GET request completion and loading indication, this is used
   // to compensate for the delay in browsers opening the print dialog
+  // @todo - make this work!
   var loadingIndicatorDelay = 1000;
 
   $ctrl.$onInit = function () {
@@ -27,20 +28,42 @@ function bhRendererController(AppCache) {
 
     $ctrl.selection = cache.selection || $ctrl.options[0];
 
-    $ctrl.reportOptions = $ctrl.reportOptions || {};
-
     $ctrl.$loading = false;
+
+    combineAndSerializeParameters();
   };
 
   $ctrl.select = function (option) {
     $ctrl.selection = cache.selection = option;
   };
 
-  /*
+  // watch for changes on the component's border and behave appropriately
   $ctrl.$onChanges = function (changes) {
-    console.log('changes:', changes);
+    var hasParameterChanges = (changes && changes.reportOptions);
+
+    // if there are changes to the report options, serialize them
+    if (hasParameterChanges) {
+      combineAndSerializeParameters();
+    }
   };
-  */
+
+  /**
+   * @method combineAndSerializeParameters
+   *
+   * @description
+   * This method combines the renderers parameter and the reportOptions into
+   * a url to be passed to ngHref.
+   */
+  function combineAndSerializeParameters() {
+    var rendererParams = $ctrl.selection && $ctrl.selection.parameters || {};
+    var reportParams = $ctrl.reportOptions || {};
+
+    // combine the parameters into one
+    var combined = angular.merge(rendererParams, reportParams);
+
+    // serialize the parameters with the $http parameter serializer
+    $ctrl.params = $httpParamSerializer(combined);
+  }
 
   /**
    * @method toggleLoading

--- a/client/src/partials/templates/bhRendererDropdown.tmpl.html
+++ b/client/src/partials/templates/bhRendererDropdown.tmpl.html
@@ -1,5 +1,5 @@
 <div class="btn-group" uib-dropdown>
-  <a class="btn btn-default" ng-href="{{::$ctrl.reportUrl}}?renderer={{::$ctrl.selection.parameters.renderer}}" download>
+  <a class="btn btn-default" ng-href="{{::$ctrl.reportUrl}}?{{$ctrl.params}}" download>
     <span ng-show="$ctrl.loading">
       <i class="fa fa-circle-notch-o"></i> <span translate>FORM.INFO.LOAING</span>
     </span>

--- a/client/src/partials/templates/bhRendererDropdown.tmpl.html
+++ b/client/src/partials/templates/bhRendererDropdown.tmpl.html
@@ -1,5 +1,5 @@
 <div class="btn-group" uib-dropdown>
-  <a class="btn btn-default" ng-href="{{$ctrl.reportUrl}}?renderer={{$ctrl.selection.parameters.renderer}}" download>
+  <a class="btn btn-default" ng-href="{{::$ctrl.reportUrl}}?renderer={{::$ctrl.selection.parameters.renderer}}" download>
     <span ng-show="$ctrl.loading">
       <i class="fa fa-circle-notch-o"></i> <span translate>FORM.INFO.LOAING</span>
     </span>
@@ -9,7 +9,7 @@
     </span>
   </a>
   <a class="btn btn-default" uib-dropdown-toggle>
-      <span class="caret"></span>
+    <span class="caret"></span>
   </a>
   <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="single-button">
     <li ng-repeat="option in ::$ctrl.options">

--- a/server/lib/renderers/csv.js
+++ b/server/lib/renderers/csv.js
@@ -32,6 +32,8 @@ const defaults = {
   trimHeaderFields : true
 };
 
+const ID_KEYWORDS = ['_id', 'uuid'];
+
 // this field will tell the csv renderer what to render
 const DEFAULT_DATA_KEY = 'csv';
 
@@ -92,6 +94,20 @@ function dateFormatter(csvRow) {
   return _.mapValues(csvRow, convertIfDate);
 }
 
+
+/**
+ * @function containsIdKeyword
+ *
+ * @private
+ *
+ * @description
+ * Accepts in a columnName and returns true if it is included in the
+ * list of reserved identifiers
+ */
+function containsIdKeyword(columnName) {
+  return ID_KEYWORDS.some((keyword) => columnName.includes(keyword));
+}
+
 /**
  * @method idFilter
  *
@@ -100,12 +116,7 @@ function dateFormatter(csvRow) {
  * all columns that match a pre-defined list of keywords
  */
 function idFilter(csvRow) {
-  const ID_KEYWORDS = ['_id', 'uuid'];
   const invalidColumns = _.keys(csvRow).filter(containsIdKeyword);
-
-  function containsIdKeyword(columnName) {
-    return ID_KEYWORDS.some((keyword) => columnName.includes(keyword));
-  }
 
   invalidColumns.forEach((columnName) => delete csvRow[columnName]);
   return csvRow;


### PR DESCRIPTION
This PR fixes two issues:
 1. It removes the JSON option from the `bhRendererDropdown` component.  Closes #1123. 
 2. It preserves the filters to send back to the server.  Closes Vanga-Hospital#221.

Parameters are watched for changes on the component border and are subsequently serialized and passed to the `ngHref`.

---
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!