### PR TITLE
refactor(uiGrid): registry dropdowns anchors

### DIFF
--- a/client/src/partials/billing_services/index.html
+++ b/client/src/partials/billing_services/index.html
@@ -1,8 +1,8 @@
 <div class="flex-header">
   <div class="bhima-title">
     <ol class="headercrumb">
-      <li class="static">{{ "TREE.ADMIN" | translate }}</li>
-      <li class="title">{{ "BILLING_SERVICES.TITLE" | translate }}</li>
+      <li class="static" translate>TREE.ADMIN</li>
+      <li class="title" translate>BILLING_SERVICES.TITLE</li>
     </ol>
 
     <div class="toolbar">
@@ -12,9 +12,8 @@
           class="btn btn-default"
           data-method="create"
           ui-sref="billingServices.create"
-          ui-sref-opts="{notify:false}"
-          >
-          <span class="glyphicon glyphicon-plus"></span> {{ "BILLING_SERVICES.BTN.CREATE" | translate }}
+          ui-sref-opts="{notify:false}">
+          <span class="glyphicon glyphicon-plus"></span> <span translate>BILLING_SERVICES.BTN.CREATE</span>
         </a>
       </div>
     </div>
@@ -34,8 +33,7 @@
       <bh-grid-loading-indicator
         loading-state="BillingServicesCtrl.loading"
         empty-state="BillingServicesCtrl.options.data.length === 0"
-        error-state="BillingServicesCtrl.hasError"
-        >
+        error-state="BillingServicesCtrl.hasError">
       </bh-grid-loading-indicator>
 
     </div>

--- a/client/src/partials/inventory/list/modals/actions.tmpl.html
+++ b/client/src/partials/inventory/list/modals/actions.tmpl.html
@@ -11,7 +11,7 @@
     </ol>
   </div>
 
-  <div class="modal-body">
+  <div class="modal-body" style="max-height:500px; overflow-y: scroll;">
     <div
       class="form-group"
       ng-class="{ 'has-error' : ActionForm.$submitted && ActionForm.code.$invalid }">

--- a/client/src/partials/inventory/list/templates/action.cell.html
+++ b/client/src/partials/inventory/list/templates/action.cell.html
@@ -1,19 +1,18 @@
-<div class="ui-grid-cell-contents" data-row-item="{{ row.entity.code }}">
-  <span uib-dropdown dropdown-append-to-body>
+<div class="ui-grid-cell-contents" data-row-item="{{ row.entity.code }}" uib-dropdown dropdown-append-to-body>
 
-    <span uib-dropdown-toggle class="text-action">
-      <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
-      <span class="caret"></span>
-    </span>
-    <ul class="dropdown-menu-right" uib-dropdown-menu>
-      <li>
-        <a href
-            data-method="edit"
-            data-edit-metadata="{{ row.entity.code }}"
-            ng-hide="row.groupHeader" ui-sref="inventory.update({uuid : row.entity.uuid })">
-            <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
-        </a>
-      </li>
-    </ul>
-  </span>
+  <a href uib-dropdown-toggle>
+    <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
+    <span class="caret"></span>
+  </a>
+
+  <ul class="dropdown-menu-right" uib-dropdown-menu>
+    <li>
+      <a href
+          data-method="edit"
+          data-edit-metadata="{{ row.entity.code }}"
+          ng-hide="row.groupHeader" ui-sref="inventory.update({uuid : row.entity.uuid })">
+          <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
+      </a>
+    </li>
+  </ul>
 </div>

--- a/client/src/partials/patients/templates/action.cell.html
+++ b/client/src/partials/patients/templates/action.cell.html
@@ -1,4 +1,4 @@
-<div class="ui-grid-cell-contents text-action" uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
+<div class="ui-grid-cell-contents" uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
   <a href>
     <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
@@ -30,6 +30,6 @@
       <a data-method="card" ui-sref="cashRegistry({ filters : { debtor_uuid : row.entity.debtor_uuid }, display : {debtor_uuid : row.entity.display_name}})" href>
         <span class="fa fa-money"></span> <span translate>PATIENT_REGISTRY.PAYMENTS</span>
       </a>
-    </li>        
+    </li>
   </ul>
 </div>

--- a/client/src/partials/users/templates/grid/action.cell.html
+++ b/client/src/partials/users/templates/grid/action.cell.html
@@ -1,4 +1,4 @@
-<div class="ui-grid-cell-contents text-action" uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
+<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
   <a href>
     <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>

--- a/client/src/partials/users/users.js
+++ b/client/src/partials/users/users.js
@@ -1,5 +1,5 @@
 angular.module('bhima.controllers')
-.controller('UsersController', UsersController);
+  .controller('UsersController', UsersController);
 
 UsersController.$inject = ['$state', 'UserService', 'NotifyService'];
 


### PR DESCRIPTION
This commit refactors the ui-grids in the application to use a[href]
links for their dropdowns. Hyperlinks are more familiar to users than
triangles.  The affected grids are users, inventory list, and Billing
Services.

It also limits the height of the inventory modal to a more sensible grid
height.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
