### PR TITLE
fix(reports) Account statement period total currency

### DIFF
--- a/server/controllers/finance/reports/reportAccounts/report.handlebars
+++ b/server/controllers/finance/reports/reportAccounts/report.handlebars
@@ -77,9 +77,9 @@
           <tr>
             <td><strong>{{date params.dateTo}}</strong></th>
             <td colspan="3"><strong>{{translate "FORM.LABELS.PERIOD_TOTAL"}}</strong></td>
-            <td class="text-right"><strong>{{currency sum.period.debit}}</strong></td>
-            <td class="text-right"><strong>{{currency sum.period.credit}}</strong></td>
-            <td class="text-right"><strong>{{currency sum.period.balance}}</strong></td>
+            <td class="text-right"><strong>{{currency sum.period.debit metadata.enterprise.currency_id}}</strong></td>
+            <td class="text-right"><strong>{{currency sum.period.credit metadata.enterprise.currency_id}}</strong></td>
+            <td class="text-right"><strong>{{currency sum.period.balance metadata.enterprise.currency_id}}</strong></td>
           </tr>
         {{/if}}
       </tbody>


### PR DESCRIPTION
This commit ensures that the period total displayed at the bottom
of the account statement report respects the correct currency.
The enterprise currency ID is now correctly passed to the
currency helper.