### PR TITLE
(Fix) Reference links component

### DIFF
--- a/client/src/js/components/bhReferenceLink.js
+++ b/client/src/js/components/bhReferenceLink.js
@@ -2,7 +2,7 @@ angular.module('bhima.components')
 .component('bhReferenceLink', {
   bindings : {
     reference : '<',
-    display : '@?' 
+    display : '@?'
   },
   templateUrl : 'modules/templates/bhReferenceLink.tmpl.html',
   controller : bhReferenceLink
@@ -10,14 +10,28 @@ angular.module('bhima.components')
 
 bhReferenceLink.$inject = ['LanguageService'];
 
-// @TODO(sfount) allow a user setting to determine if this link should link directly 
+// @TODO(sfount) allow a user setting to determine if this link should link directly
 //               to external documents or take the user to a financial document search
-function bhReferenceLink(Languages) { 
+function bhReferenceLink(Languages) {
   var $ctrl = this;
-  
-  $ctrl.languageKey = Languages.key;
 
-  $ctrl.$onInit = function onInit() { 
-    $ctrl.display = $ctrl.display || $ctrl.reference;
+  $ctrl.languageKey = Languages.key;
+  $ctrl.displayLabel = '-';
+
+  $ctrl.$onInit = function onInit() {
+    $ctrl.displayLabel = $ctrl.display || $ctrl.reference;
+  };
+
+  $ctrl.$onChanges = function onChanges(changes) {
+    // if the reference has changed - update the display value to keep up to date with this value
+    if (changes.reference) {
+      // still respect the display value if it has been explicitly defined
+      $ctrl.displayLabel = $ctrl.display || changes.reference.currentValue;
+    }
+
+    // ensure the display value is given highest priority
+    if (changes.display) {
+      $ctrl.displayLabel = changes.display.currentValue;
+    }
   };
 }

--- a/client/src/modules/templates/bhReferenceLink.tmpl.html
+++ b/client/src/modules/templates/bhReferenceLink.tmpl.html
@@ -1,5 +1,5 @@
-<a 
+<a
   ng-href="/refenceLookup/{{$ctrl.reference}}/{{$ctrl.languageKey}}"
   target="_blank">
-  {{$ctrl.display}}
+  {{$ctrl.displayLabel}}
 </a>


### PR DESCRIPTION
This commit ensures that the reference link component works in a UI grid
when underlying data is changed. UI Grid optimises the creation of components by
updating existing components instead of replacing them. This requires the
component to act and change the display label on change - it cannot assume
the reference value passed will be static.