### PR TITLE
fix(invoices): currency right-align

### DIFF
--- a/client/src/modules/invoices/registry/registry.js
+++ b/client/src/modules/invoices/registry/registry.js
@@ -62,6 +62,7 @@ function InvoiceRegistryController(
     field : 'cost',
     displayName : 'TABLE.COLUMNS.COST',
     headerCellFilter : 'translate',
+    cellClass : 'text-right',
     cellFilter : 'currency:'.concat(Session.enterprise.currency_id),
     aggregationType : uiGridConstants.aggregationTypes.sum,
     aggregationHideLabel : true,
@@ -161,9 +162,9 @@ function InvoiceRegistryController(
   // startup function. Checks for cached filters and loads them.  This behavior could be changed.
   function startup() {
     if ($state.params.filters) {
-      // Fix me, generate change dynamically 
+      // Fix me, generate change dynamically
       var change = [{ key : $state.params.filters.key, value : $state.params.filters.value }];
-      
+
       Invoices.filters.replaceFilters(change);
       Invoices.cacheFilters();
     }


### PR DESCRIPTION
The currency is now right-aligned on the invoice registry for faster comparison.  It also matches the footer.

![invoicecostcolumnbefore](https://user-images.githubusercontent.com/896472/28717803-379ac2ca-7371-11e7-9cde-40b6da15e080.png)
_Fig 1: Invoice Cost Column Before_

![invoicecostcolumnafter](https://user-images.githubusercontent.com/896472/28717804-37a47446-7371-11e7-9089-34ea2ef07714.png)
_Fig 2: Invoice Cost Column After_

