### PR TITLE
feat(express): enable caching in production

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -228,7 +228,7 @@ gulp.task('watch-client', () => {
 });
 
 // gather a list of files to rewrite revisions for
-const toHash = ['**/*.min.js', '**/*.css'].map(file => `${CLIENT_FOLDER}${file}`);
+const toHash = ['**/*.min.js', '**/*.css', '**/*.html'].map(file => `${CLIENT_FOLDER}${file}`);
 
 gulp.task('client-compute-hashes', ['client-compile-js', 'client-compile-vendor', 'client-compile-css'], () =>
   gulp.src(toHash)

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -24,9 +24,7 @@ const uploads = require('../lib/uploader');
 
 // accept generic express instances (initialised in app.js)
 exports.configure = function configure(app) {
-  // TODO - things don't work well yet.
-  // const isProduction = (process.env.NODE_ENV === 'production');
-  const isProduction = false;
+  const isProduction = (process.env.NODE_ENV === 'production');
 
   winston.debug('Configuring middleware.');
 
@@ -57,10 +55,12 @@ exports.configure = function configure(app) {
   };
 
   // indicate that we are running behind a trust proxy and should use a secure cookie
+  /*
   if (isProduction) {
     app.set('trust proxy', true);
     sess.cookie.secure = true;
   }
+  */
 
   // bind the session to the middleware
   app.use(session(sess));
@@ -76,9 +76,8 @@ exports.configure = function configure(app) {
 
   // public static directories include the entire client and the uploads
   // directory.
-  const days = 1000 * 60 * 60 * 24;
   const params = {};
-  params.maxAge = isProduction ? 7 * days : 0;
+  params.maxAge = isProduction ? '1y' : 0;
   app.use(express.static('client/', params));
   app.use(`/${uploads.directory}`, express.static(uploads.directory));
 


### PR DESCRIPTION
This commit implements caching of static resources in production based
on environmental flag.  This is made possible by the recent addition of
revision control.

![beforecache](https://cloud.githubusercontent.com/assets/896472/23182648/a09de14e-f879-11e6-987e-d55e886825d9.png)
_Fig 1: Google Chrome Audit Before Caching_

![aftercache](https://cloud.githubusercontent.com/assets/896472/23182647/a09839d8-f879-11e6-95f1-d6a7ac90e35f.png)
_Fig 2: Google Chrome Audit After Caching_

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
