### PR TITLE
fix(cash): do not show filters on failure

### DIFF
--- a/client/src/partials/cash/payments/registry.js
+++ b/client/src/partials/cash/payments/registry.js
@@ -87,7 +87,7 @@ function CashPaymentRegistryController(Cash, bhConstants, Notify, Session, uiGri
     Modal.openSearchCashPayment()
       .then(function (filters) {
         if (!filters) { return; }
-        reload(filters);
+        load(filters);
       });
   }
 
@@ -95,32 +95,29 @@ function CashPaymentRegistryController(Cash, bhConstants, Notify, Session, uiGri
   function onRemoveFilter(key) {
     delete vm.filters.identifiers[key];
     delete vm.filters.display[key];
-    reload(vm.filters);
+    load(vm.filters);
   }
 
   // remove a filter with from the filter object, save the filters and reload
   function clearFilters() {
-    reload({ display : [], identifiers : {} });
-  }
-
-  // reload with filter
-  function reload(filters) {
-    vm.filters = filters;
-    vm.formatedFilters = Cash.formatFilterParameters(filters.display);
-
-    // show filter bar as needed
-    vm.filterBarHeight = (vm.formatedFilters.length > 0) ?  FILTER_BAR_HEIGHT : {};
-
-    load(filters.identifiers);
+    load({ display : [], identifiers : {} });
   }
 
   // load cash
   function load(filters) {
     vm.hasError = false;
 
+    // cache filters
+    vm.filters = filters;
+    vm.formatedFilters = Cash.formatFilterParameters(filters.display);
+
+    // show filter bar as needed
+    vm.filterBarHeight = (vm.formatedFilters.length > 0) ?  FILTER_BAR_HEIGHT : {};
+
+
     toggleLoadingIndicator();
 
-    Cash.search(filters)
+    Cash.search(filters.identifiers)
       .then(function (rows) {
 
         rows.forEach(function (row) {


### PR DESCRIPTION
This commit changes the cash registry so that the filters are no longer
applied at the top of the registry in case of request failure.

Closes #997.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [ ] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
