### PR TITLE
(fix) Registry filters

### DIFF
--- a/client/src/js/services/CashService.js
+++ b/client/src/js/services/CashService.js
@@ -136,6 +136,7 @@ function CashService(Modal, Api, Exchange, Session, moment) {
       { field: 'dateTo', displayName: 'FORM.LABELS.DATE_TO', comparitor: '<', ngFilter:'date' },
       { field: 'currency_id', displayName: 'FORM.LABELS.CURRENCY' },
       { field: 'reversed', displayName: 'CASH.REGISTRY.REVERSED_RECORDS' },
+      { field : 'patientReference', displayName: 'FORM.LABELS.REFERENCE_PATIENT'}
     ];
 
     // returns columns from filters

--- a/client/src/js/services/ModalService.js
+++ b/client/src/js/services/ModalService.js
@@ -342,7 +342,7 @@ function ModalService(Modal) {
     }
 
     /** searchCashPayment */
-    function openSearchCashPayment(request) {
+    function openSearchCashPayment(filters) {
       var params = angular.extend(modalParameters, {
         templateUrl  : 'partials/cash/payments/templates/search.modal.html',
         controller   : 'SearchCashPaymentModalController',
@@ -351,7 +351,7 @@ function ModalService(Modal) {
         backdrop     : 'static',
         animation    : false,
         resolve : {
-          data :  function dataProvider() { return request; }
+          filters :  function filtersProvider() { return filters; }
         }
       });
 

--- a/client/src/partials/cash/payments/registry.html
+++ b/client/src/partials/cash/payments/registry.html
@@ -32,10 +32,10 @@
   </div>
 </div>
 
-<div class="flex-util bh-filter-bar" ng-show="CPRCtrl.formatedFilters.length > 0">
+<div class="flex-util bh-filter-bar" ng-show="CPRCtrl.filtersFmt.length > 0">
   <bh-filters-applied
     style="max-width:90%"
-    filters="CPRCtrl.formatedFilters"
+    filters="CPRCtrl.filtersFmt"
     on-remove-filter="CPRCtrl.onRemoveFilter(filter)">
   </bh-filters-applied>
 

--- a/client/src/partials/cash/payments/registry.js
+++ b/client/src/partials/cash/payments/registry.js
@@ -26,7 +26,7 @@ function CashPaymentRegistryController(Cash, bhConstants, Notify, Session, uiGri
 
   // global variables
   vm.filters = { lang: Languages.key };
-  vm.formatedFilters = [];
+  vm.filtersFmt = [];
   vm.gridOptions = {};
   vm.enterprise = Session.enterprise;
   vm.bhConstants = bhConstants;
@@ -84,10 +84,12 @@ function CashPaymentRegistryController(Cash, bhConstants, Notify, Session, uiGri
 
   // search
   function search() {
-    Modal.openSearchCashPayment()
+    Modal.openSearchCashPayment(vm.filters.identifiers)
       .then(function (filters) {
         if (!filters) { return; }
-        reload(filters);
+
+        cacheFilters(filters);
+        load(vm.filters.identifiers);
       });
   }
 
@@ -95,44 +97,27 @@ function CashPaymentRegistryController(Cash, bhConstants, Notify, Session, uiGri
   function onRemoveFilter(key) {
     delete vm.filters.identifiers[key];
     delete vm.filters.display[key];
-    reload(vm.filters);
+    cacheFilters(vm.filters);
+    load(vm.filters.identifiers);
   }
 
   // remove a filter with from the filter object, save the filters and reload
   function clearFilters() {
-    $state.params.filters = null;
-    $state.params.display = null;
-    reload({ display : [], identifiers : {} });
-  }
-
-  // reload with filter
-  function reload(filters) {
-    vm.filters = filters;
-    vm.formatedFilters = Cash.formatFilterParameters(filters.display);
-
-    // show filter bar as needed
-    vm.filterBarHeight = (vm.formatedFilters.length > 0) ?  FILTER_BAR_HEIGHT : {};
-
-    load(filters.identifiers);
+    // @TODO standardise all client side filters
+    cacheFilters({ display : {} });
+    load(vm.filters.identifiers);
   }
 
   // load cash
   function load(filters) {
-
     vm.hasError = false;
-    filters = $state.params.filters ? $state.params.filters : filters;
-
-    if($state.params.display){ 
-      var display = $state.params.display;
-      vm.formatedFilters = Cash.formatFilterParameters(display);
-      // show filter bar as needed
-      vm.filterBarHeight = (vm.formatedFilters.length > 0) ?  FILTER_BAR_HEIGHT : {};
-    }
-
     toggleLoadingIndicator();
 
-    Cash.search(filters)
-      .then(function (rows) {
+    var request = angular.isDefined(filters) ?
+      Cash.search(filters) :
+      Cash.read();
+
+    request.then(function (rows) {
 
         rows.forEach(function (row) {
           var hasCreditNote = (row.type_id === bhConstants.transactionType.CREDIT_NOTE);
@@ -154,7 +139,7 @@ function CashPaymentRegistryController(Cash, bhConstants, Notify, Session, uiGri
       .then(function (success) {
         if (!success) { return; }
         Notify.success('FORM.INFO.TRANSACTION_REVER_SUCCESS');
-        load();
+        load(vm.filters.identifiers);
       });
   }
 
@@ -162,6 +147,29 @@ function CashPaymentRegistryController(Cash, bhConstants, Notify, Session, uiGri
     vm.loading = !vm.loading;
   }
 
-  // startup
-  load();
+  function cacheFilters(filters) {
+    vm.filters = cache.filters = filters;
+    vm.filtersFmt = Cash.formatFilterParameters(filters.display);
+    vm.filterBarHeight = (vm.filtersFmt.length > 0) ?  FILTER_BAR_HEIGHT : {};
+  }
+
+  function startup() {
+    if ($state.params.filters) {
+      cacheFilters($state.params.filters);
+    }
+
+    vm.filters = cache.filters;
+
+    // ensure that filters exists, filter object is assumed by a number of methods
+    if (!vm.filters) {
+      cacheFilters({ display : {} });
+    }
+
+    vm.filtersFmt = Cash.formatFilterParameters(vm.filters.display);
+    load(vm.filters.identifiers);
+
+    vm.filterBarHeight = (vm.filtersFmt.length > 0) ?  FILTER_BAR_HEIGHT : {};
+  }
+
+  startup();
 }

--- a/client/src/partials/cash/payments/templates/search.modal.html
+++ b/client/src/partials/cash/payments/templates/search.modal.html
@@ -71,6 +71,11 @@
         </ui-select>
       </div>
 
+      <div class="form-group">
+        <label class="control-label" translate>FORM.LABELS.REFERENCE_PATIENT</label>
+        <input type="text" class="form-control" ng-model="$ctrl.bundle.patientReference"/>
+      </div>
+
       <bh-currency-select
         currency-id="$ctrl.bundle.currency_id"
         validation-trigger="CashVoucherForm.$submitted">

--- a/client/src/partials/cash/payments/templates/search.modal.js
+++ b/client/src/partials/cash/payments/templates/search.modal.js
@@ -4,12 +4,13 @@ angular.module('bhima.controllers')
 // dependencies injections
 SearchCashPaymentModalController.$inject = [
   'UserService', 'CashboxService', 'NotifyService', '$uibModalInstance',
+  'filters'
 ];
 
 /**
  * Search Cash Payment controller
  */
-function SearchCashPaymentModalController(Users, Cashboxes, Notify, Instance) {
+function SearchCashPaymentModalController(Users, Cashboxes, Notify, Instance, filters) {
   var vm = this;
 
   // global variables
@@ -17,7 +18,7 @@ function SearchCashPaymentModalController(Users, Cashboxes, Notify, Instance) {
   var isObject = angular.isObject;
 
   // expose to the view
-  vm.bundle = {};
+  vm.bundle = angular.copy(filters || {});
   vm.validate = validate;
   vm.submit = submit;
   vm.cancel = Instance.close;
@@ -77,6 +78,7 @@ function SearchCashPaymentModalController(Users, Cashboxes, Notify, Instance) {
         formattedFilters[key].uuid || formattedFilters[key].id || formattedFilters[key] : formattedFilters[key];
 
       // get value to display
+      // @FIXME custom very specific logic has to change - this is not maintainable
       out.display[key] = isObject(formattedFilters[key]) ?
         formattedFilters[key].text || formattedFilters[key].label || formattedFilters[key].display_name || formattedFilters[key] : formattedFilters[key];
     }

--- a/client/src/partials/patient_invoice/registry/registry.html
+++ b/client/src/partials/patient_invoice/registry/registry.html
@@ -1,8 +1,8 @@
 <div class="flex-header static">
   <div class="bhima-title">
     <ol class="headercrumb">
-      <li class="static">{{ "TREE.FINANCE" | translate }}</li>
-      <li class="title">{{ "INVOICE_REGISTRY.TITLE" | translate }}</li>
+      <li class="static" translate>TREE.FINANCE</li>
+      <li class="title" translate>INVOICE_REGISTRY.TITLE</li>
     </ol>
 
     <div class="toolbar">
@@ -11,7 +11,7 @@
           ng-click="InvoiceRegistryCtrl.search()"
           data-method="search"
           class="btn btn-default">
-          <span class="fa fa-search"></span> {{ "FORM.BUTTONS.SEARCH" | translate }}
+          <span class="fa fa-search"></span> <span translate>FORM.BUTTONS.SEARCH</span>
         </button>
       </div>
       <div class="toolbar-item">

--- a/client/src/partials/patient_invoice/registry/registry.js
+++ b/client/src/partials/patient_invoice/registry/registry.js
@@ -90,17 +90,6 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, Recei
     vm.hasError = false;
     toggleLoadingIndicator();
 
-    parameters = $state.params.filters ? $state.params.filters : parameters;
-
-    if($state.params.display){ 
-      var display = $state.params.display;
-      vm.filtersFmt = Invoices.formatFilterParameters(display);
-      // show filter bar as needed
-      vm.filterBarHeight = (vm.filtersFmt.length > 0) ?  FILTER_BAR_HEIGHT : {};
-
-    }
-
-
     // if we have search parameters, use search.  Otherwise, just read all
     // invoices.
     var request = angular.isDefined(parameters) ?
@@ -162,10 +151,14 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, Recei
 
   // startup function. Checks for cached filters and loads them.  This behavior could be changed.
   function startup() {
+    // @TODO standardise loading/ caching/ assigning filters with a client service
+    // if filters are directly passed in through params, override cached filters
+    if ($state.params.filters) {
+      cacheFilters($state.params.filters);
+    }
+
     vm.filters = cache.filters;
-
     vm.filtersFmt = Invoices.formatFilterParameters(vm.filters || {});
-
     load(vm.filters);
 
     // show filter bar as needed
@@ -178,7 +171,7 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, Recei
       .then(function (success) {
         if (success) {
           Notify.success('FORM.INFO.TRANSACTION_REVER_SUCCESS');
-          return load();
+          return load(vm.filters);
         }
       })
       .catch(Notify.handleError);

--- a/client/src/partials/patients/templates/action.cell.html
+++ b/client/src/partials/patients/templates/action.cell.html
@@ -22,12 +22,12 @@
     </li>
     <li class="divider"></li>
     <li>
-      <a data-method="card"  ui-sref="invoiceRegistry({ filters : { debtor_uuid : row.entity.debtor_uuid }, display : {debtor_uuid : row.entity.display_name}})" href>
+      <a data-method="card"  ui-sref="invoiceRegistry({ filters : { patientReference : row.entity.reference } })" href>
         <span class="fa fa-file-text-o"></span> <span translate>PATIENT_REGISTRY.INVOICES</span>
       </a>
     </li>
     <li>
-      <a data-method="card" ui-sref="cashRegistry({ filters : { debtor_uuid : row.entity.debtor_uuid }, display : {debtor_uuid : row.entity.display_name}})" href>
+    <a data-method="card" ui-sref="cashRegistry({ filters : { identifiers : { patientReference : row.entity.reference }, display : { patientReference : row.entity.reference } }})" href>
         <span class="fa fa-money"></span> <span translate>PATIENT_REGISTRY.PAYMENTS</span>
       </a>
     </li>

--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -176,6 +176,9 @@ function listPayment(options) {
   let referenceStatement = `CONCAT_WS('.', '${identifiers.CASH_PAYMENT.key}', project.abbr, cash.reference) = ?`;
   filters.custom('reference', referenceStatement);
 
+  let patientReferenceStatement = `CONCAT_WS('.', '${identifiers.PATIENT.key}', project.abbr, p.reference) = ?`;
+  filters.custom('patientReference', patientReferenceStatement);
+
   // filter reversed cash records
   filters.reversed('reversed');
 

--- a/server/lib/filter.js
+++ b/server/lib/filter.js
@@ -140,7 +140,7 @@ class FilterParser {
         preparedStatement = `voucher.type_id = ?`;
       } else {
         // exclude all record that meet the reversed criteria
-        preparedStatement = `voucher.type_id IS NULL OR voucher.type_id <> ?`;
+        preparedStatement = `(voucher.type_id IS NULL OR voucher.type_id <> ?)`;
       }
 
       // using the reversal voucher id as the parameter is a hack, this will be


### PR DESCRIPTION
This pull request fixes a number of issues in the cash and invoices registry filters. 
* After reversing a record filters are ignored even though the filters are still shown in the module 
* Allow filters to be removed when passes in through a `$state.parameter` link 
* Ensure invoice `reversed` filter respects other filters 

For linking modules with filters: 
* Removes debtor_uuid filter from being passed in as this can't even be search in the registry 
* Uses patient reference to filter through the link

It also works to bring the cash payment registry inline with more up to date standards. 
* Support caching filters 
* Rename variables/ methods to match other modules 
* Update the loading of cached and state parameters to read like other modules
* Remove very specific logic for display text on filters (still requires a standard across module)
* Adds patient reference filter to cash payments

Closes #1192 
Closes #1191 
Closes #1190
