### PR TITLE
fix(bhRendererDropdown): rebuild URL on selection

### DIFF
--- a/client/src/js/components/bhRendererDropdown.js
+++ b/client/src/js/components/bhRendererDropdown.js
@@ -30,7 +30,8 @@ function bhRendererController(AppCache, $httpParamSerializer) {
 
   $ctrl.select = function select(option) {
     $ctrl.selection = option;
-    cache.selection = option;
+    cache.selection = $ctrl.selection;
+    combineAndSerializeParameters();
   };
 
   // watch for changes on the component's border and behave appropriately

--- a/client/src/partials/templates/bhRendererDropdown.tmpl.html
+++ b/client/src/partials/templates/bhRendererDropdown.tmpl.html
@@ -1,5 +1,5 @@
 <div class="btn-group" uib-dropdown>
-  <a class="btn btn-default" ng-href="{{::$ctrl.reportUrl}}?{{$ctrl.params}}" download>
+  <a class="btn btn-default" ng-href="{{$ctrl.reportUrl}}?{{$ctrl.params}}" download>
     <span ng-show="$ctrl.loading">
       <i class="fa fa-circle-notch-o"></i> <span translate>FORM.INFO.LOAING</span>
     </span>
@@ -12,7 +12,7 @@
     <span class="caret"></span>
   </a>
   <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="single-button">
-    <li ng-repeat="option in ::$ctrl.options">
+    <li ng-repeat="option in $ctrl.options">
       <a href ng-click="$ctrl.select(option)">
         <i class="fa fa-{{::option.icon}}"></i>
         <span translate>{{ ::option.key }}</span>


### PR DESCRIPTION
This commit instructs the bhRendererDropdown to rebuild the URL
parameters when the users changes the dropdown menu selection.

Closes #1239.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
