### PR TITLE
Transactions shown can exceed transactions in Database

### DIFF
--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -278,7 +278,7 @@ function queryTransactionAggregates(journalRows) {
       SUM(debit_equiv) as debit_equiv, COUNT(uuid) as totalRows
     FROM posting_journal
     WHERE record_uuid in (?)
-    GROUP BY record_uuid;
+    GROUP BY trans_id;
   `;
 
   // if there are no record uuids to search on we can optimise by not running the query


### PR DESCRIPTION
Transactions shown can exceed transactions in Database  
- Group by trans_id instead by record_uuid because the column
  'record_uuid' in group statement is ambiguous

closes #1593 