### PR TITLE
fix(build) Resolve uglify syntax error in employee

### DIFF
--- a/client/src/modules/employees/registration/employees.js
+++ b/client/src/modules/employees/registration/employees.js
@@ -8,7 +8,7 @@ EmployeeController.$inject = [
   'bhConstants', 'ReceiptModal', 'SessionService',
 ];
 
-function EmployeeController(Employees, Services, Grades, Functions, CreditorGroups, util, Notify, bhConstants, Receipts, Session,) {
+function EmployeeController(Employees, Services, Grades, Functions, CreditorGroups, util, Notify, bhConstants, Receipts, Session) {
   var vm = this;
   vm.enterprise = Session.enterprise;
 


### PR DESCRIPTION
This commit removes a trailing comma in a function definition
that forces the uglify (minify) JS step of the build process
to crash on production servers.