### PR TITLE
fix(patient): breakout financial activity query

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -994,7 +994,7 @@
       "MISSING_SALES_ACCOUNT" : "The record contains an inventory item missing a sales account.  You cannot make an invoice without a sales account.",
       "NOT_CONFIGURED" : "The record is missing an inventory item. Please put in an inventory item or remove the row."
     },
-    "DESCRIPTION"        : "Invoice to {{ patientName }} ({{ patientReference }} for {{ numItems }} items from service {{ serviceName }}. {{ description }}",
+    "DESCRIPTION"        : "Invoice to {{ patientName }} ({{ patientReference }}) for {{ numItems }} items from service {{ serviceName }}. {{ description }}",
     "INVALID_DETAILS"    : "This invoice contains invalid details",
     "INVALID_ITEMS"      : "This invoice contains invalid items",
     "PAGE_TITLE"         : "Patient Invoice",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -1002,7 +1002,7 @@
       "MISSING_SALES_ACCOUNT" : "L'enregistrement contient un item d'inventaire qui n'a pas de compte de vente associé à son groupe",
       "NOT_CONFIGURED"        : "L'enregistrement ne contient pas d'item inventaire. Veuillez inserer un item ou supprimer la ligne."
     },
-    "DESCRIPTION"        : "Facture a {{ patientName }} ({{ patientReference }} pour {{ numItems }} items dans le service {{ serviceName }}. {{ description }}",
+    "DESCRIPTION"        : "Facture a {{ patientName }} ({{ patientReference }}) pour {{ numItems }} items dans le service {{ serviceName }}. {{ description }}",
     "INVALID_DETAILS"    : "Cette facture contient des détails invalides",
     "INVALID_ITEMS"      : "Cette facture contient des articles invalides",
     "LABEL_PAID"         : "Cette facture a été payé.",


### PR DESCRIPTION
This commit breaks the financial activity query out into several parts
using the posting_journal and general_ledger instead of the
combined_ledger.  This should result in a significant speedup.

It also implements a tiny bugfix to make sure large errors are not
displayed for patients that are never billed.


---
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
