### PR TITLE
refactor(indexes): use JOIN in CalculateCashInvoiceBalances()

### DIFF
--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -124,6 +124,7 @@ CREATE TABLE `cash_item` (
   `invoice_uuid`    BINARY(16) DEFAULT NULL,
   PRIMARY KEY (`uuid`),
   KEY `cash_uuid` (`cash_uuid`),
+  INDEX (`invoice_uuid`),
   FOREIGN KEY (`cash_uuid`) REFERENCES `cash` (`uuid`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
This commit adds indexes on frequently used cash temporary tables.  It
also optimizes the SQL query by using JOINs on INDEXed columns instead
of the view, which lacks indexes.

Contributes to #1388

---
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [ ] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
