### PR TITLE
feat(env): turn off events

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,27 +1,35 @@
 # Server Config
 PORT=8080
-HTTPS=1
 
 # database configuration
 DB_HOST='localhost'
-DB_USER='YOUR_USERNAME'
+DB_USER='bhima'
 DB_PASS='YOUR_PASSWORD'
-DB_NAME='YOUR_DATABASE'
+DB_NAME='bhima'
 
 # session variables
-SESS_SECRET='YOUR_SECRET'
+SESS_SECRET='X0pEn Bl0wF1SH'
 SESS_RESAVE=0
-SESS_SAVE_UNINITIALIZED=0
-SESS_REAP_INTERVAL=-1
 SESS_UNSET='destroy'
 
-# logger configuration
-LOG_LEVEL='debug'
+# log level
+LOG_LEVEL='verbose'
 LOG_FILE='access.log'
 
 # uploads
-UPLOAD_FOLDER='client/upload'
+UPLOAD_DIR='client/upload'
 
-# SSL/TLS config
-TLS_KEY='server/config/keys/server.key'
-TLS_CERT='server/config/keys/server.crt'
+# for sentry.io error reporting
+SENTRY_DSN=''
+SENTRY_NAME=''
+SENTRY_ENVIRONMENT=''
+
+# used for broadcasting email reports
+SYSTEM_EMAIL_ADDRESS=''
+
+# used to log in to the mailgun service
+MAILGUN_DOMAIN=''
+MAILGUN_API_KEY=''
+
+# control Redis Pub/Sub
+ENABLE_EVENTS=false

--- a/.env.staging
+++ b/.env.staging
@@ -1,6 +1,5 @@
 # Server Config
 PORT=8080
-HTTPS=1
 
 # database configuration
 DB_URL = 'mysql://bhima_staging:STAGING_PASSWORD@localhost:3306/bhima_staging'
@@ -12,17 +11,18 @@ DB_HOST= 'localhost'
 # session variables
 SESS_SECRET='Tr@v1$_S3CR3T'
 SESS_RESAVE=0
-SESS_SAVE_UNINITIALIZED=0
-SESS_REAP_INTERVAL=-1
 SESS_UNSET='destroy'
 
-# logger configuraion params
-LOG_LEVEL='warn'
+# logger configuration parameters
+LOG_LEVEL='verbose'
 LOG_FILE='access.log'
 
 # uploads
-UPLOAD_FOLDER='client/upload'
+UPLOAD_DIR='client/upload'
 
-# SSL/TLS config
-TLS_KEY='server/config/keys/server.key'
-TLS_CERT='server/config/keys/server.crt'
+# used for broadcasting email reports
+SYSTEM_EMAIL_ADDRESS='staging@bhi.ma'
+
+# control Redis Pub/Sub events
+# for staging purposes, we will turn those off.
+ENABLE_EVENTS=false

--- a/server/app.js
+++ b/server/app.js
@@ -39,18 +39,17 @@ const app = express();
  * defaults to 'production'
  */
 function configureEnvironmentVariables() {
-
   // if the process NODE_ENV is not set, default to production.
   process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 
   // normalize the environmental variable name
-  let env = process.env.NODE_ENV.toLowerCase();
+  const env = process.env.NODE_ENV.toLowerCase();
 
   // decode the file path for the environmental variables.
-  let dotfile = `server/.env.${env}`.trim();
+  const dotfile = `server/.env.${env}`.trim();
 
   // load the environmental variables into process using the dotenv module
-  console.log(`[app] Loading configuration from ${dotfile}.`);
+  winston.info(`[app] Loading configuration from ${dotfile}.`);
   require('dotenv').config({ path : dotfile });
 }
 
@@ -67,22 +66,21 @@ function configureEnvironmentVariables() {
  *
  */
 function configureLogger() {
-
   // set logging levels to that found in the configuration file (default: warn)
-  winston.level = process.env.LOG_LEVEL || 'warn';
+  winston.level = (process.env.LOG_LEVEL || 'warn');
 
   const logFile = process.env.LOG_FILE;
 
   // allow logging to a file if needed
   if (logFile) {
-    winston.add(winston.transports.File, { filename : logFile });
+    winston.add(winston.transports.File, { filename: logFile });
   }
 
   // be sure to log unhandled exceptions
   winston.handleExceptions(new winston.transports.Console({
-    humanReadableUnhandledException: true,
-    colorize: true,
-    prettyPrint: true
+    humanReadableUnhandledException : true,
+    colorize                        : true,
+    prettyPrint                     : true,
   }));
 }
 
@@ -93,7 +91,6 @@ function configureLogger() {
  * Set up the HTTP server to listen on the correct
  */
 function configureServer() {
-
   // destruct the environmental variables
   const port = process.env.PORT;
   const mode = process.env.NODE_ENV;
@@ -103,7 +100,6 @@ function configureServer() {
     .listen(process.env.PORT, () => {
       winston.info(`Server started in mode ${mode} on port ${port}.`);
     });
-
 }
 
 // run configuration tools

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -141,10 +141,10 @@ function create(req, res, next) {
 
       // publish a CREATE event on the medical channel
       topic.publish(topic.channels.MEDICAL, {
-        event: topic.events.CREATE,
-        entity: topic.entities.PATIENT,
-        user_id: req.session.user.id,
-        uuid: uuid.unparse(medical.uuid)
+        event   : topic.events.CREATE,
+        entity  : topic.entities.PATIENT,
+        user_id : req.session.user.id,
+        uuid    : uuid.unparse(medical.uuid),
       });
     })
     .catch(next)


### PR DESCRIPTION
This commit adds environmental variable control of the events emitted by
Topic.  By setting the variable `ENABLE_EVENTS` to false, no Redis
subscriptions will be made at runtime.  In fact, the code is read as
dead code and returns immediately on entry into the function.

It also updates winston to no longer log massive HTTP information when
placed in debug mode.  To get all the HTTP logs, use `silly`.

Closes #948.

Thank you for contributing!

----
Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
