### PR TITLE
fix(filters): default filters are purple

### DIFF
--- a/client/src/less/bhima-bootstrap.less
+++ b/client/src/less/bhima-bootstrap.less
@@ -14,6 +14,8 @@
 @ima-light-orange:    #fdba64;
 @ima-light-blue:      #6fbdee;
 
+@ima-purple : #7859BF;
+
 /** @todo move all structure code into less with configurable variables */ /** * Application structure variables - these widths are used to determine how much
  * space the tree navigation takes up in its `expanded` and `collapsed` states.
  */
@@ -122,6 +124,11 @@ input[type=number] {-moz-appearance: textfield;}
  */
 .pad-bottom {
   padding-bottom : @grid-gutter-width / 2;
+}
+
+.label.label-emphasize{
+  background-color: @ima-purple;
+  color: #fff;
 }
 
 /* expert mode */

--- a/client/src/modules/templates/bhFilters.tmpl.html
+++ b/client/src/modules/templates/bhFilters.tmpl.html
@@ -7,7 +7,7 @@
     <!--
       TODO: these should be a custom CSS class.  Label is just too small!
     -->
-    <span class="label label-warning">
+    <span class="label label-emphasize">
       <i class="fa fa-filter"></i>
       <span translate>{{filter._label}}</span> {{ filter._comparitor ? " " + filter._comparitor : ":" }}
       {{ filter.displayValue }}


### PR DESCRIPTION
This commit makes the default filters purple to increase legibility.
The previous version had poor contrast for users without proper eye
equipment - yellow on white.  Here we use a dark purple to increase
contrast and aid readability.

Closes #1949.

<img width="201" alt="emphasizedefaultfiltersforlegibility" src="https://user-images.githubusercontent.com/896472/29485785-d66accbe-84cf-11e7-817b-b90039524928.PNG">
_Fig 1: New label-emphasize class in action_


------

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through eslint.
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the online review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
