### PR TITLE
fix(trial_balance): parse dates correctly

### DIFF
--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -1262,7 +1262,7 @@ BEGIN
     FROM posting_journal AS pj
       JOIN stage_trial_balance_transaction AS temp ON pj.record_uuid = temp.record_uuid
       JOIN period AS p ON pj.period_id = p.id
-    WHERE pj.trans_date NOT BETWEEN DATE(p.start_date) AND DATE(p.end_date)
+    WHERE DATE(pj.trans_date) NOT BETWEEN DATE(p.start_date) AND DATE(p.end_date)
     GROUP BY pj.record_uuid;
 
   -- check to make sure that all lines of a transaction have a description


### PR DESCRIPTION
This commit fixes the Trial Balance so that it parses dates correctly
when checking the periods.  Previously, without casting dates as DATE,
the comparison check would fail because anything on the final day of
the month would be greater than midnight on the last day of the month.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
