### PR TITLE
perf(enterprises): only $digest() on update

### DIFF
--- a/client/src/partials/enterprises/enterprises.html
+++ b/client/src/partials/enterprises/enterprises.html
@@ -1,8 +1,8 @@
 <div class="flex-header">
   <div class="bhima-title">
     <ol class="headercrumb">
-      <li class="static">{{ "TREE.ADMIN" | translate }}</li>
-      <li class="title">{{ "ENTERPRISE.TITLE" | translate }}</li>
+      <li class="static" translate>TREE.ADMIN</li>
+      <li class="title" translate>ENTERPRISE.TITLE</li>
     </ol>
 
     <div class="toolbar">
@@ -20,23 +20,25 @@
         <form
           name="EnterpriseForm"
           bh-submit="EnterpriseCtrl.submit(EnterpriseForm)"
-          bh-form-defaults
+          ng-model-options="{ updateOn: 'blur' }"
           novalidate>
 
           <!-- enterprise main info  -->
           <div class="panel panel-primary">
-
             <div class="panel-heading">
-              <b><i class="fa fa-building"></i> {{ 'TREE.ENTERPRISE' | translate }} :
-                <span class="text-uppercase" ng-if="EnterpriseCtrl.enterprise.name">{{ EnterpriseCtrl.enterprise.name }}</span>
+              <b>
+                <i class="fa fa-building"></i> <span translate>TREE.ENTERPRISE</span> :
+                <span class="text-uppercase" ng-if="EnterpriseCtrl.enterprise.name">
+                  {{ EnterpriseCtrl.enterprise.name }}
+                </span>
               </b>
             </div>
 
             <div class="panel-body">
 
               <div class="form-group" ng-class="{ 'has-error' : EnterpriseForm.$submitted && EnterpriseForm.name.$invalid }">
-                <label class="control-label">
-                  {{ 'FORM.LABELS.NAME' | translate }}
+                <label class="control-label" translate>
+                  FORM.LABELS.NAME
                 </label>
                 <input type="text" class="form-control" name="name" ng-model="EnterpriseCtrl.enterprise.name" autocomplete="off" ng-maxlength="EnterpriseCtrl.maxLength" required>
                 <div class="help-block" ng-messages="EnterpriseForm.name.$error" ng-show="EnterpriseForm.$submitted">
@@ -45,8 +47,8 @@
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : EnterpriseForm.$submitted && EnterpriseForm.abbr.$invalid }">
-                <label class="control-label">
-                  {{ "FORM.LABELS.ABBREVIATION" | translate }}
+                <label class="control-label" translate>
+                  FORM.LABELS.ABBREVIATION
                 </label>
                 <input type="text" class="form-control" name="abbr" ng-model="EnterpriseCtrl.enterprise.abbr" autocomplete="off" ng-maxlength="EnterpriseCtrl.length50" required >
                 <div class="help-block" ng-messages="EnterpriseForm.abbr.$error" ng-show="EnterpriseForm.$submitted">
@@ -70,7 +72,6 @@
                 name="loss_account_id"
                 on-select-callback="EnterpriseCtrl.onSelectLossAccount(account)">
               </bh-account-select>
-
             </div>
 
             <div class="panel-footer text-right">
@@ -84,14 +85,14 @@
           <div class="panel panel-default">
 
             <div class="panel-heading">
-              <i class="fa fa-info-circle"></i> {{ 'TREE.ENTERPRISE' | translate }} ({{ 'FORM.LABELS.OPTIONAL_INFO' | translate }})
+              <i class="fa fa-info-circle"></i> <span translate>TREE.ENTERPRISE</span> (<span translate>FORM.LABELS.OPTIONAL_INFO</span>)
             </div>
 
             <div class="panel-body">
 
               <div class="form-group" ng-class="{ 'has-error' : EnterpriseForm.$submitted && EnterpriseForm.po_box.$invalid }">
-                <label class="control-label">
-                  {{ "FORM.LABELS.PO_BOX" | translate }}
+                <label class="control-label" translate>
+                  FORM.LABELS.PO_BOX
                 </label>
                 <input type="text" class="form-control" autocomplete="off" name="po_box" ng-maxlength="EnterpriseCtrl.length30" ng-model="EnterpriseCtrl.enterprise.po_box">
                 <div class="help-block" ng-messages="EnterpriseForm.po_box.$error" ng-show="EnterpriseForm.$submitted">
@@ -100,8 +101,8 @@
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : EnterpriseForm.$submitted && EnterpriseForm.email.$invalid }">
-                <label class="control-label">
-                  {{ "FORM.LABELS.EMAIL" | translate }}
+                <label class="control-label" translate>
+                  FORM.LABELS.EMAIL
                 </label>
                 <input type="email" class="form-control" autocomplete="off" name="email" ng-maxlength="EnterpriseCtrl.length100" ng-model="EnterpriseCtrl.enterprise.email">
                 <div class="help-block" ng-messages="EnterpriseForm.email.$error" ng-show="EnterpriseForm.$submitted">
@@ -110,8 +111,8 @@
               </div>
 
               <div class="form-group" ng-class="{ 'has-error' : EnterpriseForm.$submitted && EnterpriseForm.phone.$invalid }">
-                <label class="control-label">
-                  {{ "FORM.LABELS.PHONE" | translate }}
+                <label class="control-label" translate>
+                  FORM.LABELS.PHONE
                 </label>
                 <input type="tel" class="form-control" autocomplete="off" name="phone" ng-maxlength="EnterpriseCtrl.length20" ng-model="EnterpriseCtrl.enterprise.phone">
                 <div class="help-block" ng-messages="EnterpriseForm.phone.$error" ng-show="EnterpriseForm.$submitted">
@@ -126,12 +127,10 @@
 
 
               <button class="btn btn-block btn-default" type="button" ng-click="EnterpriseCtrl.submit(EnterpriseForm)">
-                <i class="fa fa-save"></i> {{ "FORM.BUTTONS.UPDATE" | translate }}
+                <i class="fa fa-save"></i> <span translate>FORM.BUTTONS.UPDATE</span>
               </button>
             </div>
-
           </div>
-
         </form>
       </div>
 
@@ -139,15 +138,19 @@
       <div class="col-md-6">
         <div class="panel panel-primary">
           <div class="panel-heading">
-            <b><i class="fa fa-cube"></i> {{ 'TREE.PROJECT' | translate }}</b>
+            <b><i class="fa fa-cube"></i> <span translate>TREE.PROJECT</span></b>
           </div>
 
           <ul class="list-group">
             <li class="list-group-item" ng-repeat="p in EnterpriseCtrl.projects track by p.id">
               <i class="fa fa-hospital-o"></i>
               <span>{{ p.name }} ({{ p.abbr }})</span>
-              <a data-delete="{{ p.abbr }}" class="badge badge-danger" ng-click="EnterpriseCtrl.deleteProject(p.id, p.name)"><i class="fa fa-trash"></i> {{ 'FORM.BUTTONS.DELETE' | translate }}</a>
-              <a data-update="{{ p.abbr }}" class="badge badge-info" ng-click="EnterpriseCtrl.editProject(p.id)"><i class="fa fa-edit"></i> {{ 'FORM.BUTTONS.EDIT' | translate }}</a>
+              <a data-delete="{{ p.abbr }}" class="badge badge-danger" ng-click="EnterpriseCtrl.deleteProject(p.id, p.name)">
+                <i class="fa fa-trash"></i> <span translate>FORM.BUTTONS.DELETE</span>
+              </a>
+              <a data-update="{{ p.abbr }}" class="badge badge-info" ng-click="EnterpriseCtrl.editProject(p.id)">
+                <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
+              </a>
             </li>
           </ul>
 
@@ -155,7 +158,7 @@
             <button type="submit" class="btn btn-default"
               data-method="create"
               ng-click="EnterpriseCtrl.addProject()">
-              <i class="fa fa-plus"></i> {{ 'FORM.LABELS.ADD' | translate }}
+              <i class="fa fa-plus"></i> <span translate>FORM.LABELS.ADD</span>
             </button>
           </div>
         </div>

--- a/client/src/partials/enterprises/enterprises.js
+++ b/client/src/partials/enterprises/enterprises.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('EnterpriseController', EnterpriseController);
 
 EnterpriseController.$inject = [
-  'EnterpriseService', 'CurrencyService', 'util', 'NotifyService', 'ProjectService', 'ModalService',
+  'EnterpriseService', 'CurrencyService', 'util', 'NotifyService', 'ProjectService', 'ModalService'
 ];
 
 /**
@@ -61,7 +61,6 @@ function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, M
 
   // form submission
   function submit(form) {
-
     if (form.$invalid) {
       Notify.danger('FORM.ERRORS.HAS_ERRORS');
       return;
@@ -84,16 +83,16 @@ function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, M
 
   function cleanEnterpriseForm(enterprise) {
     return {
-      id : enterprise.id,
-      name : enterprise.name,
-      abbr : enterprise.abbr,
-      phone : enterprise.phone,
-      email : enterprise.email,
-      location_id : enterprise.location_id,
-      currency_id : enterprise.currency_id,
-      po_box : enterprise.po_box,
+      id              : enterprise.id,
+      name            : enterprise.name,
+      abbr            : enterprise.abbr,
+      phone           : enterprise.phone,
+      email           : enterprise.email,
+      location_id     : enterprise.location_id,
+      currency_id     : enterprise.currency_id,
+      po_box          : enterprise.po_box,
       gain_account_id : enterprise.gain_account_id,
-      loss_account_id : enterprise.loss_account_id
+      loss_account_id : enterprise.loss_account_id,
     };
   }
 
@@ -105,7 +104,7 @@ function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, M
 
   // refresh the displayed projects
   function refreshProjects() {
-    return Projects.read(null, { complete : 1 })
+    return Projects.read(null, { complete: 1 })
       .then(function (projects) {
         vm.projects = projects;
       });
@@ -117,9 +116,9 @@ function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, M
    */
   function editProject(id) {
     var params = {
-      action : 'edit',
+      action     : 'edit',
       identifier : id,
-      enterprise : vm.enterprise
+      enterprise : vm.enterprise,
     };
 
     Modal.openProjectActions(params)
@@ -137,11 +136,10 @@ function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, M
    * @desc launch project modal for adding new
    */
   function addProject() {
-    var params = {
-      action : 'create',
-      enterprise : vm.enterprise
-    };
-    Modal.openProjectActions(params)
+    Modal.openProjectActions({
+      action     : 'create',
+      enterprise : vm.enterprise,
+    })
     .then(function (value) {
       if (!value) { return; }
 
@@ -158,21 +156,21 @@ function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, M
    */
   function deleteProject(id, pattern) {
     var params = {
-      pattern: pattern,
-      patternName: 'FORM.PATTERNS.PROJECT_NAME'
+      pattern     : pattern,
+      patternName : 'FORM.PATTERNS.PROJECT_NAME',
     };
 
     Modal.openConfirmDialog(params)
-    .then(function (bool) {
-      if (!bool) { return; }
+      .then(function (bool) {
+        if (!bool) { return; }
 
-      Projects.delete(id)
-        .then(function () {
-          Notify.success('FORM.INFO.DELETE_SUCCESS');
-          return refreshProjects();
-        })
-        .catch(Notify.handleError);
-    });
+        Projects.delete(id)
+          .then(function () {
+            Notify.success('FORM.INFO.DELETE_SUCCESS');
+            return refreshProjects();
+          })
+          .catch(Notify.handleError);
+      });
   }
 
   startup();

--- a/client/src/partials/templates/bhAccountSelect.tmpl.html
+++ b/client/src/partials/templates/bhAccountSelect.tmpl.html
@@ -1,4 +1,4 @@
-<div ng-form="{{ $ctrl.name }}" bh-account-select>
+<div ng-form="{{ $ctrl.name }}" bh-account-select ng-model-options="{ updateOn: 'default' }">
   <div
     class="form-group"
     ng-class="{ 'has-error' : AccountForm.$$parent.$submitted && AccountForm.account_id.$invalid }">

--- a/client/src/partials/templates/bhLocationSelect.tmpl.html
+++ b/client/src/partials/templates/bhLocationSelect.tmpl.html
@@ -13,7 +13,7 @@
   ng-disabled="$ctrl.disable"
   ng-form="{{$ctrl.name}}"
   novalidate
-  bh-form-defaults
+  ng-model-options="{ updateOn : 'default' }"
   data-bh-location-select>
 
   <!-- allows a user to select a country -->

--- a/test/end-to-end/enterprises/enterprises.spec.js
+++ b/test/end-to-end/enterprises/enterprises.spec.js
@@ -1,52 +1,50 @@
 /* global element, by, inject, browser */
 const chai = require('chai');
-const expect = chai.expect;
-
 const helpers = require('../shared/helpers');
+
+const expect = chai.expect;
 helpers.configure(chai);
 
 const FU = require('../shared/FormUtils');
 const components = require('../shared/components');
 
 describe('Enterprises', function () {
-
   const path = '#!/enterprises';
-  const enterpriseId = 1;
 
   // enterprise
   const enterprise = {
-    name : 'Interchurch Medical Assistance',
-    abbr : 'IMA',
-    email : 'ima@imaworldhealth.com',
-    po_box : 'POBOX USA 1',
-    phone : '01500',
+    name            : 'Interchurch Medical Assistance',
+    abbr            : 'IMA',
+    email           : 'ima@imaworldhealth.com',
+    po_box          : 'POBOX USA 1',
+    phone           : '01500',
     gain_account_id : 'Test Gain Account',
-    loss_account_id : 'Test Loss Account'
+    loss_account_id : 'Test Loss Account',
   };
 
   // default enterprise
-  const default_enterprise = {
-    name : 'Test Enterprise',
-    abbr : 'TE',
-    email : 'enterprise@test.org',
-    po_box : 'POBOX USA 1',
-    phone : '243 81 504 0540',
+  const defaultEnterprise = {
+    name            : 'Test Enterprise',
+    abbr            : 'TE',
+    email           : 'enterprise@test.org',
+    po_box          : 'POBOX USA 1',
+    phone           : '243 81 504 0540',
     gain_account_id : 'Test Gain Account',
-    loss_account_id : 'Test Loss Account'
+    loss_account_id : 'Test Loss Account',
   };
 
   // project
   const abbr = suffix();
   const project = {
-    name : 'Test Project ' + abbr,
-    abbr : abbr
+    name : `Test Project ${abbr}`,
+    abbr,
   };
 
   // project update
-  const abbr_update = suffix();
-  const project_update = {
-    name : 'Test Project Update ' + abbr_update,
-    abbr : abbr_update
+  const abbrUpdate = suffix();
+  const projectUpdate = {
+    name : `Test Project Update ${abbrUpdate}`,
+    abbr : abbrUpdate,
   };
 
   // navigate to the enterprise module before running tests
@@ -57,7 +55,6 @@ describe('Enterprises', function () {
    * so we need only to update enterprise informations
    */
   it('set enterprise data', function () {
-
     FU.input('EnterpriseCtrl.enterprise.name', enterprise.name);
     FU.input('EnterpriseCtrl.enterprise.abbr', enterprise.abbr);
 
@@ -78,7 +75,6 @@ describe('Enterprises', function () {
   });
 
   it('blocks invalid form submission with relevant error classes', function () {
-
     FU.input('EnterpriseCtrl.enterprise.name', '');
     FU.input('EnterpriseCtrl.enterprise.abbr', '');
 
@@ -100,26 +96,25 @@ describe('Enterprises', function () {
   /**
    * Set default enterprise data for others tests
    */
-   it('reset enterprise data to default', function () {
+  it('reset enterprise data to default', function () {
+    FU.input('EnterpriseCtrl.enterprise.name', defaultEnterprise.name);
+    FU.input('EnterpriseCtrl.enterprise.abbr', defaultEnterprise.abbr);
 
-     FU.input('EnterpriseCtrl.enterprise.name', default_enterprise.name);
-     FU.input('EnterpriseCtrl.enterprise.abbr', default_enterprise.abbr);
+    components.accountSelect.set(defaultEnterprise.gain_account_id, 'gain-account-id');
+    components.accountSelect.set(defaultEnterprise.loss_account_id, 'loss-account-id');
 
-     components.accountSelect.set(default_enterprise.gain_account_id, 'gain-account-id');
-     components.accountSelect.set(default_enterprise.loss_account_id, 'loss-account-id');
+    FU.input('EnterpriseCtrl.enterprise.po_box', defaultEnterprise.po_box);
+    FU.input('EnterpriseCtrl.enterprise.email', defaultEnterprise.email);
+    FU.input('EnterpriseCtrl.enterprise.phone', defaultEnterprise.phone);
 
-     FU.input('EnterpriseCtrl.enterprise.po_box', default_enterprise.po_box);
-     FU.input('EnterpriseCtrl.enterprise.email', default_enterprise.email);
-     FU.input('EnterpriseCtrl.enterprise.phone', default_enterprise.phone);
+    // select the locations specified
+    components.locationSelect.set(helpers.data.locations);
 
-     // select the locations specified
-     components.locationSelect.set(helpers.data.locations);
+    // submit the page to the server
+    FU.buttons.submit();
 
-     // submit the page to the server
-     FU.buttons.submit();
-
-     components.notification.hasSuccess();
-   });
+    components.notification.hasSuccess();
+  });
 
   it('add a new project for the enterprise', function () {
     FU.buttons.create();
@@ -135,8 +130,8 @@ describe('Enterprises', function () {
   it('edit an existing project', function () {
     element(by.css(`[data-update="${abbr}"]`)).click();
 
-    FU.input('$ctrl.project.name', project_update.name);
-    FU.input('$ctrl.project.abbr', project_update.abbr);
+    FU.input('$ctrl.project.name', projectUpdate.name);
+    FU.input('$ctrl.project.abbr', projectUpdate.abbr);
 
     FU.modal.submit();
 
@@ -144,9 +139,9 @@ describe('Enterprises', function () {
   });
 
   it('delete an existing project', function () {
-    element(by.css(`[data-delete="${abbr_update}"]`)).click();
+    element(by.css(`[data-delete="${abbrUpdate}"]`)).click();
 
-    FU.input('$ctrl.text', project_update.name);
+    FU.input('$ctrl.text', projectUpdate.name);
 
     FU.modal.submit();
 
@@ -158,15 +153,13 @@ describe('Enterprises', function () {
    * @desc This function returns a random 3 characters string as an abbreviation
    */
   function suffix() {
-    'use strict';
-    let a = String.fromCharCode(random(65, 90));
-    let b = String.fromCharCode(random(65, 90));
-    let c = String.fromCharCode(random(65, 90));
-
-    return a.concat(b, c);
+    const a = String.fromCharCode(random(65, 90));
+    const b = String.fromCharCode(random(65, 90));
+    const c = String.fromCharCode(random(65, 90));
+    return `${a}${b}${c}`;
   }
 
-  function random(min,max) {
-    return Math.floor(Math.random()*(max-min+1)+min);
+  function random(min, max) {
+    return Math.floor((Math.random() * ((max - min) + 1)) + min);
   }
 });

--- a/test/end-to-end/shared/FormUtils.js
+++ b/test/end-to-end/shared/FormUtils.js
@@ -2,22 +2,23 @@
 'use strict';
 
 const chai = require('chai');
-const expect = chai.expect;
 const helpers = require('./helpers');
+
+const expect = chai.expect;
 helpers.configure(chai);
 
 // These buttons depend on custom data tags to indicate actions.  This seems
 // cleaner than using a whole bunch of ids which may potentially collide.
 // However, this decision can be reviewed
 const buttons =  {
-  create: function create() { return $('[data-method="create"]').click(); },
-  search: function search() { return $('[data-method="search"]').click(); },
-  submit: function submit() { return $('[data-method="submit"]').click(); },
-  cancel: function cancel() { return $('[data-method="cancel"]').click(); },
-  clear: function clear() { return $('[data-method="clear"]').click(); },
-  back: function back() { return $('[data-method="back"]').click(); },
-  reset : function reset() { return $('[data-method="reset"]').click(); },
-  delete: function delet() { return $('[data-method="delete"]').click(); }
+  create : function create() { return $('[data-method="create"]').click(); },
+  search : function search() { return $('[data-method="search"]').click(); },
+  submit : function submit() { return $('[data-method="submit"]').click(); },
+  cancel : function cancel() { return $('[data-method="cancel"]').click(); },
+  clear  : function clear() { return $('[data-method="clear"]').click(); },
+  back   : function back() { return $('[data-method="back"]').click(); },
+  reset  : function reset() { return $('[data-method="reset"]').click(); },
+  delete : function delet() { return $('[data-method="delete"]').click(); }
 };
 
 // This methods are for easily working with modals.  Works with the same custom
@@ -132,8 +133,8 @@ module.exports = {
     this.input(model, label, anchor);
 
     // select the item of the dropdown menu matching the label
-    let option = anchor.element(by.cssContainingText('.dropdown-menu > [role="option"]', label));
-    return option.click();
+    const option = anchor.element(by.cssContainingText('.dropdown-menu > [role="option"]', label));
+    option.click();
   },
 
   /**
@@ -151,7 +152,7 @@ module.exports = {
     anchor = anchor || $('body');
 
     // get the HTML <div> element that will trigger the select input
-    let select = anchor ?
+    const select = anchor ?
       anchor.element(by.model(model)) :
       element(by.model(model));
 
@@ -162,8 +163,8 @@ module.exports = {
     this.input('$select.search', label, select);
 
     // select the item of the dropdown menu matching the label
-    let option = select.element(by.cssContainingText('.dropdown-menu [role="option"]', label));
-    return option.click();
+    const option = select.element(by.cssContainingText('.dropdown-menu [role="option"]', label));
+    option.click();
   },
 
   /**
@@ -189,8 +190,8 @@ module.exports = {
     this.input('$select.search', label, externalAnchor);
 
     // select the item of the dropdown menu matching the label
-    let option = externalAnchor.element(by.cssContainingText('.dropdown-menu [role="option"]', label));
-    return option.click();
+    const option = externalAnchor.element(by.cssContainingText('.dropdown-menu [role="option"]', label));
+    option.click();
   },
 
   /**

--- a/test/end-to-end/shared/components/bhAccountSelect.js
+++ b/test/end-to-end/shared/components/bhAccountSelect.js
@@ -3,10 +3,15 @@
 const FU = require('../FormUtils');
 
 module.exports = {
-  selector: '[bh-account-select]',
-  set : function set(account, id) {
+  selector : '[bh-account-select]',
+  set      : function set(account, id) {
     const locator = (id) ? by.id(id) : by.css(this.selector);
     const target = element(locator);
+
+    // hack to make sure previous 'blur' event fires if we are using
+    // ngModelOptions updateOn 'blur' for every input
+    target.click();
+
     FU.uiSelect('$ctrl.accountId', account, target);
-  }
+  },
 };


### PR DESCRIPTION
This commit implements a first round of performance improvements to the
enterprise module.  It was chosen because it is moderately complex (has
two custom components on it) and little used, ensuring the impact of
bugs are small.

The performance improvement centers around using `ngModelOptions` to
only update inputs on blur.  The child components have been similarly
updated to ignore this - only the non-custom component inputs are
affected.

The initial performance evaluations is:
 - `browser.reload()`: unchanged (40 - 42 `$digest`s per reload)
 - `form.submit()`: unchanged (7-8 `$digest`s per submit)
 - form editing: >50% reduction in `$digest` calls (from 134 to 62
 $digests)

This needs further testing, but it shows that, with relatively small
changes, large performance boosts are possible.

Additionally, all `translate` filters have been changed to use the
`translate` directive.  This doesn't affect the number of `$digest`s, only
the amount of time spent in each `$digest` loop (by removing 
`$watchers`).

Addresses #1284.

-----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
