### PR TITLE
(feat): using user.display_name in pdf_report instead of user.username

### DIFF
--- a/server/lib/template/partials/header.handlebars
+++ b/server/lib/template/partials/header.handlebars
@@ -10,6 +10,6 @@
   </div>
   <div class="col-xs-6 text-right">
     <div>{{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time></div>
-    <div>{{translate "REPORT.PRODUCED_BY"}} {{metadata.user.username}}</div>
+    <div>{{translate "REPORT.PRODUCED_BY"}} {{metadata.user.display_name}}</div>
   </div>
 </header>


### PR DESCRIPTION
This PR helps to use user display_name in pdf report that he has initiated instead of username
 closes #2014 