### PR TITLE
fix(journal): only reload view after edit

### DIFF
--- a/client/src/modules/journal/journal.js
+++ b/client/src/modules/journal/journal.js
@@ -413,7 +413,7 @@ function JournalController(Journal, Sorting, Grouping,
       .then(function (results) {
         Notify.success('POSTING_JOURNAL.SAVE_TRANSACTION_SUCCESS');
         // ensure that all of the data now respects the current filter
-        load(vm.filters);
+        load(Journal.filters.formatHTTP(true));
       })
       .catch(function (error) {
         if (!error.status) {


### PR DESCRIPTION
The Posting Journal previously did not reload the filters after an edit.  This was a simple problem
of merging or programmer forgetting to call the `formatHTTP()`.  This commit fixes that error.

Closes #1600.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
