### PR TITLE
fix(cashflowByService): handle dates properly

### DIFF
--- a/server/controllers/finance/reports/cashflow/reportByService.handlebars
+++ b/server/controllers/finance/reports/cashflow/reportByService.handlebars
@@ -10,7 +10,7 @@
 
       <!-- page title  -->
       <h2 class="text-center text-capitalize">
-        {{translate 'CASHFLOW.BY_SERVICE'}}
+        {{translate 'REPORT.CASHFLOW_BY_SERVICE'}}
       </h2>
 
       <table class="table table-bordered table-condensed"  style="font-size:0.75em;">
@@ -21,17 +21,26 @@
             {{#each services as |service| }}
               <th>{{ service }}</th>
             {{/each}}
+            <th>{{translate "FORM.LABELS.BALANCE"}}</th>
           </tr>
         </thead>
         <tbody>
           {{#each matrix as | row |}}
             <tr>
               {{#each row as |value |}}
-                <td {{#unless @first}}class="text-right"{{/unless}}>
-                  {{#if value}}
-                    {{value}}
-                  {{/if}}
-                </td>
+
+                {{! this is the balance calculation }}
+                {{#if @last}}
+                  <th class="text-right">{{value}}</th>
+
+                {{! this is the rest of the matrix }}
+                {{else}}
+                  <td {{#unless @first}}class="text-right"{{/unless}}>
+                    {{#if value}}
+                      {{value}}
+                    {{/if}}
+                  </td>
+                {{/if}}
               {{/each}}
             </tr>
           {{else}}
@@ -43,7 +52,7 @@
           <tr>
             <th colspan="2">{{translate "TABLE.COLUMNS.TOTAL" }}</th>
             {{#each aggregates as | aggregate |}}
-              <th class="text-right">{{currency aggregate.totalCashIncome ../metadata.enterprise.currency_id }}</th>
+              <th class="text-right">{{aggregate.totalCashIncome}}</th>
             {{/each}}
           </tr>
         </tfoot>


### PR DESCRIPTION
This commit fixes the cashflow by service  report to handle dates
properly instead of excluding all values.  It also updates the report to
filter out payments that have been reversed using the `reversed` flag.

Closes #1281.  Closes #1368.

---

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
