### PR TITLE
refactor(cash): update transfer modal to standards

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -120,7 +120,8 @@
       "TITLE" : "New Cash Transfer",
       "ACTION" : "You are transferring funds out of the cashbox.",
       "REMINDER" : "Please perform a cash count and indicate both the currency and amount to be transferred in the form below.",
-      "SUCCESS" : "Successfully transferred money out of the cash window."
+      "SUCCESS" : "Successfully transferred money out of the cash window.",
+      "DESCRIPTION" : "Cash transfer of {{ amount }} from {{ fromLabel }} to {{ toLabel }} by {{ userName }}."
     },
     "VOUCHER": {
       "CASHBOXES": {

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -121,7 +121,8 @@
       "ACTION" : "Vous avez transféré des fonds de la caisse.",
       "TITLE" : "Transfert",
       "REMINDER" : "S'il vous plaît effectuer un comptage de caisse et indiquent à la fois la devise et le montant à transférer dans le formulaire ci-dessous.",
-      "SUCCESS" : "Transfer effectué vers le compte de transfer."
+      "SUCCESS" : "Transfer effectué vers le compte de transfer.",
+      "DESCRIPTION" : "Transfer de {{ amount }} viens de {{ fromLabel }} à {{ toLabel }} par {{ userName }}."
     },
     "VOUCHER": {
       "CASHBOXES": {

--- a/client/src/js/services/CashService.js
+++ b/client/src/js/services/CashService.js
@@ -2,7 +2,7 @@ angular.module('bhima.services')
 .service('CashService', CashService);
 
 CashService.$inject = [
-  '$uibModal' ,'PrototypeApiService', 'ExchangeRateService', 'SessionService', 'moment', '$http', 'util'
+  '$uibModal' ,'PrototypeApiService', 'ExchangeRateService', 'SessionService', 'moment'
 ];
 
 /**
@@ -12,18 +12,16 @@ CashService.$inject = [
  * @description
  * A service to interact with the server-side /cash API.
  */
-function CashService(Modal, Api, Exchange, Session, moment, $http, util) {
+function CashService(Modal, Api, Exchange, Session, moment) {
   var service     = new Api('/cash/');
   var urlCheckin  = '/cash/checkin/';
 
   // templates for descriptions
-  var TRANSFER_DESCRIPTION = 'Transfer Voucher / :date / :name';
   var PAYMENT_DESCRIPTION = 'Cash Payment / :date / :name \n ';
   var CAUTION_DESCRIPTION = 'Caution Payment / :date / :name';
 
   // custom methods
   service.create = create;
-  service.getTransferRecord = getTransferRecord;
   service.calculateDisabledIds = calculateDisabledIds;
   service.formatCashDescription = formatCashDescription;
   service.formatFilterParameters = formatFilterParameters;
@@ -97,32 +95,6 @@ function CashService(Modal, Api, Exchange, Session, moment, $http, util) {
   }
 
   /**
-   * This method is responsible to create a voucher object and it back
-   */
-  function getTransferRecord(cashAccountCurrency, amount, currencyId) {
-    var voucher = {
-      project_id: Session.project.id,
-      currency_id: currencyId,
-      amount: amount,
-      description: generateTransferDescription(),
-      user_id: Session.user.id,
-
-      // two lines (debit and credit) to be recorded in the database
-      items: [{
-        account_id : cashAccountCurrency.account_id,
-        debit : 0,
-        credit : amount,
-      }, {
-        account_id : cashAccountCurrency.transfer_account_id,
-        debit : amount,
-        credit : 0,
-      }]
-    };
-
-    return voucher;
-  }
-
-  /**
    * @method calculateDisabledIds
    *
    * @description
@@ -148,17 +120,6 @@ function CashService(Modal, Api, Exchange, Session, moment, $http, util) {
 
     return disabledCurrencyIds;
   }
-
-  /**
-   * This method is responsible to generate a description for the transfer operation.
-   * @private
-   */
-  function generateTransferDescription() {
-    return TRANSFER_DESCRIPTION
-      .replace(':date', moment().format('YYYY-MM-DD'))
-      .replace(':user', Session.user.display_name);
-  }
-
 
   /**
    * @method formatFilterParameters
@@ -211,10 +172,10 @@ function CashService(Modal, Api, Exchange, Session, moment, $http, util) {
    *   your code here
    *  });
    */
-  function checkCashPayment (invoiceUuid){
+  function checkCashPayment(invoiceUuid) {
     var url = urlCheckin + invoiceUuid;
-    return $http.get(url)
-      .then(util.unwrapHttpResponse);
+    return service.$http.get(url)
+      .then(service.util.unwrapHttpResponse);
   }
 
   return service;

--- a/client/src/js/services/receipts/ReceiptModal.js
+++ b/client/src/js/services/receipts/ReceiptModal.js
@@ -1,5 +1,5 @@
 angular.module('bhima.services')
-.service('ReceiptModal', ReceiptModal);
+  .service('ReceiptModal', ReceiptModal);
 
 ReceiptModal.$inject = ['$uibModal', 'ReceiptService'];
 
@@ -194,7 +194,7 @@ function ReceiptModal(Modal, Receipts) {
   }
 
   /**
-   * Invokes an invoice's credit note 
+   * Invokes an invoice's credit note
    *
    * @param {String} uuid             Target invoice UUID
    * @param {Boolean} notifyCreated   Defines if a success message should be shown for entity creation

--- a/client/src/partials/cash/modals/transfer.modal.html
+++ b/client/src/partials/cash/modals/transfer.modal.html
@@ -5,9 +5,7 @@
       <li class="static">
         {{::TransferCtrl.cashbox.label}}
       </li>
-      <li class="title">
-        {{ ::"CASH.TRANSFER.TITLE" | translate }}
-      </li>
+      <li class="title" translate>CASH.TRANSFER.TITLE</li>
     </ol>
   </div>
 
@@ -15,33 +13,36 @@
 
     <section ng-show="TransferCtrl.cashAccount.number">
       <p>
-        <i class="fa fa-info-circle text-primary"></i> {{ "CASH.TRANSFER.ACTION" | translate }}
+        <i class="fa fa-info-circle text-primary"></i> <span translate>CASH.TRANSFER.ACTION</span>
       </p>
       <dl class="dl-horizontal">
-        <dt>{{ "FORM.LABELS.FROM" | translate }}</dt>
-        <dd>[{{TransferCtrl.cashAccount.number}}] {{TransferCtrl.cashAccount.label }}</dd>
-        <dt>{{ "FORM.LABELS.TO" | translate }}</dt>
-        <dd>[{{TransferCtrl.transferAccount.number}}] {{TransferCtrl.transferAccount.label }}</dd>
+        <dt translate>FORM.LABELS.FROM</dt>
+        <dd>{{ TransferCtrl.cashAccount.hrlabel }}</dd>
+        <dt translate>FORM.LABELS.TO</dt>
+        <dd>{{ TransferCtrl.transferAccount.hrlabel }}</dd>
       </dl>
-      <p>{{ "CASH.TRANSFER.REMINDER" | translate }}</p>
+      <p translate>CASH.TRANSFER.REMINDER</p>
     </section>
 
     <bh-currency-select
       id="transfer-currency-select"
-      currency-id="TransferCtrl.record.currency_id"
+      currency-id="TransferCtrl.voucher.details.currency_id"
       validation-trigger="TransferForm.$submitted"
       disable-ids="TransferCtrl.disabledCurrencyIds"
-      on-change="TransferCtrl.loadAccountDetails()"
+      on-change="TransferCtrl.loadAccountDetails(currency)"
       cashbox-id="TransferCtrl.cashbox.id">
     </bh-currency-select>
 
     <bh-currency-input
       id="transfer-currency-input"
-      currency-id="TransferCtrl.record.currency_id"
-      model="TransferCtrl.record.amount"
-      form="TransferForm"
+      currency-id="TransferCtrl.voucher.details.currency_id"
+      model="TransferCtrl.amount"
       validation-trigger="TransferForm.$submitted">
     </bh-currency-input>
+
+    <p ng-show="TransferForm.$submitted && TransferCtrl.voucher._error" class="text-danger">
+      <i class="fa fa-exclamation-circle"></i> <span translate>{{ TransferCtrl.voucher._error }}</span>
+    </p>
   </div>
 
   <div class="modal-footer">
@@ -50,15 +51,13 @@
       class="btn btn-default"
       ui-sref="^.window({ id : TransferCtrl.cashbox.id })"
       data-modal-action="dismiss">
-      {{ "FORM.BUTTONS.CANCEL" | translate }}
+      <span translate>FORM.BUTTONS.CANCEL</span>
     </button>
 
     <bh-loading-button
       loading-state="TransferForm.$loading"
-      ng-disabled="!TransferCtrl.cashbox"
-      >
-      {{ "FORM.BUTTONS.SUBMIT" | translate }}
+      ng-disabled="!TransferCtrl.cashbox">
+      <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>
-
   </div>
 </form>

--- a/client/src/partials/templates/bhCurrencySelect.tmpl.html
+++ b/client/src/partials/templates/bhCurrencySelect.tmpl.html
@@ -1,7 +1,7 @@
 <ng-form name="$ctrl.form">
   <div class="radio" ng-class="{ 'has-error' : ($ctrl.validationTrigger && $ctrl.form.$invalid) || !$ctrl.valid }" data-bh-currency-select>
     <p class="control-label" style="margin-bottom:5px;">
-      <strong>{{ "FORM.LABELS.CURRENCY" | translate }}</strong>
+      <strong translate>FORM.LABELS.CURRENCY</strong>
     </p>
 
     <!-- repeat each currency in the application -->
@@ -29,9 +29,9 @@
 
     <!-- show danger message if all currencies are disabled -->
     <p class="help-block" ng-hide="$ctrl.valid">
-      <i class="fa fa-exclamation-circle"></i> {{ "CASHBOX.NO_SUPPORTED_CURRENCIES" | translate }}
+      <i class="fa fa-exclamation-circle"></i> <span translate>CASHBOX.NO_SUPPORTED_CURRENCIES</span>
       <a ng-show="$ctrl.cashboxId" ng-href="#/cashboxes/{{$ctrl.cashboxId}}/edit" class="text-danger">
-        <strong><i class="fa fa-link"></i> {{ "CASHBOX.SET_CURRENCY_ACCOUNTS" | translate }}</strong>
+        <strong><i class="fa fa-link"></i> <span translate>CASHBOX.SET_CURRENCY_ACCOUNTS</span></strong>
       </a>
     </p>
   </div>

--- a/client/src/partials/vouchers/VoucherForm.service.js
+++ b/client/src/partials/vouchers/VoucherForm.service.js
@@ -3,7 +3,7 @@ angular.module('bhima.services')
 
 VoucherFormService.$inject = [
   'VoucherService', 'bhConstants', 'SessionService', 'VoucherItemService',
-  'CashboxService', 'AppCache', 'Store', 'AccountService', '$timeout'
+  'CashboxService', 'AppCache', 'Store', 'AccountService', '$timeout', '$translate'
 ];
 
 /**
@@ -16,7 +16,7 @@ VoucherFormService.$inject = [
  *
  * @todo - finish the caching implementation
  */
-function VoucherFormService(Vouchers, Constants, Session, VoucherItem, Cashboxes, AppCache, Store, Accounts, $timeout) {
+function VoucherFormService(Vouchers, Constants, Session, VoucherItem, Cashboxes, AppCache, Store, Accounts, $timeout, $translate) {
 
   var ROW_ERROR_FLAG = Constants.grid.ROW_ERROR_FLAG;
 
@@ -195,8 +195,11 @@ function VoucherFormService(Vouchers, Constants, Session, VoucherItem, Cashboxes
    */
   VoucherForm.prototype.setup = function setup() {
     this.details = {};
+
     this.details.date = new Date();
+    this.details.project_id = Session.project.id;
     this.details.currency_id = Session.enterprise.currency_id;
+    this.details.user_id = Session.user.id;
 
     this.addItems(2);
   };
@@ -209,6 +212,10 @@ function VoucherFormService(Vouchers, Constants, Session, VoucherItem, Cashboxes
   VoucherForm.prototype.configureRow = function configureRow(row) {
     row.configure(row);
     this.validate();
+  };
+
+  VoucherForm.prototype.description = function description(key, options) {
+    this.details.description = $translate.instant(key, options);
   };
 
   /**

--- a/server/models/test/data.sql
+++ b/server/models/test/data.sql
@@ -201,10 +201,10 @@ INSERT INTO `cash_box` (id, label, project_id, is_auxiliary) VALUES
   (3,'Test Aux Cashbox B',1,1);
 
 INSERT INTO `cash_box_account_currency` VALUES
-  (1,1,1,3626,3626),
-  (2,2,1,3627,3627),
-  (3,1,2,3627,3627),
-  (4,2,2,3627,3627);
+  (1,1,1,3626,3627),
+  (2,2,1,3627,3626),
+  (3,1,2,3626,3627),
+  (4,2,2,3626,3627);
 
 INSERT INTO `inventory_group` VALUES
   (HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'),'Test inventory group','INVGRP',3636,NULL,NULL,NULL);

--- a/test/end-to-end/cash/cash.spec.js
+++ b/test/end-to-end/cash/cash.spec.js
@@ -247,13 +247,19 @@ function CashTransfer() {
     $('[data-action="transfer"]').click();
 
     // choose CDF as transfer currency
-    components.currencySelect.set(1, 'transfer-currency-select');
+    components.currencySelect.set(2, 'transfer-currency-select');
 
     //set a value in the currency component by model to avoid conflict
     components.currencyInput.set(mockTransfer.amount, 'transfer-currency-input');
 
     // submit the modal button
     FU.modal.submit();
+
+    // expect the receipt modal to appear
+    FU.exists(by.id('receipt-confirm-created'), true);
+
+    // dismiss the modal
+    $('[data-action="close"]').click();
 
     // make sure we have a success notification shown
     components.notification.hasSuccess();


### PR DESCRIPTION
This commit guts and rewrites the cash transfer modal for better error
handling and to add a few new features.

**Notable Changes**
 1. The transfer modal is now powered by the Voucher Form.  This gives
 several advantages:
  1. Better error messages and handling - all of these are gotten for
  free from the VoucherForm service.
  2. A better description - a new template using $translate was
  developed based on feedback from @imawh.
 2. `translate` directive replaces the `translate` filter
 3. Fixed updating bug with currency_id where model lagged behind the
 `bhCurrencySelect` by one increment.
 4. Removed transfer code from `CashService`.
 5. Fixed "TO" and "FROM" label text bug.
 6. Print a JV receipt when the transfer is complete.

Closes #872. Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/760.

![newvouchertransferreceipt](https://cloud.githubusercontent.com/assets/896472/22820757/7446c89a-ef78-11e6-9e8f-e2bff6f341a6.png)
_Fig 1: New Voucher Transfer Receipt_

![cashpaymentsincreasedvalidation](https://cloud.githubusercontent.com/assets/896472/22820826/bf23b012-ef78-11e6-9f0a-90bc620012a6.png)
_Fig 2: Extra Validation due to usage of VoucherForm_


----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
