### PR TITLE
fix(users): enhance disabled user UI

### DIFF
--- a/client/src/modules/users/templates/user.name.cell.html
+++ b/client/src/modules/users/templates/user.name.cell.html
@@ -1,3 +1,0 @@
-<div class="ui-grid-cell-contents" ng-class="{'text-muted strike' : row.entity.deactivated }">
-  {{ row.entity.username }}
-</div>

--- a/client/src/modules/users/users.html
+++ b/client/src/modules/users/users.html
@@ -9,23 +9,24 @@
       <div class="toolbar-item">
         <button
           type="button"
-          ng-click="UsersCtrl.toggleFilter()"
-          data-method="filter"
-          class="btn btn-default"
-          ng-class="{ 'btn-info' : UsersCtrl.filterEnabled }">
-          <i class="fa fa-filter"></i>
-        </button>
-      </div>      
-      
-      <div class="toolbar-item">
-        <button
-          type="button"
           class="btn btn-default text-capitalize"
           ui-sref="users.create"
           data-method="create">
           <i class="fa fa-plus"></i> <span translate>USERS.ADD_USER</span>
         </button>
       </div>
+
+      <div class="toolbar-item">
+        <button
+          type="button"
+          ng-click="UsersCtrl.toggleFilter()"
+          data-method="filter"
+          class="btn btn-default"
+          ng-class="{ 'btn-info' : UsersCtrl.filterEnabled }">
+          <i class="fa fa-filter"></i>
+        </button>
+      </div>
+
     </div>
   </div>
 </div>

--- a/client/src/modules/users/users.js
+++ b/client/src/modules/users/users.js
@@ -13,6 +13,12 @@ function UsersController($state, Users, Notify, Modal, uiGridConstants) {
   vm.filterEnabled = false;
   vm.toggleFilter = toggleFilter;
 
+  // this function selectively applies the muted cell classes to
+  // disabled user entities
+  function muteDisabledCells(grid, row, col, rowRenderIndex, colRenderIndex) {
+    if (row.entity.deactivated) { return 'text-muted strike'; }
+  }
+
   // options for the UI grid
   vm.gridOptions = {
     appScopeProvider  : vm,
@@ -22,8 +28,8 @@ function UsersController($state, Users, Notify, Modal, uiGridConstants) {
     enableSorting     : true,
     onRegisterApi     : onRegisterApiFn,
     columnDefs : [
-      { field : 'display_name', displayName : 'FORM.LABELS.USERNAME', headerCellFilter : 'translate', enableFiltering  : true },
-      { field : 'username', displayName : 'FORM.LABELS.LOGIN', headerCellFilter : 'translate', cellTemplate : '/modules/users/templates/user.name.cell.html', enableFiltering  : true },
+      { field : 'display_name', displayName : 'FORM.LABELS.USERNAME', headerCellFilter : 'translate', cellClass : muteDisabledCells, enableFiltering : true },
+      { field : 'username', displayName : 'FORM.LABELS.LOGIN', headerCellFilter : 'translate', cellClass : muteDisabledCells, enableFiltering  : true },
       { field : 'action', displayName : '', cellTemplate : '/modules/users/templates/grid/action.cell.html', enableSorting : false, enableFiltering  : false },
     ],
   };


### PR DESCRIPTION
This commit makes sure the strikethrough and muted classes are applied
to both the username and displayname of the user page.  This gives a
great visual indicator.  I've also added the classes dynamically to
remove the dependency on another template.  Finally, the button for filtering
has been moved to be the same as all other registries.

![enhanceduserinterface](https://user-images.githubusercontent.com/896472/28713656-fe6d6b0a-735d-11e7-8af7-4e941ca41d0c.png)
_Fig 1: Enhanced User Interface for Disabled Users_