### PR TITLE
chore(periods): make period_ids readable (YYYYMM)

### DIFF
--- a/server/controllers/finance/fiscal.js
+++ b/server/controllers/finance/fiscal.js
@@ -249,10 +249,10 @@ function lookupBalance(fiscalYearId, periodNumber) {
   const sql = `
     SELECT t.period_id, a.id, a.label,
       SUM(t.debit) AS debit, SUM(t.credit) AS credit, SUM(t.debit - t.credit) AS balance
-    FROM period_total t 
-    JOIN account a ON a.id = t.account_id 
-    JOIN period p ON p.id = t.period_id 
-    WHERE t.fiscal_year_id = ? AND p.number <= ?  
+    FROM period_total t
+    JOIN account a ON a.id = t.account_id
+    JOIN period p ON p.id = t.period_id
+    WHERE t.fiscal_year_id = ? AND p.number <= ?
     GROUP BY a.id HAVING balance <> 0;
   `;
 
@@ -479,7 +479,7 @@ function closing(req, res, next) {
     })
     .then(() => {
       const sqlProfitAccounts = `
-        SELECT a.id, SUM(pt.credit) AS credit, SUM(pt.debit) AS debit 
+        SELECT a.id, SUM(pt.credit) AS credit, SUM(pt.debit) AS debit
         FROM period_total AS pt
         JOIN account AS a ON pt.account_id = a.id
         JOIN account_type AS at ON a.type_id = at.id
@@ -488,7 +488,7 @@ function closing(req, res, next) {
       `;
 
       const sqlChargeAccounts = `
-        SELECT a.id, SUM(pt.credit) AS credit, SUM(pt.debit) AS debit 
+        SELECT a.id, SUM(pt.credit) AS credit, SUM(pt.debit) AS debit
         FROM period_total AS pt
         JOIN account AS a ON pt.account_id = a.id
         JOIN account_type AS at ON a.type_id = at.id
@@ -516,7 +516,7 @@ function closing(req, res, next) {
     })
     .then(() => {
       const sqlInsertVoucherItem = `
-        INSERT INTO voucher_item (uuid, account_id, debit, credit, voucher_uuid, document_uuid) 
+        INSERT INTO voucher_item (uuid, account_id, debit, credit, voucher_uuid, document_uuid)
         VALUES (?, ?, ?, ?, ?, ?);
       `;
 
@@ -641,7 +641,7 @@ function closing(req, res, next) {
 function getPeriodByFiscal(fiscalYearId) {
   const sql = `
     SELECT period.number, period.id
-    FROM period 
+    FROM period
     JOIN fiscal_year ON period.fiscal_year_id = fiscal_year.id
     WHERE period.fiscal_year_id = ? AND period.number <> 13;
   `;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -214,7 +214,7 @@ CREATE TABLE `config_cotisation_item` (
 DROP TABLE IF EXISTS `config_paiement_period`;
 
 CREATE TABLE `config_paiement_period` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `id` int(10) unsigned NOT NULL,
   `paiement_period_id` int(10) unsigned NOT NULL,
   `weekFrom` date NOT NULL,
   `weekTo` date NOT NULL,

--- a/test/data.sql
+++ b/test/data.sql
@@ -177,7 +177,7 @@ INSERT INTO permission (unit_id, user_id) VALUES
 -- [Folder] reports/balance_report: The Balance
 (150,1),
 
--- [Folder] reports/aged_debtors: The Report Aged Debtors 
+-- [Folder] reports/aged_debtors: The Report Aged Debtors
 (151,1),
 
 -- [Folder] reports/account_reports: The Report accounts
@@ -198,7 +198,7 @@ INSERT INTO permission (unit_id, user_id) VALUES
 -- Cashflow By Service Report
 (153, 1),
 
--- Purchase order folder 
+-- Purchase order folder
 (154, 1), (155, 1), (156, 1),
 
 -- Stock
@@ -381,19 +381,19 @@ INSERT INTO cash (uuid, project_id, reference, date, debtor_uuid, currency_id, a
   (@cash_payment, 1, 1, '2016-01-09 14:33:13', HUID('3be232f9-a4b9-4af6-984c-5d3f87d5c107'), 1, 100, 1, 2, "Some cool description", 1);
 
 INSERT INTO `posting_journal` VALUES
-  (HUID(UUID()),1,1,16,'TRANS1','2016-01-09 14:35:55',@first_invoice, 'description x',3631,75.0000,0.0000,75.0000,0.0000,2,HUID('3be232f9-a4b9-4af6-984c-5d3f87d5c107'),NULL,NULL,1,2,1,NULL),
-  (HUID(UUID()),1,1,16,'TRANS1','2016-01-09 14:35:55',@first_invoice,'description x',3638,0.0000,75.0000,0.0000,75.0000,2,NULL,NULL,NULL,1,2,1,NULL),
-  (HUID(UUID()),1,1,16,'TRANS2','2016-01-09 17:04:27',@second_invoice,'description x',3631,25.0000,0.0000,25.0000,0.0000,2,HUID('3be232f9-a4b9-4af6-984c-5d3f87d5c107'),NULL,NULL,1,2,1,NULL),
-  (HUID(UUID()),1,1,16,'TRANS2','2016-01-09 17:04:27',@second_invoice,'description x',3638,0.0000,25.0000,0.0000,25.0000,2,NULL,NULL,NULL,1,2,1,NULL),
+  (HUID(UUID()),1,1,201609,'TRANS1','2016-01-09 14:35:55',@first_invoice, 'description x',3631,75.0000,0.0000,75.0000,0.0000,2,HUID('3be232f9-a4b9-4af6-984c-5d3f87d5c107'),NULL,NULL,1,2,1,NULL),
+  (HUID(UUID()),1,1,201609,'TRANS1','2016-01-09 14:35:55',@first_invoice,'description x',3638,0.0000,75.0000,0.0000,75.0000,2,NULL,NULL,NULL,1,2,1,NULL),
+  (HUID(UUID()),1,1,201609,'TRANS2','2016-01-09 17:04:27',@second_invoice,'description x',3631,25.0000,0.0000,25.0000,0.0000,2,HUID('3be232f9-a4b9-4af6-984c-5d3f87d5c107'),NULL,NULL,1,2,1,NULL),
+  (HUID(UUID()),1,1,201609,'TRANS2','2016-01-09 17:04:27',@second_invoice,'description x',3638,0.0000,25.0000,0.0000,25.0000,2,NULL,NULL,NULL,1,2,1,NULL),
   -- vouchers data
-  (HUID(UUID()),1,1,16,'TRANS3','2016-01-09 17:04:27',@first_voucher,'description x',3627,100.0000,0.0000,100.0000,0.0000,2,NULL,NULL,'Sample voucher data one',1,2,1,NULL),
-  (HUID(UUID()),1,1,16,'TRANS3','2016-01-09 17:04:27',@first_voucher,'description x',3628,0.0000,100.0000,0.0000,100.0000,2,NULL,NULL,'Sample voucher data one',1,2,1,NULL),
-  (HUID(UUID()),1,1,16,'TRANS4','2016-01-09 17:04:27',@second_voucher,'description x',3627,200.0000,0.0000,200.0000,0.0000,2,NULL,NULL,'Sample voucher data two',1,2,1,NULL),
-  (HUID(UUID()),1,1,16,'TRANS4','2016-01-09 17:04:27',@second_voucher,'description x',3628,0.0000,200.0000,0.0000,200.0000,2,NULL,NULL,'Sample voucher data two',1,2,1,NULL),
-  (HUID(UUID()),1,1,16,'TRANS5','2016-02-08 17:04:27',@third_voucher,'description x',3627,300.0000,0.0000,300.0000,0.0000,2,NULL,NULL,'Sample voucher data three',1,2,1,NULL),
-  (HUID(UUID()),1,1,16,'TRANS5','2016-02-08 17:04:27',@third_voucher,'unique',3628,0.0000,300.0000,0.0000,300.0000,2,NULL,NULL,'Sample voucher data three',1,2,1,NULL),
-  (HUID(UUID()),1,1,16,'TRANS6','2017-04-07 09:18:00',@fourth_voucher, 'description x',3641,1000.0000,0.0000,1000.0000,0.0000,2,NULL,NULL,NULL,1,2,1,NULL),
-  (HUID(UUID()),1,1,16,'TRANS6','2017-04-07 09:18:00',@fourth_voucher,'description x',3643,0.0000,1000.0000,0.0000,1000.0000,2,NULL,NULL,NULL,1,2,1,NULL);
+  (HUID(UUID()),1,1,201609,'TRANS3','2016-01-09 17:04:27',@first_voucher,'description x',3627,100.0000,0.0000,100.0000,0.0000,2,NULL,NULL,'Sample voucher data one',1,2,1,NULL),
+  (HUID(UUID()),1,1,201609,'TRANS3','2016-01-09 17:04:27',@first_voucher,'description x',3628,0.0000,100.0000,0.0000,100.0000,2,NULL,NULL,'Sample voucher data one',1,2,1,NULL),
+  (HUID(UUID()),1,1,201609,'TRANS4','2016-01-09 17:04:27',@second_voucher,'description x',3627,200.0000,0.0000,200.0000,0.0000,2,NULL,NULL,'Sample voucher data two',1,2,1,NULL),
+  (HUID(UUID()),1,1,201609,'TRANS4','2016-01-09 17:04:27',@second_voucher,'description x',3628,0.0000,200.0000,0.0000,200.0000,2,NULL,NULL,'Sample voucher data two',1,2,1,NULL),
+  (HUID(UUID()),1,1,201609,'TRANS5','2016-02-08 17:04:27',@third_voucher,'description x',3627,300.0000,0.0000,300.0000,0.0000,2,NULL,NULL,'Sample voucher data three',1,2,1,NULL),
+  (HUID(UUID()),1,1,201609,'TRANS5','2016-02-08 17:04:27',@third_voucher,'unique',3628,0.0000,300.0000,0.0000,300.0000,2,NULL,NULL,'Sample voucher data three',1,2,1,NULL),
+  (HUID(UUID()),1,1,201609,'TRANS6','2017-04-07 09:18:00',@fourth_voucher, 'description x',3641,1000.0000,0.0000,1000.0000,0.0000,2,NULL,NULL,NULL,1,2,1,NULL),
+  (HUID(UUID()),1,1,201609,'TRANS6','2017-04-07 09:18:00',@fourth_voucher,'description x',3643,0.0000,1000.0000,0.0000,1000.0000,2,NULL,NULL,NULL,1,2,1,NULL);
 
 -- zones des santes SNIS
 INSERT INTO `mod_snis_zs` VALUES
@@ -436,12 +436,12 @@ INSERT INTO `purchase_item` VALUES
 -- default depots
 SET @depot_uuid = HUID("f9caeb16-1684-43c5-a6c4-47dbac1df296");
 SET @second_depot_uuid = HUID("d4bb1452-e4fa-4742-a281-814140246877");
-INSERT INTO `depot` VALUES 
+INSERT INTO `depot` VALUES
   (@depot_uuid, 'Depot Principal', 1, 1),
   (@second_depot_uuid, 'Depot Secondaire', 1, 0);
 
--- stock lots 
-INSERT INTO `lot` (`uuid`, `label`, `initial_quantity`, `quantity`, `unit_cost`, `expiration_date`, `inventory_uuid`, `origin_uuid`, `delay`, `entry_date`) VALUES 
+-- stock lots
+INSERT INTO `lot` (`uuid`, `label`, `initial_quantity`, `quantity`, `unit_cost`, `expiration_date`, `inventory_uuid`, `origin_uuid`, `delay`, `entry_date`) VALUES
   (HUID('064ab1d9-5246-4402-ae8a-958fcdb07b35'), 'VITAMINE-A', 100, 100, 1.2000, '2019-04-30', HUID('289cc0a1-b90f-11e5-8c73-159fdc73ab02'), HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
   (HUID('5a0e06c2-6ca7-4633-8b17-92e2a59db44c'), 'VITAMINE-B', 20, 20, 0.5000, '2020-04-30', HUID('289cc0a1-b90f-11e5-8c73-159fdc73ab02'), HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
   (HUID('6f80748b-1d94-4247-804e-d4be99e827d2'), 'QUININE-B', 200, 200, 0.8000, '2018-04-30', HUID('cf05da13-b477-11e5-b297-023919d3d5b0'), HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
@@ -449,8 +449,8 @@ INSERT INTO `lot` (`uuid`, `label`, `initial_quantity`, `quantity`, `unit_cost`,
   (HUID('ef24cf1a-d5b9-4846-b70c-520e601c1ea6'), 'QUININE-C', 50, 50, 2.0000, '2017-04-30', HUID('cf05da13-b477-11e5-b297-023919d3d5b0'), HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25');
 
 
--- stock lots movements 
-INSERT INTO `stock_movement` (`uuid`, `lot_uuid`, `document_uuid`, `depot_uuid`, `entity_uuid`, `flux_id`, `date`, `quantity`, `unit_cost`, `is_exit`, `user_id`) VALUES 
+-- stock lots movements
+INSERT INTO `stock_movement` (`uuid`, `lot_uuid`, `document_uuid`, `depot_uuid`, `entity_uuid`, `flux_id`, `date`, `quantity`, `unit_cost`, `is_exit`, `user_id`) VALUES
   (HUID('5b7dd0d6-9273-4955-a703-126fbd504b61'), HUID('ae735e99-8faf-417b-aa63-9b404fca99ac'), HUID('682e11c0-93a7-49f8-b79b-a4bc8e3e6f47'), HUID('f9caeb16-1684-43c5-a6c4-47dbac1df296'), '', 1, '2017-02-02', 100, 1.2000, 0, 1),
   (HUID('6529ba0c-aef4-4527-b572-5ae77273de62'), HUID('6f80748b-1d94-4247-804e-d4be99e827d2'), HUID('682e11c0-93a7-49f8-b79b-a4bc8e3e6f47'), HUID('f9caeb16-1684-43c5-a6c4-47dbac1df296'), '', 1, '2017-02-02', 200, 0.8000, 0, 1),
   (HUID('a4ff7358-f1f8-4301-86e4-e9e6fe99bd31'), HUID('5a0e06c2-6ca7-4633-8b17-92e2a59db44c'), HUID('682e11c0-93a7-49f8-b79b-a4bc8e3e6f47'), HUID('f9caeb16-1684-43c5-a6c4-47dbac1df296'), '', 1, '2017-02-02', 20, 0.5000, 0, 1),
@@ -459,6 +459,6 @@ INSERT INTO `stock_movement` (`uuid`, `lot_uuid`, `document_uuid`, `depot_uuid`,
   (HUID('e8502c3e-7483-11e7-a8de-507b9dd6de91'), HUID('064ab1d9-5246-4402-ae8a-958fcdb07b35'), HUID('0cc6c435-7484-11e7-a8de-507b9dd6de91'), HUID('f9caeb16-1684-43c5-a6c4-47dbac1df296'), HUID('d4bb1452-e4fa-4742-a281-814140246877'), 8, '2017-02-02', 75, 1.2000, 1, 1);
 
 -- general ledger data
-INSERT INTO `general_ledger` VALUES 
-  (HUID('6b2b8aa9-3ff3-11e7-b0b2-507b9dd6e004'), 1, 3, 34, 'TPB10', CURRENT_DATE(), HUID('3b2754c2-969f-4767-8a10-bb0bca06a370'), 'Facture a Test 2 Patient (PA.TPA.2) pour 1 items dans le service Administration. ', 3631, 25.0000, 0.0000, 25.0000, 0.0000, 2, HUID('3be232f9-a4b9-4af6-984c-5d3f87d5c107'), '', NULL, 11, 1, NULL, NULL),
-  (HUID('6b2b9882-3ff3-11e7-b0b2-507b9dd6e004'), 1, 3, 34, 'TPB11', CURRENT_DATE(), HUID('3b2754c2-969f-4767-8a10-bb0bca06a370'), 'Facture a Test 2 Patient (PA.TPA.2) pour 1 items dans le service Administration. ', 3642, 0.0000, 25.0000, 0.0000, 25.0000, 2, '', '', NULL, 11, 1, NULL, NULL);
+INSERT INTO `general_ledger` VALUES
+  (HUID('6b2b8aa9-3ff3-11e7-b0b2-507b9dd6e004'), 1, 3, DATE_FORMAT(NOW(), '%Y%m'), 'TPB10', CURRENT_DATE(), HUID('3b2754c2-969f-4767-8a10-bb0bca06a370'), 'Facture a Test 2 Patient (PA.TPA.2) pour 1 items dans le service Administration. ', 3631, 25.0000, 0.0000, 25.0000, 0.0000, 2, HUID('3be232f9-a4b9-4af6-984c-5d3f87d5c107'), '', NULL, 11, 1, NULL, NULL),
+  (HUID('6b2b9882-3ff3-11e7-b0b2-507b9dd6e004'), 1, 3, DATE_FORMAT(NOW(), '%Y%m'), 'TPB11', CURRENT_DATE(), HUID('3b2754c2-969f-4767-8a10-bb0bca06a370'), 'Facture a Test 2 Patient (PA.TPA.2) pour 1 items dans le service Administration. ', 3642, 0.0000, 25.0000, 0.0000, 25.0000, 2, '', '', NULL, 11, 1, NULL, NULL);

--- a/test/end-to-end/reports/income_expense/IncomeExpense.spec.js
+++ b/test/end-to-end/reports/income_expense/IncomeExpense.spec.js
@@ -13,8 +13,8 @@ describe('Income Expense report ::', () => {
 
   const dataset = {
     fiscal_id : 2,
-    periodFrom_id : 16,
-    periodTo_id : 27,
+    periodFrom_id : 201602,
+    periodTo_id : 201607,
     type : 'Recettes et dépenses',
     report_name : 'Income Expense Report Saved by E2E',
     renderer : 'PDF',

--- a/test/integration/reports/finance/income_expense.js
+++ b/test/integration/reports/finance/income_expense.js
@@ -1,25 +1,24 @@
-/* global expect, chai, agent */
-
+/* global expect, agent */
 const RenderingTests = require('../rendering');
-const target = '/reports/finance/income_expense';
 const helpers = require('../../helpers');
 
-describe(`(${target}) Income Expense Reports`, function () {
+const target = '/reports/finance/income_expense';
 
+describe(`(${target}) Income Expense Reports`, () => {
   const keys = [
     'incomes', 'expenses', 'dateFrom', 'dateTo', 'isEmpty', 'isLost', 'overallBalance', 'type_id',
   ];
 
   const parameters = {
     fiscal : 2,
-    periodFrom : 16,
-    periodTo : 27,
-    type : 1
+    periodFrom : 201603,
+    periodTo : 201607,
+    type : 1,
   };
 
   describe(`${target} Rendering`, RenderingTests(target, null, parameters));
 
-  it(`GET ${target} returns the correct JSON keys`, function () {
+  it(`GET ${target} returns the correct JSON keys`, () => {
     parameters.renderer = 'json';
     return agent.get(target)
       .query(parameters)


### PR DESCRIPTION
This commit migrates the period_ids in the period table to be human
readable by using YYYYMM.  This was proposed twice, but should help
greatly increase the legibility of database when working with raw SQL.
As a side effect, it is also much easier to check if dates are in the
correct period, as well as select all records from a given period.

Closes #1871.  Closes #1625.

----

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through eslint.
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the online review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!