### PR TITLE
fix(journal): ensure that data callbacks disable cellNav

### DIFF
--- a/client/src/js/services/grid/TransactionService.js
+++ b/client/src/js/services/grid/TransactionService.js
@@ -80,7 +80,7 @@ function TransactionService($timeout, util, uiGridConstants, bhConstants, Notify
 
   // sets the allowCellFocus parameter on grid's column definitions
   function setColumnCellNav(column) {
-    column.allowCellFocus = this._cellNavEnabled;
+    column.allowCellFocus = !!this._cellNavEnabled;
   }
 
   // called after the cellNavigationEnabled trigger is fired
@@ -139,6 +139,9 @@ function TransactionService($timeout, util, uiGridConstants, bhConstants, Notify
         });
 
         this.disableCellNavigation();
+
+        api.grid.notifyDataChange(uiGridConstants.dataChange.COLUMN);
+        api.grid.notifyDataChange(uiGridConstants.dataChange.OPTIONS);
       }.bind(this), MAGIC_NUMBER);
     }.bind(this));
   }


### PR DESCRIPTION
This commit makes sure that the Posting Journal's dataChange callbacks are run after the columns are
modified.

Closes #1495.  Addresses #1500.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
