### PR TITLE
fix(fiscal): catch fiscal year errors

### DIFF
--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -1016,27 +1016,16 @@ CREATE PROCEDURE CreateFiscalYear(
   OUT fiscalYearId MEDIUMINT(8)
 )
 BEGIN
+  INSERT INTO fiscal_year (
+    `enterprise_id`, `previous_fiscal_year_id`, `user_id`, `label`,
+    `number_of_months`, `start_date`, `end_date`, `note`
+  ) VALUES (
+    p_enterprise_id, p_previous_fiscal_year_id, p_user_id, p_label,
+    p_number_of_months, p_start_date, p_end_date, p_note
+  );
 
-  DECLARE EXIT HANDLER FOR SQLEXCEPTION
-    BEGIN
-      ROLLBACK;
-    END;
-
-  START TRANSACTION;
-
-    INSERT INTO fiscal_year (
-      `enterprise_id`, `previous_fiscal_year_id`, `user_id`, `label`,
-      `number_of_months`, `start_date`, `end_date`, `note`
-    ) VALUES (
-      p_enterprise_id, p_previous_fiscal_year_id, p_user_id, p_label,
-      p_number_of_months, p_start_date, p_end_date, p_note
-    );
-
-    SET fiscalYearId = LAST_INSERT_ID();
-    CALL CreatePeriods(fiscalYearId);
-
-  COMMIT;
-
+  SET fiscalYearId = LAST_INSERT_ID();
+  CALL CreatePeriods(fiscalYearId);
 END $$
 
 CREATE PROCEDURE GetPeriodRange(

--- a/test/integration/fiscalYear.js
+++ b/test/integration/fiscalYear.js
@@ -3,7 +3,6 @@
 const helpers = require('./helpers');
 
 describe('(/fiscal) Fiscal Year', function () {
-
   var newFiscalYear = {
     label : 'A new Fiscal Year 2018',
     start_date : new Date('2018-01-01 01:00'),
@@ -26,6 +25,15 @@ describe('(/fiscal) Fiscal Year', function () {
       .then(function (res){
         expect(res).to.have.status(200);
         expect(res.body).to.have.all.keys(responseKeys);
+      })
+     .catch(helpers.handler);
+  });
+
+  it('POST /fiscal throws errors with invalid data', function () {
+    return agent.post('/fiscal')
+      .send({ label: 'Broken Year', end_date: new Date() })
+      .then((res) => {
+        helpers.api.errored(res, 400);
       })
      .catch(helpers.handler);
   });


### PR DESCRIPTION
This commit fixes the doubly-wrapped transaction in the fiscal year
creation script.  This should allow fiscal year to report errors back to
the client.

Closes #1087.

----
Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!