### PR TITLE
(performance) Fix invoice lookup query

### DIFF
--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -175,9 +175,6 @@ function listPayment(options) {
   const patientReferenceStatement = `CONCAT_WS('.', '${identifiers.PATIENT.key}', project.abbr, p.reference) = ?`;
   filters.custom('patientReference', patientReferenceStatement);
 
-  // filter reversed cash records
-  // filters.reversed('reversed');
-
   // @TODO Support ordering query (reference support for limit)?
   filters.setOrder('ORDER BY cash.date DESC');
 

--- a/server/controllers/finance/debtors/index.js
+++ b/server/controllers/finance/debtors/index.js
@@ -161,7 +161,7 @@ function getDebtorInvoices (debtorUid){
   let sql =`
     SELECT BUID(invoice.uuid) as uuid
     FROM invoice
-    WHERE debtor_uuid = ? AND invoice.uuid NOT IN (SELECT voucher.reference_uuid FROM voucher WHERE voucher.type_id = ?)
+    WHERE debtor_uuid = ? AND invoice.reversed = 0
     ORDER BY invoice.date ASC, invoice.reference;
   `;
 

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -227,9 +227,6 @@ function find(options) {
 
   filters.period('defaultPeriod', 'date');
 
-  // support credit note toggle
-  // filters.reversed('reversed');
-
   const referenceStatement = `CONCAT_WS('.', '${identifiers.INVOICE.key}', project.abbr, invoice.reference) = ?`;
   filters.custom('reference', referenceStatement);
 

--- a/server/controllers/finance/vouchers.js
+++ b/server/controllers/finance/vouchers.js
@@ -134,9 +134,6 @@ function find(options) {
   // @todo - could this be improved
   filters.custom('account_id', 'v.uuid IN (SELECT DISTINCT voucher_uuid FROM voucher_item WHERE account_id = ?)');
 
-  // filter reversed cash records
-  filters.reversed('reversed');
-
   // @TODO Support ordering query (reference support for limit)?
   filters.setOrder('ORDER BY v.date DESC');
 

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -610,8 +610,7 @@ function loadLatestInvoice(inv) {
     `SELECT COUNT(invoice.uuid) as 'invoicesLength'
        FROM invoice
        JOIN user ON user.id = invoice.user_id
-       WHERE debtor_uuid = ? AND invoice.uuid NOT IN
-         (SELECT voucher.reference_uuid FROM voucher WHERE voucher.type_id = 10)
+       WHERE debtor_uuid = ? AND invoice.reversed = 0
        ORDER BY date DESC`;
 
 

--- a/server/lib/filter.js
+++ b/server/lib/filter.js
@@ -142,38 +142,6 @@ class FilterParser {
     }
   }
 
-  /**
-   * @method reversed
-   *
-   * @description
-   * 'reversed criteria' currently stands as joining with the voucher table on reference_uuid
-   * if a voucher exists for this record it will contain a `type_id`
-   *
-   * @TODO this is the first example of a 'toggle' filter, this should be more carefully
-   * designed
-   */
-  reversed(filterKey) {
-    const REVERSE_VOUCHER_ID = 10;
-
-    if (this._filters[filterKey]) {
-      let includeReversed = Boolean(Number(this._filters[filterKey]));
-      let preparedStatement = '';
-
-      if (includeReversed) {
-        // return only records that meet the reversed criteria
-        preparedStatement = `voucher.type_id = ?`;
-      } else {
-        // exclude all record that meet the reversed criteria
-        preparedStatement = `(voucher.type_id IS NULL OR voucher.type_id <> ?)`;
-      }
-
-      // using the reversal voucher id as the parameter is a hack, this will be
-      // addressed in standardising filters on the server and the client
-      this._addFilter(preparedStatement, REVERSE_VOUCHER_ID);
-      delete this._filters[filterKey];
-    }
-  }
-
   custom(filterKey, preparedStatement, preparedValue) {
     if (this._filters[filterKey]) {
       const searchValue = preparedValue || this._filters[filterKey];


### PR DESCRIPTION
This PR removes the relatively expensive voucher NOT IN query that
was used in the past to determine if invoices have an ascociated credit
note. This can now utilise the `reversed` column.

It also removes the implementation of the reversed filter type on
FilterParser. Our current standard is to use a `reversed` column for
performance reasons - this can be parsed by FilterParser as a default
equals filter.