### PR TITLE
feat(journal): show aggregate header for date + record

### DIFF
--- a/client/src/modules/journal/journal.js
+++ b/client/src/modules/journal/journal.js
@@ -7,7 +7,7 @@ JournalController.$inject = [
   'SessionService', 'NotifyService', 'TransactionService', 'GridEditorService',
   'bhConstants', '$state', 'uiGridConstants', 'ModalService', 'LanguageService',
   'AppCache', 'Store', 'uiGridGroupingConstants', 'ExportService', 'FindEntityService',
-  'FilterService', '$rootScope',
+  'FilterService', '$rootScope', '$filter'
 ];
 
 /**
@@ -32,8 +32,8 @@ JournalController.$inject = [
  */
 function JournalController(Journal, Sorting, Grouping,
   Filtering, Columns, Config, Session, Notify, Transactions, Editors,
-  bhConstants, $state, uiGridConstants, Modal, Languages,
-  AppCache, Store, uiGridGroupingConstants, Export, FindEntity, Filters, $rootScope) {
+  bhConstants, $state, uiGridConstants, Modal, Languages, AppCache, Store,
+  uiGridGroupingConstants, Export, FindEntity, Filters, $rootScope, $filter) {
   // Journal utilities
   var sorting;
   var grouping;
@@ -151,20 +151,27 @@ function JournalController(Journal, Sorting, Grouping,
       width            : 110,
       cellTemplate     : 'modules/journal/templates/hide-groups-label.cell.html' },
 
-    { field                : 'trans_date',
-      displayName          : 'TABLE.COLUMNS.DATE',
-      headerCellFilter     : 'translate',
-      cellFilter           : 'date:"' + bhConstants.dates.format + '"',
-      filter               : { condition: filtering.filterByDate },
-      editableCellTemplate : 'modules/journal/templates/date.edit.html',
-      enableCellEdit       : true,
-      footerCellTemplate   : '<i></i>' },
+    { field                            : 'trans_date',
+      displayName                      : 'TABLE.COLUMNS.DATE',
+      headerCellFilter                 : 'translate',
+      cellFilter                       : 'date:"' + bhConstants.dates.format + '"',
+      filter                           : { condition: filtering.filterByDate },
+      editableCellTemplate             : 'modules/journal/templates/date.edit.html',
+      treeAggregationType              : uiGridGroupingConstants.aggregation.MIN,
+      customTreeAggregationFinalizerFn : function (aggregation) {
+        aggregation.rendered = $filter('date')(aggregation.value, bhConstants.dates.format);
+      },
+      enableCellEdit     : true,
+      footerCellTemplate : '<i></i>' },
 
-    { field            : 'hrRecord',
-      displayName      : 'TABLE.COLUMNS.RECORD',
-      headerCellFilter : 'translate',
-      visible          : true,
-      enableCellEdit   : false },
+    { field                : 'hrRecord',
+      displayName          : 'TABLE.COLUMNS.RECORD',
+      headerCellFilter     : 'translate',
+      visible              : true,
+      treeAggregationType  : uiGridGroupingConstants.aggregation.MIN,
+      treeAggregationLabel : '',
+      enableCellEdit       : false,
+      footerCellTemplate   : '<i></i>' },
 
     { field              : 'description',
       displayName        : 'TABLE.COLUMNS.DESCRIPTION',


### PR DESCRIPTION
This commit implements the date and record aggregates in the Posting Journal.  I have used MIN for
the aggregation, though MAX would work as well.  Ultimately, no choice would make sense if the
column contains non-uniform information.  These columns are expected to have uniform values.

Partially addresses #1541.

-----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
