### PR TITLE
(Fix) Editing posted transactions

### DIFF
--- a/client/src/i18n/en/posting_journal.json
+++ b/client/src/i18n/en/posting_journal.json
@@ -68,7 +68,8 @@
       "SINGLE_LINE_TRANSACTION":"A transaction must have two or more lines. To correct this, locate the transaction and add the balancing line.",
       "EDIT_INVALID_ACCOUNT":"Transaction contains invalid account(s)",
       "EDIT_INVALID_ENTITY":"Transaction contains an invalid entity",
-      "EDIT_INVALID_REFERENCE":"Transaction contains an invalid reference"
+      "EDIT_INVALID_REFERENCE":"Transaction contains an invalid reference",
+      "TRANSACTION_ALREADY_POSTED":"Posted transaction cannot be altered by this process"
     },
     "WARNINGS":{
       "MISSING_ENTITY":"Record without entity type and entity ID",

--- a/client/src/i18n/en/posting_journal.json
+++ b/client/src/i18n/en/posting_journal.json
@@ -69,7 +69,8 @@
       "EDIT_INVALID_ACCOUNT":"Transaction contains invalid account(s)",
       "EDIT_INVALID_ENTITY":"Transaction contains an invalid entity",
       "EDIT_INVALID_REFERENCE":"Transaction contains an invalid reference",
-      "TRANSACTION_ALREADY_POSTED":"Posted transaction cannot be altered by this process"
+      "TRANSACTION_ALREADY_POSTED":"Transaction has already been posted and cannot be edited",
+      "USER_CANNOT_EDIT_POSTED_TRANSACTION":"User cannot edit this transaction as it has already been posted"
     },
     "WARNINGS":{
       "MISSING_ENTITY":"Record without entity type and entity ID",

--- a/client/src/i18n/en/posting_journal.json
+++ b/client/src/i18n/en/posting_journal.json
@@ -74,7 +74,8 @@
     },
     "WARNINGS":{
       "MISSING_ENTITY":"Record without entity type and entity ID",
-      "NO_TRANSACTIONS_SELECTED":"No transactions selected. You must be in Transaction view to use this tool."
+      "NO_TRANSACTIONS_SELECTED":"No transactions selected. You must be in Transaction view to use this tool.",
+      "MULTIPLE_TRANSACTION_EDIT_DISABLED":"You have multiple transactions selected. Multiple transaction editing is currently disabled"
     },
     "TRIAL_BALANCE" : {
       "TITLE" : "Trial Balance",

--- a/client/src/modules/journal/journal.js
+++ b/client/src/modules/journal/journal.js
@@ -469,7 +469,7 @@ function JournalController(Journal, Sorting, Grouping,
   function editTransactionModal() {
     // block multiple simultaneous edit
     if (selection.selected.groups.length > 1) {
-      Notify.warn('You have multiple transactions selected. Multiple transaction editing is currently disabled');
+      Notify.warn('POSTING_JOURNAL.WARNINGS.MULTIPLE_TRANSACTION_EDIT_DISABLED');
       return;
     }
 
@@ -486,30 +486,36 @@ function JournalController(Journal, Sorting, Grouping,
         var updatedRows = editSessionResult.updatedTransaction;
         var changed = angular.isDefined(updatedRows);
 
-        vm.gridApi.selection.clearSelectedRows();
-        if (changed) {
-          // update only rows that already existed and have been edited
-          editSessionResult.edited.forEach(function (uuid) {
-            // update record that already exists
-            var currentRow = journalStore.get(uuid);
-            var updatedRow = editSessionResult.updatedTransaction.get(uuid);
-
-            Object.keys(currentRow).forEach(function (key) {
-              currentRow[key] = updatedRow[key];
-            });
-          });
-
-          // remove rows that existed before and have been removed
-          editSessionResult.removed.forEach(function (uuid) {
-            journalStore.remove(uuid);
-          });
-
-          if (editSessionResult.added.length) {
-            // rows have been added, we have no guarantees on filters so display a warning
-            vm.unknownTransactionEditState = true;
-          }
-          vm.gridApi.grid.notifyDataChange(uiGridConstants.dataChange.ALL);
+        if (!changed) {
+          Notify.warn('FORM.WARNINGS.NO_CHANGES');
+          return;
         }
+
+        vm.gridApi.selection.clearSelectedRows();
+
+        // update only rows that already existed and have been edited
+        editSessionResult.edited.forEach(function (uuid) {
+          // update record that already exists
+          var currentRow = journalStore.get(uuid);
+          var updatedRow = editSessionResult.updatedTransaction.get(uuid);
+
+          Object.keys(currentRow).forEach(function (key) {
+            currentRow[key] = updatedRow[key];
+          });
+        });
+
+        // remove rows that existed before and have been removed
+        editSessionResult.removed.forEach(function (uuid) {
+          journalStore.remove(uuid);
+        });
+
+        if (editSessionResult.added.length) {
+          // rows have been added, we have no guarantees on filters so display a warning
+          vm.unknownTransactionEditState = true;
+        }
+        vm.gridApi.grid.notifyDataChange(uiGridConstants.dataChange.ALL);
+
+        Notify.success('POSTING_JOURNAL.SAVE_TRANSACTION_SUCCESS');
       });
   }
 

--- a/client/src/modules/journal/modals/editTransaction.modal.html
+++ b/client/src/modules/journal/modals/editTransaction.modal.html
@@ -2,14 +2,18 @@
   <ol class="headercrumb">
     <li class="static" translate>POSTING_JOURNAL.TRANSACTION</li>
     <li class="title" translate>{{ModalCtrl.shared.trans_id}}</li>
-    <span class="badge badge-warning" ng-if="ModalCtrl.readOnly"><i class="fa fa-eye"></i> <span translate>POSTING_JOURNAL.EDITING</span></span>
-    <span class="badge badge-primary" ng-if="!ModalCtrl.readOnly"><i class="fa fa-pencil"></i> <span translate>POSTING_JOURNAL.VIEWING</span></span>
+    <span class="badge badge-warning" ng-if="ModalCtrl.readOnly"><i class="fa fa-eye"></i> <span translate>POSTING_JOURNAL.VIEWING</span></span>
+    <span class="badge badge-primary" ng-if="!ModalCtrl.readOnly"><i class="fa fa-pencil"></i> <span translate>POSTING_JOURNAL.EDITING</span></span>
   </ol>
-
 </div>
 
 <div class="modal-body">
-    <!-- Record information -->
+  <!-- warn user that standard users cannot edit posted transactions -->
+  <div class="alert alert-warning" ng-if="ModalCtrl.validation.blockedPostedTransactionEdit"  style="border-radius : 0px; padding-left : 5px; padding-right : 5px; padding-top : 10px; padding-bottom : 10px; margin-bottom : 10px;">
+    <i class="fa fa-warning"></i> <span translate>POSTING_JOURNAL.ERRORS.USER_CANNOT_EDIT_POSTED_TRANSACTION</span>
+  </div>
+
+  <!-- Record information -->
     <div style="border : 1px solid #c4c4c4; padding : 5px; margin-bottom : 10px;">
 
       <div class="row" ng-if="ModalCtrl.loadingTransaction">
@@ -46,10 +50,10 @@
               <p class="form-control-static" translate>{{ModalCtrl.transactionTypes.get(ModalCtrl.shared.origin_id).text || '-'}}</p>
             </div>
             <div ng-if="!ModalCtrl.readOnly" class="col-sm-9">
-              <select 
-                ng-model="ModalCtrl.shared.origin_id" 
+              <select
+                ng-model="ModalCtrl.shared.origin_id"
                 ng-change="ModalCtrl.handleTransactionTypeChange(ModalCtrl.shared.origin_id)"
-                ng-options="types.id as (types.text | translate) for types in ModalCtrl.transactionTypes.data" 
+                ng-options="types.id as (types.text | translate) for types in ModalCtrl.transactionTypes.data"
                 class="form-control">
                 <option disabled value="">--<span translate>POSTING_JOURNAL.NO_TRANSACTION_TYPE</span>--</option>
               </select>
@@ -68,12 +72,12 @@
             </div>
             <div ng-if="!ModalCtrl.readOnly" class="col-sm-9">
               <div class="input-group">
-              <input 
+              <input
                 uib-datepicker-popup="dd/MM/yyyy"
-                ng-model="ModalCtrl.shared.trans_date" 
+                ng-model="ModalCtrl.shared.trans_date"
                 ng-change="ModalCtrl.handleTransactionDateChange(ModalCtrl.shared.trans_date)"
                 is-open="ModalCtrl.dateEditorOpen"
-                type="text" 
+                type="text"
                 class="form-control"></input>
               <span class="input-group-btn">
                 <button class="btn btn-default btn-sm" ng-click="ModalCtrl.openDateEditor()"><span class="fa fa-calendar"></span></button>
@@ -85,9 +89,9 @@
       </form>
       </div>
     </div>
-    
+
     <div class="alert alert-danger" ng-if="ModalCtrl.validation.errored"  style="border-radius : 0px; padding-left : 5px; padding-right : 5px; padding-top : 10px; padding-bottom : 10px; margin-bottom : 10px;">
-    <i class="fa fa-exclamation-circle"></i> <span translate>{{ModalCtrl.validation.message}}</span>
+      <i class="fa fa-exclamation-circle"></i> <span translate>{{ModalCtrl.validation.message}}</span>
     </div>
 
     <!-- Transaction row edit utilities -->
@@ -96,7 +100,7 @@
       <button ng-disabled="!ModalCtrl.settupComplete" class="btn btn-default btn-sm" ng-click="ModalCtrl.removeRows()" translate>POSTING_JOURNAL.REMOVE_ROW</button>
     </div>
     <div id="edit-grid" style="height : 230px" ui-grid="ModalCtrl.gridOptions" ui-grid-cellNav ui-grid-selection ui-grid-edit ui-grid-resize-columns ui-grid-auto-resize>
-      <bh-grid-loading-indicator 
+      <bh-grid-loading-indicator
         loading-state="ModalCtrl.loadingTransaction"
         empty-state="ModalCtrl.gridOptions.data.length === 0"
         error-state="ModalCtrl.hasError">

--- a/client/src/modules/journal/modals/editTransaction.modal.js
+++ b/client/src/modules/journal/modals/editTransaction.modal.js
@@ -160,7 +160,7 @@ function JournalEditTransactionController(Journal, Languages, Store, Transaction
     var noChanges = addedRows.length === 0 && removedRows.length === 0 && Object.keys(changes).length === 0;
 
     if (noChanges) {
-      Modal.close();
+      Modal.close({});
       return;
     }
 

--- a/client/src/modules/journal/modals/editTransaction.modal.js
+++ b/client/src/modules/journal/modals/editTransaction.modal.js
@@ -3,7 +3,7 @@ angular.module('bhima.controllers')
 
 JournalEditTransactionController.$inject = ['JournalService', 'LanguageService', 'Store', 'TransactionTypeService', '$uibModalInstance', 'transactionUuid', 'readOnly', 'uiGridConstants', 'uuid'];
 
-function JournalEditTransactionController(Journal, Languages, Store, TransactionType, Modal, transactionUuid, readOnly, uiGridConstants, uuid) { 
+function JournalEditTransactionController(Journal, Languages, Store, TransactionType, Modal, transactionUuid, readOnly, uiGridConstants, uuid) {
   var gridApi = {};
   var vm = this;
 
@@ -11,12 +11,17 @@ function JournalEditTransactionController(Journal, Languages, Store, Transaction
   vm.languages = Languages;
   vm.loadingTransaction = false;
   vm.settupComplete = false;
-  
+
   // @TODO(sfount) apply read only logic to save buttons and grid editing logic
   vm.readOnly = readOnly || false;
-  
+
+  vm.validation = {
+    errored : false,
+    blockedPostedTransactionEdit : false
+  };
+
   // @TODO(sfount) column definitions currently duplicated across journal and here
-  var editColumns = [ 
+  var editColumns = [
     { field              : 'description',
       displayName        : 'TABLE.COLUMNS.DESCRIPTION',
       headerCellFilter   : 'translate',
@@ -30,8 +35,8 @@ function JournalEditTransactionController(Journal, Languages, Store, Transaction
       cellTemplate         : '/modules/journal/templates/account.cell.html',
       enableCellEdit : !vm.readOnly,
       allowCellFocus : !vm.readOnly,
-      headerCellFilter     : 'translate' }, 
-    
+      headerCellFilter     : 'translate' },
+
     { field                            : 'debit_equiv',
       displayName                      : 'TABLE.COLUMNS.DEBIT',
       headerCellFilter                 : 'translate',
@@ -65,69 +70,85 @@ function JournalEditTransactionController(Journal, Languages, Store, Transaction
       visible          : true }
   ];
 
-  vm.gridOptions = { 
-    columnDefs : editColumns, 
+  vm.gridOptions = {
+    columnDefs : editColumns,
     showColumnFooter : true,
     showGridFooter : true,
     appScopeProvider : vm,
-    gridFooterTemplate : '<div class="ui-grid-cell-contents"><span translate>POSTING_JOURNAL.ROWS</span> <span>{{grid.rows.length}}</span></div>', 
-    onRegisterApi : function (api) { 
-      gridApi = api; 
+    gridFooterTemplate : '<div class="ui-grid-cell-contents"><span translate>POSTING_JOURNAL.ROWS</span> <span>{{grid.rows.length}}</span></div>',
+    onRegisterApi : function (api) {
+      gridApi = api;
       gridApi.edit.on.afterCellEdit(null, handleCellEdit);
     }
   };
 
-  vm.validation = { errored : false };
-
   vm.close = Modal.dismiss;
-    
+
   // @TODO(sfount) move to component vm.dateEditorOpen = false;
   vm.openDateEditor = function () { vm.dateEditorOpen = !vm.dateEditorOpen; }
- 
-  // module dependencies 
+
+  // module dependencies
   TransactionType.read()
-    .then(function (typeResults) { 
+    .then(function (typeResults) {
       vm.transactionTypes = new Store({ identifier : 'id' });
       vm.transactionTypes.setData(typeResults);
     });
 
   vm.loadingTransaction = true;
   Journal.grid(transactionUuid)
-    .then(function (transaction) { 
+    .then(function (transaction) {
       vm.settupComplete = true;
+
+      verifyEditableTransaction(transaction);
 
       vm.rows = new Store({ identifier : 'uuid' });
       vm.rows.setData(transaction);
 
-      // @FIXME(sfount) date ng-model hack 
+      // @FIXME(sfount) date ng-model hack
       vm.rows.data.forEach(function (row) { row.trans_date = new Date(row.trans_date); });
       vm.shared = sharedDetails(vm.rows.data[0]);
       vm.gridOptions.data = vm.rows.data;
     })
-    .catch(function (error) { 
+    .catch(function (error) {
       console.error(error);
-      vm.hasError = true;  
+      vm.hasError = true;
     })
-    .finally(function () { 
-      vm.loadingTransaction = false; 
-    });  
-  
+    .finally(function () {
+      vm.loadingTransaction = false;
+    });
+
+  function verifyEditableTransaction(transaction) {
+    var posted = transaction[0].posted;
+
+    if (posted) {
+      vm.validation.blockedPostedTransactionEdit = true;
+      vm.readOnly = true;
+
+      // notify the grid of options change - the grid should no longer be editable
+      vm.gridOptions.columnDefs.forEach(function (column) {
+        column.allowCellFocus = !vm.readOnly;
+        column.enableCellEdit = !vm.readOnly;
+      });
+      gridApi.core.notifyDataChange(uiGridConstants.dataChange.ALL);
+    }
+  }
+
   // Variables for tracking edits
   var removedRows = [];
   var addedRows = [];
   var changes = {};
 
-  // Editing global transaction attributes 
-  vm.handleTransactionTypeChange = function handleTransactionTypeChange(currentValue) { 
+  // Editing global transaction attributes
+  vm.handleTransactionTypeChange = function handleTransactionTypeChange(currentValue) {
     applyAttributeToRows('origin_id', currentValue);
   };
 
-  vm.handleTransactionDateChange = function handleTransactionDateChange(currentValue) { 
+  vm.handleTransactionDateChange = function handleTransactionDateChange(currentValue) {
     applyAttributeToRows('trans_date', currentValue);
   };
 
   // Edit rows functions
-  vm.addRow = function addRow() { 
+  vm.addRow = function addRow() {
     var row = { uuid : uuid(), debit_equiv : 0, credit_equiv : 0 };
     angular.extend(row, angular.copy(vm.shared));
 
@@ -135,67 +156,67 @@ function JournalEditTransactionController(Journal, Languages, Store, Transaction
     vm.rows.post(row);
   };
 
-  vm.saveTransaction = function saveTransaction() { 
+  vm.saveTransaction = function saveTransaction() {
     var noChanges = addedRows.length === 0 && removedRows.length === 0 && Object.keys(changes).length === 0;
 
-    if (noChanges) { 
+    if (noChanges) {
       Modal.close();
       return;
     }
 
-    // reset error validation 
+    // reset error validation
     vm.validation.errored = false;
     vm.validation.message = null;
     vm.saving = true;
-  
-    // building object to conform to legacy API 
+
+    // building object to conform to legacy API
     // @FIXME(sfount) update journal service API for human readable interface
-    var transactionRequest = { 
-      uuid : vm.shared.record_uuid, 
+    var transactionRequest = {
+      uuid : vm.shared.record_uuid,
       newRows : { data : filterRowsByUuid(vm.rows.data, addedRows) },
       removedRows : removedRows.map(function (uuid) { return { uuid : uuid }; })
     };
 
     Journal.saveChanges(transactionRequest, changes)
-      .then(function (resultUpdatedTransaction) { 
+      .then(function (resultUpdatedTransaction) {
         var transaction = new Store({ identifier : 'uuid' });
         transaction.setData(resultUpdatedTransaction);
 
         // collapse information for the module that might expect to apply optimistic updates
-        var editSessionResult = { 
+        var editSessionResult = {
           edited : Object.keys(changes),
-          added : addedRows, 
+          added : addedRows,
           removed : removedRows,
           updatedTransaction : transaction
         };
 
         Modal.close(editSessionResult);
       })
-      .catch(function (error) { 
+      .catch(function (error) {
         vm.validation.errored = true;
         vm.validation.message = error.data.code;
       })
-      .finally(function () { 
-        vm.saving = false; 
+      .finally(function () {
+        vm.saving = false;
       });
   };
-  
-  // rows - array of rows 
+
+  // rows - array of rows
   // uuids - array of uuids
-  function filterRowsByUuid(rows, uuids) { 
-    var result = rows.filter(function (row) { 
+  function filterRowsByUuid(rows, uuids) {
+    var result = rows.filter(function (row) {
       return contains(uuids, row.uuid);
     });
     return result;
   }
 
-  vm.removeRows = function removeRows() { 
+  vm.removeRows = function removeRows() {
     var selectedRows = gridApi.selection.getSelectedRows();
 
-    selectedRows.forEach(function (row) { 
+    selectedRows.forEach(function (row) {
       var isOriginalRow = !contains(addedRows, row.uuid);
 
-      if (isOriginalRow) { 
+      if (isOriginalRow) {
         // remove any changes tracked against this record
         delete changes[row.uuid];
         removedRows.push(row.uuid);
@@ -204,24 +225,24 @@ function JournalEditTransactionController(Journal, Languages, Store, Transaction
         addedRows.splice(addedRows.indexOf(row.uuid), 1);
       }
 
-      vm.rows.remove(row.uuid) 
-    }); 
+      vm.rows.remove(row.uuid)
+    });
   }
 
-  function handleCellEdit(rowEntity, colDef, newValue, oldValue) { 
-    if (oldValue !== newValue) { 
+  function handleCellEdit(rowEntity, colDef, newValue, oldValue) {
+    if (oldValue !== newValue) {
       var isOriginalRow = !contains(addedRows, rowEntity.uuid);
 
-      if (isOriginalRow) { 
+      if (isOriginalRow) {
         changes[rowEntity.uuid] = changes[rowEntity.uuid] || {};
         changes[rowEntity.uuid][colDef.field] = newValue;
       }
     }
   }
 
-  // Edit utilities 
-  function applyAttributeToRows(key, value) { 
-    vm.rows.data.forEach(function (row) { 
+  // Edit utilities
+  function applyAttributeToRows(key, value) {
+    vm.rows.data.forEach(function (row) {
       handleCellEdit({ uuid : row.uuid }, { field : key}, value, row[key]);
       row[key] = value;
     });
@@ -232,18 +253,18 @@ function JournalEditTransactionController(Journal, Languages, Store, Transaction
   }
 
   // @TODO(sfount)
-  function invalidate(message) { 
+  function invalidate(message) {
     vm.validation.errored = true;
     vm.validation.message = message;
   }
 
   // takes a transaction row and returns all parameters that are shared among the transaction
   // @TODO(sfount) rewrite method given current transaction service code
-  function sharedDetails(row) { 
+  function sharedDetails(row) {
     var columns = ['hrRecord', 'record_uuid', 'project_name', 'trans_id', 'origin_id', 'display_name', 'trans_date', 'project_id', 'fiscal_year_id', 'currency_id', 'user_id', 'posted', 'period_id'];
     var shared = {};
-  
-    columns.forEach(function (column) { 
+
+    columns.forEach(function (column) {
       shared[column] = row[column];
     });
     return shared;

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -244,7 +244,20 @@ function editTransaction(req, res, next) {
   rowsRemoved.forEach(row => transaction.addQuery(REMOVE_JOURNAL_ROW, [db.bid(row.uuid)]));
   // _.each(rowsChanged, (row, uuid) => transaction.addQuery(UPDATE_JOURNAL_ROW, [row, db.bid(uuid)]));
 
-  transformColumns(rowsAdded, true)
+  // verify that this transaction is NOT in the general ledger already
+  // @FIXME(sfount) this logic needs to be updated when allowing super user editing
+  lookupTransaction(recordUuid)
+    .then((currentTransaction) => {
+      // check the source of the first transaction row
+      const posted = currentTransaction[0].posted;
+
+      if (posted) {
+        throw new BadRequest('Posted transactions cannot be edited', 'POSTING_JOURNAL.ERRORS.TRANSACTION_ALREADY_POSTED');
+      }
+
+      // continue with edititing - transform requested additional columns
+      return transformColumns(rowsAdded, true)
+    })
     .then((result) => {
       result.forEach((row) => {
         db.convert(row, ['uuid', 'record_uuid', 'entity_uuid']);
@@ -262,7 +275,6 @@ function editTransaction(req, res, next) {
       return transaction.execute();
     })
     .then((result) => {
-
       // transaction chagnes written successfully - return latest version of transaction
       return lookupTransaction(recordUuid);
     })


### PR DESCRIPTION
**Server**
This commit adds a condition to posting journal editing to stop any
editing request on already posted requests. In the future super user
editing may need to be factored in here.

**Client**
This commit verifies on the client if the transaction to be edited is
marked as posted. This allows the application to stop the user before trying
to edit a posted record, the server will also respond with an invalid message if
this is circumvented.

**Notifications**
This commit adds success and warn state notifications to transaction editing.
If a transactions was edited a success notification will be displayed and the
logic is adjusted so that if no changes were made a warn notification will be
shown and the selected of the Journal UI Grid will remain unchanged.