### PR TITLE
fix(accounts): rendering parent account select

### DIFF
--- a/client/src/modules/accounts/edit/accounts.edit.modal.html
+++ b/client/src/modules/accounts/edit/accounts.edit.modal.html
@@ -85,7 +85,9 @@
         name="parent"
         ng-model="AccountEditCtrl.account.parent"
         required>
-        <ui-select-match placeholder="{{ 'ACCOUNT.SELECT_PARENT' | translate }}"><strong>{{$select.selected.number}}</strong> <span>{{$select.selected.label}}</span></ui-select-match>
+        <ui-select-match placeholder="{{ 'ACCOUNT.SELECT_PARENT' | translate }}">
+          <span><strong>{{$select.selected.number}}</strong> {{$select.selected.label}}</span>
+        </ui-select-match>
         <ui-select-choices ui-select-focus-patch repeat="account in AccountEditCtrl.accounts | filter:{ 'hrlabel' : $select.search} | filter : { type_id : AccountEditCtrl.Constants.accounts.TITLE }">
           <span ng-bind-html="account.number | highlight:$select.search"></span>
           <small ng-bind-html="account.label | highlight:$select.search"></small>


### PR DESCRIPTION
This commit fixes the rendering of the parent account select.

![accountparentselectionbefore](https://user-images.githubusercontent.com/896472/28718053-4b199e42-7372-11e7-8945-e5d1a7b3a0a5.png)
_Fig 1: Account Selection Before Update_

![accountparentselectionafter](https://user-images.githubusercontent.com/896472/28718052-4a6f86e6-7372-11e7-93c1-d5dbab7a267c.png)
_Fig 2: Account Selection After Update_