### PR TITLE
(fix) Landing page 403

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -20,27 +20,30 @@ function bhimaConfig($stateProvider, $urlMatcherFactoryProvider) {
     controller  : 'HomeController as HomeCtrl',
     templateUrl : 'partials/home/home.html',
   })
-  .state('details', {
+  .state('landing', {
     abstract : true,
-    url : '/details',
-    templateUrl : 'partials/home/details.html'
+    url : '/landing',
+    controller : ['SessionService', function (Session) { this.enterprise = Session.enterprise; }],
+    controllerAs : 'LandingCtrl',
+    templateUrl : 'partials/home/details.html',
   })
-  .state('details.more', {
-    url : '',
+  .state('landing.stats', {
+    url : '/stats',
     views : {
-      'debtors@details' : {
+      'debtors' : {
         templateUrl : 'partials/home/units/debtors.html',
         controller  : 'DashboardDebtorController as DebtorCtrl',
       },
-      'invoices@details' : {
+      'invoices' : {
         templateUrl : 'partials/home/units/invoices.html',
         controller  : 'DashboardInvoiceController as InvoiceCtrl',
       },
-      'patients@details' : {
+      'patients' : {
         templateUrl : 'partials/home/units/patients.html',
         controller  : 'DashboardPatientController as PatientCtrl',
-      },
-    }
+      }
+
+    },
   })
   .state('exchange', {
     abstract    : true,
@@ -256,7 +259,7 @@ function startupConfig($rootScope, $state, $uibModalStack, SessionService, amMom
     var path = $location.path();
 
     var paths = SessionService.paths;
-    var publicRoutes = ['/', '/settings', '/login'];
+    var publicRoutes = ['/', '/settings', '/login', '/landing/stats'];
 
     var isPublicPath = publicRoutes.indexOf(path) > -1;
 

--- a/client/src/partials/home/details.html
+++ b/client/src/partials/home/details.html
@@ -1,23 +1,24 @@
 <div class="flex-header">
   <div class="bhima-title">
     <ol class="headercrumb">
-      <li class="static" translate>TREE.ADMIN</li>
+      <li class="static" style="text-transform : uppercase">{{ "HOME.BHIMA" | translate }}</li>
+      <li class="static"><a ui-sref="index">{{ LandingCtrl.enterprise.name }}</a></li>
       <li class="title" translate>HOME.DETAILS</li>
     </ol>
   </div>
 </div>
 
 <div class="flex-content">
-  <div class="row">
-      <div ui-view="debtors"></div>
-  </div>
+  <div class="container-fluid">
+    <div class="row">
+        <div ui-view="debtors"></div>
+    </div>
 
-  <div class="row">
-    <div ui-view="invoices"></div>
-  </div>
-  <div class="row">
-    <div ui-view="patients"></div>
+    <div class="row">
+      <div ui-view="invoices"></div>
+    </div>
+    <div class="row">
+      <div ui-view="patients"></div>
+    </div>
   </div>
 </div>
-
-

--- a/client/src/partials/home/details.html
+++ b/client/src/partials/home/details.html
@@ -1,7 +1,7 @@
 <div class="flex-header">
   <div class="bhima-title">
     <ol class="headercrumb">
-      <li class="static" style="text-transform : uppercase">{{ "HOME.BHIMA" | translate }}</li>
+      <li class="static text-uppercase" translate>HOME.BHIMA</li>
       <li class="static"><a ui-sref="index">{{ LandingCtrl.enterprise.name }}</a></li>
       <li class="title" translate>HOME.DETAILS</li>
     </ol>
@@ -10,10 +10,10 @@
 
 <div class="flex-content">
   <div class="container-fluid">
-    <div class="row">
-        <div ui-view="debtors"></div>
-    </div>
-
+    <!-- @TODO investigate chart js issues for rendering debtors graph -->
+    <!-- <div class="row"> -->
+        <!-- <div ui-view="debtors"></div> -->
+    <!-- </div> -->
     <div class="row">
       <div ui-view="invoices"></div>
     </div>

--- a/client/src/partials/home/home.html
+++ b/client/src/partials/home/home.html
@@ -1,7 +1,7 @@
 <div class="flex-header">
   <div class="bhima-title">
     <ol class="headercrumb">
-      <li class="static" style="text-transform : uppercase">{{ "HOME.BHIMA" | translate }}</li>
+      <li class="static text-uppercase" translate>HOME.BHIMA</li>
       <li class="title">{{ HomeCtrl.enterprise.name }}</li>
     </ol>
   </div>
@@ -20,7 +20,7 @@
                 {{ HomeCtrl.enterprise.name }}
               </div>
               <div class="uilabel">
-                <i class="fa fa-user"></i> {{ 'HOME.CONNECTED_USER' | translate }}: {{ HomeCtrl.user.display_name }}
+                <i class="fa fa-user"></i> <span translate>HOME.CONNECTED_USER</span>: {{ HomeCtrl.user.display_name }}
               </div>
             </div>
           </div>
@@ -34,7 +34,7 @@
 
         <div class="panel panel-default segment">
           <div class="panel-body text-center">
-            <div class="segment-title">{{ "FORM.LABELS.PROJECT" | translate }}</div>
+            <div class="segment-title" translate>FORM.LABELS.PROJECT</div>
             <div class="ui huge ima-blue statistic">
               <div class="value">
                 {{HomeCtrl.project.abbr}}
@@ -50,7 +50,7 @@
 
         <div class="panel panel-default segment">
           <div class="panel-body text-center">
-            <div class="segment-title">{{ "EXCHANGE.ENTERPRISE_CURRENCY" | translate }}</div>
+            <div class="segment-title" translate>EXCHANGE.ENTERPRISE_CURRENCY</div>
             <div class="ui huge ima-blue statistic">
               <div class="value">{{ HomeCtrl.enterprise.currencySymbol }}</div>
               <div class="uilabel">{{ HomeCtrl.enterprise.currencyLabel }}</div>
@@ -63,10 +63,10 @@
 
         <div class="panel panel-default segment">
           <div class="panel-body text-center">
-            <div class="segment-title">{{ "TABLE.COLUMNS.EXCHANGE_RATE" | translate }}</div>
+            <div class="segment-title" translate>TABLE.COLUMNS.EXCHANGE_RATE</div>
             <div class="ui huge ima-blue statistic" title="{{ HomeCtrl.primaryExchange.rate}} ({{ HomeCtrl.primaryExchange.symbol }})">
               <div class="value">{{ HomeCtrl.primaryExchange.rate | limitTo:HomeCtrl.EXCHANGE_RATE_DISPLAY_SIZE }}({{ HomeCtrl.primaryExchange.symbol }})</div>
-              <div class="uilabel">{{ "HOME.EXCHANGE_SET" | translate }} {{ HomeCtrl.primaryExchange.formattedDate }}</div>
+              <div class="uilabel"><span translate>HOME.EXCHANGE_SET</span> {{ HomeCtrl.primaryExchange.formattedDate }}</div>
             </div>
           </div>
         </div>
@@ -77,7 +77,7 @@
       <div class="col-md-12">
         <div class="panel panel-default segment">
           <div class="panel-body">
-            <div class="segment-title">{{ "FISCAL.FISCAL_YEAR" | translate }}</div>
+            <div class="segment-title" translate>FISCAL.FISCAL_YEAR</div>
 
             <div style="margin-top : 12px">
             <div class="progress" style="margin-bottom:0px;">

--- a/client/src/partials/home/home.html
+++ b/client/src/partials/home/home.html
@@ -20,7 +20,7 @@
                 {{ HomeCtrl.enterprise.name }}
               </div>
               <div class="uilabel">
-                <i class="fa fa-user"></i> {{ 'HOME.CONNECTED_USER' | translate }}: {{ HomeCtrl.user.display_name }} 
+                <i class="fa fa-user"></i> {{ 'HOME.CONNECTED_USER' | translate }}: {{ HomeCtrl.user.display_name }}
               </div>
             </div>
           </div>
@@ -106,9 +106,9 @@
     <div class="row">
       <div class="col-md-12">
         <span translate>HOME.MORE_DETAILS</span>
-        <a ui-sref="details.more">
+        <a ui-sref="landing.stats">
           <span translate>HOME.CLICK_HERE</span>
-        </a>        
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This commit resolves the issue where the home details page would throw a
403 forbidden if it was ever independently routed to (page refreshed).It
adds the /landing/stats route to the exceptions for required tree
permissions.

It also refactors the layout to make this module seem part of the home
page as well as minor style adjustments to resolve broken UI.

**Details page as a child to the landing page**
![screenshot 2017-03-27 at 14 56 29](https://cloud.githubusercontent.com/assets/2844572/24369141/ef3500ba-131a-11e7-954a-064dc0297a92.png)


Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/1397