### PR TITLE
feat(ci): add callbacks for robot to build travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,10 @@ git:
 
 before_cache:
   - rm -f npm-debug.log
+
+notifications:
+  webhooks: http://kwilu.bhi.ma:54856/travis
+
+  branches:
+    only:
+      - auto


### PR DESCRIPTION
This commit adds callback hooks for an instance of homu located at
kwilu.bhi.ma to build/run Travis CI hooks on build failure.  The robot
will also be responsible for assigning reviewers and the like.

-----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
