### PR TITLE
feat(cash): filter out reversed records

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -105,6 +105,11 @@
     "CURRENT_CASHBOX" : "Current Cashbox",
     "DEBTOR_INVOICES" : "Debtor Invoices",
     "PAYMENT"         : "Payment",
+    "REGISTRY" : {
+      "INCLUDE_ONLY_REVERSED_RECORDS" : "Include only reversed cash payments",
+      "EXCLUDE_REVERSED_RECORDS" : "Exclude all reversed cash payments",
+      "REVERSED_RECORDS" : "Reversed Records"
+    },
     "SELECTION": {
       "GO_TO_CASHBOX_PAGE" : "Go to Cashbox Page",
       "MISSING_CASH"       : "Missing Cash",
@@ -1595,8 +1600,7 @@
       "TITLE"              : "Simple Voucher",
       "TRANSFER"           : "Money Transfer",
       "TRANSFER_PATIENT_INVOICE_AMOUNT" : "Patient Invoice Debt Transfer"
-    },
-    "REPORT": "Report"
+    }
   },
   "TRANSACTIONS" :  {
     "SINGLE_ACCOUNT_TRANSACTION" : "This transaction only concerns a single account.  Please select multiple accounts to complete the transaction.",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -105,6 +105,11 @@
     "DEBTOR_INVOICES": {
       "TITLE" : "Facture(s) debiteur"
     },
+    "REGISTRY" : {
+      "INCLUDE_ONLY_REVERSED_RECORDS" : "Inclure uniquement les paiements inversees",
+      "EXCLUDE_REVERSED_RECORDS" : "Exclure toutes les paiements inversees",
+      "REVERSED_RECORDS" : "Paiements Inversees"
+    },
     "PAYMENT"         : "Paiement",
     "RECEIPT": {
       "TITLE"   : "Recu",

--- a/client/src/js/services/CashService.js
+++ b/client/src/js/services/CashService.js
@@ -173,7 +173,8 @@ function CashService(Modal, Api, Exchange, Session, moment, $http, util) {
       { field: 'reference', displayName: 'FORM.LABELS.REFERENCE' },
       { field: 'dateFrom', displayName: 'FORM.LABELS.DATE_FROM', comparitor: '>', ngFilter:'date' },
       { field: 'dateTo', displayName: 'FORM.LABELS.DATE_TO', comparitor: '<', ngFilter:'date' },
-      { field: 'currency_id', displayName: 'FORM.LABELS.CURRENCY' }
+      { field: 'currency_id', displayName: 'FORM.LABELS.CURRENCY' },
+      { field: 'reversed', displayName: 'CASH.REGISTRY.REVERSED_RECORDS' },
     ];
 
     // returns columns from filters

--- a/client/src/partials/cash/payments/templates/search.modal.html
+++ b/client/src/partials/cash/payments/templates/search.modal.html
@@ -76,6 +76,23 @@
         validation-trigger="CashVoucherForm.$submitted">
       </bh-currency-select>
 
+
+      <div class="radio">
+        <p class="control-label" style="margin-bottom:5px;">
+          <strong translate>CASH.REGISTRY.REVERSED_RECORDS</strong>
+        </p>
+        <label>
+          <input type="radio" name="reversed" ng-value="1" ng-model="$ctrl.bundle.reversed">
+          <span translate>CASH.REGISTRY.INCLUDE_ONLY_REVERSED_RECORDS</span>
+        </label>
+      </div>
+
+      <div class="radio">
+        <label>
+          <input type="radio" name="reversed" ng-value="0" ng-model="$ctrl.bundle.reversed">
+          <span translate>CASH.REGISTRY.EXCLUDE_REVERSED_RECORDS</span>
+        </label>
+      </div>
     </fieldset>
   </div>
 

--- a/client/src/partials/cash/payments/templates/search.modal.js
+++ b/client/src/partials/cash/payments/templates/search.modal.js
@@ -1,15 +1,15 @@
 angular.module('bhima.controllers')
-    .controller('SearchCashPaymentModalController', SearchCashPaymentModalController);
+  .controller('SearchCashPaymentModalController', SearchCashPaymentModalController);
 
 // dependencies injections
 SearchCashPaymentModalController.$inject = [
-  'UserService', 'CashboxService', 'NotifyService', '$uibModalInstance', 'CurrencyService'
+  'UserService', 'CashboxService', 'NotifyService', '$uibModalInstance',
 ];
 
 /**
  * Search Cash Payment controller
  */
-function SearchCashPaymentModalController(Users, Cashboxes, Notify, Instance, Currencies) {
+function SearchCashPaymentModalController(Users, Cashboxes, Notify, Instance) {
   var vm = this;
 
   // global variables
@@ -51,7 +51,7 @@ function SearchCashPaymentModalController(Users, Cashboxes, Notify, Instance, Cu
   function formatFilterParameters() {
     var out = {};
     for (var i in vm.bundle) {
-      if (vm.bundle[i]) {
+      if (angular.isDefined(vm.bundle[i])) {
         out[i] = vm.bundle[i];
       }
     }

--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -160,9 +160,9 @@ function listPayment(options) {
       cash.date, BUID(cash.debtor_uuid) AS debtor_uuid, cash.currency_id, cash.amount,
       cash.description, cash.cashbox_id, cash.is_caution, cash.user_id,
       d.text AS debtor_name, cb.label AS cashbox_label, u.display_name,
-      v.type_id, p.display_name AS patientName
+      voucher.type_id, p.display_name AS patientName
     FROM cash
-      LEFT JOIN voucher v ON v.reference_uuid = cash.uuid
+      LEFT JOIN voucher ON voucher.reference_uuid = cash.uuid
       JOIN project ON cash.project_id = project.id
       JOIN debtor d ON d.uuid = cash.debtor_uuid
       JOIN patient p on p.debtor_uuid = d.uuid
@@ -175,6 +175,9 @@ function listPayment(options) {
 
   let referenceStatement = `CONCAT_WS('.', '${identifiers.CASH_PAYMENT.key}', project.abbr, cash.reference) = ?`;
   filters.custom('reference', referenceStatement);
+
+  // filter reversed cash records
+  filters.reversed('reversed');
 
   // @TODO Support ordering query (reference support for limit)?
   filters.setOrder('ORDER BY cash.date DESC');


### PR DESCRIPTION
This commit uses the `FilterParser` to filter out reversed records on the
cash payments page.  It also gives the option to exclude all records but
those that are reversed.

Closes https://github.com/Vanga-Hospital/bhima-2.X/issues/19.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
