### PR TITLE
refactor(billing-services): use account select

### DIFF
--- a/client/src/modules/accounts/edit/accounts.edit.modal.html
+++ b/client/src/modules/accounts/edit/accounts.edit.modal.html
@@ -54,7 +54,6 @@
       <!-- <p class="form-control-static" ng-if="AccountEditCtrl.account" id="type-static">{{::AccountEditCtrl.getTypeTitle(AccountEditCtrl.account.type_id) | translate }}</p> -->
     <!-- </div> -->
 
-
     <!-- TODO(@jniles): can this just use ng-options? -->
     <div class="form-group"
          ng-class="{'has-error' : (AccountForm.type_id.$invalid && AccountForm.$submitted) || AccountEditCtrl.invalidTitleAccount}">

--- a/client/src/modules/billing-services/billing-services-create.ctrl.js
+++ b/client/src/modules/billing-services/billing-services-create.ctrl.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
 .controller('BillingServicesCreateController', BillingServicesCreateController);
 
 BillingServicesCreateController.$inject = [
-  'BillingServicesService', 'AccountService', '$uibModalInstance', 'util'
+  'BillingServicesService', '$uibModalInstance', 'util',
 ];
 
 /**
@@ -11,7 +11,7 @@ BillingServicesCreateController.$inject = [
  * This controller allows the user to create a new billing service using a form.
  * Note that this uses the same HTML form as the update controller
  */
-function BillingServicesCreateController(BillingServices, Accounts, ModalInstance, util) {
+function BillingServicesCreateController(BillingServices, ModalInstance, util) {
   var vm = this;
 
   // the form title is defined in the JS to allow us to reuse templates
@@ -26,13 +26,11 @@ function BillingServicesCreateController(BillingServices, Accounts, ModalInstanc
 
   vm.length200 = util.length200;
   vm.maxLength = util.maxTextLength;
+  vm.onSelectAccount = onSelectAccount;
 
-  // fired on application startup
-  function startup() {
-    Accounts.read()
-    .then(function (accounts) {
-      vm.accounts = accounts;
-    });
+  // bhAccountSelect callback
+  function onSelectAccount(account) {
+    vm.model.account_id = account.id;
   }
 
   /**
@@ -55,14 +53,11 @@ function BillingServicesCreateController(BillingServices, Accounts, ModalInstanc
 
     // submit data to the server
     return BillingServices.create(vm.model)
-    .then(function (data) {
-      ModalInstance.close(data.id);
-    })
-    .catch(function (response) {
-      vm.error = response.data;
-    });
+      .then(function (data) {
+        ModalInstance.close(data.id);
+      })
+      .catch(function (response) {
+        vm.error = response.data;
+      });
   }
-
-  // load initial data from the server
-  startup();
 }

--- a/client/src/modules/billing-services/billing-services-modal.html
+++ b/client/src/modules/billing-services/billing-services-modal.html
@@ -3,44 +3,24 @@
 
   <div class="modal-header">
     <ol class="headercrumb">
-      <li class="static">{{ "TREE.BILLING_SERVICES" | translate }}</li>
-      <li class="title">{{ BillingServicesFormCtrl.title | translate }}</li>
+      <li class="static" translate>TREE.BILLING_SERVICES</li>
+      <li class="title" translate>{{ BillingServicesFormCtrl.title }}</li>
     </div>
   </div>
 
   <div class="modal-body">
 
     <!-- account input -->
-    <div
-      class="form-group"
-      ng-class="{ 'has-error' : BillingServicesForm.$submitted && BillingServicesForm.account.$invalid }">
-      <label class="control-label">
-        {{ "FORM.LABELS.ACCOUNT" | translate }}
-      </label>
-
-      <ui-select
-        name="account"
-        ng-model="BillingServicesFormCtrl.model.account"
-        theme="bootstrap"
-        required>
-        <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
-          <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
-        </ui-select-match>
-        <ui-select-choices ui-select-focus-patch repeat="account in BillingServicesFormCtrl.accounts | filter:$select.search">
-          <strong ng-bind-html="account.number | highlight:$select.search"></strong>
-          <span ng-bind-html="account.label | highlight:$select.search"></span>
-        </ui-select-choices>
-      </ui-select>
-
-      <div class="help-block" ng-messages="BillingServicesForm.account.$error" ng-show="BillingServicesForm.$submitted">
-        <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-      </div>
-    </div>
+    <bh-account-select
+      account-id="BillingServicesFormCtrl.model.account_id"
+      on-select-callback="BillingServicesFormCtrl.onSelectAccount(account)"
+      required="true">
+    </bh-account-select>
 
     <!-- label input -->
     <div class="form-group" ng-class="{ 'has-error' : BillingServicesForm.$submitted && BillingServicesForm.label.$invalid }">
-      <label class="control-label">
-        {{ "FORM.LABELS.LABEL" | translate }}
+      <label class="control-label" translate>
+        FORM.LABELS.LABEL
       </label>
       <input
         class="form-control"
@@ -56,8 +36,8 @@
 
     <!-- description textarea -->
     <div class="form-group" ng-class="{ 'has-error' : BillingServicesForm.$submitted && BillingServicesForm.description.$invalid }">
-      <label class="control-label">
-        {{ "FORM.LABELS.DESCRIPTION" | translate }}
+      <label class="control-label" translate>
+        FORM.LABELS.DESCRIPTION
       </label>
       <!--
         @todo - propose to the team that all text-areas should have "resize:vertical" styles
@@ -79,7 +59,7 @@
     <!-- value input -->
     <div class="form-group" ng-class="{ 'has-error' : BillingServicesForm.$submitted && BillingServicesForm.value.$invalid }">
       <label class="control-label">
-        {{ "FORM.LABELS.VALUE" | translate }} (%)
+        <span translate>FORM.LABELS.VALUE</span> (%)
       </label>
       <input
         type="number"
@@ -106,17 +86,17 @@
 
         <!-- there are (client-side) errors on the form -->
         <p ng-show="BillingServicesForm.$submitted && BillingServicesForm.$invalid">
-          <span class="glyphicon glyphicon-alert"></span> {{ "FORM.ERRORS.HAS_ERRORS" | translate }}
+          <span class="glyphicon glyphicon-alert"></span> <span translate>FORM.ERRORS.HAS_ERRORS</span>
         </p>
 
         <!-- show http errors sent from the server -->
         <p ng-show="BillingServicesFormCtrl.error">
           <span class="glyphicon glyphicon-alert"></span>
-          <span ng-show="BillingServicesFormCtrl.error.status === 404">
-            {{ "BILLING_SERVICES.NOT_FOUND" | translate }}
+          <span ng-show="BillingServicesFormCtrl.error.status === 404" translate>
+            BILLING_SERVICES.NOT_FOUND
           </span>
-          <span ng-hide="BillingServicesFormCtrl.error.status === 404">
-            {{ BillingServicesFormCtrl.error.code | translate }}
+          <span ng-hide="BillingServicesFormCtrl.error.status === 404" translate>
+            {{ BillingServicesFormCtrl.error.code }}
           </span>
         </p>
       </div>
@@ -124,12 +104,12 @@
   </div>
 
   <div class="modal-footer">
-    <button type="button" class="btn btn-default" data-method="back" ng-click="BillingServicesFormCtrl.dismiss()">
-      {{ "FORM.BUTTONS.BACK" | translate }}
+    <button type="button" class="btn btn-default" data-method="back" ng-click="BillingServicesFormCtrl.dismiss()" translate>
+      FORM.BUTTONS.BACK
     </button>
 
     <bh-loading-button loading-state="BillingServicesForm.$loading">
-      {{ "FORM.BUTTONS.SUBMIT" | translate }}
+      <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>
   </div>
 </form>

--- a/client/src/modules/billing-services/billing-services-update.ctrl.js
+++ b/client/src/modules/billing-services/billing-services-update.ctrl.js
@@ -2,17 +2,17 @@ angular.module('bhima.controllers')
 .controller('BillingServicesUpdateController', BillingServicesUpdateController);
 
 BillingServicesUpdateController.$inject = [
-  '$state', 'BillingServicesService', 'AccountService', '$uibModalInstance', 'util'
+  '$state', 'BillingServicesService', '$uibModalInstance', 'util',
 ];
 
 /**
  * Updates a billing service passed in via a URL parameter.  For example,
  * billing_services/1 will update the billing service with id 1.
  *
- * Importantly, both this controller and the BillingServicesCreateController
- * use the same template, billing_services/form.html.
+ * Importantly, both this controller and the BillingServicesUpdateController
+ * use the same template, billing-services/form.html.
  */
-function BillingServicesUpdateController($state, BillingServices, Accounts, ModalInstance, util) {
+function BillingServicesUpdateController($state, BillingServices, ModalInstance, util) {
   var vm = this;
 
   // the form title is defined in the JS to allow us to reuse templates
@@ -21,7 +21,7 @@ function BillingServicesUpdateController($state, BillingServices, Accounts, Moda
   // the label will contain a copy of the billing service's label we are updating
   vm.label = '';
 
-  // this is the CreateForm's model
+  // this is the BillingServicesForm's model
   vm.model = {};
 
   // the submit method to POST data to the server
@@ -31,41 +31,29 @@ function BillingServicesUpdateController($state, BillingServices, Accounts, Moda
   vm.length200 = util.length200;
   vm.maxLength = util.maxTextLength;
 
+  vm.onSelectAccount = onSelectAccount;
+
+  // bhAccountSelect callback
+  function onSelectAccount(account) {
+    vm.model.account_id = account.id;
+  }
+
   // fired on application startup
   function startup() {
 
     // load the billing service by id
     BillingServices.read($state.params.id)
-    .then(function (service) {
+      .then(function (service) {
 
-      // set the label to the label of the fetched service
-      vm.label = service.label;
+        // set the label to the label of the fetched service
+        vm.label = service.label;
 
-      // bind the fetched data to the form for editing
-      vm.model = service;
-
-      // load the accounts
-      return Accounts.read();
-    })
-    .then(function (accounts) {
-
-      // bind the accounts to the view
-      vm.accounts = accounts;
-
-      // loop through the accounts and select the correct account to display
-      // in the ui-select
-      vm.model.account = accounts.reduce(function (value, account) {
-
-        // if the value is not false, we have found the account, so return it
-        if (value) { return value; }
-
-        // if the ids match, return the account, otherwise false
-        return (account.id === vm.model.account_id) ? account : value;
-      }, false);
-    })
-    .catch(function (response) {
-      vm.error = response.data;
-    });
+        // bind the fetched data to the form for editing
+        vm.model = service;
+      })
+      .catch(function (response) {
+        vm.error = response.data;
+      });
   }
 
   /**
@@ -84,16 +72,16 @@ function BillingServicesUpdateController($state, BillingServices, Accounts, Moda
     // exit immediately if the form is not valid
     if (form.$invalid) {
       return;
-   }
+    }
 
-    // submit data to the server
+     // submit data to the server
     return BillingServices.update($state.params.id, vm.model)
-    .then(function (data) {
-      ModalInstance.close(data.id);
-    })
-    .catch(function (response) {
-      vm.error = response.data;
-    });
+      .then(function (data) {
+        ModalInstance.close(data.id);
+      })
+      .catch(function (response) {
+        vm.error = response.data;
+      });
   }
 
   // load initial data from the server

--- a/test/end-to-end/billingServices/billingServices.spec.js
+++ b/test/end-to-end/billingServices/billingServices.spec.js
@@ -12,9 +12,7 @@ const FU = require('../shared/FormUtils');
 const components = require('../shared/components');
 
 describe('Billing Services', function () {
-  'use strict';
-
-  const path = '#/billing_services';
+  const path = '#!/billing_services';
   const gridId = 'BillingServicesGrid';
 
   before(() => helpers.navigate(path));
@@ -26,8 +24,8 @@ describe('Billing Services', function () {
 
     // anticipate that the form should come up
     FU.exists(by.css('[name="BillingServicesForm"]'), true);
+    components.accountSelect.set('57003');
 
-    FU.uiSelect('BillingServicesFormCtrl.model.account', '57000');
     FU.input('BillingServicesFormCtrl.model.label', 'Value Added Tax');
     FU.input('BillingServicesFormCtrl.model.description', 'A tax added for people who want value!');
     FU.input('BillingServicesFormCtrl.model.value', 25);
@@ -62,7 +60,7 @@ describe('Billing Services', function () {
     // expect the modal to appear
     FU.exists(by.css('[data-confirm-modal]'), true);
 
-    //Confirm the action by a click on the buttom confirm
+    // Confirm the action by a click on the buttom confirm
     components.modalAction.confirm();
 
     components.notification.hasSuccess();


### PR DESCRIPTION
This commit migrates the Billing Services module to using the account
select component.  By introducing the component, we are able to:
 1. Disabled Title Accounts without any extra effort
 2. Order accounts properly in their nested tree
 3. Remove the AccountService import from both the Create and Update
 controllers of the modal.

In truth, both the create and update state should be combined, but this
is not the commit for it.  This commit paves the way to make the
combination super easy.

Addresses #914 - somehow this module got through the cracks.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
