### PR TITLE
fix(reports): hack to refresh reportData

### DIFF
--- a/client/src/modules/reports/reports.js
+++ b/client/src/modules/reports/reports.js
@@ -2,10 +2,10 @@ angular.module('bhima.controllers')
   .controller('ReportsController', ReportsController);
 
 ReportsController.$inject = [
-  '$state', 'reportData',
+  '$state', 'reportData', '$scope', 'BaseReportService'
 ];
 
-function ReportsController($state, reportData) {
+function ReportsController($state, reportData, $scope, SavedReports) {
   var vm = this;
   var archiveState = 'reportsBase.reportsArchive';
 
@@ -15,4 +15,20 @@ function ReportsController($state, reportData) {
   function isArchive() {
     return $state.current.name === archiveState;
   }
+
+  function refreshReportData() {
+    SavedReports.requestKey($state.params.key)
+      .then(function (results) {
+        vm.report = results[0];
+      });
+  }
+
+  // FIXME(@jniles): this is a hack to get the state to refresh the top level data
+  // without changing the way states are defined.  Since the top level state never
+  // changes, the only effective way to communicate between states is to either:
+  //  1) Have a service share the data (this would require changing a ton of files)
+  //  2) Have an event trigger the refresh (much easier, implemented here)
+  $scope.$on('$stateChangeSuccess', function () {
+    refreshReportData();
+  });
 }

--- a/client/src/modules/reports/reports.routes.js
+++ b/client/src/modules/reports/reports.routes.js
@@ -3,7 +3,7 @@ angular.module('bhima.routes')
     // a list of all supported reported and their respective keys, this allows
     // the ui-view to be populated with the correct report configuration form
     /* @const */
-    var SUPPORTED_REPORTS = [      
+    var SUPPORTED_REPORTS = [
       'cash_report',
       'account_report',
       'balance_sheet_report',
@@ -40,7 +40,7 @@ angular.module('bhima.routes')
         url : '/'.concat(key),
         controller : key.concat('Controller as ReportConfigCtrl'),
         templateUrl : '/modules/reports/generate/'.concat(key, '/', key, '.html'),
-        params : { key : key },
+        params : { key : key }
       });
     });
   }]);


### PR DESCRIPTION
~~This commit implements a $rootScope hack to refresh the $state's reportData.~~  [See updated description](https://github.com/IMA-WorldHealth/bhima-2.X/pull/1876#issuecomment-318047514)

Closes #1821.