### PR TITLE
fix(reports): right align account slip currencies

### DIFF
--- a/server/controllers/finance/reports/generalLedger/accountSlip.handlebars
+++ b/server/controllers/finance/reports/generalLedger/accountSlip.handlebars
@@ -48,9 +48,9 @@
           <tfoot>
             <tr style="background-color: #ddd;">
               <th colspan="4">{{translate "FORM.LABELS.TOTAL"}}</th>
-              <th>{{currency sum.debit metadata.enterprise.currency_id}}</th>
-              <th>{{currency sum.credit metadata.enterprise.currency_id}}</th>
-              <th>{{currency sum.balance metadata.enterprise.currency_id}}</th>
+              <th class="text-right">{{currency sum.debit metadata.enterprise.currency_id}}</th>
+              <th class="text-right">{{currency sum.credit metadata.enterprise.currency_id}}</th>
+              <th class="text-right">{{currency sum.balance metadata.enterprise.currency_id}}</th>
             </tr>
           </tfoot>
         </table>


### PR DESCRIPTION
This commit fixes the account slip report by right aligning its
currencies, allowing for easier readability.

Closes #1576.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
