### PR TITLE
refactor(journal): account typeahead opens empty on focus

### DIFF
--- a/client/src/modules/journal/modals/trialBalanceDetail.footer.html
+++ b/client/src/modules/journal/modals/trialBalanceDetail.footer.html
@@ -1,14 +1,9 @@
-<button
-  id="cancelID"
-  type="button"
-  class="btn btn-default"
-  ng-click="TrialBalanceFooterDetailCtrl.cancel()">
+<button type="button" class="btn btn-default" data-method="cancel" ui-sref="journal">
   <span translate>FORM.BUTTONS.CANCEL</span>
 </button>
 
 <button
   ng-if="TrialBalanceFooterDetailCtrl.stateParams.feedBack"
-  id="detailID"
   type="button"
   data-method="reset"
   class="btn btn-default"

--- a/client/src/modules/journal/modals/trialBalanceDetail.footer.js
+++ b/client/src/modules/journal/modals/trialBalanceDetail.footer.js
@@ -23,15 +23,5 @@ function TrialBalanceDetailFooterController($state, $stateParams) {
     $state.go('trialBalanceMain', { records: $stateParams.records }, { reload: false });
   }
 
-  /**
-   * @function cancel
-   * @description
-   * closes the modal and stop the posting process
-   **/
-  function cancel() {
-    $state.go('journal');
-  }
-
   vm.reset = reset;
-  vm.cancel = cancel;
 }

--- a/client/src/modules/journal/modals/trialBalanceError.footer.html
+++ b/client/src/modules/journal/modals/trialBalanceError.footer.html
@@ -1,12 +1,16 @@
+<button type="button" class="btn btn-default" data-method="cancel" ui-sref="journal">
+  <span translate>FORM.BUTTONS.CANCEL</span>
+</button>
+
+
 <button
   ng-if="TrialBalanceErrorFooterCtrl.stateParams.feedBack"
-  id="resetID"
   type="button"
   data-method="reset"
   ng-class="{
     'btn btn-danger' : TrialBalanceErrorFooterCtrl.stateParams.feedBack.hasError,
     'btn btn-warning': TrialBalanceErrorFooterCtrl.stateParams.feedBack.hasWarning,
     'btn btn-primary' : TrialBalanceErrorFooterCtrl.stateParams.feedBack.hasSuccess}"
-  ng-click="TrialBalanceErrorFooterCtrl.reset()">
-  {{ "FORM.BUTTONS.RETURN" | translate }}
+    ng-click="TrialBalanceErrorFooterCtrl.reset()">
+    <span translate>FORM.BUTTONS.RETURN</span>
 </button>

--- a/client/src/modules/journal/modals/trialBalanceMain.footer.html
+++ b/client/src/modules/journal/modals/trialBalanceMain.footer.html
@@ -1,15 +1,11 @@
-<button
-  id="cancelID"
-  type="button"
-  class="btn btn-default"
-  ng-click="TrialBalanceMainFooterCtrl.cancel()">
+<button type="button" class="btn btn-default" data-method="cancel" ui-sref="journal">
   <span translate>FORM.BUTTONS.CANCEL</span>
 </button>
 
 <button
   ng-if="TrialBalanceMainFooterCtrl.state.current.data.checked"
   type="button"
-  class="btn"
+  class="btn btn-default"
   ng-class="{
     'btn-danger' : TrialBalanceMainFooterCtrl.state.current.data.checkingData.feedBack.hasError,
     'btn-warning': TrialBalanceMainFooterCtrl.state.current.data.checkingData.feedBack.hasWarning,
@@ -20,5 +16,7 @@
   <span ng-show="TrialBalanceMainFooterCtrl.loading">
     <span class="fa fa-circle-o-notch fa-spin"></span> <span translate>FORM.INFO.LOADING</span>
   </span>
-  <span ng-hide="TrialBalanceMainFooterCtrl.loading" translate>FORM.BUTTONS.SUBMIT</span>
+  <span ng-hide="TrialBalanceMainFooterCtrl.loading" translate>
+    FORM.BUTTONS.SUBMIT
+  </span>
 </button>

--- a/client/src/modules/journal/modals/trialBalanceMain.footer.js
+++ b/client/src/modules/journal/modals/trialBalanceMain.footer.js
@@ -16,15 +16,6 @@ function TrialBalanceMainFooterController($state, trialBalanceService, Notify) {
   vm.state = $state;
 
   /**
-   * @function cancel
-   * @description
-   * closes the modal and stop the posting process
-   **/
-  function cancel() {
-    $state.go('journal');
-  }
-
-  /**
    * @function submit
    * @description for submitting a dialog content
    */
@@ -32,7 +23,7 @@ function TrialBalanceMainFooterController($state, trialBalanceService, Notify) {
     vm.loading = true;
     trialBalanceService.postToGeneralLedger($state.params.records)
       .then(function () {
-        $state.go('journal', null, { reload : true});
+        $state.go('journal', null, { reload: true });
       })
       .catch(Notify.handleError)
       .finally(function () {
@@ -40,6 +31,5 @@ function TrialBalanceMainFooterController($state, trialBalanceService, Notify) {
       });
   }
 
-  vm.cancel = cancel;
   vm.submit = submit;
 }

--- a/client/src/modules/journal/ui-grid-edit-account.directive.js
+++ b/client/src/modules/journal/ui-grid-edit-account.directive.js
@@ -1,18 +1,19 @@
 angular.module('bhima.directives')
   .directive('uiGridEditAccount', uiGridEditAccount);
 
-uiGridEditAccount.$inject = ['uiGridEditConstants', 'AccountService', 'uiGridConstants'];
+uiGridEditAccount.$inject = ['uiGridEditConstants', 'AccountService', 'uiGridConstants', '$timeout'];
 
-function uiGridEditAccount(uiGridEditConstants, Accounts, uiGridConstants) {
+function uiGridEditAccount(uiGridEditConstants, Accounts, uiGridConstants, $timeout) {
   return {
     restrict : 'A',
     template : function () {
       var templ =
         '<div style="display: table; margin-right: auto; margin-left: auto; width:95%">' +
-        '  <input type="text"' +
+        '  <input type="text" autofocus ' +
         '    style="width:100%" ' +
         '    ng-model="accountInputValue" ' +
         '    uib-typeahead="account.id as account.hrlabel for account in accounts | filter:{\'hrlabel\':$viewValue} | limitTo:8" ' +
+        '    typeahead-min-length="0" ' +
         '    ng-required="true"' +
         '    typeahead-editable ="false" ' +
         '    typeahead-on-select="setAccountOnRow(row.entity, $item)" />' +
@@ -31,7 +32,6 @@ function uiGridEditAccount(uiGridEditConstants, Accounts, uiGridConstants) {
           Accounts.read()
             .then(function (accounts) {
               $scope.accounts = Accounts.filterTitleAccounts(accounts);
-              setInitialAccountValue();
             });
 
           // checks to see if a click landed in a dropdown menu - if so, it's probably the typeahead's.
@@ -68,6 +68,8 @@ function uiGridEditAccount(uiGridEditConstants, Accounts, uiGridConstants) {
           };
 
           $scope.$on(uiGridEditConstants.events.BEGIN_CELL_EDIT, function () {
+            $scope.accountInputValue = '';
+
             if (uiGridCtrl.grid.api.cellNav) {
               uiGridCtrl.grid.api.cellNav.on.navigate($scope, function (newRowCol, oldRowCol) {
                 $scope.stopEdit();
@@ -76,24 +78,13 @@ function uiGridEditAccount(uiGridEditConstants, Accounts, uiGridConstants) {
               angular.element(document.querySelectorAll('.ui-grid-cell-contents')).on('click', onCellClick);
             }
 
+            $timeout(focusTypeaheadInput, 50);
             angular.element(window).on('click', onWindowClick);
           });
 
-          function setInitialAccountValue() {
-            var currentAccountId = $scope.row.entity.account_id;
-            var accounts;
-            var i;
-
-            if ($scope.accounts) {
-              i = $scope.accounts.length;
-              accounts = $scope.accounts;
-              while (i--) {
-                if (accounts[i].id === currentAccountId) {
-                  $scope.accountInputValue = accounts[i];
-                  break;
-                }
-              }
-            }
+          function focusTypeaheadInput() {
+            var $input = $elm.querySelectorAll('input')[0];
+            $input.focus();
           }
 
           $elm.on('keydown', function(evt) {

--- a/test/end-to-end/journal/trial_balance/trialBalanceDetail.page.js
+++ b/test/end-to-end/journal/trial_balance/trialBalanceDetail.page.js
@@ -7,7 +7,6 @@ function TrialBalanceDetailPage() {
   const gridRows = grid.element(by.css('.ui-grid-render-container-body')).all( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index'));
   const resetButton = $('[data-method="reset"]');
 
-
   function reset (){
     return resetButton.click();
   }
@@ -21,4 +20,3 @@ function TrialBalanceDetailPage() {
 }
 
 module.exports = TrialBalanceDetailPage;
-


### PR DESCRIPTION
A request from the accountant using the system is for the account typeahead to open automatically on
focus, for the input to autofocus, and for the input to be cleared.  This commit implements those as
best as possible with fickle HTML and typeahead API.

Closes #1545.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
