### PR TITLE
fix(db): lower deadlock wait limits

### DIFF
--- a/server/lib/db/index.js
+++ b/server/lib/db/index.js
@@ -76,7 +76,7 @@ class DatabaseConnector {
 
       // format the SQL statement using MySQL's escapes
       const statement = mysql.format(sql.trim(), params);
-    
+
       connection.query(statement, (err, rows) => {
         connection.release();
         return (err) ? deferred.reject(err) : deferred.resolve(rows);


### PR DESCRIPTION
This commit adjusts the transaction deadlock limits so that transactions
fail faster if a deadlock is encountered.  Now a transaction will fail
in approximately 3 seconds instead of ten.  This helps prevents transactions
from stacking - and frees up connections from the pool faster.

**Motivation**
We only allow 10 simultaneous connections to the database.  If 10 cash payments stack, the server becomes overwhelmed and cannot even load a single query - even a simple one.  Increasing our number of connections will not solve the problem - the heavily used tables will be locked into perpetuity.  Instead, the solution is to fail fast and hopefully give the server time to clear the locks before re-submission.