### PR TITLE
refactor(reports): account report date prominence

### DIFF
--- a/server/controllers/finance/reports/reportAccounts/report.handlebars
+++ b/server/controllers/finance/reports/reportAccounts/report.handlebars
@@ -5,10 +5,11 @@
 
   <h3 class="text-center text-uppercase"><strong>{{translate "REPORT.ACCOUNT"}}</strong></h3>
   <h4 class="text-center"><strong>{{ title.accountNumber }} | {{ title.accountLabel}}</strong></h4>
+
   {{#if title.dateFrom }}
-    <h3 style="margin:15px; font-weight:bold" class="text-center text-uppercase">
-      <small>{{date title.dateFrom }} - {{date title.dateTo }}</small>
-    </h3>
+    <h5 style="margin:15px; font-weight:bold" class="text-center text-uppercase">
+      {{date title.dateFrom }} - {{date title.dateTo }}
+    </h5>
   {{/if}}
 
   <section>


### PR DESCRIPTION
This commit makes the account report's date range a bit more prominent.
It should help on lower-end printers.

Partially addresses #1199.

**Screenshot**
![accountreportdateprominence](https://cloud.githubusercontent.com/assets/896472/23455105/c692df62-fe6e-11e6-8224-46ac4ab22ef7.png)
_Fig 1: Account Report Date Prominence_