### PR TITLE
fix(journal): order Trial Balance by account number

### DIFF
--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -607,10 +607,10 @@ exports.configure = function configure(app) {
   app.get('/finance/cashflow', financeReports.cashflow.report);
   app.get('/finance/incomeExpense', financeReports.incomeExpense.report);
 
-  // stock flux 
+  // stock flux
   app.get('/stock/flux', stock.listStockFlux);
 
-  // stock management API 
+  // stock management API
   app.post('/stock/lots/movements', stock.createMovement);
   app.get('/stock/lots/movements', stock.listLotsMovements);
 
@@ -624,7 +624,7 @@ exports.configure = function configure(app) {
   // stock integration
   app.post('/stock/integration', stock.createIntegration);
 
-  // stock reports API 
+  // stock reports API
   app.get('/reports/stock/lots', stockReports.stockLotsReport);
   app.get('/reports/stock/movements', stockReports.stockMovementsReport);
   app.get('/reports/stock/inventories', stockReports.stockInventoriesReport);

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -389,8 +389,8 @@ function transformColumns(rows, newRecord) {
 
     if (row.account_label) {
       delete row.account_label;
-    }	
-	
+    }
+
     if (row.hrEntity) {
       // reverse barcode lookup entity
       databaseRequests.push(ENTITY_QUERY);
@@ -502,10 +502,12 @@ function reverse(req, res, next) {
  *
  */
 function count(req, res, next) {
-  const sql = `SELECT COUNT(DISTINCT posting_journal.trans_id) AS number_transactions FROM posting_journal;`;
+  const sql = `
+    SELECT COUNT(DISTINCT posting_journal.trans_id) AS number_transactions FROM posting_journal;
+  `;
 
   db.exec(sql)
-    .then(function (rows) {
+    .then((rows) => {
       res.status(200).send(rows);
     })
     .catch(next);

--- a/server/controllers/finance/trialBalance/index.js
+++ b/server/controllers/finance/trialBalance/index.js
@@ -7,7 +7,7 @@
 const db = require('../../../lib/db');
 const BadRequest = require('../../../lib/errors/BadRequest');
 
-exports.getDataPerAccount = function (req, res, next) {
+exports.getDataPerAccount = function getDataPerAccount(req, res, next) {
   const transactions = req.body.transactions;
 
   if (!transactions) {
@@ -40,7 +40,8 @@ exports.getDataPerAccount = function (req, res, next) {
       WHERE posting_journal.trans_id IN (?)
       GROUP BY posting_journal.account_id
     ) AS combined
-      JOIN account ON account.id = combined.account_id;
+      JOIN account ON account.id = combined.account_id
+      ORDER BY account.number;
   `;
 
   // execute the query
@@ -108,7 +109,7 @@ exports.checkTransactions = function runTrialBalance(req, res, next) {
  * This function can be called only when there is no fatal error
  * It posts data to the general ledger.
  **/
-exports.postToGeneralLedger = function (req, res, next) {
+exports.postToGeneralLedger = function postToGeneralLedger(req, res, next) {
   const transactions = req.body.transactions;
 
   if (!transactions || !Array.isArray(transactions)) {


### PR DESCRIPTION
This commit orders the trial balance by the account number for better predictability in account
ordering.  Ideally, the accounts should be ordered respecting their account tree ordering ... but
this can be optimized later as necessary.

Closes #1599.

-----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
