### PR TITLE
refactor(users): make activate/deactivate red

### DIFF
--- a/client/src/modules/users/templates/grid/action.cell.html
+++ b/client/src/modules/users/templates/grid/action.cell.html
@@ -1,17 +1,34 @@
-<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
-  <a href>
+<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body>
+  <a uib-dropdown-toggle href>
     <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
 
   <ul data-action="{{ rowRenderIndex}}"  class="dropdown-menu-right" uib-dropdown-menu>
-    <li><a data-method="edit" ng-click="grid.appScope.edit(row.entity)" href><i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span></a></li>
-    <li><a data-method="permission" ng-click="grid.appScope.editPermissions(row.entity)" href><i class="fa fa-key"></i> <span translate>FORM.BUTTONS.EDIT_PERMISSIONS</span></a></li>
-    <li ng-if="!row.entity.deactivated"><a data-method="activated" ng-click="grid.appScope.activatePermissions(row.entity, 1, 'FORM.DIALOGS.CONFIRM_DEACTIVATION')" href>
-      <i class="fa fa-lock"></i> <span translate>FORM.LABELS.DEACTIVATE</span></a>
+    <li>
+      <a data-method="edit" ng-click="grid.appScope.edit(row.entity)" href>
+        <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
+      </a>
     </li>
-    <li ng-if="row.entity.deactivated"><a data-method="activated" ng-click="grid.appScope.activatePermissions(row.entity, 0, 'FORM.DIALOGS.CONFIRM_ACTIVATION')" href>
-      <i class="fa fa-unlock"></i><span translate>FORM.LABELS.ACTIVATE</span></a>
+    <li>
+      <a data-method="permission" ng-click="grid.appScope.editPermissions(row.entity)" href>
+        <i class="fa fa-key"></i> <span translate>FORM.BUTTONS.EDIT_PERMISSIONS</span>
+      </a>
+    </li>
+    <li class="divider"></li>
+    <li ng-if="!row.entity.deactivated">
+      <a data-method="activated" ng-click="grid.appScope.activatePermissions(row.entity, 1, 'FORM.DIALOGS.CONFIRM_DEACTIVATION')" href>
+        <span class="text-danger">
+          <i class="fa fa-lock"></i> <span translate>FORM.LABELS.DEACTIVATE</span>
+        </span>
+      </a>
+    </li>
+    <li ng-if="row.entity.deactivated">
+      <a data-method="activated" ng-click="grid.appScope.activatePermissions(row.entity, 0, 'FORM.DIALOGS.CONFIRM_ACTIVATION')" href>
+        <span class="text-danger">
+          <i class="fa fa-unlock"></i><span translate>FORM.LABELS.ACTIVATE</span>
+        </span>
+      </a>
     </li>
   </ul>
 </div>

--- a/client/src/modules/users/users.js
+++ b/client/src/modules/users/users.js
@@ -19,8 +19,8 @@ function UsersController($state, Users, Notify, Modal) {
     enableSorting     : true,
     columnDefs : [
       { field : 'display_name', name : 'Display Name' },
-      { field : 'username', name : 'User Name', cellTemplate: '/modules/users/templates/user.name.cell.html' },
-      { name : 'action', displayName : '', cellTemplate: '/modules/users/templates/grid/action.cell.html', enableSorting : false }
+      { field : 'username', name : 'User Name', cellTemplate : '/modules/users/templates/user.name.cell.html' },
+      { name : 'action', displayName : '', cellTemplate : '/modules/users/templates/grid/action.cell.html', enableSorting : false },
     ],
   };
 
@@ -40,9 +40,9 @@ function UsersController($state, Users, Notify, Modal) {
     $state.go('users.editPermission', { id: user.id });
   }
 
-  function activatePermissions(user, value, message){
+  function activatePermissions(user, value, message) {
     vm.user.deactivated = value;
-    
+
     Modal.confirm(message)
       .then(function (confirmResponse) {
         if (!confirmResponse) {
@@ -52,11 +52,11 @@ function UsersController($state, Users, Notify, Modal) {
         // user has confirmed activation or deactivation of debtor group
         return Users.update(user.id, vm.user)
           .then(function () {
-            Notify.success("USERS.UPDATED");
-            $state.go('users.list', null, {reload : true});
+            Notify.success('USERS.UPDATED');
+            $state.go('users.list', null, { reload : true });
           })
           .catch(Notify.handleError);
-      });    
+      });
   }
 
   function handleError(error) {


### PR DESCRIPTION
This commit changes the user activate/deactivate to a red color and puts
it under a divider to indicate that it's a stronger action than the
other options.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
