### PR TITLE
refactor(stock): syntax sickness in stock reports

### DIFF
--- a/server/controllers/stock/reports/index.js
+++ b/server/controllers/stock/reports/index.js
@@ -1,10 +1,8 @@
-'use strict';
-
 /**
  * @overview
  * Stock Reports
  *
- * This module is responsible for rendering reports of stock. 
+ * This module is responsible for rendering reports of stock.
  *
  * @module stock/reports/
  */
@@ -17,21 +15,23 @@ const ReportManager = require('../../../lib/ReportManager');
 
 const Stock = require('../core');
 
-// receipts
-const STOCK_EXIT_PATIENT_TEMPLATE = './server/controllers/stock/reports/stock_exit_patient.receipt.handlebars';
-const STOCK_EXIT_SERVICE_TEMPLATE = './server/controllers/stock/reports/stock_exit_service.receipt.handlebars';
-const STOCK_EXIT_DEPOT_TEMPLATE = './server/controllers/stock/reports/stock_exit_depot.receipt.handlebars';
-const STOCK_EXIT_LOSS_TEMPLATE = './server/controllers/stock/reports/stock_exit_loss.receipt.handlebars';
+const BASE_PATH = './server/controllers/stock/reports';
 
-const STOCK_ENTRY_DEPOT_TEMPLATE = './server/controllers/stock/reports/stock_entry_depot.receipt.handlebars';
-const STOCK_ENTRY_PURCHASE_TEMPLATE = './server/controllers/stock/reports/stock_entry_purchase.receipt.handlebars';
-const STOCK_ENTRY_INTEGRATION_TEMPLATE = './server/controllers/stock/reports/stock_entry_integration.receipt.handlebars';
-const STOCK_ADJUSTMENT_TEMPLATE = './server/controllers/stock/reports/stock_adjustment.receipt.handlebars';
+// receipts
+const STOCK_EXIT_PATIENT_TEMPLATE = `${BASE_PATH}/stock_exit_patient.receipt.handlebars`;
+const STOCK_EXIT_SERVICE_TEMPLATE = `${BASE_PATH}/stock_exit_service.receipt.handlebars`;
+const STOCK_EXIT_DEPOT_TEMPLATE = `${BASE_PATH}/stock_exit_depot.receipt.handlebars`;
+const STOCK_EXIT_LOSS_TEMPLATE = `${BASE_PATH}/stock_exit_loss.receipt.handlebars`;
+
+const STOCK_ENTRY_DEPOT_TEMPLATE = `${BASE_PATH}/stock_entry_depot.receipt.handlebars`;
+const STOCK_ENTRY_PURCHASE_TEMPLATE = `${BASE_PATH}/stock_entry_purchase.receipt.handlebars`;
+const STOCK_ENTRY_INTEGRATION_TEMPLATE = `${BASE_PATH}/stock_entry_integration.receipt.handlebars`;
+const STOCK_ADJUSTMENT_TEMPLATE = `${BASE_PATH}/stock_adjustment.receipt.handlebars`;
 
 // reports
-const STOCK_LOTS_REPORT_TEMPLATE = './server/controllers/stock/reports/stock_lots.report.handlebars';
-const STOCK_MOVEMENTS_REPORT_TEMPLATE = './server/controllers/stock/reports/stock_movements.report.handlebars';
-const STOCK_INVENTORIES_REPORT_TEMPLATE = './server/controllers/stock/reports/stock_inventories.report.handlebars';
+const STOCK_LOTS_REPORT_TEMPLATE = `${BASE_PATH}/stock_lots.report.handlebars`;
+const STOCK_MOVEMENTS_REPORT_TEMPLATE = `${BASE_PATH}/stock_movements.report.handlebars`;
+const STOCK_INVENTORIES_REPORT_TEMPLATE = `${BASE_PATH}/stock_inventories.report.handlebars`;
 
 // ===================================== receipts ========================================
 
@@ -58,19 +58,19 @@ function stockExitPatientReceipt(req, res, next) {
   }
 
   const sql = `
-    SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid, 
-      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description, 
-      u.display_name AS user_display_name, p.display_name AS patient_display_name, 
+    SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid,
+      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
+      u.display_name AS user_display_name, p.display_name AS patient_display_name,
       CONCAT_WS('.', '${identifiers.DOCUMENT.key}', m.reference) AS document_reference,
       CONCAT_WS('.', '${identifiers.PATIENT.key}', proj.abbr, p.reference) AS patient_reference, p.hospital_no,
-      l.label, l.expiration_date, d.text AS depot_name  
-    FROM stock_movement m 
-    JOIN lot l ON l.uuid = m.lot_uuid 
-    JOIN inventory i ON i.uuid = l.inventory_uuid 
-    JOIN depot d ON d.uuid = m.depot_uuid 
-    JOIN patient p ON p.uuid = m.entity_uuid 
-    JOIN project proj ON proj.id = p.project_id 
-    JOIN user u ON u.id = m.user_id 
+      l.label, l.expiration_date, d.text AS depot_name
+    FROM stock_movement m
+    JOIN lot l ON l.uuid = m.lot_uuid
+    JOIN inventory i ON i.uuid = l.inventory_uuid
+    JOIN depot d ON d.uuid = m.depot_uuid
+    JOIN patient p ON p.uuid = m.entity_uuid
+    JOIN project proj ON proj.id = p.project_id
+    JOIN user u ON u.id = m.user_id
     WHERE m.is_exit = 1 AND m.flux_id = ${Stock.flux.TO_PATIENT} AND m.document_uuid = ?
   `;
 
@@ -129,15 +129,15 @@ function stockAdjustmentReceipt(req, res, next) {
 
   const sql = `
     SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid, m.is_exit,
-      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description, 
+      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
       u.display_name AS user_display_name,
       CONCAT_WS('.', '${identifiers.DOCUMENT.key}', m.reference) AS document_reference,
-      l.label, l.expiration_date, d.text AS depot_name  
-    FROM stock_movement m 
-    JOIN lot l ON l.uuid = m.lot_uuid 
-    JOIN inventory i ON i.uuid = l.inventory_uuid 
-    JOIN depot d ON d.uuid = m.depot_uuid 
-    JOIN user u ON u.id = m.user_id 
+      l.label, l.expiration_date, d.text AS depot_name
+    FROM stock_movement m
+    JOIN lot l ON l.uuid = m.lot_uuid
+    JOIN inventory i ON i.uuid = l.inventory_uuid
+    JOIN depot d ON d.uuid = m.depot_uuid
+    JOIN user u ON u.id = m.user_id
     WHERE m.flux_id IN (${Stock.flux.FROM_ADJUSTMENT}, ${Stock.flux.TO_ADJUSTMENT}) AND m.document_uuid = ?
   `;
 
@@ -193,17 +193,17 @@ function stockExitServiceReceipt(req, res, next) {
   }
 
   const sql = `
-    SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid, 
-      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description, 
-      u.display_name AS user_display_name, s.name AS service_display_name, 
+    SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid,
+      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
+      u.display_name AS user_display_name, s.name AS service_display_name,
       CONCAT_WS('.', '${identifiers.DOCUMENT.key}', m.reference) AS document_reference,
-      l.label, l.expiration_date, d.text AS depot_name  
-    FROM stock_movement m 
-    JOIN lot l ON l.uuid = m.lot_uuid 
-    JOIN inventory i ON i.uuid = l.inventory_uuid 
-    JOIN depot d ON d.uuid = m.depot_uuid 
-    JOIN service s ON s.uuid = m.entity_uuid 
-    JOIN user u ON u.id = m.user_id 
+      l.label, l.expiration_date, d.text AS depot_name
+    FROM stock_movement m
+    JOIN lot l ON l.uuid = m.lot_uuid
+    JOIN inventory i ON i.uuid = l.inventory_uuid
+    JOIN depot d ON d.uuid = m.depot_uuid
+    JOIN service s ON s.uuid = m.entity_uuid
+    JOIN user u ON u.id = m.user_id
     WHERE m.is_exit = 1 AND m.flux_id = ${Stock.flux.TO_SERVICE} AND m.document_uuid = ?
   `;
 
@@ -259,16 +259,16 @@ function stockExitLossReceipt(req, res, next) {
   }
 
   const sql = `
-    SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid, 
-      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description, 
-      u.display_name AS user_display_name, 
+    SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid,
+      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
+      u.display_name AS user_display_name,
       CONCAT_WS('.', '${identifiers.DOCUMENT.key}', m.reference) AS document_reference,
-      l.label, l.expiration_date, d.text AS depot_name  
-    FROM stock_movement m 
-    JOIN lot l ON l.uuid = m.lot_uuid 
-    JOIN inventory i ON i.uuid = l.inventory_uuid 
-    JOIN depot d ON d.uuid = m.depot_uuid 
-    JOIN user u ON u.id = m.user_id 
+      l.label, l.expiration_date, d.text AS depot_name
+    FROM stock_movement m
+    JOIN lot l ON l.uuid = m.lot_uuid
+    JOIN inventory i ON i.uuid = l.inventory_uuid
+    JOIN depot d ON d.uuid = m.depot_uuid
+    JOIN user u ON u.id = m.user_id
     WHERE m.is_exit = 1 AND m.flux_id = ${Stock.flux.TO_LOSS} AND m.document_uuid = ?
   `;
 
@@ -367,7 +367,8 @@ function stockEntryDepotReceipt(req, res, next) {
  * GET /receipts/stock/entry_purchase/:document_uuid
  */
 function stockEntryPurchaseReceipt(req, res, next) {
-  let report, data = {};
+  let report;
+  const data = {};
   const documentUuid = req.params.document_uuid;
   const optionReport = _.extend(req.query, { filename: 'STOCK.RECEIPTS.ENTRY_PURCHASE' });
 
@@ -379,22 +380,23 @@ function stockEntryPurchaseReceipt(req, res, next) {
   }
 
   const sql = `
-    SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid, 
-      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description, 
+    SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid,
+      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
       u.display_name AS user_display_name,
       CONCAT_WS('.', '${identifiers.DOCUMENT.key}', m.reference) AS document_reference,
       l.label, l.expiration_date, d.text AS depot_name,
-      CONCAT_WS('.', '${identifiers.PURCHASE_ORDER.key}', proj.abbr, p.reference) AS purchase_reference, p.note, p.cost, p.date AS purchase_date, p.payment_method,
-      s.display_name AS supplier_display_name, proj.name AS project_display_name  
-    FROM stock_movement m 
-    JOIN lot l ON l.uuid = m.lot_uuid 
-    JOIN inventory i ON i.uuid = l.inventory_uuid 
-    JOIN depot d ON d.uuid = m.depot_uuid 
-    JOIN user u ON u.id = m.user_id 
+      CONCAT_WS('.', '${identifiers.PURCHASE_ORDER.key}', proj.abbr, p.reference) AS purchase_reference,
+      p.note, p.cost, p.date AS purchase_date, p.payment_method,
+      s.display_name AS supplier_display_name, proj.name AS project_display_name
+    FROM stock_movement m
+    JOIN lot l ON l.uuid = m.lot_uuid
+    JOIN inventory i ON i.uuid = l.inventory_uuid
+    JOIN depot d ON d.uuid = m.depot_uuid
+    JOIN user u ON u.id = m.user_id
     JOIN purchase p ON p.uuid = l.origin_uuid
     JOIN supplier s ON s.uuid = p.supplier_uuid
     JOIN project proj ON proj.id = p.project_id
-    WHERE m.is_exit = 0 AND m.flux_id = ${Stock.flux.FROM_PURCHASE} AND m.document_uuid = ? 
+    WHERE m.is_exit = 0 AND m.flux_id = ${Stock.flux.FROM_PURCHASE} AND m.document_uuid = ?
     ORDER BY i.text, l.label
   `;
 
@@ -443,7 +445,8 @@ function stockEntryPurchaseReceipt(req, res, next) {
  * GET /receipts/stock/entry_integration/:document_uuid
  */
 function stockEntryIntegrationReceipt(req, res, next) {
-  let report, data = {};
+  let report;
+  const data = {};
   const documentUuid = req.params.document_uuid;
   const optionReport = _.extend(req.query, { filename: 'STOCK.RECEIPTS.ENTRY_INTEGRATION' });
 
@@ -455,21 +458,22 @@ function stockEntryIntegrationReceipt(req, res, next) {
   }
 
   const sql = `
-    SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid, 
-      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description, 
+    SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid,
+      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
       u.display_name AS user_display_name,
       CONCAT_WS('.', '${identifiers.DOCUMENT.key}', m.reference) AS document_reference,
       l.label, l.expiration_date, d.text AS depot_name,
-      CONCAT_WS('.', '${identifiers.INTEGRATION.key}', proj.abbr, integ.reference) AS integration_reference, integ.description, integ.date AS integration_date,
-      proj.name AS project_display_name  
-    FROM stock_movement m 
-    JOIN lot l ON l.uuid = m.lot_uuid 
-    JOIN inventory i ON i.uuid = l.inventory_uuid 
-    JOIN depot d ON d.uuid = m.depot_uuid 
-    JOIN user u ON u.id = m.user_id 
+      CONCAT_WS('.', '${identifiers.INTEGRATION.key}', proj.abbr, integ.reference) AS integration_reference,
+      integ.description, integ.date AS integration_date,
+      proj.name AS project_display_name
+    FROM stock_movement m
+    JOIN lot l ON l.uuid = m.lot_uuid
+    JOIN inventory i ON i.uuid = l.inventory_uuid
+    JOIN depot d ON d.uuid = m.depot_uuid
+    JOIN user u ON u.id = m.user_id
     JOIN integration integ ON integ.uuid = l.origin_uuid
     JOIN project proj ON proj.id = integ.project_id
-    WHERE m.is_exit = 0 AND m.flux_id = ${Stock.flux.FROM_INTEGRATION} AND m.document_uuid = ? 
+    WHERE m.is_exit = 0 AND m.flux_id = ${Stock.flux.FROM_INTEGRATION} AND m.document_uuid = ?
     ORDER BY i.text, l.label
   `;
 
@@ -514,16 +518,16 @@ function stockEntryIntegrationReceipt(req, res, next) {
 function getDepotMovement(documentUuid, enterprise) {
   const data = {};
   const sql = `
-    SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid, 
-      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description, 
+    SELECT i.code, i.text, BUID(m.document_uuid) AS document_uuid,
+      m.quantity, m.unit_cost, (m.quantity * m.unit_cost) AS total , m.date, m.description,
       u.display_name AS user_display_name,
       CONCAT_WS('.', '${identifiers.DOCUMENT.key}', m.reference) AS document_reference,
-      l.label, l.expiration_date, d.text AS depot_name  
-    FROM stock_movement m 
-    JOIN lot l ON l.uuid = m.lot_uuid 
-    JOIN inventory i ON i.uuid = l.inventory_uuid 
-    JOIN depot d ON d.uuid = m.depot_uuid 
-    JOIN user u ON u.id = m.user_id 
+      l.label, l.expiration_date, d.text AS depot_name
+    FROM stock_movement m
+    JOIN lot l ON l.uuid = m.lot_uuid
+    JOIN inventory i ON i.uuid = l.inventory_uuid
+    JOIN depot d ON d.uuid = m.depot_uuid
+    JOIN user u ON u.id = m.user_id
     WHERE m.is_exit = ? AND m.flux_id = ? AND m.document_uuid = ?
   `;
 
@@ -590,11 +594,10 @@ function stockLotsReport(req, res, next) {
 
   const data = {};
   let report;
-  const optionReport = _.extend(req.query, { filename: 'TREE.STOCK_LOTS', orientation: 'landscape'});
+  const optionReport = _.extend(req.query, { filename: 'TREE.STOCK_LOTS', orientation: 'landscape' });
 
   // set up the report with report manager
   try {
-
     if (req.query.identifiers && req.query.display) {
       options = JSON.parse(req.query.identifiers);
       display = JSON.parse(req.query.display);
@@ -608,7 +611,6 @@ function stockLotsReport(req, res, next) {
 
   return Stock.getLotsDepot(null, options)
     .then((rows) => {
-
       data.rows = rows;
       data.hasFilter = hasFilter;
       data.csv = rows;
@@ -639,7 +641,7 @@ function stockMovementsReport(req, res, next) {
 
   const data = {};
   let report;
-  const optionReport = _.extend(req.query, { filename: 'TREE.STOCK_MOVEMENTS', orientation: 'landscape'});
+  const optionReport = _.extend(req.query, { filename: 'TREE.STOCK_MOVEMENTS', orientation: 'landscape' });
 
   // set up the report with report manager
   try {
@@ -656,7 +658,6 @@ function stockMovementsReport(req, res, next) {
 
   return Stock.getLotsMovements(null, options)
     .then((rows) => {
-
       data.rows = rows;
       data.hasFilter = hasFilter;
       data.csv = rows;
@@ -687,7 +688,7 @@ function stockInventoriesReport(req, res, next) {
 
   const data = {};
   let report;
-  const optionReport = _.extend(req.query, { filename: 'TREE.STOCK_INVENTORY', orientation: 'landscape'});
+  const optionReport = _.extend(req.query, { filename: 'TREE.STOCK_INVENTORY', orientation: 'landscape' });
 
   // set up the report with report manager
   try {
@@ -704,7 +705,6 @@ function stockInventoriesReport(req, res, next) {
 
   return Stock.getLotsDepot(null, options, ' GROUP BY l.inventory_uuid ')
     .then((rows) => {
-
       data.rows = rows;
       data.hasFilter = hasFilter;
       data.csv = rows;


### PR DESCRIPTION
This commit fixes many of the issues reported by code climate for the
stock reports.  No functionality has been changed, just code syntax.
The changes involve whitespace fixes, elimination of redundancy, and
proper variable declaration.

This does not pass tests due to a bug in the Journal I believe is fixed in https://github.com/IMA-WorldHealth/bhima-2.X/pull/1552.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
