### PR TITLE
fix(vouchers): use document instead of reference

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -1566,6 +1566,9 @@
       "VALID_TOTALS"          : "Transactions are valid (balanced transaction)",
       "VOUCHER"               : "Voucher"
     },
+    "TYPES" : {
+      "SUPPORT_PAYMENT_DESCRIPTION" : "Debt transfer from {{ patientName }} ({{ patientReference}}) for invoice {{ invoiceReference }}."
+    },
     "GLOBAL" : {
       "CASHFLOW_OPTION" : "Cashflow Option",
       "CONVENTION_INVOICES" : "Convention - Invoices payment",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -1589,6 +1589,9 @@
       "VALID_TOTALS"          : "Les transactions sont valides (Transactions balancées)",
       "VOUCHER"               : "Bordereau de Transfert"
     },
+    "TYPES" : {
+      "SUPPORT_PAYMENT_DESCRIPTION" : "Prise en charge de {{ patientName }} ({{ patientReference}}) pour la facture {{ invoiceReference }}."
+    },
     "GLOBAL" : {
       "CASHFLOW_OPTION" : "Option pour cashflow",
       "CONVENTION_INVOICES" : "Convention - Paiement factures",

--- a/client/src/js/services/VoucherService.js
+++ b/client/src/js/services/VoucherService.js
@@ -30,7 +30,6 @@ function VoucherService(Api, $http, util, TransactionTypeStore) {
 
   // strips internal keys from object
   function stripInternalObjectKeys(object) {
-
     var o = {};
 
     angular.forEach(object, function (value, key) {
@@ -57,8 +56,8 @@ function VoucherService(Api, $http, util, TransactionTypeStore) {
         escapedItem.entity_uuid = escapedItem.entity.uuid;
       }
 
-      if (escapedItem.reference) {
-        escapedItem.document_uuid = escapedItem.reference.uuid;
+      if (escapedItem.document) {
+        escapedItem.document_uuid = escapedItem.document.uuid;
       }
 
       return escapedItem;

--- a/client/src/partials/vouchers/VoucherItem.service.js
+++ b/client/src/partials/vouchers/VoucherItem.service.js
@@ -1,20 +1,19 @@
 angular.module('bhima.services')
   .service('VoucherItemService', VoucherItemService);
 
-VoucherItemService.$inject = [ 'uuid', 'bhConstants', 'util' ];
+VoucherItemService.$inject = ['uuid', 'bhConstants', 'util'];
 
 /**
  * @class VoucherItemService
  *
  * @description
- * This class implements the defaults for a patient invoice item.  The class is
- * instantiated with every row of the Patient Invoice module's grid.  It
+ * This class implements the defaults for a voucher item.  The class is
+ * instantiated with every row of the Complex Voucher module's grid.  It
  * implements the following convenience methods:
  *  1. validate() - sets the `_valid` and `_invalid` flags on the row
- *  2. configure() - sets up the row's inventory item reference
+ *  2. configure() - sets up the row's item reference
  */
 function VoucherItemService(uuid, Constants, util) {
-
   // global variables
   var MIN_DECIMAL_VALUE = Constants.lengths.minDecimalValue;
   var MIN_PRECISION_VALUE = getDecimalPrecision(MIN_DECIMAL_VALUE);
@@ -100,7 +99,6 @@ function VoucherItemService(uuid, Constants, util) {
 
     // if invalid, set the error appropriately
     if (this._invalid) {
-
       if (!initialized) {
         this._error = 'FORM.ERRORS.NOT_INITIALIZED';
       } else if (!hasValidPrecision) {
@@ -127,7 +125,6 @@ function VoucherItemService(uuid, Constants, util) {
    * the ui-select.
    */
   VoucherItem.prototype.configure = function configure(item) {
-
     if (item.account_id) {
       this.account_id = item.account_id;
     }
@@ -146,8 +143,8 @@ function VoucherItemService(uuid, Constants, util) {
       this.entity = item.entity;
     }
 
-    if (angular.isDefined(item.reference)) {
-      this.reference = item.reference;
+    if (angular.isDefined(item.document)) {
+      this.document = item.document;
     }
   };
 

--- a/client/src/partials/vouchers/complex.js
+++ b/client/src/partials/vouchers/complex.js
@@ -132,8 +132,8 @@ function ComplexJournalVoucherController(Vouchers, $translate, Currencies, Sessi
   /** Reference modal */
   function openReferenceModal(row) {
     FindReference.openModal(row.entity)
-      .then(function (reference) {
-        row.reference = reference;
+      .then(function (document) {
+        row.configure({ document : document });
       });
   }
 
@@ -169,13 +169,13 @@ function ComplexJournalVoucherController(Vouchers, $translate, Currencies, Sessi
     aggregationType: uiGridConstants.aggregationTypes.count,
     aggregationHideLabel : true,
     footerCellClass : 'text-center',
-    width: 40
+    width: 40,
   }, {
     field : 'account',
     displayName : 'FORM.LABELS.ACCOUNT',
     headerCellFilter: 'translate',
     cellTemplate: 'partials/vouchers/templates/account.grid.tmpl.html',
-    width: '35%'
+    width: '35%',
   }, {
     field : 'debit',
     displayName : 'FORM.LABELS.DEBIT',
@@ -214,7 +214,6 @@ function ComplexJournalVoucherController(Vouchers, $translate, Currencies, Sessi
 
   /** submit data */
   function submit(form) {
-
     // stop submission if the form is invalid
     if (form.$invalid) {
       Notify.danger('VOUCHERS.COMPLEX.INVALID_VALUES');

--- a/client/src/partials/vouchers/modals/scanBarcode.modal.js
+++ b/client/src/partials/vouchers/modals/scanBarcode.modal.js
@@ -3,7 +3,8 @@ angular.module('bhima.controllers')
 
 VoucherScanBarcodeController.$inject = [
   '$state', 'NotifyService', 'BarcodeService', 'PatientService', 'DebtorGroupService',
-  'bhConstants', '$uibModalInstance', '$timeout', 'PatientInvoiceService', '$rootScope'
+  'bhConstants', '$uibModalInstance', '$timeout', 'PatientInvoiceService', '$rootScope',
+  '$translate',
 ];
 
 /**
@@ -15,7 +16,7 @@ VoucherScanBarcodeController.$inject = [
  *
  * @todo - refactor this whole thing into a component.
 */
-function VoucherScanBarcodeController($state, Notify, Barcodes, Patients, DebtorGroups, bhConstants, Instance, $timeout, Invoices, RS) {
+function VoucherScanBarcodeController($state, Notify, Barcodes, Patients, DebtorGroups, bhConstants, Instance, $timeout, Invoices, RS, $translate) {
   var vm = this;
   var id = $state.params.id;
 
@@ -115,24 +116,27 @@ function VoucherScanBarcodeController($state, Notify, Barcodes, Patients, Debtor
   // this function formats the data as needed.
   function barcodeDataFinalizerFn(data) {
 
-    data.description =
-      'Prise en charge de ' + data.patient.display_name +
-      ' (' + data.patient.reference + ') ' +
-      'pour facture ' + data.invoice.reference + '.';
+    data.description = $translate.instant('VOUCHERS.TYPES.SUPPORT_PAYMENT_DESCRIPTION', {
+      patientName : data.patient.display_name,
+      patientReference : data.patient.reference,
+      invoiceReference : data.invoice.reference
+    });
+
+    data.debit = {
+      debit : data.invoice.cost,
+    };
 
     // PRISE_EN_CHARGE
     data.type_id = bhConstants.transactionType.SUPPORT_INCOME;
 
-    data.debit = {
-      debit : data.amount,
-    };
-
     data.credit = {
       account_id : data.group.account_id,
-      reference : data.invoice,
+      document : data.invoice,
       entity : { uuid : data.patient.debtor_uuid },
-      credit: data.amount
+      credit : data.invoice.cost,
     };
+
+    data.amount = data.invoice.cost;
 
     return data;
   }

--- a/client/src/partials/vouchers/simple.js
+++ b/client/src/partials/vouchers/simple.js
@@ -110,6 +110,7 @@ function SimpleJournalVoucherController(Vouchers, Accounts, Session, util, Notif
     // configure the basics of the transaction type.
     vm.Voucher.details.description = data.description;
     vm.Voucher.details.type_id = data.type_id;
+
     vm.amount = data.amount;
 
     var debitRow = vm.Voucher.store.data[0];
@@ -122,9 +123,6 @@ function SimpleJournalVoucherController(Vouchers, Accounts, Session, util, Notif
     if (data.credit) {
       creditRow.configure(data.credit);
     }
-
-    // HACK to get this to work.  Why are vouchers so poorly designed?
-    creditRow.document_uuid = data.credit.reference.uuid;
 
     vm.Voucher.validate();
   });

--- a/client/src/partials/vouchers/templates/reference.grid.tmpl.html
+++ b/client/src/partials/vouchers/templates/reference.grid.tmpl.html
@@ -1,15 +1,15 @@
 <div class="ui-grid-cell-contents"
-  ng-class="{'bg-info': row.entity.reference.uuid}">
+  ng-class="{'bg-info': row.entity.document.uuid}">
   <a class="text-action"
     ng-click="grid.appScope.openReferenceModal(row.entity)"
     data-reference-button>
 
     <span
       ng-show="row.entity.reference.uuid" class="text-primary">
-      <i class="fa fa-file-o"></i> {{ row.entity.reference.reference }} - <span translate>{{ row.entity.reference.document_type }}</span>
+      <i class="fa fa-file-o"></i> {{ row.entity.document.reference }} - <span translate>{{ row.entity.document.document_type }}</span>
     </span>
 
-    <span ng-hide="row.entity.reference.uuid">
+    <span ng-hide="row.entity.document.uuid">
       <i class="fa fa-plus"></i> <span translate>VOUCHERS.COMPLEX.REFERENCE</span>
     </span>
   </a>


### PR DESCRIPTION
The complex voucher page was incorrectly updated to use references when
the back end tables use 'document' as the column name.  This caused a lot
of confusion and a bug in production.  This commit goes through and updates
all client side references to use "document" explicitly.

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/1194.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!