### PR TITLE
fix(build): build in development mode

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -110,9 +110,9 @@
 <!-- this is templated in with variables from gulp-template -->
 <script>
   angular.module('bhima')
-  .config(['$compileProvider', function ($compileProvider) {
-    $compileProvider.debugInfoEnabled(<%= isProduction %>);
-  }])
+    .config(['$compileProvider', function ($compileProvider) {
+      $compileProvider.debugInfoEnabled(<%= isDevelopment %>);
+    }])
 </script>
 
 </body>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,6 +26,7 @@ const exec = require('child_process').exec;
 
 // toggle client javascript minification
 const isProduction = (process.env.NODE_ENV === 'production');
+const isDevelopment = (process.env.NODE_ENV !== 'production');
 
 // the output folder for built server files
 const SERVER_FOLDER = './bin/server/';
@@ -240,7 +241,7 @@ gulp.task('client-compute-hashes', ['client-compile-js', 'client-compile-vendor'
 
 gulp.task('client-compile-assets', ['client-mv-static', 'client-compute-hashes'], () =>
   gulp.src(paths.client.index)
-    .pipe(template({ isProduction: true }))
+    .pipe(template({ isProduction, isDevelopment }))
     .pipe(revReplace({ manifest: gulp.src(`${CLIENT_FOLDER}${MANIFEST_PATH}`) }))
     .pipe(gulp.dest(CLIENT_FOLDER))
 );

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A rural hospital information management system.",
   "main": "sh/deploy.sh",
   "scripts": {
-    "app": "gulp build && cd bin && NODE_ENV=production node server/app.js",
-    "dev": "gulp build && cd bin && NODE_ENV=development node server/app.js",
+    "app": "NODE_ENV=production gulp build && cd bin && NODE_ENV=production node server/app.js",
+    "dev": "NODE_ENV=development gulp build && cd bin && NODE_ENV=development node server/app.js",
     "start": "sh/deploy.sh",
     "karma": "./node_modules/.bin/karma start --single-run --no-auto-watch --concurrency 1 karma.conf.js",
     "lint": "./sh/lint.sh",


### PR DESCRIPTION
This commit fixes a bug with the gulp build that does not register the
correct build environment for setting the angular debug flags.
Previously, it was always true.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
