### PR TITLE
fix(i18n): better cash and credit note description

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -105,6 +105,8 @@
     "CURRENT_CASHBOX" : "Current Cashbox",
     "DEBTOR_INVOICES" : "Debtor Invoices",
     "PAYMENT"         : "Payment",
+    "PAYMENT_DESCRIPTION"    : "Cash payment by {{patientName}} ({{patientReference}}) against invoice(s) {{invoiceReferences}}.",
+    "PREPAYMENT_DESCRIPTION" : "Prepayment by {{patientName}} ({{patientReference}}).",
     "REGISTRY" : {
       "INCLUDE_ONLY_REVERSED_RECORDS" : "Include only reversed cash payments",
       "EXCLUDE_REVERSED_RECORDS" : "Exclude all reversed cash payments",
@@ -115,10 +117,10 @@
       "MISSING_CASH"       : "Missing Cash",
       "TITLE"              : "Select a Cashbox"
     },
-    "TITLE"           : "Cash Window",
-    "TOOLS"         : "Tools",
-    "RECEIPT": {
-      "TITLE" : "Cash Receipt",
+    "TITLE" : "Cash Window",
+    "TOOLS" : "Tools",
+    "RECEIPT"   : {
+      "TITLE"   : "Cash Receipt",
       "SUCCESS" : "Successfully created a Cash Payment"
     },
     "TRANSFER": {
@@ -417,7 +419,7 @@
       "CURRENT"              : "Current",
       "CLEAR_FILTERS"        : "Clear Filters",
       "CREDIT_NOTE"          : "Credit Note",
-      "CREDIT_NOTE_INVOICE"  : "Credit Note reversing invoice {{ invoiceReference }} ({{ invoiceAmount }}) of debtor {{ debtorName }} ({{ debtorIdentifier }}).  {{ description }}",
+      "CREDIT_NOTE_INVOICE"  : "Credit Note reversing invoice {{ invoiceReference }} of debtor {{ debtorName }} ({{ debtorIdentifier }}).  {{ description }}",
       "DANGER_ZONE"          : "Danger Zone",
       "DELETE_SUCCESS"       : "Successfully deleted a record",
       "DISABLED_CURRENCY"    : "This currency is unusable since there is no account set for it.  Use the Cashbox Management module to set an account for this currency and cashbox.",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -102,6 +102,8 @@
     "CAUTION_REMAINING" : "Caution Restante",
     "CONFIRM_PAYMENT_WHEN_CAUTION" : "Procéder au paiement alors que le patient dispose d'une caution ?",
     "CURRENT_CASHBOX" : "Caisse courante",
+    "PAYMENT_DESCRIPTION" : "Paiement par {{patientName}} ({{patientReference}}) contre les facture(s) {{invoiceReferences}}.",
+    "PREPAYMENT_DESCRIPTION" : "Paiement caution par {{patientName}} ({{patientReference}}).",
     "DEBTOR_INVOICES": {
       "TITLE" : "Facture(s) debiteur"
     },
@@ -116,7 +118,7 @@
       "SUCCESS" : "Créé avec succès un paiement en espèces"
     },
     "SELECTION": {
-      "GO_TO_CASHBOX_PAGE" : "Aller a la page de gestion de caisse",
+      "GO_TO_CASHBOX_PAGE" : "Allez a la page de gestion de caisse",
       "MISSING_CASH"       : "Caisse manquante",
       "TITLE"              : "Selection caisse"
     },
@@ -418,7 +420,7 @@
       "CREATED"              : "Crée",
       "CREATE_SUCCESS"       : "Crée avec succès",
       "CREDIT_NOTE"          : "Note de crédit",
-      "CREDIT_NOTE_INVOICE"  : "Note de credit concernant la facture {{ invoiceReference }} ({{ invoiceAmount }}) de debiteur {{ debtorName }} ({{ debtorIdentifier }}).  {{ description }}",
+      "CREDIT_NOTE_INVOICE"  : "Note de credit concernant la facture {{ invoiceReference }} de debiteur {{ debtorName }} ({{ debtorIdentifier }}).  {{ description }}",
       "CURRENT"              : "Actuel",
       "DANGER_ZONE"          : "Zone Dangereuse",
       "DELETE_SUCCESS"       : "Suppression avec succès",

--- a/client/src/partials/cash/cash.js
+++ b/client/src/partials/cash/cash.js
@@ -138,7 +138,6 @@ function CashController(Cash, Cashboxes, AppCache, Currencies, Session, Modals, 
 
   // submit payment
   function submitPayment(form) {
-
     // make a copy of the data before submitting
     var copy = angular.copy(vm.Payment.details);
 
@@ -158,7 +157,7 @@ function CashController(Cash, Cashboxes, AppCache, Currencies, Session, Modals, 
         clear(form);
 
         if (vm.openBarcodeModalOnSuccess) {
-          $state.go('^.scan', { id : vm.cashbox.id });
+          $state.go('^.scan', { id: vm.cashbox.id });
         }
       })
       .catch(Notify.handleError);

--- a/client/src/partials/patient_invoice/registry/modalCreditNote.js
+++ b/client/src/partials/patient_invoice/registry/modalCreditNote.js
@@ -3,17 +3,15 @@ angular.module('bhima.controllers')
 
 ModalCreditNoteController.$inject = [
   '$uibModalInstance', 'PatientInvoiceService', 'data', 'VoucherService', 'NotifyService',
-  '$translate', '$filter',
+  '$translate',
 ];
 
-function ModalCreditNoteController(Instance, Invoices, data, Vouchers, Notify, $translate, $filter) {
+function ModalCreditNoteController(Instance, Invoices, data, Vouchers, Notify, $translate) {
   var vm = this;
-
-  var $currency = $filter('currency');
 
   vm.creditNote = {};
   vm.submit = submit;
-  vm.cancel = function () { Instance.close(false); };
+  vm.cancel = function cancel() { Instance.close(false); };
 
   vm.creditNote.uuid = data.invoice.uuid;
   vm.patientInvoice = data.invoice;
@@ -25,7 +23,6 @@ function ModalCreditNoteController(Instance, Invoices, data, Vouchers, Notify, $
     .catch(Notify.handleError);
 
   function submit(form) {
-
      // stop submission if the form is invalid
     if (form.$invalid) { return; }
 
@@ -33,7 +30,6 @@ function ModalCreditNoteController(Instance, Invoices, data, Vouchers, Notify, $
 
     var creditNoteMessage = $translate.instant('FORM.INFO.CREDIT_NOTE_INVOICE', {
       invoiceReference : vm.patientInvoice.reference,
-      invoiceAmount    : $currency(vm.patientInvoice.cost, data.invoice.currency_id),
       description      : vm.creditNote.description,
       debtorName       : data.invoice.patientName,
       debtorIdentifier : data.invoice.patientReference,

--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -89,12 +89,12 @@ function lookup(id) {
       JOIN invoice AS i ON ci.invoice_uuid = i.uuid
       JOIN project AS p ON i.project_id = p.id
       LEFT JOIN service AS s ON i.service_id = s.id
-    WHERE ci.cash_uuid = ?;
+    WHERE ci.cash_uuid = ?
+    ORDER BY i.date ASC;
   `;
 
-  return db.exec(cashRecordSql, [ bid ])
-    .then(function (rows) {
-
+  return db.exec(cashRecordSql, [bid])
+    .then((rows) => {
       if (!rows.length) {
         throw new NotFound(`No cash record by uuid: ${id}`);
       }
@@ -104,8 +104,7 @@ function lookup(id) {
 
       return db.exec(cashItemsRecordSql, bid);
     })
-    .then(function (rows) {
-
+    .then((rows) => {
       // bind the cash items to the "items" property and return
       record.items = rows;
 
@@ -127,7 +126,7 @@ function lookup(id) {
  */
 function list(req, res, next) {
   listPayment()
-    .then(function (rows) {
+    .then((rows) => {
       res.status(200).json(rows);
     })
     .catch(next)
@@ -140,7 +139,7 @@ function list(req, res, next) {
  */
  function search(req, res, next) {
    listPayment(req.query)
-     .then(rows => {
+     .then((rows) => {
        res.status(200).json(rows);
      })
      .catch(next)

--- a/server/controllers/finance/reports/cash/receipt.handlebars
+++ b/server/controllers/finance/reports/cash/receipt.handlebars
@@ -13,6 +13,7 @@
           <span class="text-capitalize">{{translate 'FORM.LABELS.EMAIL'}}</span>: {{enterprise.email}}
         </p>
       </div>
+
       <div class="col-xs-6 text-right">
         <h3 style="margin: 0px;">
           <span class="text-uppercase">
@@ -44,26 +45,29 @@
         <span class="text-capitalize">{{translate 'FORM.LABELS.PAYMENT'}}</span>: <strong>{{payment.reference}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.AMOUNT'}}</span>: <strong>{{currency payment.amount payment.currency_id}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date payment.date}} <br>
-        {{#if hasRate}} <i class="fa fa-balance-scale"></i> {{currency rate payment.currency_id}} <br>{{/if}}
+        {{#if hasRate}}
+          <span class="text-capitalize">{{translate 'FORM.LABELS.EXCHANGE_RATE'}} {{currency rate payment.currency_id}}</span> <br>
+        {{/if}}
         <span class="text-capitalize">{{translate "TABLE.COLUMNS.CREATED_BY"}}</span>: {{user.display_name}}
       </div>
     </div>
   </header>
 
+  <!-- describe the payment -->
+  <p>{{payment.description}}</p>
+
   <!-- list of items paid -->
   <table class="table table-condensed">
     <thead>
       <tr>
-
-          {{#with payment}}
-            {{#if is_caution}}
-              <th>{{translate "CASH.CAUTION"}}</th>
-            {{else}}
-              <th>{{translate "FORM.LABELS.INVOICE"}}</th>
-              <th>{{translate "FORM.LABELS.SERVICE"}}</th>
-            {{/if}}
-          {{/with}}
-
+        {{#with payment}}
+          {{#if is_caution}}
+            <th>{{translate "CASH.CAUTION"}}</th>
+          {{else}}
+            <th>{{translate "FORM.LABELS.INVOICE"}}</th>
+            <th>{{translate "FORM.LABELS.SERVICE"}}</th>
+          {{/if}}
+        {{/with}}
         <th class="text-right">{{translate "FORM.LABELS.AMOUNT"}}</th>
       </tr>
     </thead>
@@ -88,14 +92,13 @@
           <th class="text-right">{{currency payment.amount payment.currency_id}}</th>
       </tr>
 
-      <tr>
-        {{#if payment.is_caution}}
-          <th>{{translate "FORM.LABELS.TOTAL_BALANCE_REMAINING"}}</th>
-        {{else}}
+      <!-- the balance only makes sense to show if the debtor is paying an invoice -->
+      {{#unless payment.is_caution}}
+        <tr>
           <th colspan="2">{{translate "FORM.LABELS.TOTAL_BALANCE_REMAINING"}}</th>
-        {{/if }}
-        <th class="text-right">{{currency debtorTotalBalance enterprise.currency_id}}</th>
-      </tr>
+          <th class="text-right">{{currency debtorTotalBalance enterprise.currency_id}}</th>
+        </tr>
+      {{/unless }}
     </tfoot>
   </table>
 

--- a/server/controllers/finance/reports/cash/receipt.pos.handlebars
+++ b/server/controllers/finance/reports/cash/receipt.pos.handlebars
@@ -34,8 +34,9 @@
 
 <!-- if !payment.is_caution -->
 {{#each payment.items as |item| }}
-
-<p style="font-weight : bold; text-decoration : underline; margin-bottom : 0px;">{{translate "FORM.LABELS.INVOICE"}} {{item.reference}} / {{translate "FORM.LABELS.SERVICE"}} {{item.serviceName}}</p>
+  <p style="font-weight : bold; text-decoration : underline; margin-bottom : 0px;">
+    {{translate "FORM.LABELS.INVOICE"}} {{item.reference}} -- {{item.serviceName}}
+  </p>
 <table style="width : 100%">
   <thead>
     <tr>


### PR DESCRIPTION
This commit refactors the cash payments and credit note descriptions.
It makes sure that we have human readable text for our reports to aid
our administrators to better track references by their human readable
equivalents.  This is based on feedback from the administrative team at
Vanga as well as a need to have translated description.

It also slightly improves the cash thermal receipts by ordering the paid
invoices in the order in which they are paid.  The invoices not fully
paid appear at the bottom of the list as one might expect.

Finally, the cash description is now on the receipt.  Icons have been
removed in favor of text.

Partially addresses #1330.  Closes #1331.

---
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
