### PR TITLE
refactor(enterprises): improve form submission

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -614,7 +614,8 @@
             "EMPTY_SELECTION": "Empty Selection",
             "NOT_AUTHORISED": "The requested page is not authorised",
             "NOT_FOUND": "Not found",
-            "PAGE_NOT_FOUND": "The page you requested could not be found"
+            "PAGE_NOT_FOUND": "The page you requested could not be found",
+            "NO_CHANGES" : "You haven't changed any form values.  Nothing will be submitted to the server."
         }
     }
 }

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -614,7 +614,8 @@
             "EMPTY_SELECTION": "Sélection vide",
             "NOT_AUTHORISED": "La page demandée n'est pas autorisée",
             "NOT_FOUND": "Non trouvee",
-            "PAGE_NOT_FOUND": "La page demandée n'a pas été trouvée"
+            "PAGE_NOT_FOUND": "La page demandée n'a pas été trouvée",
+            "NO_CHANGES" : "Vous n'avez pas changé les données dans le formulaire.  Rien a été submis au server."
         }
     }
 }

--- a/client/src/modules/enterprises/enterprises.html
+++ b/client/src/modules/enterprises/enterprises.html
@@ -74,7 +74,7 @@
               </bh-account-select>
             </div>
 
-            <div class="panel-footer text-right">
+            <div class="panel-footer text-right" id="submission">
               <bh-loading-button loading-state="EnterpriseForm.$loading">
                 <span translate>FORM.BUTTONS.UPDATE</span>
               </bh-loading-button>
@@ -94,7 +94,7 @@
                 <label class="control-label" translate>
                   FORM.LABELS.PO_BOX
                 </label>
-                <input type="text" class="form-control" autocomplete="off" name="po_box" ng-maxlength="EnterpriseCtrl.length30" ng-model="EnterpriseCtrl.enterprise.po_box">
+                <input type="text" class="form-control" autocomplete="off" name="po_box" ng-model="EnterpriseCtrl.enterprise.po_box">
                 <div class="help-block" ng-messages="EnterpriseForm.po_box.$error" ng-show="EnterpriseForm.$submitted">
                   <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
                 </div>
@@ -114,7 +114,7 @@
                 <label class="control-label" translate>
                   FORM.LABELS.PHONE
                 </label>
-                <input type="tel" class="form-control" autocomplete="off" name="phone" ng-maxlength="EnterpriseCtrl.length20" ng-model="EnterpriseCtrl.enterprise.phone">
+                <input type="tel" class="form-control" autocomplete="off" name="phone" ng-model="EnterpriseCtrl.enterprise.phone">
                 <div class="help-block" ng-messages="EnterpriseForm.phone.$error" ng-show="EnterpriseForm.$submitted">
                   <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
                 </div>
@@ -125,10 +125,12 @@
                 location-uuid="EnterpriseCtrl.enterprise.location_id">
               </bh-location-select>
 
+              <p class="text-center text-info">
+                <a href ng-click="EnterpriseCtrl.scrollToSubmission()" id="submissionLink">
+                  <span class="fa fa-arrow-circle-o-up"></span> <span translate>FORM.BUTTONS.LINK_SUBMISSION</span>
+                </a>
+              </p>
 
-              <button class="btn btn-block btn-default" type="button" ng-click="EnterpriseCtrl.submit(EnterpriseForm)">
-                <i class="fa fa-save"></i> <span translate>FORM.BUTTONS.UPDATE</span>
-              </button>
             </div>
           </div>
         </form>

--- a/client/src/modules/enterprises/enterprises.js
+++ b/client/src/modules/enterprises/enterprises.js
@@ -2,22 +2,21 @@ angular.module('bhima.controllers')
   .controller('EnterpriseController', EnterpriseController);
 
 EnterpriseController.$inject = [
-  'EnterpriseService', 'CurrencyService', 'util', 'NotifyService', 'ProjectService', 'ModalService'
+  'EnterpriseService', 'CurrencyService', 'util', 'NotifyService', 'ProjectService', 'ModalService',
+  'ScrollService',
 ];
 
 /**
  * Enterprise Controller
  */
-function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, Modal) {
+function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, Modal, ScrollTo) {
   var vm = this;
 
   vm.enterprises = [];
   vm.enterprise = {};
   vm.maxLength = util.maxTextLength;
   vm.length50 = util.length50;
-  vm.length20 = util.length20;
   vm.length100 = util.length100;
-  vm.length30 = util.length30;
   vm.hasEnterprise = false;
 
   // bind methods
@@ -55,6 +54,10 @@ function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, M
     vm.enterprise.gain_account_id = account.id;
   }
 
+  vm.scrollToSubmission = function scrollToSubmission() {
+    ScrollTo('submission');
+  };
+
   function onSelectLossAccount(account) {
     vm.enterprise.loss_account_id = account.id;
   }
@@ -66,34 +69,25 @@ function EnterpriseController(Enterprises, Currencies, util, Notify, Projects, M
       return;
     }
 
+    // make sure only fresh data is sent to the server.
+    if (form.$pristine) {
+      Notify.warn('FORM.WARNINGS.NO_CHANGES');
+      return;
+    }
+
     var promise;
     var creation = (vm.hasEnterprise === false);
-    var enterprise = cleanEnterpriseForm(vm.enterprise);
+    var changes = util.filterFormElements(form, true);
 
     promise = (creation) ?
-      Enterprises.create(enterprise) :
-      Enterprises.update(enterprise.id, enterprise);
+      Enterprises.create(changes) :
+      Enterprises.update(vm.enterprise.id, changes);
 
     return promise
       .then(function () {
         Notify.success(creation ? 'FORM.INFO.SAVE_SUCCESS' : 'FORM.INFO.UPDATE_SUCCESS');
       })
       .catch(Notify.handleError);
-  }
-
-  function cleanEnterpriseForm(enterprise) {
-    return {
-      id              : enterprise.id,
-      name            : enterprise.name,
-      abbr            : enterprise.abbr,
-      phone           : enterprise.phone,
-      email           : enterprise.email,
-      location_id     : enterprise.location_id,
-      currency_id     : enterprise.currency_id,
-      po_box          : enterprise.po_box,
-      gain_account_id : enterprise.gain_account_id,
-      loss_account_id : enterprise.loss_account_id,
-    };
   }
 
   /* ================================ PROJECT ================================ */


### PR DESCRIPTION
This commit improves the enterprise form submission by:
 1. Removing two avenues for submission - there is now only a single
 button as in Patient Registration.  The other is a link to scroll back
 up to the submit button.
 2. Remove the cleanEnterprise() function.  This information is already
 encoded in the form models.
 3. Do not send an HTTP request if nothing changed.

Closes #661.