### PR TITLE
fix(report): accounts report gives the document

### DIFF
--- a/server/controllers/finance/reports/reportAccounts/report.handlebars
+++ b/server/controllers/finance/reports/reportAccounts/report.handlebars
@@ -15,12 +15,13 @@
     <table class="table table-condensed table-striped table-report table-bordered">
       <thead>
         <tr class="text-capitalize text-center" style="background-color: #ddd;">
-          <th style="width: 10%;">{{translate "TABLE.COLUMNS.DATE" }}</th>
-		      <th style="width: 10%;">{{translate "TABLE.COLUMNS.TRANSACTION" }}</th>
-          <th style="width: 40%;">{{translate "TABLE.COLUMNS.DESCRIPTION" }}</th>
-          <th style="width: 12%;">{{translate "TABLE.COLUMNS.DEBIT" }}</th>
-          <th style="width: 12%;">{{translate "TABLE.COLUMNS.CREDIT" }}</th>
-          <th style="width: 16%;">{{translate "TABLE.COLUMNS.BALANCE" }}</th>
+          <th>{{translate "TABLE.COLUMNS.DATE" }}</th>
+          <th>{{translate "TABLE.COLUMNS.TRANSACTION" }}</th>
+          <th>{{translate "TABLE.COLUMNS.DOCUMENT" }}</th>
+          <th>{{translate "TABLE.COLUMNS.DESCRIPTION" }}</th>
+          <th style="width:12%">{{translate "TABLE.COLUMNS.DEBIT" }}</th>
+          <th style="width:12%">{{translate "TABLE.COLUMNS.CREDIT" }}</th>
+          <th style="width:12%">{{translate "TABLE.COLUMNS.BALANCE" }}</th>
         </tr>
       </thead>
       <tbody>
@@ -28,18 +29,19 @@
           <tr>
             <td>{{date this.trans_date}}</td>
             <td>{{this.trans_id}}</td>
+            <td>{{this.document_reference}}</td>
             <td>{{this.description}}</td>
             <td class="text-right">{{currency this.debit ../metadata.enterprise.currency_id}}</td>
             <td class="text-right">{{currency this.credit ../metadata.enterprise.currency_id}}</td>
             <td class="text-right">{{currency this.cumulBalance ../metadata.enterprise.currency_id}}</td>
           </tr>
         {{else}}
-          {{> emptyTable columns=5}}
+          {{> emptyTable columns=7}}
         {{/each}}
       </tbody>
       <tfoot>
         <tr style="background-color: #ddd;">
-          <td colspan="3"><strong>{{translate "FORM.LABELS.TOTAL" }}</strong></td>
+          <td colspan="4"><strong>{{translate "FORM.LABELS.TOTAL" }}</strong></td>
           <td class="text-right"><strong>{{currency sum.debit metadata.enterprise.currency_id}}</strong></td>
           <td class="text-right"><strong>{{currency sum.credit metadata.enterprise.currency_id}}</strong></td>
           <td class="text-right"><strong>{{currency sum.balance metadata.enterprise.currency_id}}</strong></td>
@@ -54,7 +56,7 @@
       </tr>
       <tr>
         <th colspan="5" class="text-right">
-          <i>{{translate "TABLE.COLUMNS.DATA_SOURCE" }} : {{translate title.source }}</i> 
+          <i>{{translate "TABLE.COLUMNS.DATA_SOURCE" }} : {{translate title.source }}</i>
         </th>
       </tr>
     </table>


### PR DESCRIPTION
This commit finally fixes the cumulative SUM in the accounts report as
well as putting in a new column with the originating document number.
This will allow administrators to really quickly look up the details of
that transaction.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!