### PR TITLE
refactor(bhDateEditor): use onChange() callback

### DIFF
--- a/client/src/js/components/bhDateEditor.js
+++ b/client/src/js/components/bhDateEditor.js
@@ -1,19 +1,19 @@
 angular.module('bhima.components')
-.component('bhDateEditor', {
-  templateUrl : '/modules/templates/bhDateEditor.tmpl.html',
-  controller  : dateEditorController,
-  bindings    : {
-    dateValue         : '=', // two-way binding
-    minDate           : '<', // one-way binding
-    maxDate           : '<', // one-way binding
-    validationTrigger : '<', // one-way binding
-    disabled          : '<', // one-way binding
-    dateFormat        : '@', // bind text
-    label             : '@', // bind text
-  },
-});
+  .component('bhDateEditor', {
+    templateUrl : '/modules/templates/bhDateEditor.tmpl.html',
+    controller  : DateEditorController,
+    bindings    : {
+      dateValue : '<',
+      onChange : '&',
+      minDate : '<',
+      maxDate : '<',
+      disabled : '<?',
+      dateFormat : '@?',
+      label : '@?',
+    },
+  });
 
-dateEditorController.$inject = ['bhConstants'];
+DateEditorController.$inject = ['bhConstants'];
 
 /**
  * bhDateEditor Component
@@ -28,30 +28,35 @@ dateEditorController.$inject = ['bhConstants'];
  *  date-format="'yyyy-MM-dd'"
  *  min-date="Ctrl.min"
  *  max-date="Ctrl.max"
- *  validation-trigger="Form.$submitted"
  *  disabled="Ctrl.isDisabled">
  * </bh-date-editor>
  *
  * @module components/bhDateEditor
  */
-function dateEditorController(bhConstants) {
-  var ctrl = this;
+function DateEditorController(bhConstants) {
+  var $ctrl = this;
 
-  this.$onInit = function $onInit() {
-    ctrl.dateFormat = bhConstants.dayOptions.format;
+  $ctrl.$onInit = function $onInit() {
+    $ctrl.dateFormat = bhConstants.dayOptions.format;
 
-    ctrl.editMode = false;
-    ctrl.toggleEditMode = toggleEditMode;
+    $ctrl.editMode = false;
+
+    $ctrl.label = $ctrl.label || 'FORM.LABELS.DATE';
 
     // options to be passed to datepicker-option
-    ctrl.options = {
-      minDate : ctrl.minDate,
-      maxDate : ctrl.maxDate,
+    $ctrl.options = {
+      minDate : $ctrl.minDate,
+      maxDate : $ctrl.maxDate,
     };
   };
 
+
   // opens/closes the date dropdown
-  function toggleEditMode() {
-    ctrl.editMode = !ctrl.editMode;
-  }
+  $ctrl.toggleEditMode = function toggleEditMode() {
+    $ctrl.editMode = !$ctrl.editMode;
+  };
+
+  $ctrl._onChange = function _onChange() {
+    $ctrl.onChange({ date : $ctrl.dateValue });
+  };
 }

--- a/client/src/modules/cash/cash-form.service.js
+++ b/client/src/modules/cash/cash-form.service.js
@@ -58,7 +58,6 @@ function CashFormService(AppCache, Session, Patients, Exchange) {
    * cash form.  It also stores the selection in AppCache.
    */
   CashForm.prototype.setCautionType = function setCautionType(isCaution) {
-
     // change the form value
     this.details.is_caution = isCaution;
 
@@ -71,6 +70,16 @@ function CashFormService(AppCache, Session, Patients, Exchange) {
     }
   };
 
+  /**
+   * @method setDate
+   *
+   * @description
+   * This method takes in the date from the bhDateEdit component and sets it on the
+   * form.
+   */
+  CashForm.prototype.setDate = function setDate(date) {
+    this.details.date = date;
+  };
 
   /**
    * @method isCaution
@@ -115,7 +124,6 @@ function CashFormService(AppCache, Session, Patients, Exchange) {
    * object passed into the form.
    */
   CashForm.prototype.configure = function configure(config) {
-
     if (config.patient) {
       this.setPatient(config.invoices);
     }

--- a/client/src/modules/cash/cash.html
+++ b/client/src/modules/cash/cash.html
@@ -63,7 +63,7 @@
 
                 <bh-date-editor
                   date-value="CashCtrl.Payment.details.date"
-                  validation-trigger="CashVoucherForm.$submitted"
+                  on-change="CashCtrl.Payment.setDate(date)"
                   max-date="CashCtrl.timestamp">
                 </bh-date-editor>
 

--- a/client/src/modules/cash/cash.js
+++ b/client/src/modules/cash/cash.js
@@ -100,7 +100,7 @@ function CashController(Cash, Cashboxes, AppCache, Currencies, Session, Modals, 
       invoices: vm.Payment.details.invoices
         .map(function (invoice) {
           return invoice.uuid;
-        })
+        }),
     });
   }
 

--- a/client/src/modules/invoices/patientInvoice.html
+++ b/client/src/modules/invoices/patientInvoice.html
@@ -50,7 +50,7 @@
                   -->
                   <bh-date-editor
                     date-value="PatientInvoiceCtrl.Invoice.details.date"
-                    validation-trigger="InvoiceForm.$submitted"
+                    on-change="PatientInvoiceCtrl.Invoice.setDate(date)"
                     min-date="PatientInvoiceCtrl.minimumDate"
                     max-date="PatientInvoiceCtrl.timestamp">
                   </bh-date-editor>

--- a/client/src/modules/invoices/patientInvoiceForm.service.js
+++ b/client/src/modules/invoices/patientInvoiceForm.service.js
@@ -266,6 +266,19 @@ function PatientInvoiceFormService(Patients, PriceLists, Inventory, AppCache, St
     this.prices.setData(priceList.items);
   };
 
+
+  /**
+   * @method setDate
+   *
+   * @description
+   * This method sets the date in the details object.
+   *
+   * @param {Object} date - the date for the invoice
+   */
+  PatientInvoiceForm.prototype.setDate = function setDate(date) {
+    this.details.date = date;
+  };
+
   /**
    * @method setService
    *

--- a/client/src/modules/templates/bhDateEditor.tmpl.html
+++ b/client/src/modules/templates/bhDateEditor.tmpl.html
@@ -12,12 +12,11 @@
 <ng-form name="DateEditorForm" novalidate>
   <div
     class="form-group"
-    ng-class="{ 'has-error' : $ctrl.validationTrigger && DateEditorForm.$invalid } "
-    data-date-editor
-    >
+    ng-class="{ 'has-error' : DateEditorForm.$$parentForm.$submitted && DateEditorForm.$invalid } "
+    data-date-editor>
 
-    <label class="control-label">
-      {{ ($ctrl.label || "FORM.LABELS.DATE") | translate }}
+    <label class="control-label" translate>
+      {{ $ctrl.label }}
     </label>
 
     <!-- input component implementation -->
@@ -31,11 +30,11 @@
         is-open="$ctrl.editMode"
         datepicker-options="$ctrl.options"
         show-button-bar="false"
-        data-date-editor-input
         ng-readonly="!$ctrl.editMode"
+        ng-change="$ctrl._onChange()"
         ng-disabled="$ctrl.disabled"
         ng-required="required"
-        >
+        data-date-editor-input>
       <span class="input-group-btn">
         <button
           type="button"
@@ -43,24 +42,22 @@
           ng-click="$ctrl.toggleEditMode()"
           ng-disabled="$ctrl.editMode || $ctrl.disabled"
           data-date-editor-dropdown-toggle>
-          <span class="glyphicon glyphicon-calendar"></span>
-          {{ "FORM.LABELS.SET_DATE" | translate }}
+          <i class="fa fa-calendar-plus"></i> <span translate>FORM.LABELS.SET_DATE</span>
         </button>
       </span>
     </div>
 
     <!-- validation/error messages for the form (see discussion at the top -->
-    <div class="help-block" ng-messages="DateEditorForm.$error" ng-show="$ctrl.validationTrigger && DateEditorForm.$invalid">
+    <div class="help-block" ng-messages="DateEditorForm.$error" ng-show="DateEditorForm.$$parentForm.$submitted">
 
       <!-- @todo - potentially include this message in the generic date validation messages -->
       <p ng-message="dateDisabled">
-        <span class="glyphicon glyphicon-warning-sign"></span>
-        {{ "FORM.ERRORS.DATE_OUT_OF_RANGE" | translate }}
+        <i class="fa fa-warning"></i> <span translate>FORM.ERRORS.DATE_OUT_OF_RANGE</span>
       </p>
     </div>
 
     <!-- validation/error messages for date input -->
-    <div class="help-block" ng-messages="DateEditorForm.date.$error" ng-show="$ctrl.validationTrigger && DateEditorForm.date.$invalid">
+    <div class="help-block" ng-messages="DateEditorForm.date.$error" ng-show="DateEditorForm.$$parentForm.$submitted">
       <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
     </div>
   </div>


### PR DESCRIPTION
BREAKING CHANGE

This commit migrates the bhDateEditor component to an onChange() style
of callbacks.  This is the recommended Angular 2-style syntax, and
allows the component bindings to dictate the flow of data from `<` and
`@` bindings into the component to `&` for returning data via callbacks.

Additionally, the bhDateEditor has been modernized with `translate`
directives instead of the filter, and everything has been moved into the
$onInit method.

Closes #1960.

----

If this style of component gets reviewed and approved, _all_ instances of the `bhDateEditor` will need to be updated.  I've put this PR on a feature branch so that anyone can contribute to its progress.