### PR TITLE
fix(Invoice text)

### DIFF
--- a/server/controllers/finance/reports/invoices/receipt.handlebars
+++ b/server/controllers/finance/reports/invoices/receipt.handlebars
@@ -88,7 +88,7 @@
   {{/if}}
 
   <div class="row">
-    <div class="col-xs-6 col-xs-offset-6" >
+    <div class="col-xs-8 col-xs-offset-4" >
       <!-- billing service  -->
       {{#if billing.length}}
         <h4>


### PR DESCRIPTION
- Prevent overflow when Billing Service Name too Long
- Update property invoice/receipt.handlebars

closes #1858