### PR TITLE
refactor(search) Add name search, minimal repsonse

### DIFF
--- a/client/src/js/components/bhFindPatient.js
+++ b/client/src/js/components/bhFindPatient.js
@@ -154,16 +154,7 @@ function FindPatientComponent(Patients, AppCache, Notify, SessionService, bhCons
       limit        : LIMIT,
     };
 
-    return Patients.search(options)
-      .then(function (patients) {
-
-        // loop through each
-        patients.forEach(function (patient) {
-          patient.label = formatPatient(patient);
-        });
-
-        return patients;
-      });
+    return Patients.searchByName(options);
   }
 
   /**
@@ -176,7 +167,9 @@ function FindPatientComponent(Patients, AppCache, Notify, SessionService, bhCons
     if (vm.selected === vm.options.findById && vm.idInput) {
       searchByReference(vm.idInput);
     } else if (vm.selected === vm.options.findByName && vm.nameInput) {
-      selectPatient(vm.nameInput);
+      // patient has been selected from a list of names/ references
+      // very limited information is known about the patient - get details by UUID
+      searchByUuid(vm.nameInput.uuid);
     }
   }
 

--- a/client/src/js/services/PatientService.js
+++ b/client/src/js/services/PatientService.js
@@ -36,6 +36,7 @@ function PatientService($http, util, Session, $uibModal, Documents, Visits) {
 
   // uses the "search" endpoint to pass query strings to the database
   service.search = search;
+  service.searchByName = searchByName;
   service.formatFilterParameters = formatFilterParameters;
 
   // document exposition definition
@@ -154,6 +155,15 @@ function PatientService($http, util, Session, $uibModal, Documents, Visits) {
     options = angular.copy(options || {});
 
     var target = baseUrl.concat('search');
+
+    return $http.get(target, { params : options })
+      .then(util.unwrapHttpResponse);
+  }
+
+  function searchByName(options) {
+    options = angular.copy(options || {});
+
+    var target = baseUrl.concat('search/name');
 
     return $http.get(target, { params : options })
       .then(util.unwrapHttpResponse);

--- a/client/src/partials/templates/bhFindPatient.tmpl.html
+++ b/client/src/partials/templates/bhFindPatient.tmpl.html
@@ -42,11 +42,11 @@
         ng-model="$ctrl.nameInput"
         ng-if="$ctrl.selected == $ctrl.options.findByName"
         ng-keypress="$ctrl.onKeyPress($event)"
-        uib-typeahead="patient as patient.label for patient in $ctrl.searchByName($viewValue)"
+        uib-typeahead="patient as patient.display_name for patient in $ctrl.searchByName($viewValue)"
         typeahead-no-results="$ctrl.noPatients"
         typeahead-loading="$ctrl.loadingPatients"
         typeahead-template-url="/partials/templates/patientList.tmpl.html"
-        typeahead-on-select="$ctrl.selectPatient($item)"
+        typeahead-on-select="$ctrl.submit($item)"
         placeholder="{{ $ctrl.selected.placeholder | translate }}..."
         ng-required="$ctrl.required">
 

--- a/client/src/partials/templates/patientList.tmpl.html
+++ b/client/src/partials/templates/patientList.tmpl.html
@@ -1,5 +1,5 @@
 <a href>
   <span style="display:inline-block; min-width:64px;">[{{ match.model.reference }}]</span>
   <!-- <span>{{ match.model.label }}</span> -->
-  <span ng-bind-html="match.model.label | uibTypeaheadHighlight:query"></span>
+  <span ng-bind-html="match.model.display_name | uibTypeaheadHighlight:query"></span>
 </a>

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -411,6 +411,10 @@ exports.configure = function configure(app) {
   app.delete('/patients/groups/:uuid', patientGroups.remove);
 
   app.get('/patients/search', patients.search);
+
+  // route specifically for quick searches on patient name, it will return minimal info
+  app.get('/patients/search/name', patients.searchByName);
+
   app.get('/patients/visits', patients.visits.list);
 
   // Patients API


### PR DESCRIPTION
This commit introduces the patients/search/name API. This can be used to
search for a patient by name. It only returns the very minimal data
required to represent a patient, UUID, display name and reference.

This has been applied to the find patient directive when find by name is
selected, drastically reducing the complexity of the query to find a
patient by name.

Requirements: 
- [x] Implement `patients/search/name` route, minimal response for components 
- [x] Use new route in FindPatient directive 
- [ ] Integration tests for `patients/search/name` to work against future regressions 

**patients/search?display_name=nzala**
![performance_after](https://cloud.githubusercontent.com/assets/2844572/24107279/9c04030e-0d8a-11e7-9cd1-34f1b1851d4b.png)

**patients/search/name?display_name=nzala**
![performance_before](https://cloud.githubusercontent.com/assets/2844572/24107270/937469ae-0d8a-11e7-9fae-82e6b41df38d.png)

The key metric to look at here is 'Waiting', the time it took for the server to respond with the required results. 
Full patient search route : **98.57ms**
Proposed patient search route : **17.49ms**

This response is significantly faster than doing a search on all patient information, on capable machines the difference is negligible however this can be crippling on lower end server hardware (as described https://github.com/IMA-WorldHealth/bhima-2.X/issues/1373)

Contributes to https://github.com/IMA-WorldHealth/bhima-2.X/issues/1373
