### PR TITLE
fix(creditNote): reverse all rows in a reversal

### DIFF
--- a/client/src/js/services/VoucherService.js
+++ b/client/src/js/services/VoucherService.js
@@ -77,7 +77,8 @@ function VoucherService(Api, $http, util, TransactionTypeStore) {
    * This method facilitate annulling a transaction,
    * bhima should automatically be able to reverse
    * any transaction in the posting_journal by creating a
-   * new transaction that is an exact duplicate of the original transaction with sign minous.
+   * new transaction that is an exact duplicate of the original transaction with the
+   * debits and credits switched.
    */
   function reverse(creditNote) {
     return $http.post(baseUrl.concat(creditNote.uuid, '/reverse'), creditNote)

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -197,7 +197,7 @@ function find(options) {
 * journalEntryList
 * Allows you to select which transactions to print
 */
-function journalEntryList(options) { 
+function journalEntryList(options) {
   let uuids =  options.uuids.map(function(uuid) {
     return db.bid(uuid);
   });
@@ -293,7 +293,7 @@ function getTransaction (req, res, next) {
  *
  * @description
  * This is a generic wrapper for reversing any transaction in the posting
- * journal or general ledger. 
+ * journal or general ledger.
  *
  * POST /journal/:uuid/reverse
  */
@@ -303,20 +303,20 @@ function reverse(req, res, next) {
   const recordUuid  = db.bid(req.params.uuid);
   const params = [ recordUuid, req.session.user.id, req.body.description, db.bid(voucherUuid) ];
 
-  /** 
-   * Check already cancelled 
+  /**
+   * Check already cancelled
    * Transaction type for cancelled operation is 10
    */
   const CANCELLED_ID = 10;
-  const query = 
-    `SELECT uuid FROM voucher 
+  const query =
+    `SELECT uuid FROM voucher
      WHERE voucher.type_id = ${CANCELLED_ID} AND voucher.reference_uuid = ?`;
 
-  // create and execute a transaction if necessary 
+  // create and execute a transaction if necessary
   db.exec(query, [recordUuid])
     .then(rows => {
       if (rows.length > 0) {
-        // transaction already cancelled 
+        // transaction already cancelled
         throw new BadRequest('The transaction has been already cancelled', 'POSTING_JOURNAL.ERRORS.MULTIPLE_CANCELLING');
       }
       return db.exec('CALL ReverseTransaction(?, ?, ?, ?);', params);

--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -548,7 +548,7 @@ BEGIN
 
   DECLARE cashPaymentOriginId SMALLINT(5);
 
-  -- set origin to the CASH_PAYMENT transaction type 
+  -- set origin to the CASH_PAYMENT transaction type
   SET cashPaymentOriginId = 2;
 
   -- copy cash payment values into working variables
@@ -1128,7 +1128,7 @@ BEGIN
     SELECT voucher_uuid, NOW(), zz.project_id, enterprise.currency_id, 0, CONCAT_WS(' ', '[REVERSAL]', description, ' -- ', zz.description), user_id, 10, uuid
     FROM (
       SELECT pj.project_id, pj.description FROM posting_journal AS pj WHERE pj.record_uuid = uuid
-      UNION
+      UNION ALL
       SELECT gl.project_id, gl.description FROM general_ledger AS gl WHERE gl.record_uuid = uuid
     ) AS zz
       JOIN project ON zz.project_id = project.id
@@ -1141,7 +1141,7 @@ BEGIN
     FROM (
       SELECT pj.account_id, pj.credit_equiv, pj.debit_equiv, pj.reference_uuid, pj.entity_uuid
       FROM posting_journal AS pj WHERE pj.record_uuid = uuid
-      UNION
+      UNION ALL
       SELECT gl.account_id, gl.credit_equiv, gl.debit_equiv, gl.reference_uuid, gl.entity_uuid
       FROM general_ledger AS gl WHERE gl.record_uuid = uuid
     ) AS zz;


### PR DESCRIPTION
This is a critical bug fix.

This commit changes the `ReverseTransaction()` method to using UNION ALL instead of a simple UNION to avoid only reversing unique rows.  The lack of the `ALL` term has resulted in multiple unbalanced credit notes in production.

**Description**
The problem was found while running the Trial Balance on ~5,000 unposted transactions containing over 100 credit notes.  Approximately 25% of the credit notes were unbalanced.  The problem was reproducible by removing the offending credit note and re-creating it, resulting in vouchers that looked like this one:

![creditnoteunbalancedvouchers](https://cloud.githubusercontent.com/assets/896472/22698043/ac51c824-ed53-11e6-8874-178c448c4976.png)
_Fig 1: Unbalanced Credit Note Voucher_

Since the problem was reproducible for those vouchers, it appeared to be data-driven.  A quick audit of the `ReverseTransaction()` stored procedure revealed that it was using [UNION instead of UNION ALL](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/server/models/procedures.sql#L1141) to combine the results of the posting_journal and general_ledger.  [UNION removes identical results](http://stackoverflow.com/questions/49925/what-is-the-difference-between-union-and-union-all).


**FIX**
This problem could be solved in two ways:
 1. Include a unique value in the SELECT statement OR
 2. Use UNION ALL

This PR favors (2) because it requires that the database do less work.


------
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
