### PR TITLE
feat(journal): the bhAccountSelect is clear-able

### DIFF
--- a/client/src/js/components/bhAccountSelect.js
+++ b/client/src/js/components/bhAccountSelect.js
@@ -1,15 +1,16 @@
 angular.module('bhima.components')
   .component('bhAccountSelect', {
     templateUrl : 'modules/templates/bhAccountSelect.tmpl.html',
-    controller : AccountSelectController,
-    bindings: {
+    controller  : AccountSelectController,
+    transclude  : true,
+    bindings    : {
       accountId        : '<',
       disable          : '<',
       onSelectCallback : '&?',
       required         : '<?',
       label            : '@?',
       name             : '@?',
-    }
+    },
   });
 
 AccountSelectController.$inject = [

--- a/client/src/modules/journal/modals/search.modal.html
+++ b/client/src/modules/journal/modals/search.modal.html
@@ -62,11 +62,11 @@
       name="account_id"
       on-select-callback="ModalCtrl.onSelectAccount(account)"
       required="0">
+      <bh-clear on-clear="ModalCtrl.clear('account_id')"></bh-clear>
     </bh-account-select>
 
     <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.project_id.$invalid }">
       <label class="control-label" translate>FORM.LABELS.PROJECT</label>
-      <bh-clear on-clear="ModalCtrl.clear('project_id')"></bh-clear>
       <select
         class="form-control"
         name="project_id"

--- a/client/src/modules/templates/bhAccountSelect.tmpl.html
+++ b/client/src/modules/templates/bhAccountSelect.tmpl.html
@@ -7,6 +7,8 @@
       {{ ::$ctrl.label }}
     </label>
 
+    <ng-transclude></ng-transclude>
+
     <ui-select
       name="account_id"
       ng-model="$ctrl.accountId"


### PR DESCRIPTION
The bhAccountSelect did not previously support transclusion, leading to a poor experience for users
who wanted to search on the account field.  They would have to clear the entire field (from outside
the search modal) to be able to erase the account select.  This commit allows the account select to
be cleared with minimal code changes.

**Before**
![bhaccountselectbeforetransclude](https://cloud.githubusercontent.com/assets/896472/25047006/5ae815bc-212c-11e7-9e92-c45e55fcd54c.png)

**After**
![bhaccountselectaftertransclude](https://cloud.githubusercontent.com/assets/896472/25047004/5aae7f96-212c-11e7-997b-33859032c61b.png)

------

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
