### PR TITLE
fix(reports): Use correct end period comparison for account balance

### DIFF
--- a/server/controllers/finance/accounts/extra.js
+++ b/server/controllers/finance/accounts/extra.js
@@ -63,11 +63,15 @@ function getPeriodForDate(date) {
  * @returns Promise - promise wrapping the balance object
  */
 function getPeriodAccountBalanceUntilDate(accountId, date, fiscalYearId) {
-  // always factor in period 0 which does not have a valid end date entry
+  // - always factor in period 0 which does not have a valid end date entry
+  // - period end date is strictly less than the current date as the transactions
+  // for the current period will be added on top - if the last (end) date of a period
+  // is selected transactions will be added on top and the current period will
+  // be selected
   const periodCondition = `
     period.number = 0
     OR
-    period.end_date <= DATE(?)
+    period.end_date < DATE(?)
   `;
 
   const sql = `


### PR DESCRIPTION
This commit ensures that values the current period are not included in
the period total calculation for determining an accounts opening
balance. This is essential as transactions from the current period (up
to the current date) are then summed and added to the total value. If
the last date in a period is selected this would then result in counting
the current period twice.