### PR TITLE
feat(journal): default limit to today's records

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,7 +17,7 @@ LOG_LEVEL='warn'
 UPLOAD_DIR='client/upload'
 
 # this will toggle all MYSQL errors to be reflected to the client.
-LOG_ALL_MYSQL_ERRORS=false
+LOG_ALL_MYSQL_ERRORS=0
 
 # control Redis Pub/Sub
 ENABLE_EVENTS=false

--- a/client/src/modules/inventory/list/list.js
+++ b/client/src/modules/inventory/list/list.js
@@ -83,14 +83,14 @@ function InventoryListController ($translate, Inventory, Notify, uiGridConstants
     vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
   }
 
-  function runResearch(params){ 
+  function runResearch(params){
 
     vm.filtersFmt = Inventory.formatFilterParameters(params);
     Inventory.search(params)
       .then(function (rows) {
         vm.gridOptions.data = rows;
       })
-      .catch(Notify.handleError);     
+      .catch(Notify.handleError);
   }
 
   // research and filter data in Inventory List
@@ -110,7 +110,7 @@ function InventoryListController ($translate, Inventory, Notify, uiGridConstants
     runResearch(vm.filters);
   }
 
-  // clears the filters 
+  // clears the filters
   function clearFilters() {
     startup();
     $state.params.filters = null;
@@ -121,7 +121,7 @@ function InventoryListController ($translate, Inventory, Notify, uiGridConstants
   function startup() {
     vm.filters = {};
 
-    // if filters are directly passed in 
+    // if filters are directly passed in
     if ($state.params.filters) {
       runResearch($state.params.filters);
 
@@ -130,7 +130,7 @@ function InventoryListController ($translate, Inventory, Notify, uiGridConstants
         .then(function (inventory) {
           vm.gridOptions.data = inventory;
         })
-        .catch(Notify.handleError);      
+        .catch(Notify.handleError);
     }
 
 

--- a/client/src/modules/invoices/patientInvoice.service.js
+++ b/client/src/modules/invoices/patientInvoice.service.js
@@ -2,7 +2,7 @@ angular.module('bhima.services')
   .service('PatientInvoiceService', PatientInvoiceService);
 
 PatientInvoiceService.$inject = [
-  '$uibModal', 'util', 'SessionService', 'PrototypeApiService', 'FilterService'
+  '$uibModal', 'util', 'SessionService', 'PrototypeApiService', 'FilterService',
 ];
 
 /**

--- a/client/src/modules/invoices/registry/registry.js
+++ b/client/src/modules/invoices/registry/registry.js
@@ -118,7 +118,6 @@ function InvoiceRegistryController(Invoices, bhConstants, Notify, Session, Recei
 
   // search and filter data in Invoice Registry
   function search() {
-
     Invoices.openSearchModal(vm.filters)
       .then(function (parameters) {
         // no parameters means the modal was dismissed.

--- a/client/src/modules/journal/journal.html
+++ b/client/src/modules/journal/journal.html
@@ -76,6 +76,7 @@
   <a
     href
     ng-click="JournalCtrl.clearFilters()"
+    ng-if="JournalCtrl.filter.customFiltersApplied(JournalCtrl.filters)"
     class="text-danger"
     data-method="clear">
     <i class="fa fa-close text-danger"></i>

--- a/client/src/modules/journal/journal.service.js
+++ b/client/src/modules/journal/journal.service.js
@@ -2,15 +2,17 @@ angular.module('bhima.services')
   .service('JournalService', JournalService);
 
 // Dependencies injection
-JournalService.$inject = ['PrototypeApiService'];
+JournalService.$inject = ['PrototypeApiService', 'FilterService'];
 
 /**
  * Journal Service
  * This service is responsible of all process with the posting journal
  */
-function JournalService(Api) {
+function JournalService(Api, Filters) {
   var URL = '/journal/';
   var service = new Api(URL);
+
+  var filter = new Filters();
 
   service.formatFilterParameters = formatFilterParameters;
   service.grid = grid;
@@ -34,7 +36,7 @@ function JournalService(Api) {
       added   : sanitiseNewRows(added),
       removed : entity.removedRows,
     };
-    
+
     return service.$http.post('/journal/'.concat(entity.uuid, '/edit'), saveRequest)
       .then(service.util.unwrapHttpRequest);
   }
@@ -72,6 +74,7 @@ function JournalService(Api) {
       { field: 'amount', displayName: 'FORM.LABELS.AMOUNT' },
       { field: 'project_id', displayName: 'FORM.LABELS.PROJECT' },
       { field: 'origin_id', displayName: 'FORM.LABELS.TRANSACTION_TYPE' },
+      { field: 'defaultPeriod', displayName: 'TABLE.COLUMNS.PERIOD', ngFilter: 'translate' },
     ];
 
     // returns columns from filters
@@ -86,6 +89,11 @@ function JournalService(Api) {
           column.value = String(value).substring(0, column.truncate) + '... ';
         } else {
           column.value = value;
+        }
+
+        // @FIXME temporary hack for default period
+        if (column.field === 'defaultPeriod') {
+          column.value = filter.lookupPeriod(value).label;
         }
 
         return true;

--- a/client/src/modules/journal/modals/search.modal.js
+++ b/client/src/modules/journal/modals/search.modal.js
@@ -10,6 +10,9 @@ function JournalSearchModalController(Instance, Users, Projects, Notify, options
 
   vm.options = options || {};
 
+  // @FIXME patch hack - this should be handled by FilterService
+  delete vm.options.defaultPeriod;
+
   Users.read()
     .then(function (users) {
       vm.users = users;

--- a/server/config/interceptors.js
+++ b/server/config/interceptors.js
@@ -15,7 +15,7 @@
 const winston = require('winston');
 const BadRequest = require('../lib/errors/BadRequest');
 
-const LOG_ALL_MYSQL_ERRORS = process.env.LOG_ALL_MYSQL_ERRORS;
+const LOG_ALL_MYSQL_ERRORS = Number(process.env.LOG_ALL_MYSQL_ERRORS);
 
 // map MySQL error codes to HTTP status codes
 const map = {

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -111,6 +111,8 @@ function find(options, source) {
       LEFT JOIN document_map dm2 ON dm2.uuid = p.reference_uuid
   `;
 
+  filters.period('defaultPeriod', 'trans_date');
+
   filters.dateFrom('dateFrom', 'trans_date');
   filters.dateTo('dateTo', 'trans_date');
 

--- a/test/end-to-end/edit_journal/edit_journal.spec.js
+++ b/test/end-to-end/edit_journal/edit_journal.spec.js
@@ -6,32 +6,25 @@ const GU = require('../shared/GridUtils');
 const components = require('../shared/components');
 
 helpers.configure(chai);
-const expect = chai.expect;
 
 describe('Edit Posting Journal', () => {
   const path = '#!/journal';
   const gridId = 'journal-grid';
-  
+
   // simulates a double click
-  const doubleClick = (element) => browser.actions().mouseMove(element).doubleClick().perform();
+  const doubleClick = element => browser.actions().mouseMove(element).doubleClick().perform();
 
   before(() => helpers.navigate(path));
 
-  var accountKey = 11;
-
-  it('edits a transaction change an account', function () {
+  it('edits a transaction change an account', () => {
     // click the "grouping" button
     FU.buttons.grouping();
     element.all(by.css('[class="ui-grid-icon-plus-squared"]')).get(0).click();
     element.all(by.css('[class="fa fa-edit"]')).get(0).click();
-    const accountNumberCell = GU.getCellName(gridId, 1, 4);    
+    const accountNumberCell = GU.getCellName(gridId, 1, 4);
     doubleClick(accountNumberCell);
-    
-    accountNumberCell.element(by.css("input")).clear();
 
-    accountNumberCell.element(by.css("input")).sendKeys(accountKey);
-    element.all(by.css('[title="1100 - Test Capital One"]')).click();
-
+    FU.typeahead('accountInputValue', '1100', accountNumberCell);
     element.all(by.css('[data-method="save"]')).click();
 
     components.notification.hasSuccess();
@@ -40,19 +33,19 @@ describe('Edit Posting Journal', () => {
   });
 
 
-  it('edits a transaction change value of Debit and Credit', function () {
+  it('edits a transaction change value of Debit and Credit', () => {
     FU.buttons.grouping();
     element.all(by.css('[class="ui-grid-icon-plus-squared"]')).get(1).click();
     element.all(by.css('[class="fa fa-edit"]')).get(1).click();
-    
+
     const debitCell = GU.getCellName(gridId, 2, 5);
     const creditCell = GU.getCellName(gridId, 3, 6);
-    
+
     doubleClick(debitCell);
-    debitCell.element(by.css("input")).sendKeys(50);
+    debitCell.element(by.css('input')).sendKeys(50);
 
     doubleClick(creditCell);
-    creditCell.element(by.css("input")).sendKeys(50);
+    creditCell.element(by.css('input')).sendKeys(50);
 
     element.all(by.css('[data-method="save"]')).click();
 
@@ -61,8 +54,8 @@ describe('Edit Posting Journal', () => {
     FU.buttons.grouping();
   });
 
-  // Test for validation 
-  it('Preventing a single-line transaction', function () {
+  // Test for validation
+  it('Preventing a single-line transaction', () => {
     FU.buttons.grouping();
     element.all(by.css('[class="ui-grid-icon-plus-squared"]')).get(1).click();
     element.all(by.css('[class="fa fa-edit"]')).get(1).click();
@@ -78,19 +71,19 @@ describe('Edit Posting Journal', () => {
     FU.buttons.grouping();
   });
 
-  it('Preventing unbalanced transaction', function () {
+  it('Preventing unbalanced transaction', () => {
     FU.buttons.grouping();
     element.all(by.css('[class="ui-grid-icon-plus-squared"]')).get(1).click();
     element.all(by.css('[class="fa fa-edit"]')).get(1).click();
-    
+
     const debitCell = GU.getCellName(gridId, 2, 5);
     const creditCell = GU.getCellName(gridId, 3, 6);
-   
+
     doubleClick(debitCell);
-    debitCell.element(by.css("input")).sendKeys(100);
+    debitCell.element(by.css('input')).sendKeys(100);
 
     browser.actions().mouseMove(creditCell).doubleClick().perform();
-    creditCell.element(by.css("input")).sendKeys(50);
+    creditCell.element(by.css('input')).sendKeys(50);
 
     element.all(by.css('[data-method="save"]')).click();
 
@@ -100,19 +93,19 @@ describe('Edit Posting Journal', () => {
     FU.buttons.grouping();
   });
 
-  it('Preventing transaction who have debit and Credit null', function () {
+  it('Preventing transaction who have debit and Credit null', () => {
     FU.buttons.grouping();
     element.all(by.css('[class="ui-grid-icon-plus-squared"]')).get(1).click();
     element.all(by.css('[class="fa fa-edit"]')).get(1).click();
-    
+
     const debitCell = GU.getCellName(gridId, 2, 5);
     const creditCell = GU.getCellName(gridId, 2, 6);
 
     doubleClick(debitCell);
-    debitCell.element(by.css("input")).sendKeys(0);
+    debitCell.element(by.css('input')).sendKeys(0);
 
     doubleClick(creditCell);
-    creditCell.element(by.css("input")).sendKeys(0);
+    creditCell.element(by.css('input')).sendKeys(0);
 
     element.all(by.css('[data-method="save"]')).click();
 
@@ -122,19 +115,19 @@ describe('Edit Posting Journal', () => {
     FU.buttons.grouping();
   });
 
-  it('Preventing transaction who was debited and Credited in a same line', function () {
+  it('Preventing transaction who was debited and Credited in a same line', () => {
     FU.buttons.grouping();
     element.all(by.css('[class="ui-grid-icon-plus-squared"]')).get(1).click();
     element.all(by.css('[class="fa fa-edit"]')).get(1).click();
-    
+
     const debitCell = GU.getCellName(gridId, 2, 5);
     const creditCell = GU.getCellName(gridId, 2, 6);
 
     doubleClick(debitCell);
-    debitCell.element(by.css("input")).sendKeys(50);
+    debitCell.element(by.css('input')).sendKeys(50);
 
     doubleClick(creditCell);
-    creditCell.element(by.css("input")).sendKeys(50);
+    creditCell.element(by.css('input')).sendKeys(50);
 
     element.all(by.css('[data-method="save"]')).click();
 
@@ -143,5 +136,4 @@ describe('Edit Posting Journal', () => {
     element.all(by.css('[class="ui-grid-icon-minus-squared"]')).get(0).click();
     FU.buttons.grouping();
   });
-
 });


### PR DESCRIPTION
This commit extends the hacks done for other registries to the Posting Journal, so that it defaults
to today's records as a search.  This should speed up the initial startup of the module considerably
while we develop a better representation of our filters on the client.

Addresses #1436 in a hacky way.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
