### PR TITLE
(refactor) Patient registry links

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -993,6 +993,7 @@
     "UPDATE_PICTURE"     : "Update Patient Photo",
     "UPLOAD_PICTURE"     : "Upload Patient Photo",
     "NOT_FOUND"          : "Unable to find patient with that ID. Please check with your system administrator.",
+    "DOB_NOT_SPECIFIED"  : "Only a year of birth was specified during patient registration. This is an approximate date.",
     "CHECK_IN" : {
       "TITLE" : "Check In",
       "SUBMIT" : "Check Patient In",
@@ -1168,7 +1169,7 @@
     "RECEIPT" : {
       "TITLE" : "Purchase Order Receipt",
       "SUCCESS" : "Purchase Order created."
-    }, 
+    },
     "STATUS" : {
       "CONFIRMED"                 : "Confirmed",
       "CONFIRMED_DESC"            : "The purchase order has been confirmed by the supplier that it can be delivered",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -1032,7 +1032,8 @@
     "TITLE"              : "Patients",
     "UPDATE_PICTURE"     : "Mettre à jour la Photo",
     "UPLOAD_PICTURE"     : "Télécharger Photo Patient",
-    "NOT_FOUND"          : "Impossible de trouver le patient ayant ce ID. Veuillez contacter votre administrateur systeme"
+    "NOT_FOUND"          : "Impossible de trouver le patient ayant ce ID. Veuillez contacter votre administrateur systeme",
+    "DOB_NOT_SPECIFIED"  : "Seulement une année de naissance a été spécifiée lors de l'enregistrement du patient. C'est une date approximative."
   },
   "PATIENT_REG": {
     "CARD"                : "Fiche du patient",

--- a/client/src/partials/patient_invoice/registry/templates/action.cell.html
+++ b/client/src/partials/patient_invoice/registry/templates/action.cell.html
@@ -6,7 +6,6 @@
   </a>
 
   <ul class="dropdown-menu-right" data-list="{{ rowRenderIndex }}" uib-dropdown-menu>
-
     <li>
       <a ng-click="grid.appScope.openReceiptModal(row.entity.uuid, false, grid.appScope.receiptOptions)" data-method="invoiceReceipt" href>
         <i class="fa fa-file-pdf-o"></i> <span translate>REPORT.VIEW_RECEIPT</span>

--- a/client/src/partials/patients/record/patient_record.html
+++ b/client/src/partials/patients/record/patient_record.html
@@ -57,6 +57,13 @@
                   <dt>{{ "TABLE.COLUMNS.AGE" | translate }}</dt>
                   <dd id="age">{{::PatientRecordCtrl.patient.age}}</dd>
 
+                  <dt translate>TABLE.COLUMNS.DOB</dt>
+                  <dd id="dob">{{::PatientRecordCtrl.patient.dobFormatted}}</dd>
+                  <p ng-if="PatientRecordCtrl.patient.dob_unknown_date" class="text-info">
+                    <i class="fa fa-info-circle"></i>
+                    <span translate>PATIENT_RECORDS.DOB_NOT_SPECIFIED</span>
+                  </p>
+
                   <dt>{{ "TABLE.COLUMNS.GENDER" | translate }}</dt>
                   <dd id="gender">{{::PatientRecordCtrl.patient.sex}}</dd>
                 </dl>

--- a/client/src/partials/patients/record/patient_record.js
+++ b/client/src/partials/patients/record/patient_record.js
@@ -53,6 +53,7 @@ function PatientRecordController($stateParams, Patients, Notify, moment, Upload,
       /** @todo move to service or mysql query */
       vm.patient.name = vm.patient.display_name;
       vm.patient.age = moment().diff(vm.patient.dob, 'years');
+      vm.patient.dobFormatted = moment(vm.patient.dob).format('L');
     })
     .catch(function (error) {
       vm.loading = false;

--- a/client/src/partials/patients/registry/registry.html
+++ b/client/src/partials/patients/registry/registry.html
@@ -1,8 +1,8 @@
 <div class="flex-header static">
   <div class="bhima-title">
     <ol class="headercrumb">
-      <li class="static">{{ "TREE.HOSPITAL" | translate }}</li>
-      <li class="title">{{ "PATIENT_REGISTRY.TITLE" | translate }}</li>
+      <li class="static" translate>TREE.HOSPITAL</li>
+      <li class="title" translate>PATIENT_REGISTRY.TITLE</li>
     </ol>
 
     <div class="toolbar">
@@ -11,7 +11,7 @@
           ng-click="PatientRegistryCtrl.search()"
           data-method="search"
           class="btn btn-default">
-          <span class="fa fa-search"></span> {{ "FORM.BUTTONS.SEARCH" | translate }}
+          <span class="fa fa-search"></span> <span translate>FORM.BUTTONS.SEARCH</span>
         </button>
       </div>
 
@@ -55,7 +55,7 @@
     class="text-danger"
     data-method="clear">
     <i class="fa fa-ban text-danger"></i>
-    {{ "FORM.INFO.CLEAR_FILTERS" | translate }}
+    <span translate>FORM.INFO.CLEAR_FILTERS</span>
   </a>
 </div>
 

--- a/client/src/partials/patients/registry/registry.js
+++ b/client/src/partials/patients/registry/registry.js
@@ -33,10 +33,11 @@ function PatientRegistryController($state, Patients, Notify, AppCache, util, Rec
       displayName : 'TABLE.COLUMNS.REFERENCE',
       aggregationType: uiGridConstants.aggregationTypes.count,
       aggregationHideLabel : true, headerCellFilter: 'translate',
+      cellTemplate : '/partials/templates/grid/patient.card.cell.html',
       footerCellClass : 'text-center',
       sortingAlgorithm : Sorting.algorithms.sortByReference
     },
-    { field : 'display_name', displayName : 'TABLE.COLUMNS.NAME', headerCellFilter: 'translate' },
+    { field : 'display_name', displayName : 'TABLE.COLUMNS.NAME', headerCellFilter: 'translate', cellTemplate : '/partials/templates/grid/patient.cell.html' },
     { field : 'patientAge', displayName : 'TABLE.COLUMNS.AGE', headerCellFilter: 'translate', type: 'number' },
     { field : 'sex', displayName : 'TABLE.COLUMNS.GENDER', headerCellFilter: 'translate' },
     { field : 'hospital_no', displayName : 'TABLE.COLUMNS.HOSPITAL_FILE_NR', headerCellFilter: 'translate' },
@@ -57,9 +58,7 @@ function PatientRegistryController($state, Patients, Notify, AppCache, util, Rec
     enableColumnMenus : false,
     flatEntityAccess : true,
     fastWatch: true,
-    columnDefs : columnDefs,
-    rowTemplate: '/partials/templates/grid/patient.row.html'
-
+    columnDefs : columnDefs
   };
 
   var columnConfig = new Columns(vm.uiGridOptions, cacheKey);

--- a/client/src/partials/patients/templates/action.cell.html
+++ b/client/src/partials/patients/templates/action.cell.html
@@ -5,6 +5,7 @@
   </a>
 
   <ul data-action="{{ rowRenderIndex}}"  class="dropdown-menu-right" uib-dropdown-menu>
+    <li class="dropdown-header">{{row.entity.reference}}</li>
     <li>
       <a data-method="record" ui-sref="patientRecord.details({patientID : row.entity.uuid})" href>
         <span class="fa fa-book"></span> <span translate>PATIENT_REGISTRY.RECORD</span>
@@ -17,7 +18,7 @@
     </li>
     <li>
       <a data-method="card" ng-click="grid.appScope.patientCard(row.entity.uuid)" href>
-        <span class="fa fa-user"></span> <span translate>PATIENT_REGISTRY.CARD</span>
+        <span class="fa fa-id-card-o"></span> <span translate>PATIENT_REGISTRY.CARD</span>
       </a>
     </li>
     <li class="divider"></li>

--- a/client/src/partials/templates/grid/patient.card.cell.html
+++ b/client/src/partials/templates/grid/patient.card.cell.html
@@ -1,0 +1,3 @@
+<div class="ui-grid-cell-contents">
+  <a href="" ng-click="grid.appScope.patientCard(row.entity.uuid)">{{row.entity.reference}}</a>
+</div>

--- a/client/src/partials/templates/grid/patient.cell.html
+++ b/client/src/partials/templates/grid/patient.cell.html
@@ -1,0 +1,3 @@
+<div class="ui-grid-cell-contents">
+  <a ui-sref="patientRecord.details({ patientID : row.entity.uuid })">{{row.entity.display_name}}</a>
+</div>

--- a/client/src/partials/templates/grid/patient.row.html
+++ b/client/src/partials/templates/grid/patient.row.html
@@ -1,6 +1,0 @@
-<div
-  ng-repeat="(colRenderIndex, col) in colContainer.renderedColumns track by col.colDef.name"
-  class="ui-grid-cell"
-  ui-grid-cell
-  ng-dblClick="grid.appScope.patientCard(row.entity.uuid)">
-</div>

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -231,7 +231,7 @@ function lookupPatient(patientUuid) {
 
   const sql = `
     SELECT BUID(p.uuid) as uuid, p.project_id, BUID(p.debtor_uuid) AS debtor_uuid, p.display_name, p.hospital_no,
-      p.sex, p.registration_date, p.email, p.phone, p.dob, BUID(p.origin_location_id) as origin_location_id, BUID(p.current_location_id) as current_location_id,
+      p.sex, p.registration_date, p.email, p.phone, p.dob, p.dob_unknown_date, BUID(p.origin_location_id) as origin_location_id, BUID(p.current_location_id) as current_location_id,
       CONCAT_WS('.', '${identifiers.PATIENT.key}', proj.abbr, p.reference) AS reference, p.title, p.address_1, p.address_2,
       p.father_name, p.mother_name, p.religion, p.marital_status, p.profession, p.employer, p.spouse,
       p.spouse_profession, p.spouse_employer, p.notes, p.avatar, proj.abbr, d.text,


### PR DESCRIPTION
This commit removes the double click to open the patient card on the
patient registry. To maintain the same functionality the card is now
linked from the patient reference.
This issue is discussed in https://github.com/IMA-WorldHealth/bhima-2.X/issues/1232 with a proposed first solution in https://github.com/IMA-WorldHealth/bhima-2.X/issues/1226

It also refactors the dropdown actions menu to include the reference and
use the new identity card icon.
![screenshot 2017-02-20 at 18 20 23](https://cloud.githubusercontent.com/assets/2844572/23166367/b13644b2-f840-11e6-9b04-d1fa25d9d61d.png)

It also adds date of birth to the patient record page with a disclaimer if only the year of birth was collected at registratio.
![screenshot 2017-02-21 at 10 17 36](https://cloud.githubusercontent.com/assets/2844572/23166352/a4458e52-f840-11e6-8999-fb3c4f93e555.png)

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/1226
Closes #1206 
