### PR TITLE
refactor(journal): cancel Trial Balance from all screens

### DIFF
--- a/client/src/modules/journal/modals/trialBalanceDetail.footer.html
+++ b/client/src/modules/journal/modals/trialBalanceDetail.footer.html
@@ -1,14 +1,9 @@
-<button
-  id="cancelID"
-  type="button"
-  class="btn btn-default"
-  ng-click="TrialBalanceFooterDetailCtrl.cancel()">
+<button type="button" class="btn btn-default" data-method="cancel" ui-sref="journal">
   <span translate>FORM.BUTTONS.CANCEL</span>
 </button>
 
 <button
   ng-if="TrialBalanceFooterDetailCtrl.stateParams.feedBack"
-  id="detailID"
   type="button"
   data-method="reset"
   class="btn btn-default"

--- a/client/src/modules/journal/modals/trialBalanceDetail.footer.js
+++ b/client/src/modules/journal/modals/trialBalanceDetail.footer.js
@@ -23,15 +23,5 @@ function TrialBalanceDetailFooterController($state, $stateParams) {
     $state.go('trialBalanceMain', { records: $stateParams.records }, { reload: false });
   }
 
-  /**
-   * @function cancel
-   * @description
-   * closes the modal and stop the posting process
-   **/
-  function cancel() {
-    $state.go('journal');
-  }
-
   vm.reset = reset;
-  vm.cancel = cancel;
 }

--- a/client/src/modules/journal/modals/trialBalanceError.footer.html
+++ b/client/src/modules/journal/modals/trialBalanceError.footer.html
@@ -1,12 +1,16 @@
+<button type="button" class="btn btn-default" data-method="cancel" ui-sref="journal">
+  <span translate>FORM.BUTTONS.CANCEL</span>
+</button>
+
+
 <button
   ng-if="TrialBalanceErrorFooterCtrl.stateParams.feedBack"
-  id="resetID"
   type="button"
   data-method="reset"
   ng-class="{
     'btn btn-danger' : TrialBalanceErrorFooterCtrl.stateParams.feedBack.hasError,
     'btn btn-warning': TrialBalanceErrorFooterCtrl.stateParams.feedBack.hasWarning,
     'btn btn-primary' : TrialBalanceErrorFooterCtrl.stateParams.feedBack.hasSuccess}"
-  ng-click="TrialBalanceErrorFooterCtrl.reset()">
-  {{ "FORM.BUTTONS.RETURN" | translate }}
+    ng-click="TrialBalanceErrorFooterCtrl.reset()">
+    <span translate>FORM.BUTTONS.RETURN</span>
 </button>

--- a/client/src/modules/journal/modals/trialBalanceMain.footer.html
+++ b/client/src/modules/journal/modals/trialBalanceMain.footer.html
@@ -1,15 +1,11 @@
-<button
-  id="cancelID"
-  type="button"
-  class="btn btn-default"
-  ng-click="TrialBalanceMainFooterCtrl.cancel()">
+<button type="button" class="btn btn-default" data-method="cancel" ui-sref="journal">
   <span translate>FORM.BUTTONS.CANCEL</span>
 </button>
 
 <button
   ng-if="TrialBalanceMainFooterCtrl.state.current.data.checked"
   type="button"
-  class="btn"
+  class="btn btn-default"
   ng-class="{
     'btn-danger' : TrialBalanceMainFooterCtrl.state.current.data.checkingData.feedBack.hasError,
     'btn-warning': TrialBalanceMainFooterCtrl.state.current.data.checkingData.feedBack.hasWarning,
@@ -20,5 +16,7 @@
   <span ng-show="TrialBalanceMainFooterCtrl.loading">
     <span class="fa fa-circle-o-notch fa-spin"></span> <span translate>FORM.INFO.LOADING</span>
   </span>
-  <span ng-hide="TrialBalanceMainFooterCtrl.loading" translate>FORM.BUTTONS.SUBMIT</span>
+  <span ng-hide="TrialBalanceMainFooterCtrl.loading" translate>
+    FORM.BUTTONS.SUBMIT
+  </span>
 </button>

--- a/client/src/modules/journal/modals/trialBalanceMain.footer.js
+++ b/client/src/modules/journal/modals/trialBalanceMain.footer.js
@@ -16,15 +16,6 @@ function TrialBalanceMainFooterController($state, trialBalanceService, Notify) {
   vm.state = $state;
 
   /**
-   * @function cancel
-   * @description
-   * closes the modal and stop the posting process
-   **/
-  function cancel() {
-    $state.go('journal');
-  }
-
-  /**
    * @function submit
    * @description for submitting a dialog content
    */
@@ -32,7 +23,7 @@ function TrialBalanceMainFooterController($state, trialBalanceService, Notify) {
     vm.loading = true;
     trialBalanceService.postToGeneralLedger($state.params.records)
       .then(function () {
-        $state.go('journal', null, { reload : true});
+        $state.go('journal', null, { reload: true });
       })
       .catch(Notify.handleError)
       .finally(function () {
@@ -40,6 +31,5 @@ function TrialBalanceMainFooterController($state, trialBalanceService, Notify) {
       });
   }
 
-  vm.cancel = cancel;
   vm.submit = submit;
 }

--- a/test/end-to-end/journal/trial_balance/trialBalanceDetail.page.js
+++ b/test/end-to-end/journal/trial_balance/trialBalanceDetail.page.js
@@ -7,7 +7,6 @@ function TrialBalanceDetailPage() {
   const gridRows = grid.element(by.css('.ui-grid-render-container-body')).all( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index'));
   const resetButton = $('[data-method="reset"]');
 
-
   function reset (){
     return resetButton.click();
   }
@@ -21,4 +20,3 @@ function TrialBalanceDetailPage() {
 }
 
 module.exports = TrialBalanceDetailPage;
-


### PR DESCRIPTION
The Trial Balance would only let you cancel from the "Main" screen - the error screen forced you to
reload the data for the "main" screen before being able to dismiss the modal.  This corrects that
misfeature.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!