### PR TITLE
refactor(fiscal): best practices for closing

### DIFF
--- a/client/src/modules/fiscal/fiscal.manage.js
+++ b/client/src/modules/fiscal/fiscal.manage.js
@@ -11,6 +11,8 @@ FiscalManagementController.$inject = [
  */
 function FiscalManagementController($state, Fiscal, Notify, Modal, util, moment) {
   var vm = this;
+  var id;
+  var isUpdate;
 
   // state variables
   vm.isUpdateState = $state.current.name === 'fiscal.update';
@@ -18,8 +20,8 @@ function FiscalManagementController($state, Fiscal, Notify, Modal, util, moment)
   vm.isCreateState = $state.current.name === 'fiscal.create';
 
   // identifier
-  var id = $state.params.id;
-  var isUpdate = (id && vm.isUpdateState);
+  id = $state.params.id;
+  isUpdate = (id && vm.isUpdateState);
 
   // global variables
   vm.fiscal = {};
@@ -49,9 +51,9 @@ function FiscalManagementController($state, Fiscal, Notify, Modal, util, moment)
     }
 
     // previous fiscal year
-    Fiscal.read(null, { detailed: 1})
+    Fiscal.read(null, { detailed: 1 })
     .then(function (previous) {
-      if (!previous.length) { return ; }
+      if (!previous.length) { return; }
 
       vm.previous_fiscal_year = previous.map(function (fy) {
         fy.hrLabel = fy.label

--- a/client/src/modules/fiscal/fiscal.openingBalance.html
+++ b/client/src/modules/fiscal/fiscal.openingBalance.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-md-12">
 
-    <form name="OpeningAccountForm" bh-submit="FiscalOBCtrl.submit(OpeningAccountForm)" bh-form-defaults novalidate>
+    <form name="OpeningAccountForm" bh-submit="FiscalOBCtrl.submit(OpeningAccountForm)" novalidate>
 
       <div class="panel panel-primary">
 
@@ -25,13 +25,11 @@
 
         <!-- body  -->
         <section>
-
           <div
             id="account-balance-grid"
             style="height : 600px;"
             ui-grid="FiscalOBCtrl.gridOptions">
           </div>
-
         </section>
 
         <!-- footer  -->
@@ -50,10 +48,7 @@
             <span ng-show="FiscalOBCtrl.previousFiscalYearExist">{{ 'FORM.BUTTONS.IMPORT' | translate }}</span>
           </button>
         </div>
-
       </div>
-
     </form>
-
   </div>
 </div>

--- a/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.html
+++ b/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.html
@@ -1,111 +1,90 @@
-<form name="ClosingFiscalYear" bh-submit="$ctrl.stepForward(ClosingFiscalYear)" bh-form-defaults novalidate>
-  <div class="modal-header bg-danger text-danger">
-    <i class="fa fa-lock"></i>
-    <strong>{{ 'FISCAL.CLOSING_FISCAL_YEAR' | translate }}</strong>
+<form name="ClosingFiscalYear" bh-submit="$ctrl.stepForward(ClosingFiscalYear)" novalidate>
+  <div class="modal-header">
+    <ol class="headercrumb">
+      <li class="static" translate>FISCAL.TITLE</li>
+      <li class="title" translate>FISCAL.CLOSING_FISCAL_YEAR</li>
+    </ol>
   </div>
 
   <div class="modal-body">
     <div ng-show="!$ctrl.fiscal.locked">
 
       <h1 class="text-center">
-        {{'FORM.INFO.CLOSE_FISCAL_YEAR' | translate }}<br>
+        <span translate>FORM.INFO.CLOSE_FISCAL_YEAR</span>
+        <br>
         <strong>{{ $ctrl.fiscal.label }}</strong>
       </h1>
 
       <div ng-switch="$ctrl.steps">
-
         <div ng-switch-default>
 
           <!-- first step  -->
           <dl class="dl-horizontal">
             <!-- incomes  -->
-            <h3 class="bg-success text-success">
-              <dt>{{ 'FORM.LABELS.PROFIT' | translate }}</dt>
-              <dd>
-                <div class="text-right">
-                  {{ $ctrl.profit | currency: $ctrl.currency_id }}
-                </div>
+            <h3 class="text-success">
+              <dt translate>FORM.LABELS.PROFIT</dt>
+              <dd class="text-right">
+                {{ $ctrl.profit | currency: $ctrl.currency_id }}
               </dd>
             </h3>
 
             <!-- expenses  -->
-            <h3 style="margin: 10px 0px;" class="bg-danger text-danger">
-              <dt>{{ 'FORM.LABELS.CHARGE' | translate }}</dt>
-              <dd>
-                <div class="text-right">
-                  {{ $ctrl.charge | currency: $ctrl.currency_id }}
-                </div>
+            <h3 style="margin: 10px 0px;" class="text-danger">
+              <dt translate>FORM.LABELS.CHARGE</dt>
+              <dd class="text-right">
+                {{ $ctrl.charge | currency: $ctrl.currency_id }}
               </dd>
             </h3>
 
             <!-- results  -->
             <h3 style="border-top: 1px dashed #ccc; margin-top: 10px;" class="text-bold">
-              <dt>{{ 'FORM.LABELS.RESULT' | translate }}</dt>
-              <dd>
-                <div class="text-right" ng-class="{'text-danger' : $ctrl.globalResult < 0, 'text-success' : $ctrl.globalResult > 0 }">
-                  {{ $ctrl.globalResult | currency: $ctrl.currency_id }}
-                </div>
+              <dt translate>FORM.LABELS.RESULT</dt>
+              <dd class="text-right" ng-class="{'text-danger' : $ctrl.globalResult < 0, 'text-success' : $ctrl.globalResult > 0 }">
+                {{ $ctrl.globalResult | currency: $ctrl.currency_id }}
               </dd>
             </h3>
           </dl>
 
           <br>
 
-          <div class="form-group" ng-class="{ 'has-error' : ClosingFiscalYear.$submitted && ClosingFiscalYear.resultAccount.$invalid }">
-            <label class="control-label">
-              {{ "FORM.LABELS.RESULT_ACCOUNT_SCT" | translate }}
-            </label>
-
-            <ui-select name="resultAccount" ng-model="$ctrl.resultAccount" theme="bootstrap" required>
-              <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}">
-                <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
-              </ui-select-match>
-              <ui-select-choices ui-select-focus-patch repeat="account in $ctrl.accounts | filter:$select.search">
-                <strong ng-bind-html="account.number | highlight:$select.search"></strong>
-                <span ng-bind-html="account.label | highlight:$select.search"></span>
-              </ui-select-choices>
-            </ui-select>
-
-            <div class="help-block" ng-messages="ClosingFiscalYear.resultAccount.$error" ng-show="ClosingFiscalYear.$submitted">
-              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-            </div>
-          </div>
-
+          <bh-account-select
+            account-id="$ctrl.resultAccount.id"
+            on-select-callback="$ctrl.onSelectAccount(account)"
+            label="FORM.LABELS.RESULT_ACCOUNT_SCT"
+            excludeTitleAccounts="true">
+          </bh-account-select>
         </div>
 
         <div class="text-center" ng-switch-when="summary">
-          <h3>{{ 'FISCAL.SOLD_DESCRIPTION' | translate }}</h3>
+          <h3 translate>FISCAL.SOLD_DESCRIPTION</h3>
           <h3 class="text-primary">{{ $ctrl.resultAccount.number + ' - ' + $ctrl.resultAccount.label }}</h3>
           <h3>
-            {{ 'FISCAL.RESULT_AMOUNT' | translate }}:
+            <span translate>FISCAL.RESULT_AMOUNT</span>
             <span ng-class="{'text-danger' : $ctrl.globalResult < 0, 'text-success' : $ctrl.globalResult > 0 }">
               {{ $ctrl.globalResult | currency: $ctrl.currency_id }}
             </span>
           </h3>
         </div>
-
       </div>
 
     </div>
 
     <div ng-show="$ctrl.fiscal.locked">
       <h1 class="text-center">
-        <strong>{{ $ctrl.fiscal.label }}</strong><br>
-        {{ 'FISCAL.ALREADY_CLOSED' | translate }}
+        <strong>{{ $ctrl.fiscal.label }}</strong>
+        <br>
+        <span translate>FISCAL.ALREADY_CLOSED</span>
       </h1>
     </div>
-
   </div>
 
   <div class="modal-footer">
-    <!-- cancel  -->
     <button type="button" class="btn btn-default" ng-click="$ctrl.cancel()">
-      {{ 'FORM.BUTTONS.CANCEL' | translate }}
+      <span translate>FORM.BUTTONS.CANCEL</span>
     </button>
 
-    <!-- submit  -->
     <bh-loading-button loading-state="ClosingFiscalYear.$loading" ng-disabled="$ctrl.fiscal.locked">
-      {{ "FORM.BUTTONS.VALIDATE" | translate }}
+      <span translate>FORM.BUTTONS.VALIDATE</span>
     </bh-loading-button>
   </div>
 </form>

--- a/test/end-to-end/fiscalYears/fiscalYears.spec.js
+++ b/test/end-to-end/fiscalYears/fiscalYears.spec.js
@@ -171,7 +171,7 @@ describe('Fiscal Year', () => {
     const fiscalYearPattern = 'Test Fiscal Year 2015';
 
     // set the result account
-    FU.uiSelect('$ctrl.resultAccount', resultAccount);
+    components.accountSelect.set(resultAccount);
 
     // submit to next step
     submitButton.click();


### PR DESCRIPTION
This commit updates the Fiscal Year module with the current best coding
practices.  It specifically targets the closing fiscal year code and
updates it with the following changes:
 1. The translate directive is used instead of the translate filter
 2. The bhAccountSelect is used instead of a custom ui-select
 3. The modal uses a headercrumb(tm)
 4. Removed bhFormDefaults from the form.

This commit addresses most of the points in #1646 for closing a fiscal
year.  Tests have been updated accordingly. The rest of the fiscal year
modules should be updated in a similar fashion.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
