### PR TITLE
chore(db): zRecalculatePeriodTotals()

### DIFF
--- a/server/models/admin.sql
+++ b/server/models/admin.sql
@@ -103,4 +103,24 @@ BEGIN
   CALL PostCash(cUuid);
 END $$
 
+/*
+ zRecalculatePeriodTotals
+
+ Removes all data from the period_total table and rebuilds it.
+*/
+CREATE PROCEDURE zRecalculatePeriodTotals()
+BEGIN
+
+  -- wipe the period total table
+  TRUNCATE period_total;
+
+  INSERT INTO period_total (enterprise_id, fiscal_year_id, period_id, account_id, credit, debit)
+    SELECT project.enterprise_id, period.fiscal_year_id, period_id, account_id, SUM(credit_equiv) AS credit, SUM(debit_equiv) AS debit
+    FROM general_ledger
+      JOIN period ON general_ledger.period_id = period.id
+      JOIN project ON general_ledger.project_id = project.id
+    GROUP BY account_id, period_id;
+
+END $$
+
 DELIMITER ;


### PR DESCRIPTION
This commit adds the administrative tool `zRecalculatePeriodTotals()`.
This stored procedure wipes clean the period_total table and rebuilds it
from scratch using a corrected query.  This should cleanup all broken
data from previous postings or corruption in the database.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
