### PR TITLE
(fix) Voucher tool select

### DIFF
--- a/client/src/js/components/bhFindPatient.js
+++ b/client/src/js/components/bhFindPatient.js
@@ -122,6 +122,7 @@ function FindPatientComponent(Patients, AppCache, Notify, SessionService, bhCons
 
     options = {
       reference : isValidNumber ? [bhConstants.identifiers.PATIENT.key, SessionService.project.abbr, reference].join('.') : reference,
+      detailed : 1,
       limit     : 1
     };
 

--- a/test/client-unit/components/bhFindPatient/controller.spec.js
+++ b/test/client-unit/components/bhFindPatient/controller.spec.js
@@ -62,7 +62,7 @@ function ControllerTests() {
     const response = [patient];
     const id = 'TPA1';
 
-    $httpBackend.expect('GET', `/patients/?limit=1&reference=${id}`)
+    $httpBackend.expect('GET', `/patients/?detailed=1&limit=1&reference=${id}`)
       .respond(200, response);
 
     $controller.selected = $controller.options.findById;


### PR DESCRIPTION
This commit ensures that both methods of searching for a patient
return a detailed patient object.
Finding by reference uses the /patients/ route and find by name uses
/patients/:uuid. By passing detailed : 1 to the generic route we
can make sure both objects returned have the same information.

This resolves the voucher tools for covering patients not having
enough information to create all rows.

This PR also removes two large GET requests in the patient support tool. 

Contributes to https://github.com/IMA-WorldHealth/bhima-2.X/issues/1915
Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/1915