### PR TITLE
fix(docs): remove broken link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 Thank you for contributing!
 
 Before submitting this pull request, please verify that you have:
- - [ ] Run your code through ESLint.  [Check out our styleguide](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/docs/STYLEGUIDE.md).
+ - [ ] Run your code through eslint.
  - [ ] Run integration tests.
  - [ ] Run end-to-end tests.
  - [ ] Accurately described the changes your are making in this pull request.
 
-For a more detailed checklist, [see the official review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.
+For a more detailed checklist, [see the online review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.
 
 Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!


### PR DESCRIPTION
This commit fixes the broken styleguide link in the PR template.  We no
longer use a styleguide, but instead rely on eslint rules to enforce
styling.