### PR TITLE
(perf) Break apart combined_ledger receipt queries

### DIFF
--- a/server/controllers/finance/debtors/index.js
+++ b/server/controllers/finance/debtors/index.js
@@ -269,13 +269,20 @@ function balance(debtorUid) {
       SELECT SUM(debit - credit) AS balance, BUID(entity_uuid) as entity_uuid
       FROM (
         SELECT entity_uuid, record_uuid as uuid, debit_equiv as debit, credit_equiv as credit
-        FROM combined_ledger
+        FROM posting_journal
         WHERE entity_uuid = ?
+
+        UNION ALL
+
+        SELECT entity_uuid, record_uuid as uuid, debit_equiv as debit, credit_equiv as credit
+        FROM general_ledger
+        WHERE entity_uuid = ?
+
       ) AS ledger
       GROUP BY ledger.entity_uuid;
     `;
 
-    return db.one(sql, [debtorUid]);
+    return db.one(sql, [debtorUid, debtorUid]);
   });
 }
 


### PR DESCRIPTION
These commits splits the debtor invoices and overall debtor balance query into multiple parts
to make use of MySQL's index. 
The combined_ledger is no longer used as
it does not index the required columns correctly.

Contributes to https://github.com/IMA-WorldHealth/bhima-2.X/issues/1405
