### PR TITLE
refactor(ui): standardize module headers

### DIFF
--- a/client/src/modules/employees/employees.html
+++ b/client/src/modules/employees/employees.html
@@ -2,7 +2,7 @@
   <div class="bhima-title">
     <ol class="headercrumb">
       <li class="static">{{ "TREE.ADMIN" | translate }}</li>
-      <li class="active">{{ "EMPLOYEE.TITLE" | translate }}</li>
+      <li class="title">{{ "EMPLOYEE.TITLE" | translate }}</li>
     </ol>
   </div>
 </div>

--- a/client/src/modules/locations/country/country.html
+++ b/client/src/modules/locations/country/country.html
@@ -2,7 +2,9 @@
   <div class="bhima-title">
     <ol class="headercrumb">
       <li class="static" translate>TREE.ADMIN</li>
-      <li class="static" translate>TREE.LOCATION</li>
+      <li class="static">
+        <a ui-sref="locations" translate href>TREE.LOCATION</a>
+      </li>
       <li class="title" translate>COUNTRY.TITLE</li>
     </ol>
     <div class="toolbar">

--- a/client/src/modules/locations/province/province.html
+++ b/client/src/modules/locations/province/province.html
@@ -2,7 +2,9 @@
   <div class="bhima-title">
     <ol class="headercrumb">
       <li class="static" translate>TREE.ADMIN</li>
-      <li class="static" translate>TREE.LOCATION</li>
+      <li class="static">
+        <a ui-sref="locations" translate href>TREE.LOCATION</a>
+      </li>
       <li class="title" translate>PROVINCE.TITLE</li>
     </ol>
     <div class="toolbar">

--- a/client/src/modules/locations/sector/sector.html
+++ b/client/src/modules/locations/sector/sector.html
@@ -2,7 +2,9 @@
   <div class="bhima-title">
     <ol class="headercrumb">
       <li class="static" translate>TREE.ADMIN</li>
-      <li class="static" translate>TREE.LOCATION</li>
+      <li class="static">
+        <a ui-sref="locations" translate href>TREE.LOCATION</a>
+      </li>
       <li class="title" translate>SECTOR.TITLE</li>
     </ol>
     <div class="toolbar">

--- a/client/src/modules/locations/village/village.html
+++ b/client/src/modules/locations/village/village.html
@@ -2,7 +2,9 @@
   <div class="bhima-title">
     <ol class="headercrumb">
       <li class="static" translate>TREE.ADMIN</li>
-      <li class="static" translate>TREE.LOCATION</li>
+      <li class="static">
+        <a ui-sref="locations" translate href>TREE.LOCATION</a>
+      </li>
       <li class="title" translate>VILLAGE.TITLE</li>
     </ol>
 

--- a/client/src/modules/vouchers/complex-voucher.ctrl.js
+++ b/client/src/modules/vouchers/complex-voucher.ctrl.js
@@ -45,6 +45,8 @@ function ComplexJournalVoucherController(Vouchers, $translate, Currencies, Sessi
 
   // bread crumb paths
   vm.paths = [{
+    label : $translate.instant('TREE.FINANCE'),
+  }, {
     label   : $translate.instant('VOUCHERS.COMPLEX.TITLE'),
     current : true,
   }];


### PR DESCRIPTION
This change standardizes the module headers with links to their parent modules and makes sure the
top level is always displayed in the headercrumb.

Closes #1070.


---
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!