### PR TITLE
feat(account): add excludeTitleAccounts option to bhAccountSelect

### DIFF
--- a/client/src/js/components/bhAccountSelect.js
+++ b/client/src/js/components/bhAccountSelect.js
@@ -10,6 +10,7 @@ angular.module('bhima.components')
       required         : '<?',
       label            : '@?',
       name             : '@?',
+      excludeTitleAccounts : '@?',
     },
   });
 
@@ -32,9 +33,6 @@ function AccountSelectController(Accounts, AppCache, $timeout, bhConstants, $sco
 
   // fired at the beginning of the account select
   $ctrl.$onInit = function () {
-    // load accounts
-    loadAccounts();
-
     // cache the title account ID for convenience
     $ctrl.TITLE_ACCOUNT_ID = bhConstants.accounts.TITLE;
 
@@ -54,6 +52,10 @@ function AccountSelectController(Accounts, AppCache, $timeout, bhConstants, $sco
       $ctrl.required = true;
     }
 
+    $ctrl.excludeTitleAccounts = $ctrl.excludeTitleAccounts || false;
+
+    // load accounts
+    loadAccounts();
 
     // alias the name as AccountForm
     $timeout(aliasComponentForm);
@@ -90,7 +92,13 @@ function AccountSelectController(Accounts, AppCache, $timeout, bhConstants, $sco
       .then(function (elements) {
 
         // bind the accounts to the controller
-        $ctrl.accounts = Accounts.order(elements);
+        var accounts = Accounts.order(elements);
+
+        if ($ctrl.excludeTitleAccounts) {
+          accounts = Accounts.filterTitleAccounts(accounts);
+        }
+
+        $ctrl.accounts = accounts;
 
         // writes the accounts into localstorage
         //cacheAccounts($ctrl.accounts);

--- a/client/src/modules/journal/modals/search.modal.html
+++ b/client/src/modules/journal/modals/search.modal.html
@@ -56,9 +56,10 @@
         </div>
 
         <bh-account-select
-          account-id="ModalCtrl.searchQueries.account_id"
+          account-id="ModalCtrl.options.account_id"
           name="account_id"
           on-select-callback="ModalCtrl.onSelectAccount(account)"
+          exclude-title-accounts="true"
           required="0">
           <bh-clear on-clear="ModalCtrl.clear('account_id')"></bh-clear>
         </bh-account-select>
@@ -158,7 +159,6 @@
       </uib-tab>
 
     </uib-tabset>
-
   </div>
 
   <div class="modal-footer">


### PR DESCRIPTION
Sometimes, the account select should just remove title accounts from the view (rather than just
disabling them).  Such is the case for a search modal.  This commit implements `excludeTitleAccounts`
Boolean binding on the `bhAccountSelect` to provide this case.  Defaults to false.

Closes #1544.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
