### PR TITLE
refactor(util): remove unused util.js fns

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -13,7 +13,7 @@ SESS_RESAVE=0
 SESS_UNSET='destroy'
 
 LOG_LEVEL='warn'
-# LOG_LEVEL='debug'
+#LOG_LEVEL='debug'
 UPLOAD_DIR='client/upload'
 
 # this will toggle all MYSQL errors to be reflected to the client.

--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -177,7 +177,7 @@ function listPayment(options) {
 
   // @TODO Support ordering query (reference support for limit)?
   filters.setOrder('ORDER BY cash.date DESC');
- 
+
   filters.custom('invoice_uuid', 'cash.uuid IN (SELECT cash_item.cash_uuid FROM cash_item WHERE cash_item.invoice_uuid = HUID(?))');
 
   const query = filters.applyQuery(sql);

--- a/server/controllers/finance/reports/cashflow/index.js
+++ b/server/controllers/finance/reports/cashflow/index.js
@@ -10,7 +10,6 @@
  * @requires node-uuid
  * @requires moment
  * @requires lib/db
- * @requires lib/util
  * @requires lib/ReportManager
  * @requires lib/errors/BadRequest
  */
@@ -21,7 +20,6 @@ const uuid       = require('node-uuid');
 const moment     = require('moment');
 
 const db         = require('../../../../lib/db');
-const util       = require('../../../../lib/util');
 const ReportManager = require('../../../../lib/ReportManager');
 const BadRequest = require('../../../../lib/errors/BadRequest');
 
@@ -113,7 +111,7 @@ function queryIncomeExpense (params, dateFrom, dateTo) {
             pj.account_id, pj.entity_uuid, pj.currency_id, pj.trans_id,
             pj.description, pj.comment, pj.origin_id, pj.user_id
           FROM posting_journal pj
-          WHERE pj.account_id IN (?) AND DATE(pj.trans_date) >= DATE(?) AND DATE(pj.trans_date) <= DATE(?) AND pj.origin_id <> 10 
+          WHERE pj.account_id IN (?) AND DATE(pj.trans_date) >= DATE(?) AND DATE(pj.trans_date) <= DATE(?) AND pj.origin_id <> 10
             AND pj.record_uuid NOT IN (SELECT reference_uuid FROM voucher WHERE type_id = 10)
         ) UNION (
           SELECT gl.project_id, gl.uuid, gl.record_uuid, gl.trans_date,
@@ -121,7 +119,7 @@ function queryIncomeExpense (params, dateFrom, dateTo) {
             gl.account_id, gl.entity_uuid, gl.currency_id, gl.trans_id,
             gl.description, gl.comment, gl.origin_id, gl.user_id
           FROM general_ledger gl
-          WHERE gl.account_id IN (?) AND DATE(gl.trans_date) >= DATE(?) AND DATE(gl.trans_date) <= DATE(?) AND gl.origin_id <> 10 
+          WHERE gl.account_id IN (?) AND DATE(gl.trans_date) >= DATE(?) AND DATE(gl.trans_date) <= DATE(?) AND gl.origin_id <> 10
             AND gl.record_uuid NOT IN (SELECT reference_uuid FROM voucher WHERE type_id = 10)
         )
       ) AS t, account AS a, user as u, transaction_type as x
@@ -465,8 +463,8 @@ function document(req, res, next) {
    */
   function labelization () {
     var uniqueIncomes = [], uniqueExpenses = [];
-    session.incomesLabels = util.uniquelize(session.incomesLabels);
-    session.expensesLabels = util.uniquelize(session.expensesLabels);
+    session.incomesLabels = _.uniq(session.incomesLabels);
+    session.expensesLabels = _.uniq(session.expensesLabels);
 
     /** incomes rows */
     session.periodStartArray.forEach(function (period) {

--- a/server/lib/filter.js
+++ b/server/lib/filter.js
@@ -16,7 +16,6 @@ const DEFAULT_UUID_PARTIAL_KEY = 'uuid';
   // week : () => { return { start : moment().startOf('week').toDate(), end : moment().endOf('week').toDate() } },
   // month : () => {  return { start : moment().startOf('month').toDate(), end : moment().endOf('month').toDate() } }
 // };
-
 /**
  * @class FilterParser
  *
@@ -40,14 +39,12 @@ const DEFAULT_UUID_PARTIAL_KEY = 'uuid';
  */
 class FilterParser {
   // options that are used by all routes that shouldn't be considered unique filters
-  constructor(filters, filterOptions) {
-    let options = filterOptions || {};
-
+  constructor(filters = {}, options = {}) {
     // stores for processing options
     this._statements = [];
     this._parameters = [];
 
-    this._filters = _.clone(filters) || {};
+    this._filters = _.clone(filters);
 
     // configure default options
     this._tableAlias = options.tableAlias || null;
@@ -55,6 +52,7 @@ class FilterParser {
     this._order = '';
     this._parseUuids = _.isUndefined(options.parseUuids) ? true : options.parseUuids;
     this._autoParseStatements = _.isUndefined(options.autoParseStatements) ? true : options.autoParseStatements;
+    this._group = '';
   }
 
 
@@ -72,11 +70,11 @@ class FilterParser {
    *                              the object table alias if it exists
    */
   fullText(filterKey, columnAlias = filterKey, tableAlias = this._tableAlias) {
-    let tableString = this._formatTableAlias(tableAlias);
+    const tableString = this._formatTableAlias(tableAlias);
 
     if (this._filters[filterKey]) {
-      let searchString = `%${this._filters[filterKey]}%`;
-      let preparedStatement = `LOWER(${tableString}${columnAlias}) LIKE ? `;
+      const searchString = `%${this._filters[filterKey]}%`;
+      const preparedStatement = `LOWER(${tableString}${columnAlias}) LIKE ? `;
 
       this._addFilter(preparedStatement, searchString);
       delete this._filters[filterKey];
@@ -84,7 +82,7 @@ class FilterParser {
   }
 
   period(filterKey, columnAlias = filterKey, tableAlias = this._tableAlias) {
-    let tableString = this._formatTableAlias(tableAlias);
+    const tableString = this._formatTableAlias(tableAlias);
 
     if (this._filters[filterKey]) {
       // if a client timestamp has been passed - this will be passed in here
@@ -97,8 +95,8 @@ class FilterParser {
         return;
       }
 
-      let periodFromStatement = `DATE(${tableString}${columnAlias}) >= DATE(?)`;
-      let periodToStatement = `DATE(${tableString}${columnAlias}) <= DATE(?)`;
+      const periodFromStatement = `DATE(${tableString}${columnAlias}) >= DATE(?)`;
+      const periodToStatement = `DATE(${tableString}${columnAlias}) <= DATE(?)`;
 
       this._addFilter(periodFromStatement, targetPeriod.limit.start());
       this._addFilter(periodToStatement, targetPeriod.limit.end());
@@ -117,10 +115,10 @@ class FilterParser {
    *                              the object table alias if it exists
    */
   dateFrom(filterKey, columnAlias = filterKey, tableAlias = this._tableAlias) {
-    let tableString = this._formatTableAlias(tableAlias);
+    const tableString = this._formatTableAlias(tableAlias);
 
     if (this._filters[filterKey]) {
-      let preparedStatement = `DATE(${tableString}${columnAlias}) >= DATE(?)`;
+      const preparedStatement = `DATE(${tableString}${columnAlias}) >= DATE(?)`;
       this._addFilter(preparedStatement, moment(this._filters[filterKey]).format('YYYY-MM-DD').toString());
 
       delete this._filters[filterKey];
@@ -137,10 +135,10 @@ class FilterParser {
    *                              the object table alias if it exists
    */
   dateTo(filterKey, columnAlias = filterKey, tableAlias = this._tableAlias) {
-    let tableString = this._formatTableAlias(tableAlias);
+    const tableString = this._formatTableAlias(tableAlias);
 
     if (this._filters[filterKey]) {
-      let preparedStatement = `DATE(${tableString}${columnAlias}) <= DATE(?)`;
+      const preparedStatement = `DATE(${tableString}${columnAlias}) <= DATE(?)`;
 
       this._addFilter(preparedStatement, moment(this._filters[filterKey]).format('YYYY-MM-DD').toString());
       delete this._filters[filterKey];
@@ -148,10 +146,10 @@ class FilterParser {
   }
 
   equals(filterKey, columnAlias = filterKey, tableAlias = this._tableAlias) {
-    let tableString = this._formatTableAlias(tableAlias);
+    const tableString = this._formatTableAlias(tableAlias);
 
     if (this._filters[filterKey]) {
-      let preparedStatement = `${tableString}${columnAlias} = ?`;
+      const preparedStatement = `${tableString}${columnAlias} = ?`;
 
       this._addFilter(preparedStatement, this._filters[filterKey]);
       delete this._filters[filterKey];
@@ -198,27 +196,42 @@ class FilterParser {
   }
 
   /**
-   * @TODO
+   * @method setOrder
+   *
    * @description
-   * Temporary solution to setting ordering on complex querries - this should be
+   * Allows setting the SQL ordering on complex queries - this should be
    * exposed through the same interface as all other filters.
    */
   setOrder(orderString) {
     this._order = orderString;
   }
 
+  /**
+   * @method setGroup
+   *
+   * @description
+   * Allows setting the SQL groups in the GROUP BY statement.  A developer is expected to
+   * provide a valid SQL string.  This will be appended to the SQL statement after the
+   * WHERE clause.
+   */
+  setGroup(groupString) {
+    this._group = groupString;
+  }
+
   applyQuery(sql) {
     // optionally call utility method to parse all remaining options as simple
     // equality filters into `_statements`
-    let limitCondition = this._parseLimit();
+    const limitCondition = this._parseLimit();
 
     if (this._autoParseStatements) {
       this._parseDefaultFilters();
     }
-    let conditionStatements = this._parseStatements();
-    let order = this._order;
 
-    return `${sql} WHERE ${conditionStatements} ${order} ${limitCondition}`;
+    const conditionStatements = this._parseStatements();
+    const order = this._order;
+    const group = this._group;
+
+    return `${sql} WHERE ${conditionStatements} ${group} ${order} ${limitCondition}`;
   }
 
   parameters() {
@@ -249,13 +262,12 @@ class FilterParser {
    * have filter types - these always check for equality
    */
   _parseDefaultFilters() {
-
     // remove options that represent reserved keys
     this._filters = _.omit(this._filters, RESERVED_KEYWORDS);
 
     _.each(this._filters, (value, key) => {
       let valueString = '?';
-      let tableString = this._formatTableAlias(this._tableAlias);
+      const tableString = this._formatTableAlias(this._tableAlias);
 
       if (this._parseUuids) {
         // check to see if key contains the text uuid - if it does and parseUuids has
@@ -271,12 +283,12 @@ class FilterParser {
   _parseStatements() {
     // this will always return true for a condition statement
     const DEFAULT_NO_STATEMENTS = '1';
-    return _.isEmpty(this._statements) ? DEFAULT_NO_STATEMENTS :this._statements.join(' AND ');
+    return _.isEmpty(this._statements) ? DEFAULT_NO_STATEMENTS : this._statements.join(' AND ');
   }
 
   _parseLimit() {
     let limitString = '';
-    let limit = Number(this._filters[this._limitKey]);
+    const limit = Number(this._filters[this._limitKey]);
 
     if (limit) {
       limitString = `LIMIT ${limit} `;


### PR DESCRIPTION
This commit removes unused util.js function from the server library.
Many of these were never used; ~~however, to fully address some of the
changes required, we are required to updated `filters.js` to allow
arbitrary WHERE clause positioning.  I'm not confident in this method,
but it does allow the power of `FilterParser` to be used with `GROUP BY`
clauses, provided the developer is careful in crafting their queries.~~

**EDIT**
To fully address some of the changes required, I've extended the `FilterParser` library with a special method `setGroup()` that will encapsulate the GROUP BY clause of the SQL.  It turns out pretty cleanly.

I've also refactored the `FilterParser` class to be in conformance with ESLint.

Closes #1530.  Closes #1531.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
