### PR TITLE
docs: include contributing guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ BHIMA
 [![Build Status](https://travis-ci.org/IMA-WorldHealth/bhima-2.X.svg)](https://travis-ci.org/IMA-WorldHealth/bhima-2.X)
 [![API Doc](https://doclets.io/IMA-WorldHealth/bhima-2.X/master.svg)](https://doclets.io/IMA-WorldHealth/bhima-2.X/master)
 
-_Bhima is alpha version software. Please do not use this in a commerical context._
-
 Bhima is a free, open source accounting and hospital information management system
 (HIMS) tailored for rural hospitals in Africa.  We are an international team
 based in the Democratic Republic of the Congo.
+
+BHIMA is an acronym for _basic hospital information management application_.
 
 Project Goals
 --------------------
@@ -28,10 +28,17 @@ accessing the server simultaneously.
 
 Contributing
 ---------------
-All contributions are welcome!  Our project is still in the alpha phase; we
-provide no guarantee on the build until our first releases (Spring 2014).
-However, feel free to fork, send us a pull request, do some style or
-translation work!
+All contributions are welcome!  If you want to get started hacking on BHIMA, the
+[developer wiki](https://github.com/IMA-WorldHealth/bhima-2.X/wiki) contains notes
+on our designs and testing infrastructure.  If you have any questions or need help
+getting started, please [open an issue](https://github.com/IMA-WorldHealth/bhima-2.X/issues/new) - 
+chances are you are not the only one!
+
+If you are new to git/Github check out our [Getting Started Guide](https://github.com/IMA-WorldHealth/bhima-2.X/wiki/Getting-Started:-Contributing-on-Github).
+
+Want to jump straight into code?  The [First Time Contributor](https://github.com/IMA-WorldHealth/bhima-2.X/issues?q=is%3Aissue+is%3Aopen+label%3A%22first+time+contributor%22)
+issues are a decent place to start.
+
 
 Installation
 -------------------


### PR DESCRIPTION
This commit adds links to the wiki, removes the scary alpha label, and references to Spring of 2014.  It also contains the actual BHIMA acronym - imagine that!