### PR TITLE
fix(fiscal): add missing i18n translations

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -148,7 +148,8 @@
             "UNPOSTED_TRANSACTION": "Unposted Transactions",
             "UPDATE_SUCCESS": "Updated successfully",
             "UPLOAD_PICTURE_FAILED": "The selected file is not an picture",
-            "VIEW_BEGINNING_BALACE": "View Beginning Balance"
+            "VIEW_BEGINNING_BALANCE": "View Beginning Balance",
+            "VIEW_CLOSING_BALANCE": "View Closing Balance"
         },
         "LABELS": {
             "ABBREVIATION": "Abbreviation",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -148,7 +148,8 @@
             "UNPOSTED_TRANSACTION": "Transactions non postées",
             "UPDATE_SUCCESS": "Mise à jour avec succès",
             "UPLOAD_PICTURE_FAILED": "Le fichier selectionné n'est pas une image",
-            "VIEW_BEGINNING_BALACE": "Aperçue de la balance d'ouverture"
+            "VIEW_BEGINNING_BALANCE": "Aperçue de la balance d'ouverture",
+            "VIEW_CLOSING_BALANCE": "Aperçue de la balance de cloture"
         },
         "LABELS": {
             "ABBREVIATION": "Abbreviation",

--- a/client/src/modules/fiscal/fiscal.manage.html
+++ b/client/src/modules/fiscal/fiscal.manage.html
@@ -74,7 +74,7 @@
         <!-- opening balance  -->
         <button type="button" class="btn btn-default" data-action="opening-balance" ui-sref="fiscal.openingBalance({ id: FiscalManageCtrl.fiscal.id })">
           <i class="fa fa-balance-scale"></i>
-          <span translate>FORM.INFO.VIEW_BEGINING_BALANCE</span>
+          <span translate>FORM.INFO.VIEW_BEGINNING_BALANCE</span>
         </button>
 
         <!-- closing balance  -->

--- a/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.html
+++ b/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.html
@@ -61,7 +61,7 @@
           <bh-account-select
             account-id="$ctrl.resultAccount.id"
             on-select-callback="$ctrl.onSelectAccount(account)"
-            label="FORM.SELECT.RESULT_ACCOUNT"
+            label="FORM.SELECT.RESULT_ACCOUNT_SCT"
             excludeTitleAccounts="true">
           </bh-account-select>
         </div>


### PR DESCRIPTION
This commit fixes a few keys in the fiscal year module that were untranslated.