### PR TITLE
Fix: ui select option rendering

### DIFF
--- a/client/src/modules/inventory/configuration/groups/groups.html
+++ b/client/src/modules/inventory/configuration/groups/groups.html
@@ -10,7 +10,7 @@
       ng-click="GroupsCtrl.addInventoryGroup()"
       class="pull-right btn btn-default btn-sm"
       type="button" data-create-group>
-      <i class="fa fa-plus"></i><span translate> FORM.LABELS.ADD </span>
+      <i class="fa fa-plus"> </i><span translate> FORM.LABELS.ADD </span>
     </button>
   </div>
 
@@ -48,7 +48,7 @@
             <a href
               ng-click="GroupsCtrl.editInventoryGroup(group.uuid)"
               data-edit-group="{{ group.code }}">
-              <i class="fa fa-edit"></i> {{ 'FORM.BUTTONS.EDIT' | translate }}
+              <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
             </a>
           </td>
           <td>
@@ -56,7 +56,7 @@
               ng-click="GroupsCtrl.deleteInventoryGroup(group.uuid)"
               class="text-danger"
               data-delete-group="{{ group.code }}">
-              <i class="fa fa-remove"></i> {{ 'FORM.BUTTONS.DELETE' | translate }}
+              <i class="fa fa-remove"></i> <span translate>FORM.BUTTONS.DELETE</span>
             </a>
           </td>
         </tr>

--- a/client/src/modules/inventory/configuration/groups/groups.html
+++ b/client/src/modules/inventory/configuration/groups/groups.html
@@ -10,7 +10,7 @@
       ng-click="GroupsCtrl.addInventoryGroup()"
       class="pull-right btn btn-default btn-sm"
       type="button" data-create-group>
-      <i class="fa fa-plus"> </i><span translate> FORM.LABELS.ADD </span>
+      <i class="fa fa-plus"> </i> <span translate>FORM.LABELS.ADD</span>
     </button>
   </div>
 
@@ -38,7 +38,7 @@
           <td>{{ group.name }}</td>
           <td>
             <a ui-sref="inventory.list({ filters : { group_uuid : group.uuid }})" href>
-              {{ group.inventory_counted }} <small class="text-lowercase" translate> INVENTORY.ELEMENT</small>(s)<span class="fa fa-link"></span>
+              {{ group.inventory_counted }} <span class="text-lowercase" translate> INVENTORY.ELEMENT</span>(s)
             </a>
           </td>
           <td class="text-center">{{ group.saleAccountNumber }}</td>

--- a/client/src/modules/inventory/configuration/groups/modals/actions.tmpl.html
+++ b/client/src/modules/inventory/configuration/groups/modals/actions.tmpl.html
@@ -1,15 +1,15 @@
 <form name="ActionForm" bh-submit="$ctrl.submit(ActionForm)" novalidate>
   <div class="modal-header">
     <i class="fa fa-list"></i>
-    <span ng-if="$ctrl.action==='add'">{{ 'INVENTORY.ADD_GROUP' | translate }}</span>
-    <span ng-if="$ctrl.action==='edit'">{{ 'INVENTORY.EDIT_GROUP' | translate }}</span>
+    <span ng-if="$ctrl.action==='add'" translate>INVENTORY.ADD_GROUP</span>
+    <span ng-if="$ctrl.action==='edit'" translate>INVENTORY.EDIT_GROUP</span>
   </div>
 
   <div class="modal-body">
     <div
       class="form-group"
       ng-class="{ 'has-error' : ActionForm.$submitted && ActionForm.name.$invalid }">
-      <label class="control-label">{{ 'FORM.LABELS.NAME' | translate }}</label>
+      <label class="control-label" translate>FORM.LABELS.NAME</label>
       <input ng-model="$ctrl.session.name"
         class="form-control"
         type="text"
@@ -24,7 +24,7 @@
 
     <div class="form-group"
       ng-class="{ 'has-error' : ActionForm.$submitted && ActionForm.code.$invalid }">
-      <label class="control-label">{{ 'FORM.LABELS.CODE' | translate }}</label>
+      <label class="control-label" translate>FORM.LABELS.CODE</label>
       <input ng-model="$ctrl.session.code"
         class="form-control"
         type="text"
@@ -40,14 +40,14 @@
     <div class="form-group"
       ng-class="{ 'has-error' : ActionForm.$submitted && ActionForm.salesAccount.$invalid }">
       <label class="control-label">
-        {{ 'FORM.SELECT.ACCOUNT' | translate }} ({{ 'FORM.LABELS.SALE' | translate }})
+        <span translate>FORM.SELECT.ACCOUNT</span> (<span translate>FORM.LABELS.SALE</span>)
       </label>
 
       <ui-select
         name="salesAccount"
         ng-model="$ctrl.session.salesAccount">
         <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}" allow-clear="true">
-          <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
+          <span><strong>{{$select.selected.number}}</strong> {{$select.selected.label}}</span>
         </ui-select-match>
         <ui-select-choices
           ui-select-focus-patch
@@ -65,13 +65,13 @@
 
     <div class="form-group">
       <label class="control-label">
-        {{ 'FORM.SELECT.ACCOUNT' | translate }} ({{ 'FORM.LABELS.STOCK' | translate }})
+        <span translate>FORM.SELECT.ACCOUNT</span> (<span translate>FORM.LABELS.STOCK</span>)
       </label>
       <ui-select
         name="stockAccount"
         ng-model="$ctrl.session.stockAccount">
         <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}"  allow-clear="true">
-          <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
+          <span><strong>{{$select.selected.number}}</strong> {{$select.selected.label}}</span>
         </ui-select-match>
         <ui-select-choices
           ui-select-focus-patch
@@ -85,14 +85,14 @@
 
     <div class="form-group">
       <label class="control-label">
-        {{ 'FORM.SELECT.ACCOUNT' | translate }} ({{ 'FORM.LABELS.CHARGE' | translate }})
+        <span translate>FORM.SELECT.ACCOUNT</span> (<span translate>FORM.LABELS.CHARGE</span>)
       </label>
 
       <ui-select
         name="cogsAccount"
         ng-model="$ctrl.session.cogsAccount">
         <ui-select-match placeholder="{{ 'FORM.PLACEHOLDERS.ACCOUNT' | translate }}" allow-clear="true">
-          <strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span>
+          <span><strong>{{$select.selected.number}}</strong> {{$select.selected.label}}</span>
         </ui-select-match>
         <ui-select-choices
           ui-select-focus-patch
@@ -108,12 +108,12 @@
   <div class="modal-footer">
     <button type="button"
       class="btn btn-default"
-      ng-click="$ctrl.cancel()">
-      {{ 'FORM.BUTTONS.CANCEL' | translate }}
+      ng-click="$ctrl.cancel()" translate>
+      FORM.BUTTONS.CANCEL
     </button>
 
     <bh-loading-button loading-state="ActionForm.$loading">
-      {{ 'FORM.BUTTONS.SUBMIT' | translate }}
+      <span translate>FORM.BUTTONS.SUBMIT </span>
     </bh-loading-button>
   </div>
 </form>

--- a/client/src/modules/inventory/configuration/types/types.html
+++ b/client/src/modules/inventory/configuration/types/types.html
@@ -2,14 +2,14 @@
   <div class="panel-heading" style="display: flex; justify-content: space-between;">
     <span>
       <i class="fa fa-list"></i>
-      {{ 'INVENTORY.LIST_TYPE' | translate }} ({{ TypesCtrl.typeList.length }})
+      <span translate>INVENTORY.LIST_TYPE</span> ({{ TypesCtrl.typeList.length }})
     </span>
 
     <button
       ng-click="TypesCtrl.addInventoryType()"
       class="btn btn-default btn-sm"
-      type="button"
-      data-create-type><i class="fa fa-plus"></i>
+      type="button" data-create-type>
+      <i class="fa fa-plus"></i> <span translate>FORM.BUTTONS.ADD</span>
     </button>
   </div>
 
@@ -18,7 +18,7 @@
       <thead>
         <tr>
           <th>#</th>
-          <th>{{ 'FORM.LABELS.LABEL' | translate }}</th>
+          <th translate>FORM.LABELS.LABEL</th>
           <th>&nbsp;</th>
         </tr>
       </thead>
@@ -31,7 +31,7 @@
             <a style="cursor:pointer; text-decoration:none;"
               ng-click="TypesCtrl.editInventoryType(type.id)"
               data-edit-type="{{ type.text }}">
-              <i class="fa fa-edit"></i> {{ "FORM.BUTTONS.EDIT" | translate }}
+              <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
             </a>
           </td>
           <td>
@@ -39,7 +39,7 @@
               ng-click="TypesCtrl.deleteInventoryType(type.id)"
               class="text-danger"
               data-delete-type="{{ type.text }}">
-              <i class="fa fa-remove"></i> {{ "FORM.BUTTONS.DELETE" | translate }}
+              <i class="fa fa-remove"></i> <span translate>FORM.BUTTONS.DELETE</span>
             </a>
           </td>
         </tr>

--- a/client/src/modules/inventory/configuration/units/units.html
+++ b/client/src/modules/inventory/configuration/units/units.html
@@ -2,14 +2,14 @@
   <div class="panel-heading" style="display: flex; justify-content: space-between;">
     <span>
       <i class="fa fa-list"></i>
-      {{ 'INVENTORY.LIST_UNIT' | translate }} ({{ UnitsCtrl.unitList.length }})
+      <span translate>INVENTORY.LIST_UNIT</span> ({{ UnitsCtrl.unitList.length }})
     </span>
 
     <button
       ng-click="UnitsCtrl.addInventoryUnit()"
       class="btn btn-default btn-sm"
       type="button"
-      data-create-unit><i class="fa fa-plus"></i>
+      data-create-unit><i class="fa fa-plus"></i> <span translate>FORM.BUTTONS.ADD</span>
     </button>
   </div>
 
@@ -18,7 +18,7 @@
       <thead>
         <tr>
           <th>#</th>
-          <th>{{ 'FORM.LABELS.LABEL' | translate }}</th>
+          <th translate>FORM.LABELS.LABEL</th>
           <th>&nbsp;</th>
         </tr>
       </thead>
@@ -29,12 +29,12 @@
           <td>{{ unit.text }}</td>
           <td>
             <a href ng-click="UnitsCtrl.editInventoryUnit(unit.id)" data-edit-unit="{{ unit.text }}">
-              <i class="fa fa-edit"></i> {{ "FORM.BUTTONS.EDIT" | translate }}
+              <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
             </a>
           </td>
           <td>
             <a href ng-click="UnitsCtrl.deleteInventoryUnit(unit.id)" data-delete-unit="{{ unit.text }}" class="text-danger">
-              <i class="fa fa-remove"></i> {{ "FORM.BUTTONS.DELETE" | translate }}
+              <i class="fa fa-remove"></i> <span translate>FORM.BUTTONS.DELETE</span>
             </a>
           </td>
         </tr>

--- a/client/src/modules/prices/modal.html
+++ b/client/src/modules/prices/modal.html
@@ -1,12 +1,12 @@
 <form  name="ModalForm" bh-submit="ModalCtrl.submit(ModalForm.$invalid)" novalidate>
   <div class="modal-header">
-    <h4>{{ 'PRICE_LIST.PRICE_LIST_ITEMS' | translate }}</h4>
+    <h4 translate>PRICE_LIST.PRICE_LIST_ITEMS</h4>
   </div>
 
   <div class="modal-body">
 
     <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.label.$invalid }">
-      <label class="control-label">{{ 'FORM.LABELS.DESIGNATION' | translate }}</label>
+      <label class="control-label" translate>FORM.LABELS.DESIGNATION</label>
       <input type="text" class="form-control" name="label" ng-maxlength="ModalCtrl.length250" autocomplete="off" ng-model="ModalCtrl.data.label" required>
       <div class="help-block" ng-messages="ModalForm.label.$error" ng-show="ModalForm.$submitted">
         <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
@@ -14,7 +14,7 @@
     </div>
 
     <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && (ModalForm.value.$invalid || ModalCtrl.error) }">
-      <label class="control-label">{{ 'FORM.LABELS.VALUE' | translate }}</label>
+      <label class="control-label" translate>FORM.LABELS.VALUE</label>
       <input type="number" class="form-control" autocomplete="off" name="value" ng-model="ModalCtrl.data.value" required>
       <div class="help-block" ng-messages="ModalForm.value.$error" ng-show="ModalForm.$submitted">
         <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
@@ -23,18 +23,19 @@
 
     <div class="checkbox">
       <label>
-        <input type="checkbox" name="is_percentage" id="is_percentage" ng-true-value="1" ng-false-value="0" ng-model="ModalCtrl.data.is_percentage">  {{ 'FORM.LABELS.IS_PERCENT' | translate }}
+        <input type="checkbox" name="is_percentage" id="is_percentage" ng-true-value="1" ng-false-value="0" ng-model="ModalCtrl.data.is_percentage">
+        <span translate>FORM.LABELS.IS_PERCENT</span>
       </label>
     </div>
 
     <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.inventory_uuid.$invalid }">
-      <label class="control-label">{{ "FORM.LABELS.INVENTORY" | translate }}</label>
+      <label class="control-label" translate>FORM.LABELS.INVENTORY</label>
       <ui-select
         name="inventory_uuid"
         ng-model="ModalCtrl.data.inventory_uuid"
         required>
         <ui-select-match placeholder="{{ 'FORM.SELECT.INVENTORY' | translate }}">
-          <strong>{{$select.selected.code }}</strong> <span>{{$select.selected.label}}</span>
+          <span><strong>{{$select.selected.code }}</strong> {{ $select.selected.label }}</span>
         </ui-select-match>
         <ui-select-choices
           ui-select-focus-patch
@@ -49,16 +50,16 @@
     </div>
 
     <span ng-if="ModalCtrl.error" class="text-danger">
-      <i class="fa fa-alert"></i> {{ ModalCtrl.error | translate }}
+      <i class="fa fa-alert"></i> <span translate>{{ ModalCtrl.error }}</span>
     </span>
   </div>
 
   <div class="modal-footer">
     <bh-loading-button loading-state="ModalForm.$loading" id="submit-price-list">
-      {{ "FORM.BUTTONS.ADD" | translate }}
+      <span translate>FORM.BUTTONS.ADD</span>
     </bh-loading-button>
-    <button type="button" class="btn btn-default" ng-click="ModalCtrl.cancel()">
-      {{ "FORM.BUTTONS.CANCEL" | translate }}
+    <button type="button" class="btn btn-default" ng-click="ModalCtrl.cancel()" translate>
+      FORM.BUTTONS.CANCEL
     </button>
   </div>
 </form>

--- a/client/src/modules/prices/prices.html
+++ b/client/src/modules/prices/prices.html
@@ -38,7 +38,11 @@
             <tbody>
               <tr ng-class="{'rowSelected' : PriceListCtrl.priceList.uuid === list.uuid}" ng-repeat="list in PriceListCtrl.priceLists | orderBy:'label'">
                 <td> {{ list.label }} </td>
-                <td colspan="2"><a class="btn btn-xs btn-default" id="price_list_{{ $index+1 }}" ng-click="PriceListCtrl.update(list)"><i class="fa fa-pencil"></i></a></td>
+                <td colspan="2">
+                  <a class="btn btn-xs btn-default" id="price_list_{{ $index+1 }}" ng-click="PriceListCtrl.update(list)">
+                    <i class="fa fa-pencil"></i> <span translate>FORM.BUTTONS.EDIT</span>
+                  </a>
+                </td>
               </tr>
               <tr ng-if="PriceListCtrl.priceList.data.length===0">
                 <td colspan="3"><i translate> PRICE_LIST.NO_RECORDS </i></tr>


### PR DESCRIPTION
For some reason, a `ui-select` can only have a single `<span>` element within due to a miscreated CSS selector in the bootstrap css theme.  Otherwise, the text is not labeled on the same line and is misaligned.  This PR fixes those issues in the prices.html file and the inventory management page.

It also uses the `translate` directive where applicable.

Closes #993.  Closes #1720.