### PR TITLE
fix(reports): Ensure period 0 is considered in balance calculations

### DIFF
--- a/server/controllers/finance/accounts/extra.js
+++ b/server/controllers/finance/accounts/extra.js
@@ -63,11 +63,18 @@ function getPeriodForDate(date) {
  * @returns Promise - promise wrapping the balance object
  */
 function getPeriodAccountBalanceUntilDate(accountId, date, fiscalYearId) {
+  // always factor in period 0 which does not have a valid end date entry
+  const periodCondition = `
+    period.number = 0
+    OR
+    period.end_date <= DATE(?)
+  `;
+
   const sql = `
     SELECT SUM(debit - credit) AS balance
     FROM period_total JOIN period ON period.id = period_total.period_id
     WHERE period_total.account_id = ?
-      AND period.end_date <= DATE(?)
+      AND ${periodCondition}
       AND period.fiscal_year_id = ?;
   `;
 
@@ -101,7 +108,7 @@ function getComputedAccountBalanceUntilDate(accountId, date, periodId) {
  *
  * @description
  * Query the database for an account's balance as of a start date.  Note that the date should be escaped (via new
- * Date()) prior to calling this function - this method is expected to does not do any escaping.
+ * Date()) prior to calling this function
  *
  * @param {Number} accountId - the identifier for the account
  * @param {Date} date - the date that the opening balance should be computed through
@@ -111,13 +118,20 @@ function getOpeningBalanceForDate(accountId, date) {
   let balance = 0;
 
   return getFiscalYearForDate(date)
+
+    // 1. sum period totals up to the current required period
     .then(fiscalYearId =>
       getPeriodAccountBalanceUntilDate(accountId, date, fiscalYearId)
     )
+
+    // 2. fetch the current dates period
     .then((previousPeriodClosingBalance) => {
       balance += previousPeriodClosingBalance;
       return getPeriodForDate(date);
     })
+
+    // 3. calculate the sum of all general ledger transaction against this account
+    //    for the current period up to the current date
     .then(periodId =>
       getComputedAccountBalanceUntilDate(accountId, date, periodId)
     )


### PR DESCRIPTION
This commit ensures that period 0 is factored into opening balance
calculations. Currently as no start or end date is provided for period 0
it is ignored in opening balance calculations. This adds a general
exception for period 0.