### PR TITLE
fix(report): Fix ordering in Extrait de Compte

### DIFF
--- a/server/controllers/finance/reports/generalLedger/accountSlip.handlebars
+++ b/server/controllers/finance/reports/generalLedger/accountSlip.handlebars
@@ -21,9 +21,9 @@
         <table class="table table-condensed table-striped table-report table-bordered">
           <thead>
             <tr class="text-capitalize text-center" style="background-color: #ddd;">
+              <th>{{translate "TABLE.COLUMNS.DATE"}}</th>
               <th>{{translate "TABLE.COLUMNS.TRANSACTION"}}</th>
               <th>{{translate "TABLE.COLUMNS.REFERENCE"}}</th>
-              <th>{{translate "TABLE.COLUMNS.DATE"}}</th>
               <th>{{translate "TABLE.COLUMNS.DESCRIPTION"}}</th>
               <th style="width: 15%;">{{translate "TABLE.COLUMNS.DEBIT"}}</th>
               <th style="width: 15%;">{{translate "TABLE.COLUMNS.CREDIT"}}</th>


### PR DESCRIPTION
This commit fixes incorrect ordering in the column headers of the Extrait
de Compte report.

---
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
