### PR TITLE
fix(cash): use semicolons to enable CSV export

### DIFF
--- a/client/src/js/services/CashService.js
+++ b/client/src/js/services/CashService.js
@@ -83,7 +83,8 @@ function CashService(Modal, Api, Exchange, Session, moment, $translate) {
       return invoice.reference;
     });
 
-    var referencesString = invoicesReferences.join(', ');
+    // this must be semicolons, otherwise the CSV file breaks.
+    var referencesString = invoicesReferences.join('; ');
 
     var tmpl = isCaution ? 'CASH.PREPAYMENT_DESCRIPTION' : 'CASH.PAYMENT_DESCRIPTION';
 


### PR DESCRIPTION
This commit fixes a bug in the cash payment registry CSV export caused
by a description that used commas to join lists of invoices together.
By updating to semicolons, this has been fixed.  However, we may wish to
allow a user to change the delimiter of a CSV export file in case as
user-made description breaks the export.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
