### PR TITLE
fix(cashflow): do not filter reversals

### DIFF
--- a/server/controllers/finance/reports/cashflow/index.js
+++ b/server/controllers/finance/reports/cashflow/index.js
@@ -612,8 +612,6 @@ function reportByService(req, res, next) {
       JOIN service ON invoice.service_id = service.id
     WHERE cash.is_caution = 0
       AND cash.date >= DATE(?) AND cash.date <= DATE(?)
-      AND cash.uuid NOT IN
-        (SELECT DISTINCT voucher.reference_uuid FROM voucher WHERE voucher.type_id = ${CASH_RETURN_ID})
     ORDER BY cash.date;
   `;
 


### PR DESCRIPTION
This commit fixes the cashflow report by not filtering by reversals.  If
the reversal query is NULL, it will simply print it inline.  However,
previously the NULL killed the entire report.

This should be investigated... but at least our clients can use the
report.

---
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
