### PR TITLE
fix(journal): edit transaction doesn't load accounts

### DIFF
--- a/client/src/modules/journal/journal.js
+++ b/client/src/modules/journal/journal.js
@@ -166,13 +166,13 @@ function JournalController(Journal, Sorting, Grouping,
       headerCellFilter   : 'translate',
       footerCellTemplate : '<i></i>' },
 
-    { field            : 'account_number',
-      displayName      : 'TABLE.COLUMNS.ACCOUNT',
-      editableCellTemplate: '<div><form name="inputForm"><div ui-grid-edit-account ng-class="\'colt\' + col.uid"></div></form></div>',
-      enableCellEdit: true,
-      headerCellFilter : 'translate' },
-
-    { field                            : 'debit_equiv',
+    { field                : 'account_number',
+      displayName          : 'TABLE.COLUMNS.ACCOUNT',
+      editableCellTemplate : '<div><form name="inputForm"><div ui-grid-edit-account></div></form></div>',
+      enableCellEdit       : true,
+      headerCellFilter     : 'translate',
+    }, {
+      field                            : 'debit_equiv',
       displayName                      : 'TABLE.COLUMNS.DEBIT',
       headerCellFilter                 : 'translate',
       treeAggregationType              : uiGridGroupingConstants.aggregation.SUM,
@@ -380,18 +380,6 @@ function JournalController(Journal, Sorting, Grouping,
 
     // disable inline filtering when editing
     filtering.disableInlineFiltering();
-
-    // only load the accounts once - on first edit
-    if (!vm.accounts) {
-      loadAccounts();
-    }
-  }
-
-  function loadAccounts() {
-    Accounts.read()
-      .then(function (accounts) {
-        vm.accounts = accounts;
-      });
   }
 
   vm.saveTransaction = saveTransaction;

--- a/client/src/modules/journal/ui-grid-edit-account.directive.js
+++ b/client/src/modules/journal/ui-grid-edit-account.directive.js
@@ -5,7 +5,7 @@ uiGridEditAccount.$inject = ['uiGridEditConstants', 'AccountService', 'uiGridCon
 
 function uiGridEditAccount(uiGridEditConstants, Accounts, uiGridConstants) {
   return {
-    restrict : 'EA',
+    restrict : 'A',
     template : function () {
       var templ =
         '<div style="display: table; margin-right: auto; margin-left: auto; width:95%">' +


### PR DESCRIPTION
This `editTransaction()` method called for accounts to load even when they did not exist.  This was a
hold over from the old way of editing accounts, which have now been moved to a directive.
Unfortunately, it caused errors to be thrown in the console  and blocked some digests.  This commit
removes the offending code.

Thanks to @mbayopanda for catching this regression.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!