### PR TITLE
feat(db): administrative utilities

### DIFF
--- a/server/models/admin.sql
+++ b/server/models/admin.sql
@@ -1,0 +1,105 @@
+DELIMITER $$
+
+/*
+ zRecomputeEntityMap
+
+ Abolishes and recomputes the entity_map from the base tables in the system.  This is
+ useful in case of database corruption in which references get out of sync.
+*/
+CREATE PROCEDURE zRecomputeEntityMap()
+BEGIN
+  DELETE FROM entity_map;
+
+  -- employee
+  INSERT INTO entity_map
+    SELECT employee.debtor_uuid, CONCAT_WS('.', 'EM', employee.id) FROM employee;
+
+  -- patient
+  INSERT INTO entity_map
+    SELECT patient.uuid, CONCAT_WS('.', 'PA', project.abbr, patient.reference)
+    FROM patient JOIN project ON patient.project_id = project.id;
+
+  -- patient debtor
+  INSERT INTO entity_map
+    SELECT patient.debtor_uuid, CONCAT_WS('.', 'PA', project.abbr, patient.reference)
+    FROM patient JOIN project ON patient.project_id = project.id;
+
+  -- supplier
+  INSERT INTO entity_map
+    SELECT supplier.creditor_uuid, CONCAT_WS('.', 'FO', supplier.reference) FROM supplier;
+END $$
+
+/*
+ zRecomputDocumentMap
+
+ Abolishes and recomputes the document_map entries from the base tables in the
+ database.  This is useful in case of data corruption.
+*/
+CREATE PROCEDURE zRecomputeDocumentMap()
+BEGIN
+  DELETE FROM document_map;
+
+  -- cash payments
+  INSERT INTO document_map
+    SELECT cash.uuid, CONCAT_WS('.', 'CP', project.abbr, cash.reference)
+    FROM cash JOIN project where project.id = cash.project_id;
+
+  -- invoices
+  INSERT INTO document_map
+    SELECT invoice.uuid, CONCAT_WS('.', 'IV', project.abbr, invoice.reference)
+    FROM invoice JOIN project where project.id = invoice.project_id;
+
+  -- purchases
+  INSERT INTO document_map
+    SELECT purchase.uuid, CONCAT_WS('.', 'PO', project.abbr, purchase.reference)
+    FROM purchase JOIN project where project.id = purchase.project_id;
+
+  -- vouchers
+  INSERT INTO document_map
+    SELECT voucher.uuid, CONCAT_WS('.', 'VO', project.abbr, voucher.reference)
+    FROM voucher JOIN project where project.id = voucher.project_id;
+END $$
+
+/*
+ zRepostVoucher
+
+ Removes the voucher record from the posting_journal and calls the PostVoucher() method on
+ the record in the voucher table to re-post it to the journal.
+*/
+CREATE PROCEDURE zRepostVoucher(
+  IN vUuid BINARY(16)
+)
+BEGIN
+  DELETE FROM posting_journal WHERE posting_journal.record_uuid = vUuid;
+  CALL PostVoucher(vUuid);
+END $$
+
+/*
+ zRepostInvoice
+
+ Removes the invoice record from the posting_journal and calls the PostInvoice() method on
+ the record in the invoice table to re-post it to the journal.
+*/
+CREATE PROCEDURE zRepostInvoice(
+  IN iUuid BINARY(16)
+)
+BEGIN
+  DELETE FROM posting_journal WHERE posting_journal.record_uuid = iUuid;
+  CALL PostInvoice(iUuid);
+END $$
+
+/*
+ zRepostCash
+
+ Removes the cash record from the posting_journal and calls the PostCash() method on
+ the record in the cash table to re-post it to the journal.
+*/
+CREATE PROCEDURE zRepostCash(
+  IN cUuid BINARY(16)
+)
+BEGIN
+  DELETE FROM posting_journal WHERE posting_journal.record_uuid = cUuid;
+  CALL PostCash(cUuid);
+END $$
+
+DELIMITER ;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -410,30 +410,6 @@ CREATE TABLE `country` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
-DROP TABLE IF EXISTS `credit_note`;
-CREATE TABLE `credit_note` (
-  `uuid`            BINARY(16) NOT NULL,
-  `project_id`      SMALLINT(5) UNSIGNED NOT NULL,
-  `reference`       INT(10) UNSIGNED NOT NULL DEFAULT 0,
-  `cost`            DECIMAL(19,4) UNSIGNED NOT NULL,
-  `debtor_uuid`     BINARY(16) NOT NULL,
-  `seller_id`       SMALLINT(5) UNSIGNED NOT NULL DEFAULT 0,
-  `invoice_uuid`    BINARY(36) NOT NULL,
-  `note_date`       DATE NOT NULL,
-  `description`     text NOT NULL,
-  `posted` tinyint(1) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`uuid`),
-  UNIQUE KEY `credit_note_1` (`invoice_uuid`),
-  UNIQUE KEY `credit_note_2` (`project_id`, `reference`),
-  KEY `reference` (`reference`),
-  KEY `project_id` (`project_id`),
-  KEY `debtor_uuid` (`debtor_uuid`),
-  KEY `invoice_uuid` (`invoice_uuid`),
-  FOREIGN KEY (`project_id`) REFERENCES `project` (`id`),
-  FOREIGN KEY (`debtor_uuid`) REFERENCES `debtor` (`uuid`),
-  FOREIGN KEY (`invoice_uuid`) REFERENCES `invoice` (`uuid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
 DROP TABLE IF EXISTS `creditor`;
 
 CREATE TABLE `creditor` (

--- a/server/models/triggers.sql
+++ b/server/models/triggers.sql
@@ -14,7 +14,7 @@ FOR EACH ROW BEGIN
     SELECT new.uuid, CONCAT_WS('.', 'PA', project.abbr, new.reference) FROM project where project.id = new.project_id;
 
   -- this writes a debtor entity into the entity_map table
-  -- NOTE: the debtor actually points to the patient entity for convienence
+  -- NOTE: the debtor actually points to the patient entity for convenience
   INSERT INTO entity_map
     SELECT new.debtor_uuid, CONCAT_WS('.', 'PA', project.abbr, new.reference) FROM project where project.id = new.project_id;
 END$$
@@ -56,20 +56,6 @@ FOR EACH ROW BEGIN
   INSERT INTO document_map
     SELECT new.uuid, CONCAT_WS('.', 'CP', project.abbr, new.reference) FROM project where project.id = new.project_id;
 END$$
-
-
--- Credit Note Triggers
--- @FIXME - why are we still using a credit note table?
-CREATE TRIGGER credit_note_before_insert BEFORE INSERT ON credit_note
-FOR EACH ROW
-  SET NEW.reference = (SELECT IF(NEW.reference, NEW.reference, IFNULL(MAX(credit_note.reference) + 1, 1)) FROM credit_note WHERE credit_note.project_id = new.project_id);$$
-
-CREATE TRIGGER credit_note_document_map AFTER INSERT ON credit_note
-FOR EACH ROW BEGIN
-  INSERT INTO document_map
-    SELECT new.uuid, CONCAT_WS('.', 'CN', project.abbr, new.reference) FROM project where project.id = new.project_id;
-END$$
-
 
 -- Voucher Triggers
 


### PR DESCRIPTION
This commit creates administrative utilities for the database that are
useful in correcting database issues.  It includes the ability to repost
every single transaction type as well as recalculate the entity maps.

It also removes the check for the old `deb_cred_type` field (now `entity_type`).
This makes sure the Posting Journal does not report errors which users cannot
resolve.

Finally, it removes the `credit_note` table which is apparently not in use in
the application.

-----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
