### PR TITLE
deps(bower): bump angular versions to 1.6.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,10 +15,10 @@
     "src"
   ],
   "dependencies": {
-    "angular": "1.6.2",
-    "angular-animate": "1.6.2",
-    "angular-sanitize": "1.6.2",
-    "angular-messages": "1.6.2",
+    "angular": "1.6.4",
+    "angular-animate": "1.6.4",
+    "angular-sanitize": "1.6.4",
+    "angular-messages": "1.6.4",
     "angular-bootstrap": "2.5.0",
     "angular-ui-router": "1.0.0-rc.1",
     "angular-ui-grid": "4.0.4",
@@ -37,13 +37,13 @@
     "components-font-awesome": "4.7.0",
     "angular-ui-select": "0.19.6",
     "JsBarcode": "jsbarcode#3.5.9",
-    "angular-touch": "1.6.2",
+    "angular-touch": "1.6.4",
     "angular-growl-notifications": "2.5.0"
   },
   "devDependencies": {
-    "angular-mocks": "1.6.2"
+    "angular-mocks": "1.6.4"
   },
   "resolutions": {
-    "angular": "1.6.2"
+    "angular": "1.6.4"
   }
 }


### PR DESCRIPTION
I debugged an unrelated issue that caused me to try the latest angular
version.  Tests seem to pass.

See the full AngularJS CHANGELOG here:
https://github.com/angular/angular.js/blob/master/CHANGELOG.md#164-phenomenal-footnote-2017-03-31

-----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
