### PR TITLE
fix(journal): do not close search on external click

### DIFF
--- a/client/src/modules/journal/journal.js
+++ b/client/src/modules/journal/journal.js
@@ -382,9 +382,6 @@ function JournalController(Journal, Sorting, Grouping,
 
         // @TODO investigate why footer totals aren't updated automatically on data change
         vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.ALL);
-
-        // try to unfold groups
-        // try { grouping.unfoldAllGroups(); } catch (e) {}
       })
       .catch(errorHandler)
       .finally(toggleLoadingIndicator);

--- a/client/src/modules/journal/journalConfig.service.js
+++ b/client/src/modules/journal/journalConfig.service.js
@@ -13,6 +13,7 @@ function JournalConfigService(Modal) {
     return Modal.open({
       templateUrl: 'modules/journal/modals/search.modal.html',
       controller:  'JournalSearchModalController as ModalCtrl',
+      backdrop : 'static',
       resolve : {
         filters : function () { return filters; }
       }


### PR DESCRIPTION
This commit fixes a usability issue that would automatically close the Journal Search modal when a
user clicked outside of it.  Users often clicked outside the search modal to try and dismiss a
dropdown, but ended up dismissing the entire modal.  Operating on the princple of least surprise
(and least frustration), the dismiss-on-external-click has been removed.

Closes #1617.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
