### PR TITLE
fix(ci): ensure notifications get through https

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_cache:
   - rm -f npm-debug.log
 
 notifications:
-  webhooks: http://kwilu.bhi.ma:54856/travis
+  webhooks: https://kwilu.bhi.ma/travis
  
 branches:
   only:


### PR DESCRIPTION
This commit changes Travis's webhooks to ensure that the notifications get through HTTPS and properly routed.  At the moment, @kwilu doesn't seem to respond to Travis CI.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!