### PR TITLE
(refactor) Link parent modules in headercrumb

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -461,8 +461,7 @@ ol.headercrumb {
   font-weight : bold;
 }
 
-.headercrumb > .static,
-.headercrumb > .static > a {
+.headercrumb > .static {
   text-decoration: none;
   color: #828080;
 }

--- a/client/src/partials/debtors/groups.html
+++ b/client/src/partials/debtors/groups.html
@@ -4,13 +4,25 @@
     <ol class="headercrumb">
       <li class="static" translate>TREE.FINANCE</li>
 
-      <li ng-class="{'static' : GroupCtrl.state.current.name==='debtorGroups.update', 'title' : GroupCtrl.state.current.name!=='debtorGroups.update'}">
+      <!-- @TODO come up with standard for switching these states -->
+      <!-- Debtor groups list -->
+      <li
+        ng-if="GroupCtrl.state.current.name!=='debtorGroups.update'"
+        class="title">
         <span translate>DEBTOR_GROUP.TITLE</span>
       </li>
+
+      <!-- Editing/ overview state -->
+      <li
+        ng-if="GroupCtrl.state.current.name==='debtorGroups.update'"
+        class="static">
+        <a ui-sref="debtorGroups.list" translate>DEBTOR_GROUP.TITLE</a>
+      </li>
+
       <li class="title" ng-if="!GroupCtrl.state.current.data.label && GroupCtrl.state.current.name==='debtorGroups.update'">
         <i class="fa fa-spin fa-circle-o-notch"></i>
       </li>
-      <li class="title" ng-if="GroupCtrl.state.current.data.label">{{GroupCtrl.state.current.data.label | translate}}</li>
+      <li class="title" ng-if="GroupCtrl.state.current.data.label" translate>{{GroupCtrl.state.current.data.label}}</li>
     </ol>
 
 

--- a/client/src/partials/debtors/groups.update.html
+++ b/client/src/partials/debtors/groups.update.html
@@ -1,16 +1,16 @@
 <div class="container-fluid" ng-form="debtorGroup" bh-form-defaults novalidate>
   <div class="row" ng-if="GroupUpdateCtrl.$loading">
     <div class="col-xs-12">
-      <i class="fa fa-circle-o-notch fa-spin"></i> {{ "DEBTOR_GROUP.LOADING" | translate }}
+      <i class="fa fa-circle-o-notch fa-spin"></i> <span translate>DEBTOR_GROUP.LOADING</span>
     </div>
   </div>
   <div ng-if="GroupUpdateCtrl.$loaded">
     <div class="row">
       <div class="col-xs-12">
         <p>
-          <a ng-href="#/debtors/groups">
+          <a ui-sref="debtorGroups.list">
             <span class="fa fa-arrow-circle-left" aria-hidden="true"></span>
-            {{ "DEBTOR_GROUP.BACK" | translate }}
+            <span translate>DEBTOR_GROUP.BACK</translate>
           </a>
         </p>
       </div>
@@ -23,7 +23,7 @@
           <div
             class="form-group has-feedback"
             ng-class="{'has-error' : debtorGroup.name.$invalid && debtorGroup.$submitted}">
-            <label class="control-label">{{ "FORM.LABELS.NAME" | translate }}</label>
+            <label class="control-label" translate>FORM.LABELS.NAME</label>
             <input name="name" ng-model="GroupUpdateCtrl.group.name" autocomplete="off" class="form-control" required>
 
             <div class="help-block" ng-messages="debtorGroup.name.$error" ng-show="debtorGroup.$submitted">
@@ -42,13 +42,13 @@
             class="form-group has-feedback"
             ng-class="{'has-error' : debtorGroup.price_list.$invalid && debtorGroup.$submitted}">
 
-            <label class="control-label">{{ "TABLE.COLUMNS.PRICE_LIST" | translate }}</label>
+            <label class="control-label" translate>TABLE.COLUMNS.PRICE_LIST</label>
             <select
               name="price_list_uuid"
               ng-model="GroupUpdateCtrl.group.price_list_uuid"
               ng-options="priceList.uuid as priceList.label for priceList in GroupUpdateCtrl.priceLists"
               class="form-control">
-              <option value="">{{ "PRICE_LIST.NONE" | translate }}</option>
+              <option value="" translate>PRICE_LIST.NONE</option>
             </select>
 
             <div class="help-block" ng-messages="debtorGroup.price_list.$error" ng-show="debtorGroup.$submitted">
@@ -60,8 +60,8 @@
             class="form-group has-feedback"
             ng-class="{'has-error' : debtorGroup.max_credit.$invalid && debtorGroup.$submitted}">
 
-            <label class="control-label">{{ "FORM.LABELS.MAX_CREDIT" | translate }}</label>
-            <p class="text-info"><span class="fa fa-info-circle" aria-hidden="true"></span> {{ "FORM.LABELS.MAX_CREDIT_INFO" | translate }}</p>
+            <label class="control-label" translate>FORM.LABELS.MAX_CREDIT</label>
+            <p class="text-info"><span class="fa fa-info-circle" aria-hidden="true"></span> <span translate>FORM.LABELS.MAX_CREDIT_INFO</span></p>
             <input type="number" ng-model="GroupUpdateCtrl.group.max_credit" autocomplete="off" name="max_credit" class="form-control" bh-integer required>
 
             <div class="help-block" ng-messages="debtorGroup.max_credit.$error" ng-show="debtorGroup.$submitted">

--- a/client/src/partials/patients/edit/edit.html
+++ b/client/src/partials/patients/edit/edit.html
@@ -3,7 +3,7 @@
 
     <ol class="headercrumb">
       <li class="static"><span translate>TREE.HOSPITAL</span></li>
-      <li class="static"><span translate>PATIENT_RECORDS.TITLE</span></li>
+      <li class="static"><span><a ui-sref="patientRegistry" translate>PATIENT_RECORDS.TITLE</a></span></li>
       <li class="title">{{ PatientEditCtrl.medical.name }}</li>
     </ol>
 
@@ -12,7 +12,7 @@
         ng-show="PatientEditCtrl.medical.name"
         style="margin-left : 5px"
         class="label label-warning">
-      <span style="text-transform : uppercase">{{ "FORM.LABELS.EDIT" | translate }}</span>
+      <span style="text-transform : uppercase" translate>FORM.LABELS.EDIT</span>
     </span>
 
   </div>
@@ -24,7 +24,7 @@
     <div class="row" ng-if="PatientEditCtrl.unknownId">
       <div class="col-md-12">
         <div class="alert alert-danger">
-          <i class="fa fa-search"></i> {{ "PATIENT_EDIT.PAGE_FAIL" | translate }}
+          <i class="fa fa-search"></i> <span translate>PATIENT_EDIT.PAGE_FAIL</span>
         </div>
       </div>
     </div>
@@ -34,15 +34,15 @@
       <div class="col-md-5 col-md-push-7">
 
         <div class="panel panel-default">
-          <div class="panel-heading">
-            {{ "PATIENT_EDIT.FINANCIAL_INFO" | translate }}
+          <div class="panel-heading" translate>
+            PATIENT_EDIT.FINANCIAL_INFO
           </div>
           <div class="panel-body">
             <form name="finance" bh-form-defaults novalidate>
 
               <!-- Patient Group -->
               <div class="form-group">
-                <label class="control-label">{{ "FORM.LABELS.GROUPS_PATIENT_TITLE" | translate }}</label>
+                <label class="control-label" translate>FORM.LABELS.GROUPS_PATIENT_TITLE</label>
 
                 <!-- Iterate through patient groups -->
                  <ul>
@@ -54,7 +54,7 @@
                  </ul>
 
                  <p class="text-info form-control-static" ng-if="PatientEditCtrl.finance.patientGroups.length === 0">
-                 <span class="fa fa-info-circle"></span> {{ "FORM.LABELS.GROUPS_PATIENT_EMPTY" | translate }}
+                  <span class="fa fa-info-circle"></span> <span translate>FORM.LABELS.GROUPS_PATIENT_EMPTY</span>
                  </p>
 
               </div>

--- a/client/src/partials/patients/record/patient_record.html
+++ b/client/src/partials/patients/record/patient_record.html
@@ -1,8 +1,8 @@
 <div class="flex-header">
   <div class="bhima-title">
     <ol class="headercrumb">
-      <li class="static">{{ "TREE.HOSPITAL" | translate }}</li>
-      <li class="static">{{ "PATIENT_RECORDS.TITLE" | translate }}</li>
+      <li class="static" translate>TREE.HOSPITAL</li>
+      <li class="static"><a ui-sref="patientRegistry" translate>PATIENT_RECORDS.TITLE</a></li>
       <li class="title">{{ PatientRecordCtrl.patient.name }}</li>
     </ol>
   </div>
@@ -13,7 +13,7 @@
   <!-- Unknown patient state -->
   <div class="container-fluid" ng-if="!PatientRecordCtrl.patient && PatientRecordCtrl.loading===false">
     <div class="alert alert-danger" id="nopatient">
-      <span class="glyphicon glyphicon-search"></span> {{ "PATIENT_RECORDS.NOT_FOUND" | translate }}
+      <span class="fa fa-search"></span> <span translate>PATIENT_RECORDS.NOT_FOUND</span>
     </div>
   </div>
 
@@ -26,8 +26,8 @@
 
           <div class="panel panel-primary">
             <div class="panel-heading clearfix">
-              <span class="glyphicon glyphicon-list-alt"></span>
-              {{ "FORM.LABELS.PATIENT_DETAILS" | translate }}
+              <span class="fa fa-list-alt"></span>
+              <span translate>FORM.LABELS.PATIENT_DETAILS</span>
             </div>
 
             <div class="panel-body">
@@ -35,16 +35,16 @@
                 <div>
 
                   <dl>
-                    <dt>{{"FORM.LABELS.NAME" | translate}}</dt>
+                    <dt translate>FORM.LABELS.NAME</dt>
                     <dd id="name">{{::PatientRecordCtrl.patient.name}}</dd>
 
-                    <dt>{{"FORM.LABELS.PATIENT_ID" | translate}}</dt>
+                    <dt translate>FORM.LABELS.PATIENT_ID</dt>
                     <dd id="patientID">{{::PatientRecordCtrl.patient.reference}}</dd>
 
-                    <dt>{{"FORM.LABELS.HOSPITAL_FILE_NR" | translate}}</dt>
+                    <dt translate>FORM.LABELS.HOSPITAL_FILE_NR</dt>
                     <dd id="hospitalNo">{{::PatientRecordCtrl.patient.hospital_no}}</dd>
 
-                    <dt>{{ "TABLE.COLUMNS.DATE_REGISTERED" | translate }}</dt>
+                    <dt translate>TABLE.COLUMNS.DATE_REGISTERED</dt>
                     <dd><span am-time-ago="PatientRecordCtrl.patient.registration_date"></span></dd>
                   </dl>
 
@@ -54,7 +54,7 @@
               <div class="col-sm-4">
 
                 <dl>
-                  <dt>{{ "TABLE.COLUMNS.AGE" | translate }}</dt>
+                  <dt translate>TABLE.COLUMNS.AGE</dt>
                   <dd id="age">{{::PatientRecordCtrl.patient.age}}</dd>
 
                   <dt translate>TABLE.COLUMNS.DOB</dt>
@@ -64,7 +64,7 @@
                     <span translate>PATIENT_RECORDS.DOB_NOT_SPECIFIED</span>
                   </p>
 
-                  <dt>{{ "TABLE.COLUMNS.GENDER" | translate }}</dt>
+                  <dt translate>TABLE.COLUMNS.GENDER</dt>
                   <dd id="gender">{{::PatientRecordCtrl.patient.sex}}</dd>
                 </dl>
               </div>
@@ -86,10 +86,10 @@
 
                 <a
                   data-method="edit"
-                  ng-href="/#/patients/{{::PatientRecordCtrl.patient.uuid}}/edit"
+                  ui-sref="patientEdit({ uuid : PatientRecordCtrl.patient.uuid })"
                   class="btn btn-default btn-block">
                   <span class="glyphicon glyphicon-edit"></span>
-                  {{ "PATIENT_EDIT.EDIT_DETAILS" | translate }}
+                  <span translate>PATIENT_EDIT.EDIT_DETAILS</span>
                 </a>
               </div>
             </div>


### PR DESCRIPTION
This commit adds anchor tags to the headercrumb*(tm)* module title for
the following modules:
* Patient editing -> Patient Registry
* Patient records -> Patient Registry
* Debtor Group Management Update -> Debtor Group Managment Lists

It also updates the `<a>` style for the headercrumb to differentiate a
link. This style can be refined in the future.

![screenshot 2017-02-21 at 14 12 13](https://cloud.githubusercontent.com/assets/2844572/23166169/c9c07350-f83f-11e6-81a5-13fb61dbb56f.png)

This commit also fixes a number of links that were broken with
dependency updates.

Closes #1207 
Closes #1231 
Closes #1228 