### PR TITLE
chore(travis): build minified version of app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - ./node_modules/.bin/karma start --single-run
   - sh sh/install.sh
   - ./node_modules/.bin/webdriver-manager update
-  - sleep 8
+  - sleep 10
   - ./node_modules/.bin/protractor protractor.conf.js
 
 git:

--- a/sh/deploy.sh
+++ b/sh/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # post install script to deploy the application for testing
-export NODE_ENV="staging"
+NODE_ENV="production"
 
 # remove the progress bar for fun and profit
 npm set progress=false
@@ -17,6 +17,8 @@ npm install
 
 # cd into the built directory
 cd bin
+
+export NODE_ENV="staging"
 
 # start the application
 node server/app.js &

--- a/sh/install.sh
+++ b/sh/install.sh
@@ -2,8 +2,6 @@
 
 # A small script to set up virtual machine instances for deployment or testing.
 
-export ENV="staging"
-
 # make sure we are using the correct SQL mode
 mysql -h $DB_HOST -u root -e "SET GLOBAL sql_mode='STRICT_ALL_TABLES';"
 


### PR DESCRIPTION
This commit makes sure Travis CI builds a minified version of the
application.  Without building minified, introducing ES6 into the client
will break the build without warning in production.  With Travis
building a minified version, we'll be able to catch these bugs before
deployment.

Closes #1267