### PR TITLE
fix(cash): do not assign currency to aggregation

### DIFF
--- a/client/src/modules/cash/payments/registry.js
+++ b/client/src/modules/cash/payments/registry.js
@@ -79,7 +79,7 @@ function CashPaymentRegistryController(
     // @TODO(jniles): This is temporary, as it doesn't take into account USD payments
     aggregationType : uiGridConstants.aggregationTypes.sum,
     aggregationHideLabel : true,
-    footerCellFilter : 'currency:'.concat(Session.enterprise.currency_id),
+    footerCellClass: 'text-right',
   }, {
     field : 'cashbox_label',
     displayName : 'TABLE.COLUMNS.CASHBOX',
@@ -109,7 +109,7 @@ function CashPaymentRegistryController(
 
   gridColumns = new Columns(vm.gridOptions, cacheKey);
   state = new GridState(vm.gridOptions, cacheKey);
-  
+
   // saves the grid's current configuration
   vm.saveGridState = state.saveGridState;
   function clearGridState() {
@@ -185,7 +185,7 @@ function CashPaymentRegistryController(
 
   function startup() {
     if ($state.params.filters) {
-      // Fix me, generate change dynamically 
+      // Fix me, generate change dynamically
       var change = [{ key : $state.params.filters.key, value : $state.params.filters.value }];
 
       Cash.filters.replaceFilters(change);


### PR DESCRIPTION
This commit refactors the cash payment registry footer to right align
the amount aggregation in the footer and remove the currency value.  At
present, the registry does not factor in currency into it's aggregation,
producing incorrect results.

![newaggregation](https://user-images.githubusercontent.com/896472/28716904-9ed00ff8-736d-11e7-949f-88ce1a71cded.png)
_Fig 1: New Aggregation UI_

![oldaggregation](https://user-images.githubusercontent.com/896472/28716905-9ee8caf2-736d-11e7-9ad9-c3576f643869.png)
_Fig 2: Old Aggregation UI_
