### PR TITLE
feat(receipts) Add service line to invoice receipt

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -975,6 +975,7 @@
     "COMBINED_SUBSIDIES" : "Combined Subsidies",
     "DISTRIBUTION_TYPE"  : "Distribution Type",
     "DISTRIBUTION_TYPE_EXPLANATION" : "This option determines whether the invoice items can be distributed at the pharmacy or if they have already been consumed.",
+    "INVOICED_FOR"       : "Invoiced for",
     "ERRORS"             : {
       "INVALID_NUMBERS" : "The record contains negative, zero, or invalid numbers",
       "MISSING_SALES_ACCOUNT" : "The record contains an inventory item missing a sales account.  You cannot make an invoice without a sales account.",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -984,6 +984,7 @@
     "COMBINED_SUBSIDIES" : "Les subventions combinées",
     "DISTRIBUTION_TYPE"  : "Type des distributions",
     "DISTRIBUTION_TYPE_EXPLANATION" : "Cette option détermine si les éléments de facturation peuvent être distribués à la pharmacie ou si elles ont déjà été consommés.",
+    "INVOICED_FOR"       : "Facturé pour",
     "ERRORS"             : {
       "INVALID_NUMBERS"       : "L'enregistrement contient des nombres qui sont soit negatifs, soit des zeros ou soit invalides",
       "MISSING_SALES_ACCOUNT" : "L'enregistrement contient un item d'inventaire qui n'a pas de compte de vente associé à son groupe",

--- a/server/controllers/finance/reports/invoices/index.js
+++ b/server/controllers/finance/reports/invoices/index.js
@@ -138,8 +138,8 @@ function receipt(req, res, next) {
     .then(headerResult => {
       _.extend(invoiceResponse, headerResult, metadata);
 
-      if (invoiceResponse.creditNote) { 
-        invoiceResponse.isCreditNoted = true; 
+      if (invoiceResponse.creditNote) {
+        invoiceResponse.isCreditNoted = true;
         invoiceResponse.creditNoteReference = invoiceResponse.creditNote.reference;
       }
 
@@ -212,7 +212,7 @@ function creditNote(req, res, next) {
       if (invoiceResponse.exchange) {
         invoiceResponse.exchangedTotal = _.round(invoiceResponse.cost * invoiceResponse.exchange);
       }
-      
+
       // return Invoices.lookupInvoiceCreditNote(invoiceUuid);
     })
     .then(creditNoteResult => {

--- a/server/controllers/finance/reports/invoices/receipt.handlebars
+++ b/server/controllers/finance/reports/invoices/receipt.handlebars
@@ -41,7 +41,7 @@
       </div>
       <div class="col-xs-6">
         <span class="text-capitalize">{{translate 'FORM.LABELS.INVOICE'}}</span>: <strong>{{reference}}</strong> <br>
-        <span class="text-capitalize">{{translate 'FORM.LABELS.AMOUNT'}}</span>: <strong>{{currency cost metadata.enterprise.currency_id}}</strong> <br>
+        <span class="text-capitalize">{{translate 'TABLE.COLUMNS.SERVICE'}}</span>: {{serviceName}} <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date date}} <br>
         <span class="text-capitalize">{{translate "FORM.LABELS.CREATED_BY"}}</span>: {{display_name}}
       </div>

--- a/server/controllers/finance/reports/invoices/receipt.pos.handlebars
+++ b/server/controllers/finance/reports/invoices/receipt.pos.handlebars
@@ -14,6 +14,8 @@
 <h2 style="margin-bottom : 0px">{{recipient.display_name}}</h2>
 ({{recipient.reference}}) - {{recipient.debtor_group_name}}
 {{> underline}}
+{{translate 'PATIENT_INVOICE.INVOICED_FOR'}} {{serviceName}} {{translate 'TABLE.COLUMNS.SERVICE'}}
+{{> underline}}
 <table style="width : 100%">
   <thead>
     <tr>


### PR DESCRIPTION
This commit adds the service that the invoice was created for to both
the invoice POS and standard receipt. On the standard receipt it
replaces the duplicated amount field, this is so that there is one point
of truth for the total amount on the receipt, it can be undone if
required.

Closes #1130 

**POS Receipt**
![screenshot 2017-02-28 at 15 37 37](https://cloud.githubusercontent.com/assets/2844572/23409767/0ec88b4e-fdcd-11e6-9a14-563664eb254e.png)

**Standard Receipt**
![screenshot 2017-02-28 at 15 38 45](https://cloud.githubusercontent.com/assets/2844572/23409744/f760b12a-fdcc-11e6-9037-655f83b99eb3.png)
