### PR TITLE
(refactor) Inverse Journal default transaction sort

### DIFF
--- a/client/src/js/services/grid/GridSorting.js
+++ b/client/src/js/services/grid/GridSorting.js
@@ -36,11 +36,11 @@ function GridSortingService(util) {
     first = Number(/[a-z,A-Z]*([0-9]*)/g.exec(a)[1]);
     second = Number(/[a-z,A-Z]*([0-9]*)/g.exec(b)[1]);
 
-    if (first > second) {
+    if (first < second) {
       return 1;
     }
 
-    if (first < second) {
+    if (first > second) {
       return -1;
     }
 


### PR DESCRIPTION
This commit sorts transactions from smallest to largest by default.
Usually transactions with a smaller ID will have an earlier timestamp -
this change will implicitly (roughly) order transactions by date so that
the ordering is not swapped when moving to the grouped view.