### PR TITLE
fix(build) call asset hash/ compilation on JS watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -223,7 +223,9 @@ gulp.task('lint-i18n', (cb) => {
 // watches for any change and builds the appropriate route
 gulp.task('watch-client', () => {
   gulp.watch(paths.client.css, ['client-compile-css']);
-  gulp.watch(paths.client.javascript, ['client-compile-js']);
+
+  // client-compile-assets calls client-compute-hashes which in turn runs client-compile-js
+  gulp.watch(paths.client.javascript, ['client-compile-assets']);
   gulp.watch(paths.client.static, ['client-mv-static']);
   gulp.watch(paths.client.vendor, ['client-mv-vendor-style', 'client-compile-vendor']);
 });


### PR DESCRIPTION
This commit replaces direct Javascript compilation with re-versioning
and compiling assets on every javascript file change. This ensures that
the changes are factored into the build being used by the current
server.