### PR TITLE
fix(filters) Default cash registry filter by period (Today) 

### DIFF
--- a/client/src/js/services/CashService.js
+++ b/client/src/js/services/CashService.js
@@ -136,7 +136,8 @@ function CashService(Modal, Api, Exchange, Session, moment) {
       { field: 'dateTo', displayName: 'FORM.LABELS.DATE_TO', comparitor: '<', ngFilter:'date' },
       { field: 'currency_id', displayName: 'FORM.LABELS.CURRENCY' },
       { field: 'reversed', displayName: 'CASH.REGISTRY.REVERSED_RECORDS' },
-      { field : 'patientReference', displayName: 'FORM.LABELS.REFERENCE_PATIENT'}
+      { field : 'patientReference', displayName: 'FORM.LABELS.REFERENCE_PATIENT'},
+      { field : 'defaultPeriod', displayName : 'TABLE.COLUMNS.PERIOD', ngFilter : 'translate'}
     ];
 
     // returns columns from filters

--- a/client/src/partials/cash/payments/registry.html
+++ b/client/src/partials/cash/payments/registry.html
@@ -40,6 +40,7 @@
   </bh-filters-applied>
 
   <a href
+    ng-if="CPRCtrl.filter.customFiltersApplied(CPRCtrl.filters.identifiers)"
     ng-click="CPRCtrl.clearFilters()"
     class="text-danger"
     data-method="clear">

--- a/client/src/partials/cash/payments/templates/search.modal.js
+++ b/client/src/partials/cash/payments/templates/search.modal.js
@@ -23,6 +23,9 @@ function SearchCashPaymentModalController(Users, Cashboxes, Notify, Instance, fi
   vm.submit = submit;
   vm.cancel = Instance.close;
 
+  // @FIXME patch hack - this should be handled by FilterService
+  delete(vm.bundle.defaultPeriod);
+
   // cashboxes
   Cashboxes.read()
     .then(function (list) {

--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -172,6 +172,7 @@ function listPayment(options) {
 
   filters.dateFrom('dateFrom', 'date');
   filters.dateTo('dateTo', 'date');
+  filters.period('defaultPeriod', 'date');
 
   let referenceStatement = `CONCAT_WS('.', '${identifiers.CASH_PAYMENT.key}', project.abbr, cash.reference) = ?`;
   filters.custom('reference', referenceStatement);


### PR DESCRIPTION
This commit updates the cash registry to include the hot fix patch
introduced in #1339. Only the invoice registry was limited to show daily
records however this is an issue with all commonly used registries.

This commit introduces temporary hot fix code that should be superseeded
by #1347.

This branch should be pulled and manually tested before merging with
master.