### PR TITLE
Refactor: Use bhAccountSelect

### DIFF
--- a/client/src/js/components/bhAccountSelect.js
+++ b/client/src/js/components/bhAccountSelect.js
@@ -85,10 +85,10 @@ function AccountSelectController(Accounts, AppCache, $timeout, bhConstants, $sco
         $ctrl.accounts = Accounts.order(elements);
 
         // writes the accounts into localstorage
-        cacheAccounts($ctrl.accounts);
+        //cacheAccounts($ctrl.accounts);
 
         // set the timeout for removing cached accounts
-        $timeout(removeCachedAccounts, CACHE_TIMEOUT);
+        //$timeout(removeCachedAccounts, CACHE_TIMEOUT);
       });
   }
 

--- a/client/src/partials/admin/creditor_groups/creditor_groups.js
+++ b/client/src/partials/admin/creditor_groups/creditor_groups.js
@@ -1,9 +1,8 @@
 angular.module('bhima.controllers')
-.controller('CreditorGroupController', CreditorGroupController);
+  .controller('CreditorGroupController', CreditorGroupController);
 
 CreditorGroupController.$inject = [
-  '$state', 'CreditorGroupService', 'AccountService',
-  'NotifyService', 'ModalService'
+  '$state', 'CreditorGroupService', 'NotifyService', 'ModalService',
 ];
 
 /**
@@ -12,7 +11,7 @@ CreditorGroupController.$inject = [
  *
  * @module admin/creditor_groups
  */
-function CreditorGroupController($state, CreditorGroup, Accounts, Notify, Modal) {
+function CreditorGroupController($state, CreditorGroup, Notify, Modal) {
   var vm = this;
 
   var uuid = $state.params.uuid;
@@ -27,6 +26,7 @@ function CreditorGroupController($state, CreditorGroup, Accounts, Notify, Modal)
   // expose to public
   vm.submit = submit;
   vm.deleteGroup = deleteGroup;
+  vm.onSelectAccount = onSelectAccount;
 
   // load the list state
   loadListState();
@@ -34,18 +34,14 @@ function CreditorGroupController($state, CreditorGroup, Accounts, Notify, Modal)
   // load the detail of the creditor group
   loadDetails();
 
+  function onSelectAccount(account) {
+    vm.bundle.account_id = account.id;
+  }
 
   // load creditor groups
   CreditorGroup.read(null, { detailed : 1 })
   .then(function (list) {
     vm.creditorGroupList = list;
-  })
-  .catch(Notify.handleError);
-
-  // load accounts
-  Accounts.read(null, { detailed: 1 })
-  .then(function (list) {
-    vm.accounts = list;
   })
   .catch(Notify.handleError);
 
@@ -67,10 +63,10 @@ function CreditorGroupController($state, CreditorGroup, Accounts, Notify, Modal)
     if (!vm.isUpdateState) { return; }
 
     CreditorGroup.read($state.params.uuid)
-    .then(function (detail) {
-      vm.bundle = detail;
-    })
-    .catch(Notify.handleError);
+      .then(function (detail) {
+        vm.bundle = detail;
+      })
+      .catch(Notify.handleError);
   }
 
   /**

--- a/client/src/partials/admin/creditor_groups/creditor_groups.manage.html
+++ b/client/src/partials/admin/creditor_groups/creditor_groups.manage.html
@@ -1,84 +1,60 @@
 <div class="container-fluid">
-    <!-- back to list  -->
-    <div class="row">
-      <div class="col-xs-12">
-        <p>
-          <a ui-sref="creditorGroups.list" ui-sref-opts="CreditorGroupCtrl.reload">
-            <span class="glyphicon glyphicon-circle-arrow-left"></span>
-            {{ 'CREDITOR_GROUP.BACK' | translate }}
-          </a>
-        </p>
-      </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <p>
+        <a ui-sref="creditorGroups.list" ui-sref-opts="CreditorGroupCtrl.reload">
+          <span class="glyphicon glyphicon-circle-arrow-left"></span>
+          {{ 'CREDITOR_GROUP.BACK' | translate }}
+        </a>
+      </p>
     </div>
+  </div>
 
-    <!-- form  -->
-    <div class="row">
-      <div class="col-md-8 col-md-offset-2">
-        <form name="CreditorGroupManager" bh-submit="CreditorGroupCtrl.submit(CreditorGroupManager)" bh-form-defaults novalidate>
+  <!-- form  -->
+  <div class="row">
+    <div class="col-md-8 col-md-offset-2">
+      <form name="CreditorGroupManager" bh-submit="CreditorGroupCtrl.submit(CreditorGroupManager)" bh-form-defaults novalidate>
 
-          <div class="panel panel-primary">
+        <div class="panel panel-primary">
 
-            <div class="panel-heading">
-              <span ng-if="CreditorGroupCtrl.isUpdateState">{{ 'CREDITOR_GROUP.UPDATE' | translate }}</span>
-              <span ng-if="CreditorGroupCtrl.isCreateState">{{ 'CREDITOR_GROUP.CREATE' | translate }}</span>
+          <div class="panel-heading">
+            <span ng-if="CreditorGroupCtrl.isUpdateState" translate>CREDITOR_GROUP.UPDATE</span>
+            <span ng-if="CreditorGroupCtrl.isCreateState" translate>CREDITOR_GROUP.CREATE</span>
+          </div>
+
+          <div class="panel-body">
+            <!-- name  -->
+            <div class="form-group" ng-class="{ 'has-error' : CreditorGroupManager.$submitted && CreditorGroupManager.name.$invalid }">
+              <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>
+              <input class="form-control" name="name" type="text" autocomplete="off" ng-model="CreditorGroupCtrl.bundle.name" required>
+              <div class="help-block" ng-messages="CreditorGroupManager.name.$error" ng-show="CreditorGroupManager.$submitted">
+                <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
-            <div class="panel-body">
-              <!-- name  -->
-              <div class="form-group" ng-class="{ 'has-error' : CreditorGroupManager.$submitted && CreditorGroupManager.name.$invalid }">
-                <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>
-                <input class="form-control" name="name" type="text" autocomplete="off" ng-model="CreditorGroupCtrl.bundle.name" required>
+            <bh-account-select
+              name="account_id"
+              account-id="CreditorGroupCtrl.bundle.account_id"
+              on-select-callback="CreditorGroupCtrl.onSelectAccount(account)">
+            </bh-account-select>
 
-                <div class="help-block" ng-messages="CreditorGroupManager.name.$error" ng-show="CreditorGroupManager.$submitted">
-                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>
-              </div>
-
-              <!-- creditor group account  -->
-              <div class="form-group"
-                ng-class="{ 'has-error' : CreditorGroupManager.$submitted && CreditorGroupManager.account_id.$invalid }">
-                <label class="control-label">
-                  {{ "FORM.LABELS.ACCOUNT" | translate }}
-                </label>
-
-                <ui-select
-                  name="account_id"
-                  ng-model="CreditorGroupCtrl.bundle.account_id"
-                  theme="bootstrap"
-                  required>
-                  <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
-                    <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
-                  </ui-select-match>
-                  <ui-select-choices ui-select-focus-patch repeat="account.id as account in CreditorGroupCtrl.accounts | filter:$select.search">
-                    <strong ng-bind-html="account.number | highlight:$select.search"></strong>
-                    <span ng-bind-html="account.label | highlight:$select.search"></span>
-                  </ui-select-choices>
-                </ui-select>
-
-                <div class="help-block" ng-messages="CreditorGroupManager.account.$error" ng-show="CreditorGroupManager.$submitted">
-                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>
-              </div>
-
-              <!-- is locked ?  -->
-              <div class="form-group">
-                <label class="control-label">
-                  {{ "FORM.LABELS.LOCKED" | translate }}
-                  <input type="checkbox" ng-model="CreditorGroupCtrl.bundle.locked" ng-true-value="1" ng-false-value="0">
-                </label>
-              </div>
-
-            </div>
-
-            <div class="panel-footer text-right">
-              <bh-loading-button loading-state="CreditorGroupManager.$loading">
-                {{ "FORM.BUTTONS.SUBMIT" | translate }}
-              </bh-loading-button>
+            <!-- is locked ?  -->
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="CreditorGroupCtrl.bundle.locked" ng-true-value="1" ng-false-value="0">
+                <span translate>FORM.LABELS.LOCKED</span>
+              </label>
             </div>
 
           </div>
 
-        </form>
-      </div>
+          <div class="panel-footer text-right">
+            <bh-loading-button loading-state="CreditorGroupManager.$loading">
+              <span translate>FORM.BUTTONS.SUBMIT</span>
+            </bh-loading-button>
+          </div>
+        </div>
+      </form>
     </div>
+  </div>
 </div>

--- a/client/src/partials/cash/cashboxes/configure_currency/modal.html
+++ b/client/src/partials/cash/cashboxes/configure_currency/modal.html
@@ -1,73 +1,55 @@
 <form name="CashboxModalForm" bh-submit="CashboxModalCtrl.submit(CashboxModalForm)" bh-form-defaults novalidate>
   <div class="modal-header">
     <ol class="headercrumb">
-      <li class="static">{{ "CASHBOX.TITLE" | translate }}</li>
-      <li class="title">{{ "CASHBOX.CONFIG_ACCOUNTS" | translate }} <small>{{ CashboxModalCtrl.cashbox.text }}</small></li>
+      <li class="static" translate>CASHBOX.TITLE</li>
+      <li class="title">
+        <span translate>CASHBOX.CONFIG_ACCOUNTS</span> <small>{{ CashboxModalCtrl.cashbox.text }}</small>
+      </li>
     </ol>
   </div>
 
   <div class="modal-body">
+
     <p class="text-danger text-justify" ng-if="CashboxModalCtrl.error">
-      <i class="glyphicon glyphicon-exclamation-sign"></i> {{ "FORM.ERRORS.CONNECTION" | translate }}
+      <i class="glyphicon glyphicon-exclamation-sign"></i> <span translate>FORM.ERRORS.CONNECTION</span>
     </p>
 
     <div class="form-group">
-      <label>{{ "FORM.LABELS.CURRENCY" | translate }}</label>
+      <label class="control-label" translate>FORM.LABELS.CURRENCY</label>
       <p class="form-control-static">
         {{ CashboxModalCtrl.currency.name }} ({{ CashboxModalCtrl.currency.symbol}})
       </p>
     </div>
 
-    <div class="form-group" ng-class="{ 'has-error' : CashboxModalForm.$submitted && CashboxModalForm.account_id.$invalid }">
-      <label class="control-label">{{ "FORM.LABELS.CASH_ACCOUNT" | translate }}</label>
-      <ui-select
-        name="account_id"
-        ng-model="CashboxModalCtrl.data.account_id"
-        required>
-        <ui-select-match placeholder="{{ 'FORM.SELECT.ACCOUNT' | translate }}">
-          <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
-        </ui-select-match>
-        <ui-select-choices
-          ui-select-focus-patch
-          ui-disable-choice="account.type_id === CashboxModalCtrl.bhConstants.accounts.TITLE"
-          repeat="account.id as account in CashboxModalCtrl.accounts | filter: { 'hrlabel' : $select.search }">
-          <span ng-bind-html="account.number | highlight:$select.search"></span>
-          <small ng-bind-html="account.label | highlight:$select.search"></small>
-        </ui-select-choices>
-      </ui-select>
-    </div>
+    <bh-account-select
+      id="account-id"
+      account-id="CashboxModalCtrl.data.account_id"
+      label="FORM.LABELS.CASH_ACCOUNT"
+      name="account_id"
+      on-select-callback="CashboxModalCtrl.onSelectCashAccount(account)">
+    </bh-account-select>
 
-    <div class="form-group" ng-class="{ 'has-error' : CashboxModalForm.$submitted && CashboxModalForm.transfer_account_id.$invalid }">
-      <label class="control-label">{{ "FORM.LABELS.TRANSFER_ACCOUNT" | translate }}</label>
-      <ui-select
-        name="transfer_account_id"
-        ng-model="CashboxModalCtrl.data.transfer_account_id"
-        required>
-        <ui-select-match placeholder="{{ 'FORM.SELECT.ACCOUNT' | translate }}">
-          <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
-        </ui-select-match>
-        <ui-select-choices
-          ui-select-focus-patch
-          ui-disable-choice="account.type_id === CashboxModalCtrl.bhConstants.accounts.TITLE"
-          repeat="account.id as account in CashboxModalCtrl.accounts | filter: { 'hrlabel' : $select.search }">
-          <span ng-bind-html="account.number | highlight:$select.search"></span>
-          <small ng-bind-html="account.label | highlight:$select.search"></small>
-        </ui-select-choices>
-      </ui-select>
-    </div>
+    <bh-account-select
+      id="transfer-account-id"
+      account-id="CashboxModalCtrl.data.transfer_account_id"
+      label="FORM.LABELS.TRANSFER_ACCOUNT"
+      name="transfer_account_id"
+      on-select-callback="CashboxModalCtrl.onSelectTransferAccount(account)">
+    </bh-account-select>
   </div>
 
   <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="CashboxModalCtrl.dismiss()" data-method="cancel">
-      {{ "FORM.BUTTONS.CANCEL" | translate }}
+      <span translate>FORM.BUTTONS.CANCEL</span>
     </button>
+
     <bh-loading-button loading-state="CashboxModalForm.$loading">
-      {{ "FORM.BUTTONS.SUBMIT" | translate }}
+      <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>
 
     <span data-role="feedback">
       <span ng-if="CashboxModalForm.$submitted && CashboxModalForm.$invalid" class="text-danger">
-        <i class="glyphicon glyphicon-remove-sign"></i> {{ "FORM.ERRORS.HAS_ERROR" | translate }}
+        <i class="glyphicon glyphicon-remove-sign"></i> <span translate>FORM.ERRORS.HAS_ERROR</span>
       </span>
     </span>
   </div>

--- a/client/src/partials/cash/cashboxes/configure_currency/modal.js
+++ b/client/src/partials/cash/cashboxes/configure_currency/modal.js
@@ -2,8 +2,7 @@ angular.module('bhima.controllers')
   .controller('CashboxCurrencyModalController', CashboxCurrencyModalController);
 
 CashboxCurrencyModalController.$inject = [
-  '$uibModalInstance', 'AccountService', 'CashboxService',
-  'currency', 'cashbox', 'data', 'bhConstants', 'NotifyService'
+  '$uibModalInstance', 'AccountService', 'CashboxService', 'currency', 'cashbox', 'data', 'NotifyService',
 ];
 
 /**
@@ -13,15 +12,13 @@ CashboxCurrencyModalController.$inject = [
  * cashboxes.  Each cashbox must have a currencied account defined for each currency
  * supported by the application.
  */
-function CashboxCurrencyModalController(ModalInstance, Accounts, Boxes, currency, cashbox, data, bhConstants, Notify) {
+function CashboxCurrencyModalController(ModalInstance, Accounts, Boxes, currency, cashbox, data, Notify) {
   var vm = this;
 
   // if a currency matches, we are updating.  Otherwise, we are creating.
   var currencyIds = cashbox.currencies.map(function (row) {
     return row.currency_id;
   });
-
-  vm.bhConstants = bhConstants;
 
   // determine whether we will send a POST or a PUT request to the server
   var method = (currencyIds.indexOf(currency.id) > -1) ?
@@ -33,25 +30,24 @@ function CashboxCurrencyModalController(ModalInstance, Accounts, Boxes, currency
   vm.cashbox = cashbox;
   vm.data = data;
   vm.data.currency_id = currency.id;
+  vm.onSelectCashAccount = onSelectCashAccount;
+  vm.onSelectTransferAccount = onSelectTransferAccount;
 
   // bind methods to the view-model
   vm.dismiss = ModalInstance.dismiss;
   vm.submit = submit;
 
-  /* ------------------------------------------------------------------------ */
-
-  // startup script for the controller
-  function startup() {
-
-    // load accounts and properly order them
-    Accounts.read(null, { detailed : 1 })
-      .then(function (accounts) {
-        vm.accounts = Accounts.order(accounts);
-      })
-      .catch(Notify.handleError);
+  // callback for currency account
+  function onSelectCashAccount(account) {
+    vm.data.account_id = account.id;
   }
 
-  // return data to the
+  // callback for transfer account
+  function onSelectTransferAccount(account) {
+    vm.data.transfer_account_id = account.id;
+  }
+
+  // submit to the server
   function submit(form) {
 
     // if the form has errors, exit immediately
@@ -66,11 +62,8 @@ function CashboxCurrencyModalController(ModalInstance, Accounts, Boxes, currency
       Boxes.currencies.update(vm.cashbox.id, vm.data);
 
     // upon successful completion, close the modal or error out
-  return promise
-    .then(function () { ModalInstance.close(); })
-    .catch(Notify.handleError);
+    return promise
+      .then(function () { ModalInstance.close(); })
+      .catch(Notify.handleError);
   }
-
-  // startup the controller
-  startup();
 }

--- a/client/src/partials/enterprises/enterprises.html
+++ b/client/src/partials/enterprises/enterprises.html
@@ -55,67 +55,29 @@
               </div>
 
               <!-- gain account  -->
-              <div class="form-group" ng-class="{ 'has-error' : EnterpriseForm.$submitted && EnterpriseForm.gain_account.$invalid }">
-                <label class="control-label">
-                  {{ "FORM.LABELS.GAIN_ACCOUNT" | translate }}
-                </label>
+              <bh-account-select
+                id="gain-account-id"
+                account-id="EnterpriseCtrl.enterprise.gain_account_id"
+                label="FORM.LABELS.GAIN_ACCOUNT"
+                name="gain_account_id"
+                on-select-callback="EnterpriseCtrl.onSelectGainAccount(account)">
+              </bh-account-select>
 
-                <ui-select
-                  name="gain_account"
-                  ng-model="EnterpriseCtrl.enterprise.gain_account_id"
-                  required>
-                  <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
-                    <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
-                  </ui-select-match>
-                  <ui-select-choices
-                    ui-select-focus-patch
-                    ui-disable-choice="account.type_id === EnterpriseCtrl.bhConstants.accounts.TITLE"
-                    repeat="account.id as account in  EnterpriseCtrl.accounts | filter: { 'hrlabel': $select.search }">
-                    <strong ng-bind-html="account.number | highlight:$select.search"></strong>
-                    <span ng-bind-html="account.label | highlight:$select.search"></span>
-                  </ui-select-choices>
-                </ui-select>
-
-                <div class="help-block" ng-messages="EnterpriseForm.gain_account.$error" ng-show="EnterpriseForm.$submitted">
-                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>
-              </div>
-
-              <!-- loss account  -->
-              <div class="form-group" ng-class="{ 'has-error' : EnterpriseForm.$submitted && EnterpriseForm.loss_account.$invalid }">
-                <label class="control-label">
-                  {{ "FORM.LABELS.LOSS_ACCOUNT" | translate }}
-                </label>
-
-                <ui-select
-                  name="loss_account"
-                  ng-model="EnterpriseCtrl.enterprise.loss_account_id"
-                  required>
-                  <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
-                    <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
-                  </ui-select-match>
-                  <ui-select-choices
-                    ui-select-focus-patch
-                    ui-disable-choice="account.type_id === EnterpriseCtrl.bhConstants.accounts.TITLE"
-                    repeat="account.id as account in  EnterpriseCtrl.accounts | filter:{'hrlabel' : $select.search}">
-                    <strong ng-bind-html="account.number | highlight:$select.search"></strong>
-                    <span ng-bind-html="account.label | highlight:$select.search"></span>
-                  </ui-select-choices>
-                </ui-select>
-
-                <div class="help-block" ng-messages="EnterpriseForm.loss_account.$error" ng-show="EnterpriseForm.$submitted">
-                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>
-              </div>
+              <bh-account-select
+                id="loss-account-id"
+                account-id="EnterpriseCtrl.enterprise.loss_account_id"
+                label="FORM.LABELS.LOSS_ACCOUNT"
+                name="loss_account_id"
+                on-select-callback="EnterpriseCtrl.onSelectLossAccount(account)">
+              </bh-account-select>
 
             </div>
 
             <div class="panel-footer text-right">
               <bh-loading-button loading-state="EnterpriseForm.$loading">
-                {{ "FORM.BUTTONS.UPDATE" | translate }}
+                <span translate>FORM.BUTTONS.UPDATE</span>
               </bh-loading-button>
             </div>
-
           </div>
 
           <!-- enterprise optional info  -->
@@ -200,7 +162,6 @@
 
         <!-- embedded exchange rate -->
         <div ui-view="exchange"></div>
-
       </div>
     </div>
   </div>

--- a/client/src/partials/enterprises/enterprises.js
+++ b/client/src/partials/enterprises/enterprises.js
@@ -2,17 +2,14 @@ angular.module('bhima.controllers')
   .controller('EnterpriseController', EnterpriseController);
 
 EnterpriseController.$inject = [
-  'EnterpriseService', 'CurrencyService', 'util', 'NotifyService',
-  'ProjectService', 'ModalService', 'AccountService', 'bhConstants'
+  'EnterpriseService', 'CurrencyService', 'util', 'NotifyService', 'ProjectService', 'ModalService',
 ];
 
 /**
  * Enterprise Controller
  */
-function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, Modal, Accounts, bhConstants) {
+function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, Modal) {
   var vm = this;
-
-  vm.bhConstants = bhConstants;
 
   vm.enterprises = [];
   vm.enterprise = {};
@@ -25,12 +22,14 @@ function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, M
 
   // bind methods
   vm.submit = submit;
+  vm.onSelectGainAccount = onSelectGainAccount;
+  vm.onSelectLossAccount = onSelectLossAccount;
 
   // fired on startup
   function startup() {
 
     // load enterprises
-    Enterprises.read(null, { detailed : 1 })
+    Enterprises.read(null, { detailed: 1 })
       .then(function (enterprises) {
         vm.hasEnterprise = (enterprises.length > 0);
         vm.enterprises = vm.hasEnterprise ? enterprises : [];
@@ -40,11 +39,6 @@ function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, M
          * this choice need the team point of view for to setting the default enterprise
          */
         vm.enterprise = vm.hasEnterprise ? vm.enterprises[0] : {};
-
-        return Accounts.read();
-      })
-      .then(function (accounts) {
-        vm.accounts = Accounts.order(accounts);
         return refreshProjects();
       })
       .catch(Notify.handleError);
@@ -55,7 +49,14 @@ function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, M
         vm.currencies = currencies;
       })
       .catch(Notify.handleError);
+  }
 
+  function onSelectGainAccount(account) {
+    vm.enterprise.gain_account_id = account.id;
+  }
+
+  function onSelectLossAccount(account) {
+    vm.enterprise.loss_account_id = account.id;
   }
 
   // form submission
@@ -120,6 +121,7 @@ function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, M
       identifier : id,
       enterprise : vm.enterprise
     };
+
     Modal.openProjectActions(params)
     .then(function (value) {
       if (!value) { return; }

--- a/client/src/partials/subsidies/subsidies.html
+++ b/client/src/partials/subsidies/subsidies.html
@@ -111,26 +111,11 @@
                 </div>
               </div>
 
-              <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.account_id.$invalid }">
-                <label class="col-md-3 control-label">{{ "FORM.LABELS.ACCOUNT" | translate }}</label>
-                <ui-select
-                  name="account_id"
-                  ng-model="SubsidyCtrl.subsidy.account_id"
-                  theme="bootstrap"
-                  required>
-                  <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
-                    <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
-                  </ui-select-match>
-                  <ui-select-choices ui-select-focus-patch repeat="account.id as account in SubsidyCtrl.accounts | filter:$select.search">
-                    <strong ng-bind-html="account.number | highlight:$select.search"></strong>
-                    <span ng-bind-html="account.label | highlight:$select.search"></span>
-                  </ui-select-choices>
-                </ui-select>
-
-                <div class="help-block" ng-messages="CreateForm.account_id.$error" ng-show="CreateForm.$submitted">
-                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>
-              </div>
+              <bh-account-select
+                account-id="SubsidyCtrl.subsidy.account_id"
+                name="account_id"
+                on-select-callback="SubsidyCtrl.onAccountSelect(account)">
+              </bh-account-select>
 
               <div class="form-group" ng-class="{ 'has-error' : CreateForm.$submitted && CreateForm.description.$invalid }">
                 <label class="control-label" for="description">{{ 'FORM.LABELS.DESCRIPTION' | translate }}</label>
@@ -173,26 +158,11 @@
                 </div>
               </div>
 
-              <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.account_id.$invalid }">
-                <label class="control-label">{{ "FORM.LABELS.ACCOUNT" | translate }}</label>
-                <ui-select
-                  name="account_id"
-                  ng-model="SubsidyCtrl.subsidy.account_id"
-                  theme="bootstrap"
-                  required>
-                  <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
-                    <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
-                  </ui-select-match>
-                  <ui-select-choices ui-select-focus-patch repeat="account.id as account in SubsidyCtrl.accounts | filter:$select.search">
-                    <strong ng-bind-html="account.number | highlight:$select.search"></strong>
-                    <span ng-bind-html="account.label | highlight:$select.search"></span>
-                  </ui-select-choices>
-                </ui-select>
-
-                <div class="help-block" ng-messages="UpdateForm.account_id.$error" ng-show="UpdateForm.$submitted">
-                  <div ng-messages-include="partials/templates/messages.tmpl.html"></div>
-                </div>
-              </div>
+              <bh-account-select
+                account-id="SubsidyCtrl.subsidy.account_id"
+                name="account_id"
+                on-select-callback="SubsidyCtrl.onAccountSelect(account)">
+              </bh-account-select>
 
               <div class="form-group" ng-class="{ 'has-error' : UpdateForm.$submitted && UpdateForm.description.$invalid }">
                 <label class="control-label" for="description">{{ 'FORM.LABELS.DESCRIPTION' | translate }}</label>

--- a/client/src/partials/subsidies/subsidies.js
+++ b/client/src/partials/subsidies/subsidies.js
@@ -1,12 +1,12 @@
 // TODO Handle HTTP exception errors (displayed contextually on form)
 angular.module('bhima.controllers')
-.controller('SubsidyController', SubsidyController);
+  .controller('SubsidyController', SubsidyController);
 
 SubsidyController.$inject = [
-  'SubsidyService', 'AccountService', '$translate', 'ModalService', 'util', 'NotifyService'
+  'SubsidyService', 'ModalService', 'util', 'NotifyService',
 ];
 
-function SubsidyController(Subsidy , Accounts, $translate, ModalService, util, Notify) {
+function SubsidyController(Subsidy, ModalService, util, Notify) {
   var vm = this;
   vm.session = {};
   vm.view = 'default';
@@ -15,24 +15,21 @@ function SubsidyController(Subsidy , Accounts, $translate, ModalService, util, N
   vm.create = create;
   vm.submit = submit;
   vm.update = update;
-  vm.del    = del;
+  vm.del = del;
   vm.cancel = cancel;
+  vm.onAccountSelect = onAccountSelect;
 
   vm.length250 = 200;
   vm.maxLength = util.maxTextLength;
 
   // fired on startup
   function startup() {
-
-    // load accounts and properly formats their labels
-    Accounts.read(null, { detailed : 1 })
-      .then(function (accounts) {
-        vm.accounts = accounts;
-      })
-      .catch(Notify.handleError);
-
     // load Subsidies
     refreshSubsidies();
+  }
+
+  function onAccountSelect(account) {
+    vm.subsidy.account_id = account.id;
   }
 
   function cancel() {
@@ -50,7 +47,6 @@ function SubsidyController(Subsidy , Accounts, $translate, ModalService, util, N
     vm.view = 'update';
     vm.subsidy = data;
   }
-
 
   // refresh the displayed Subsidies
   function refreshSubsidies() {

--- a/client/src/partials/templates/bhAccountSelect.tmpl.html
+++ b/client/src/partials/templates/bhAccountSelect.tmpl.html
@@ -1,7 +1,7 @@
 <div ng-form="{{ $ctrl.name }}" bh-account-select>
   <div
     class="form-group"
-    ng-class="{ 'has-error' : AccountForm.$$parent.$submitted && AccountFrom.account_id.$invalid }">
+    ng-class="{ 'has-error' : AccountForm.$$parent.$submitted && AccountForm.account_id.$invalid }">
 
     <label class="control-label" translate>
       {{ ::$ctrl.label }}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,7 @@ const paths = {
       'client/vendor/angular-messages/angular-messages.min.js',
 
       // Angular Sanitize
-      'client/vendor/angular-sanitize/angular-sanitize.js',
+      'client/vendor/angular-sanitize/angular-sanitize.min.js',
 
       // Angular UI
       'client/vendor/angular-ui-router/release/angular-ui-router.min.js',
@@ -64,26 +64,26 @@ const paths = {
       // @TODO - rm this
       'client/vendor/angular-ui-router/release/stateEvents.min.js',
 
-      'client/vendor/angular-bootstrap/ui-bootstrap-tpls.js',
+      'client/vendor/angular-bootstrap/ui-bootstrap-tpls.min.js',
       'client/vendor/angular-ui-grid/ui-grid.min.js',
 
       // Angular Touch
       'client/vendor/angular-touch/angular-touch.min.js',
 
       // Angular UI Select
-      'client/vendor/angular-ui-select/dist/select.js',
+      'client/vendor/angular-ui-select/dist/select.min.js',
 
       // ChartJS
       'client/vendor/chart.js/dist/Chart.min.js',
       'client/vendor/angular-chart.js/dist/angular-chart.min.js',
 
       // Angular Growl
-      'client/vendor/angular-growl-notifications/dist/angular-growl-notifications.js',
-      'client/vendor/angular-animate/angular-animate.js',
+      'client/vendor/angular-growl-notifications/dist/angular-growl-notifications.min.js',
+      'client/vendor/angular-animate/angular-animate.min.js',
 
       // MomentJS
       'client/vendor/moment/moment.js',
-      'client/vendor/angular-moment/angular-moment.js',
+      'client/vendor/angular-moment/angular-moment.min.js',
       'client/vendor/moment/locale/fr.js',
 
       // Angular Translate
@@ -98,7 +98,7 @@ const paths = {
       'client/vendor/ng-file-upload/ng-file-upload.min.js',
 
       // ngStorage
-      'client/vendor/ngstorage/ngStorage.min.js'
+      'client/vendor/ngstorage/ngStorage.min.js',
     ],
 
     // these must be globs ("**" syntax) to retain their folder structures

--- a/test/end-to-end/cashboxes/cashboxes.spec.js
+++ b/test/end-to-end/cashboxes/cashboxes.spec.js
@@ -64,8 +64,8 @@ describe('Cashboxes', () => {
     FU.exists(by.css('[uib-modal-window]'), true);
     FU.exists(by.name('CashboxModalForm'), true);
 
-    FU.uiSelect('CashboxModalCtrl.data.account_id', 'Test Gain Account');
-    FU.uiSelect('CashboxModalCtrl.data.transfer_account_id', 'Test Loss Account');
+    components.accountSelect.set('Test Gain Account', 'account-id');
+    components.accountSelect.set('Test Loss Account', 'transfer-account-id');
 
     // submit the modal
     FU.modal.submit();
@@ -87,7 +87,7 @@ describe('Cashboxes', () => {
     // confirm that the modal appears
     FU.exists(by.css('[uib-modal-window]'), true);
 
-    FU.uiSelect('CashboxModalCtrl.data.account_id', 'First Test Item Account');
+    components.accountSelect.set('First Test Item Account', 'account-id');
 
     // submit the modal
     FU.modal.submit();
@@ -95,11 +95,7 @@ describe('Cashboxes', () => {
     // confirm that the modal did not disappear
     FU.exists(by.css('[uib-modal-window]'), true);
 
-    // these inputs should not have error states
-    FU.validation.ok('CashboxModalCtrl.data.account_id');
-    FU.validation.error('CashboxModalCtrl.data.transfer_account_id');
-
-    FU.uiSelect('CashboxModalCtrl.data.transfer_account_id', 'Test Debtor Group Account');
+    components.accountSelect.set('Test Debtor Group Account', 'transfer-account-id');
 
     // submit the modal
     FU.modal.submit();

--- a/test/end-to-end/creditor_groups/creditor_groups.spec.js
+++ b/test/end-to-end/creditor_groups/creditor_groups.spec.js
@@ -32,7 +32,7 @@ describe('Creditor Groups Management', () => {
     FU.buttons.create();
 
     FU.input('CreditorGroupCtrl.bundle.name', group.name);
-    FU.uiSelect('CreditorGroupCtrl.bundle.account_id', group.account);
+    components.accountSelect.set(group.account);
 
     FU.buttons.submit();
     components.notification.hasSuccess();

--- a/test/end-to-end/enterprises/enterprises.spec.js
+++ b/test/end-to-end/enterprises/enterprises.spec.js
@@ -21,7 +21,7 @@ describe('Enterprises', function () {
     po_box : 'POBOX USA 1',
     phone : '01500',
     gain_account_id : 'Test Gain Account',
-    loss_account_id : 'Test Expense Accounts'
+    loss_account_id : 'Test Loss Account'
   };
 
   // default enterprise
@@ -32,7 +32,7 @@ describe('Enterprises', function () {
     po_box : 'POBOX USA 1',
     phone : '243 81 504 0540',
     gain_account_id : 'Test Gain Account',
-    loss_account_id : 'Test Expense Accounts'
+    loss_account_id : 'Test Loss Account'
   };
 
   // project
@@ -61,8 +61,8 @@ describe('Enterprises', function () {
     FU.input('EnterpriseCtrl.enterprise.name', enterprise.name);
     FU.input('EnterpriseCtrl.enterprise.abbr', enterprise.abbr);
 
-    FU.uiSelect('EnterpriseCtrl.enterprise.gain_account_id', enterprise.gain_account_id);
-    FU.uiSelect('EnterpriseCtrl.enterprise.loss_account_id', enterprise.loss_account_id);
+    components.accountSelect.set(enterprise.gain_account_id, 'gain-account-id');
+    components.accountSelect.set(enterprise.loss_account_id, 'loss-account-id');
 
     FU.input('EnterpriseCtrl.enterprise.po_box', enterprise.po_box);
     FU.input('EnterpriseCtrl.enterprise.email', enterprise.email);
@@ -105,8 +105,8 @@ describe('Enterprises', function () {
      FU.input('EnterpriseCtrl.enterprise.name', default_enterprise.name);
      FU.input('EnterpriseCtrl.enterprise.abbr', default_enterprise.abbr);
 
-     FU.uiSelect('EnterpriseCtrl.enterprise.gain_account_id', default_enterprise.gain_account_id);
-     FU.uiSelect('EnterpriseCtrl.enterprise.loss_account_id', default_enterprise.loss_account_id);
+     components.accountSelect.set(default_enterprise.gain_account_id, 'gain-account-id');
+     components.accountSelect.set(default_enterprise.loss_account_id, 'loss-account-id');
 
      FU.input('EnterpriseCtrl.enterprise.po_box', default_enterprise.po_box);
      FU.input('EnterpriseCtrl.enterprise.email', default_enterprise.email);

--- a/test/end-to-end/subsidies/subsidies.spec.js
+++ b/test/end-to-end/subsidies/subsidies.spec.js
@@ -25,7 +25,7 @@ describe('Subsidies', () => {
     FU.buttons.create();
     FU.input('SubsidyCtrl.subsidy.label', subsidy.label);
     FU.input('SubsidyCtrl.subsidy.value', subsidy.value);
-    FU.uiSelect('SubsidyCtrl.subsidy.account_id', 'Test Debtor Accounts2');
+    components.accountSelect.set('Test Debtor Accounts2');
     FU.input('SubsidyCtrl.subsidy.description', subsidy.description);
 
     // submit the page to the server
@@ -58,7 +58,6 @@ describe('Subsidies', () => {
     // the following fields should be required
     FU.validation.error('SubsidyCtrl.subsidy.label');
     FU.validation.error('SubsidyCtrl.subsidy.value');
-    FU.validation.error('SubsidyCtrl.subsidy.account_id');
     // the following fields are not required
     FU.validation.ok('SubsidyCtrl.subsidy.description');
   });


### PR DESCRIPTION
This PR transitions many of our account selects to use `bhAccountSelect`.  It doesn't touch the complex voucher module, but virtually everything else now uses `bhAccountSelect`.

I noticed that the caching mechanism was slowing down our pages (or, at least our end-to-end tests).  I have commented it out temporarily - it should be investigated.  It's likely the same issue that affected  our `growl` notifications library.

Progress towards #1013.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!