### PR TITLE
refactor(breadcrumb): standardize UI

### DIFF
--- a/client/src/modules/templates/breadcrumb.tmpl.html
+++ b/client/src/modules/templates/breadcrumb.tmpl.html
@@ -3,7 +3,7 @@
 
     <ol class="headercrumb">
       <li ng-repeat="p in vm.bcPaths" data-method="{{ p.dataMethod }}"  ng-class="{ 'static' : !$last, 'title' : $last }">
-        <span ng-hide="p.link">{{ p.label | translate }}</span>
+        <span ng-hide="p.link" translate>{{ p.label }}</span>
         <span ng-show="p.link">
           <a ng-href="{{ p.link }}" id="{{ vm.prefix + p.id }}" href translate>{{ p.label }}</a>
         </span>
@@ -14,11 +14,12 @@
       <!-- dropdown buttons -->
       <div class="toolbar-item" ng-if="vm.bcDropdowns.length">
         <span ng-repeat="d in vm.bcDropdowns" uib-dropdown toolbar-dropdown>
-          <a class="btn btn-sm" ng-class="d.color" id="{{ vm.prefix + d.id }}" data-method="{{ d.dataMethod }}" uib-dropdown-toggle>
-            <i class="fa" ng-class="'{{d.icon}}'"></i> {{ d.selected | translate }} <span class="caret"></span>
-          </a>
-          <ul class="pull-right" uib-dropdown-menu>
-            <li ng-repeat="opt in d.option"  class="text-left">
+          <button class="btn btn-default" ng-class="d.color" id="{{ vm.prefix + d.id }}" data-method="{{ d.dataMethod }}" uib-dropdown-toggle>
+            <i class="fa" ng-class="'{{d.icon}}'"></i> <span translate>{{ d.selected }}</span> <span class="caret"></span>
+          </button>
+
+          <ul class="dropdown-menu-right" uib-dropdown-menu>
+            <li ng-repeat="opt in d.option">
               <a href ng-click="vm.helperDropdown(opt, d)" id="{{ vm.prefix + opt.id }}" data-method="{{ opt.dataMethod }}">
                  <i class="fa" ng-class="'{{opt.icon}}'"></i> <span translate>{{ opt.label }}</span>
               </a>
@@ -46,7 +47,7 @@
         <button class="toolbar-item btn"
           id="{{ vm.prefix + a.id }}"
           ng-class="a.color"
-          ng-repeat="a in vm.bcButtons"
+          ng-repeat="a in vm.bcButtons track by a.id"
           ng-click="a.action(a.label)"
           data-method="{{ a.dataMethod }}"
           ng-disabled="a.disabled">


### PR DESCRIPTION
This commit refactors the bhBreadcrumb styles to use a larger button for
the dropdown menu, remove the "pull-right" classes, translate with the 
translate directive, and optimize the dropdown rendering.

![breadcrumbnewui](https://user-images.githubusercontent.com/896472/28714958-d7780e8c-7363-11e7-9999-6e9dec1accf2.png)
_Fig 1: New BreadCrumb UI_

![breadcrumboldui](https://user-images.githubusercontent.com/896472/28714959-d77c86ce-7363-11e7-8f9b-a4dea0ff223d.png)
_Fig 2: Old BreadCrumb UI_
