### PR TITLE
fix: allow navigation to settings after 403 error

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -92,8 +92,10 @@ function startupConfig($rootScope, $state, $uibModalStack, SessionService, amMom
       next.name.indexOf('403') !== -1
     );
 
-    // pass through to error state
-    if (isErrorState) {
+    var isSettingsState = next.name.indexOf('settings') !== -1;
+
+    // pass through to error state or settings state
+    if (isErrorState || isSettingsState) {
       return;
     }
 


### PR DESCRIPTION
This commit fixes a small bug does not a user log out after they have
hit the 403 state.

Closes #1862.