### PR TITLE
fix: trial balance error does not render trans_id

### DIFF
--- a/client/src/modules/journal/modals/trialBalanceError.body.js
+++ b/client/src/modules/journal/modals/trialBalanceError.body.js
@@ -15,10 +15,18 @@ TrialBalanceErrorBodyController.$inject = [
 function TrialBalanceErrorBodyController(trialBalanceService, Grouping, $stateParams) {
   var vm = this;
   var cssClass = trialBalanceService.getCSSClass($stateParams.feedBack);
-  var columns = [
-    { field: 'code', displayName : 'TABLE.COLUMNS.ERROR_TYPE', headerCellFilter : 'translate', headerCellClass : cssClass},
-    { field: 'transaction', displayName : 'TABLE.COLUMNS.TRANSACTION', headerCellFilter : 'translate', headerCellClass : cssClass}
-  ];
+
+  var columns = [{
+    field            : 'code',
+    displayName      : 'TABLE.COLUMNS.ERROR_TYPE',
+    headerCellFilter : 'translate',
+    headerCellClass  : cssClass,
+  }, {
+    field            : 'trans_id',
+    displayName      : 'TABLE.COLUMNS.TRANSACTION',
+    headerCellFilter : 'translate',
+    headerCellClass  : cssClass,
+  }];
 
   vm.gridOptions = {
     enableColumnMenus          : false,


### PR DESCRIPTION
The API to the Trial Balance changed for performance reasons, however, the error state was not
updated correctly and did not show the trans_ids affected by the errors.  This commit fixes that
issue.

Closes #1594.


-----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
