### PR TITLE
refactor(reports): Aged Debtor date made prominent

### DIFF
--- a/server/controllers/finance/reports/debtors/aged.handlebars
+++ b/server/controllers/finance/reports/debtors/aged.handlebars
@@ -4,9 +4,12 @@
   <main class="container">
     {{> header }}
 
-    <h4 class="text-center">
+    <h3 class="text-center">
       {{translate "REPORT.AGED_DEBTORS.TITLE"}}
-      <p><small>{{date this.timestamp }}</small></p>
+    </h3>
+
+    <h4 class="text-center">
+      <span class="text-capitalize">{{translate "FORM.LABELS.UNTIL_DATE"}}</span> {{date this.timestamp }}
     </h4>
 
     <!-- margin is the cell size -->


### PR DESCRIPTION
This commit makes the aged debtor date more prominent on the report.

Partially address #1199.

**ScreenShot**
![ageddebtorsdateprominence](https://cloud.githubusercontent.com/assets/896472/23456760/11277d52-fe75-11e6-854f-03feaa143b16.png)
