### PR TITLE
fix(db): build TEMP tables before posting

### DIFF
--- a/server/models/admin.sql
+++ b/server/models/admin.sql
@@ -99,6 +99,7 @@ CREATE PROCEDURE zRepostCash(
 )
 BEGIN
   DELETE FROM posting_journal WHERE posting_journal.record_uuid = cUuid;
+  CALL VerifyCashTemporaryTables();
   CALL PostCash(cUuid);
 END $$
 


### PR DESCRIPTION
This commit fixes a bug specifically in the administrative tools that
builds temporary tables required for posting cash payments before
the zRepostCash() method attempts to repost them.  This also helps
modularize the procedure code.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through JSHint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
