### PR TITLE
fix(db): add voucher indexes

### DIFF
--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1132,7 +1132,7 @@ CREATE TABLE `patient` (
   /* @TODO analyse performance implications of indexing frequently searched columns */
   INDEX `registration_date` (`registration_date`),
   INDEX `dob` (`dob`),
-  INDEX `sex` (`sex`), 
+  INDEX `sex` (`sex`),
 
   /* @TODO fulltext index may degrade INSERT performance over time */
   FULLTEXT `display_name` (`display_name`),
@@ -1823,6 +1823,7 @@ CREATE TABLE IF NOT EXISTS `voucher` (
   KEY `project_id` (`project_id`),
   KEY `currency_id` (`currency_id`),
   KEY `user_id` (`user_id`),
+  INDEX (`reference_uuid`),
   FOREIGN KEY (`project_id`) REFERENCES `project` (`id`),
   FOREIGN KEY (`currency_id`) REFERENCES `currency` (`id`),
   FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
@@ -1837,11 +1838,13 @@ CREATE TABLE IF NOT EXISTS `voucher_item` (
   `debit`           DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.0000,
   `credit`          DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.0000,
   `voucher_uuid`    BINARY(16) NOT NULL,
-  `document_uuid`   BINARY(16) DEFAULT NULL,
-  `entity_uuid`     BINARY(16) DEFAULT NULL,
+  `document_uuid`   binary(16) default null,
+  `entity_uuid`     binary(16) default null,
   PRIMARY KEY (`uuid`),
   KEY `account_id` (`account_id`),
   KEY `voucher_uuid` (`voucher_uuid`),
+  INDEX (`document_uuid`),
+  INDEX (`entity_uuid`),
   FOREIGN KEY (`account_id`) REFERENCES `account` (`id`),
   FOREIGN KEY (`voucher_uuid`) REFERENCES `voucher` (`uuid`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
This commit adds indexes to the voucher tables.  Affected columns:
 1. `voucher.reference_uuid`
 2. `voucher_item.document_uuid`
 3. `voucher_item.entity_uuid`

Closes #1455.


---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
