### PR TITLE
updating zRecalculatePeriodTotals procedure

### DIFF
--- a/server/models/admin.sql
+++ b/server/models/admin.sql
@@ -9,7 +9,7 @@ DELIMITER $$
 CREATE PROCEDURE zRecomputeEntityMap()
 BEGIN
   DELETE FROM entity_map;
-  
+
   -- patient
   INSERT INTO entity_map
     SELECT patient.uuid, CONCAT_WS('.', 'PA', project.abbr, patient.reference)
@@ -108,7 +108,12 @@ CREATE PROCEDURE zRecalculatePeriodTotals()
 BEGIN
 
   -- wipe the period total table
-  TRUNCATE period_total;
+  DELETE FROM  period_total
+  WHERE period_id IN(
+    SELECT id
+    FROM  period
+    WHERE number<>0
+  );
 
   INSERT INTO period_total (enterprise_id, fiscal_year_id, period_id, account_id, credit, debit)
     SELECT project.enterprise_id, period.fiscal_year_id, period_id, account_id, SUM(credit_equiv) AS credit, SUM(debit_equiv) AS debit


### PR DESCRIPTION
This PR allows to update zRecalculatePeriodTotals() procedure by specify witch row must be deleted while the period_total is being recomputed instead of truncating the all table

closes #1927