### PR TITLE
fix(filters): Invoice filter custom period start

### DIFF
--- a/client/src/js/services/FilterService.js
+++ b/client/src/js/services/FilterService.js
@@ -30,7 +30,7 @@ function FilterService(Store) {
   //       with a toggle between the array to populate and the default value
   FilterList.prototype.registerDefaultFilters = function registerDefaultFilters(filterDefinitions) {
     var formattedFilters = filterDefinitions.map(function (filterDefinition) {
-      var filter = new Filter(filterDefinition.key, filterDefinition.label, filterDefinition.valueFilter);
+      var filter = new Filter(filterDefinition.key, filterDefinition.label, filterDefinition.valueFilter, filterDefinition.comparitor);
       filter.setDefault(true);
 
       if (filterDefinition.defaultValue) {
@@ -46,7 +46,7 @@ function FilterService(Store) {
 
   FilterList.prototype.registerCustomFilters = function registerCustomFilters(filterDefinitions) {
     var formattedFilters = filterDefinitions.map(function (filterDefinition) {
-      var filter = new Filter(filterDefinition.key, filterDefinition.label, filterDefinition.valueFilter);
+      var filter = new Filter(filterDefinition.key, filterDefinition.label, filterDefinition.valueFilter, filterDefinition.comparitor);
       filter.setDefault(false);
       return filter;
     });
@@ -70,7 +70,7 @@ function FilterService(Store) {
   // ]
   FilterList.prototype.assignFilters = function assignFilters(valueList) {
     valueList.forEach(function (valueMap) {
-      this.assignFilter(valueMap.key, valueMap.value, valueMap.displayValue);
+      this.assignFilter(valueMap.key, valueMap.value, valueMap.displayValue, valueMap.comparitor);
     }.bind(this));
   };
 
@@ -167,11 +167,12 @@ function FilterService(Store) {
 
 // Filter class for storing filter information in a uniform way
 // @TODO add debug asserts to ensure that key and value are specified when required
-function Filter(key, label, valueFilter) {
+function Filter(key, label, valueFilter, comparitor) {
   // initialise internal state
   this._key = key;
   this._label = label;
   this._valueFilter = valueFilter;
+  this._comparitor = comparitor;
   this._value = null;
   this._isDefault = null;
   this._displayValue = null;

--- a/client/src/modules/cash/cash.service.js
+++ b/client/src/modules/cash/cash.service.js
@@ -126,8 +126,8 @@ function CashService(Modal, Api, Exchange, Session, moment, $translate, Filters,
 
   cashFilters.registerDefaultFilters([
     { key : 'period', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
-    { key : 'custom_period_start', label : 'PERIODS.START', valueFilter : 'date' },
-    { key : 'custom_period_end', label : 'PERIODS.END', valueFilter : 'date' },
+    { key : 'custom_period_start', label : 'PERIODS.START', valueFilter : 'date', comparitor : '>' },
+    { key : 'custom_period_end', label : 'PERIODS.END', valueFilter : 'date', comparitor : '<' },
     { key : 'limit', label : 'FORM.LABELS.LIMIT' }]);
 
   cashFilters.registerCustomFilters([

--- a/client/src/modules/invoices/patientInvoice.service.js
+++ b/client/src/modules/invoices/patientInvoice.service.js
@@ -119,8 +119,8 @@ function PatientInvoiceService(Modal, Session, Api, Filters, AppCache, Periods, 
 
   invoiceFilters.registerDefaultFilters([
     { key : 'period', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
-    { key : 'custom_period_start', label : 'PERIODS.START', valueFilter : 'date' },
-    { key : 'custom_period_end', label : 'PERIODS.END', valueFilter : 'date' },
+    { key : 'custom_period_start', label : 'PERIODS.START', valueFilter : 'date', comparitor : '>' },
+    { key : 'custom_period_end', label : 'PERIODS.END', valueFilter : 'date', comparitor : '<' },
     { key : 'limit', label : 'FORM.LABELS.LIMIT' }]);
 
   invoiceFilters.registerCustomFilters([

--- a/client/src/modules/templates/bhFilters.tmpl.html
+++ b/client/src/modules/templates/bhFilters.tmpl.html
@@ -9,7 +9,7 @@
     -->
     <span class="label label-warning">
       <i class="fa fa-filter"></i>
-      <span translate>{{filter._label}}</span> {{ filter.comparitor ? " " + filter.comparitor : ":" }}
+      <span translate>{{filter._label}}</span> {{ filter._comparitor ? " " + filter._comparitor : ":" }}
       {{ filter.displayValue }}
     </span>
   </li>
@@ -24,7 +24,7 @@
     <span class="label label-primary">
       <i class="fa fa-filter"></i>
       <span translate>{{filter._label}}</span>
-      {{ filter.comparitor ? " " + filter.comparitor : ":" }}
+      {{ filter._comparitor ? " " + filter._comparitor : ":" }}
       {{ filter.displayValue }}
 
       <a ng-if="!filter.isDefault" href ng-click="$ctrl.onRemoveFilter({ filter : filter._key })"

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -232,7 +232,7 @@ function find(options) {
   );
 
   filters.period('period', 'date');
-  filters.dateFrom('custion_period_start', 'date');
+  filters.dateFrom('custom_period_start', 'date');
   filters.dateTo('custom_period_end', 'date');
 
   const referenceStatement = `CONCAT_WS('.', '${identifiers.INVOICE.key}', project.abbr, invoice.reference) = ?`;


### PR DESCRIPTION
This commit resolves a typo in the custom period start filter for the
invoice registry.

It also introduces the comparitor alias for the FilterService, allowing
custom comparitors to be assigned to period start and end dates.