### PR TITLE
fix(income/expense): allow any cashbox in report

### DIFF
--- a/client/src/js/services/CashBoxService.js
+++ b/client/src/js/services/CashBoxService.js
@@ -1,5 +1,5 @@
 angular.module('bhima.services')
-.service('CashboxService', CashboxService);
+  .service('CashboxService', CashboxService);
 
 CashboxService.$inject = [ '$http', 'util' ];
 

--- a/client/src/partials/reports/modals/income_expense.config.js
+++ b/client/src/partials/reports/modals/income_expense.config.js
@@ -2,7 +2,8 @@ angular.module('bhima.controllers')
   .controller('income_expenseController', IncomeExpenseConfigController);
 
 IncomeExpenseConfigController.$inject = [
-  '$state', '$uibModalInstance', 'CashboxService', 'NotifyService', 'LanguageService', 'BaseReportService', 'reportDetails'
+  '$state', '$uibModalInstance', 'CashboxService', 'NotifyService',
+  'LanguageService', 'BaseReportService', 'reportDetails',
 ];
 
 /**
@@ -22,12 +23,12 @@ function IncomeExpenseConfigController($state, ModalInstance, Cashbox, Notify, L
   vm.report = report;
 
   vm.reportType = [
-    {id: 1, label : 'FORM.LABELS.INCOME_EXPENSE'},
-    {id: 2, label : 'FORM.LABELS.INCOME'},
-    {id: 3, label : 'FORM.LABELS.EXPENSE'}
+    { id: 1, label: 'FORM.LABELS.INCOME_EXPENSE' },
+    { id: 2, label: 'FORM.LABELS.INCOME' },
+    { id: 3, label: 'FORM.LABELS.EXPENSE' },
   ];
 
-  Cashbox.read(null, { detailed: 1, is_auxiliary: 0})
+  Cashbox.read(null, { detailed: 1 })
     .then(function (cashboxes) {
       cashboxes.forEach(function (cashbox) {
         cashbox.hrlabel = cashbox.label + ' ' + cashbox.symbol;
@@ -39,23 +40,21 @@ function IncomeExpenseConfigController($state, ModalInstance, Cashbox, Notify, L
 
   function generate(form) {
     var url = 'reports/finance/income_expense';
+    var options;
 
     if (form.$invalid) { return; }
 
-    vm.$loading = true;
-
-    var options = {
-      account_id: vm.cashbox.account_id,
-      dateFrom: vm.dateFrom,
-      label : vm.label,
-      dateTo: vm.dateTo,
-      lang: Languages.key,
-      reportType: vm.type
+    options = {
+      account_id : vm.cashbox.account_id,
+      dateFrom   : vm.dateFrom,
+      label      : vm.label,
+      dateTo     : vm.dateTo,
+      lang       : Languages.key,
+      reportType : vm.type,
     };
 
     return SavedReports.requestPDF(url, report, options)
-      .then(function (result) {
-        vm.$loading = false;
+      .then(function () {
         ModalInstance.dismiss();
         $state.reload();
       });

--- a/client/src/partials/reports/modals/income_expense.modal.html
+++ b/client/src/partials/reports/modals/income_expense.modal.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <ol class="headercrumb">
-    <li class="static">{{ ::ReportConfigCtrl.report.title_key | translate }}</li>
+    <li class="static text-capitalize">{{ ::ReportConfigCtrl.report.title_key | translate }}</li>
     <li class="title">{{ "FORM.LABELS.CREATE" | translate }}</li>
   </ol>
 </div>
@@ -70,8 +70,7 @@
     {{ "FORM.BUTTONS.CANCEL" | translate }}
   </button>
 
-  <bh-loading-button loading-state="ReportConfigCtrl.$loading"
-    ng-disabled="ConfigForm.$invalid">
+  <bh-loading-button loading-state="ConfigForm.$loading" ng-disabled="ConfigForm.$invalid">
     {{ "FORM.BUTTONS.GENERATE" | translate }}
   </bh-loading-button>
 </div>


### PR DESCRIPTION
This commit removes the restriction on only primary cashboxes.  A report
on auxiliary cashboxes may yield little data, but this limitation
should not be built into the software.

It also makes the loading button standard.

---
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
