### PR TITLE
fix(db): do not require service UUID

### DIFF
--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -845,9 +845,9 @@ CREATE TABLE `inventory` (
   `stock_min` INT(10) UNSIGNED NOT NULL DEFAULT 0,
   `type_id` TINYINT(3) UNSIGNED NOT NULL DEFAULT 0,
   `consumable` TINYINT(1) NOT NULL DEFAULT 0,
-  `delay` INT(10) UNSIGNED NOT NULL DEFAULT 1 COMMENT 'Delai de livraison', 
-  `avg_consumption` DECIMAL(10,4) UNSIGNED NOT NULL DEFAULT 1 COMMENT 'Consommation moyenne' , 
-  `purchase_interval` DECIMAL(10,4) UNSIGNED NOT NULL DEFAULT 1 COMMENT 'Intervalle de commande' , 
+  `delay` INT(10) UNSIGNED NOT NULL DEFAULT 1 COMMENT 'Delai de livraison',
+  `avg_consumption` DECIMAL(10,4) UNSIGNED NOT NULL DEFAULT 1 COMMENT 'Consommation moyenne' ,
+  `purchase_interval` DECIMAL(10,4) UNSIGNED NOT NULL DEFAULT 1 COMMENT 'Intervalle de commande' ,
   `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`uuid`),
@@ -1607,7 +1607,7 @@ CREATE TABLE `sector` (
 DROP TABLE IF EXISTS `service`;
 CREATE TABLE `service` (
   `id` smallint(5) unsigned not null auto_increment,
-  `uuid` BINARY(16) NOT NULL,
+  `uuid` BINARY(16) NULL,
   `enterprise_id` SMALLINT(5) UNSIGNED NOT NULL,
   `name` VARCHAR(80) NOT NULL,
   `cost_center_id` SMALLINT(6) DEFAULT NULL,
@@ -1830,7 +1830,7 @@ CREATE VIEW combined_ledger AS
 SET foreign_key_checks = 1;
 
 
--- stock tables 
+-- stock tables
 
 DROP TABLE IF EXISTS `flux`;
 CREATE TABLE `flux` (


### PR DESCRIPTION
By making the service `uuid` NOT NULL, we break previous builds and databsae dumps without an easy way to migrate forward.  This fix temporarily relaxes this constraint while we settle the design of
stock management and juggle the needs of cost centers.

--
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
