### PR TITLE
Fix: report running balances

### DIFF
--- a/server/controllers/finance/reports/reportAccounts/report.handlebars
+++ b/server/controllers/finance/reports/reportAccounts/report.handlebars
@@ -35,7 +35,7 @@
             <td>{{this.description}}</td>
             <td class="text-right">{{currency this.debit ../metadata.enterprise.currency_id}}</td>
             <td class="text-right">{{currency this.credit ../metadata.enterprise.currency_id}}</td>
-            <td class="text-right">{{currency this.cumulBalance ../metadata.enterprise.currency_id}}</td>
+            <td class="text-right">{{currency this.cumsum ../metadata.enterprise.currency_id}}</td>
           </tr>
         {{else}}
           {{> emptyTable columns=7}}


### PR DESCRIPTION
This commit implements the correct cumulative balance summation for the
accounts report that initializes and updates variables in the same SQL
statement. By maintaining all variables in the same statement, the
variables are ensured to be zeroes out prior to usage and do not spread
over multiple MySQL connections.

This solution, while complex, allows total control over filtering via
our standard filtering solutions.  Placing the query in a Stored
Procedure (another solution to localize the variable to a single MySQL
connection/context) would require that any further filters write a new
interface to the stored procedure.

Closes #1273.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!