### PR TITLE
fix(cash): remove faulty SQL exception handlers

### DIFF
--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -839,9 +839,6 @@ BEGIN
   DECLARE enterpriseCurrencyId INT;
   DECLARE currentExchangeRate DECIMAL(19,4);
 
-  DECLARE EXIT HANDLER FOR SQLEXCEPTION ROLLBACK;
-  DECLARE EXIT HANDLER FOR SQLWARNING ROLLBACK;
-
   -- copy cash payment values into working variables
   SELECT cash.date, cash.currency_id, enterprise.id, enterprise.currency_id, cash.debtor_uuid
     INTO cashDate, cashCurrencyId, cashEnterpriseId, enterpriseCurrencyId, cashDebtorUuid


### PR DESCRIPTION
This commit removes problematic SQL exception handlers from the
CalculateCashInvoiceBalances() stored procedure.  All exception handling
should be done with the `db.transaction()` framework ... having these
extra handler in the SQL code led to confusing error messages when
strict mode throws exceptions.

With these exceptions removed, and the Vanga database re-created, the
issues posting USD cash payments disappears.

Closes #1445.

---
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

------

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
