### PR TITLE
test(search) regression tests for name search

### DIFF
--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -339,6 +339,10 @@ function searchByName(req, res, next) {
   const searchValue = req.query.display_name;
   const searchParameter = `%${searchValue}%`;
 
+  if (_.isUndefined(searchValue)) {
+    return next(new BadRequest('display_name attribute must be specified for a name search'));
+  }
+
   // current default limit - this could be defined through req.query if there is a need for this
   const limit = 10;
 

--- a/test/integration/patients.js
+++ b/test/integration/patients.js
@@ -95,12 +95,37 @@ describe('(/patients) Patients', function () {
         .catch(helpers.handler);
     });
 
-    it('GET /patients/search with \'name\' parameter', function () {
+    it('GET /patients/search with \'display_name\' parameter', function () {
       let conditions = { display_name : 'Test' };
       return agent.get('/patients/search/')
         .query(conditions)
         .then(function (res) {
           helpers.api.listed(res, 2);
+        })
+        .catch(helpers.handler);
+    });
+
+    it('GET /patients/search/name with display_name parameter should return only a small subset of patient information', function () {
+      let conditions = { display_name : 'Test' };
+
+      return agent.get('/patients/search/name')
+        .query(conditions)
+        .then(function (res) {
+          helpers.api.listed(res, 2);
+
+          const firstRecord = res.body[0];
+          expect(firstRecord).to.have.all.keys(['uuid', 'display_name', 'reference']);
+        })
+        .catch(helpers.handler);
+    });
+
+    it('GET /patients/search/name results in bad request with no name provided', function () {
+      let conditions = {};
+
+      return agent.get('/patients/search/name')
+        .query(conditions)
+        .then(function (res) {
+          helpers.api.errored(res, 400);
         })
         .catch(helpers.handler);
     });


### PR DESCRIPTION
This commit adds a basic integration test to guard against regressions
on the /patients/search/name API.