### PR TITLE
feat(Home page) Make exchange rate display human-readable

### DIFF
--- a/client/src/modules/home/home.ctrl.js
+++ b/client/src/modules/home/home.ctrl.js
@@ -31,6 +31,12 @@ function HomeController(Currencies, Rates, Session, Notify, Fiscal, DashboardSer
   vm.project = Session.project;
   vm.user = Session.user;
   vm.enterprise = Session.enterprise;
+  /*
+    vm.isFirstCurencyLabel is used to check the exchange Rate
+    is lower then 1  the program show display something
+    mutch better for reading
+  */
+  vm.isFirstCurencyLabel = false;
 
   // load exchange rates
   Currencies.read(true)
@@ -38,7 +44,6 @@ function HomeController(Currencies, Rates, Session, Notify, Fiscal, DashboardSer
       vm.currencies = currencies.filter(function (currency) {
         return currency.id !== Session.enterprise.currency_id;
       });
-
       // format the enterprise currency
       vm.enterprise.currencyLabel = Currencies.format(vm.enterprise.currency_id);
 
@@ -48,11 +53,24 @@ function HomeController(Currencies, Rates, Session, Notify, Fiscal, DashboardSer
     .then(function () {
       vm.currencies.forEach(function (currency) {
         currency.rate = Rates.getCurrentRate(currency.id);
+
+
+        /*
+          Let check is the currency rate is lower the 1
+          so that we could format it in a readable way
+        */
+        if (currency.rate < 1) {
+          currency.rate = (1 / currency.rate);
+          vm.isFirstCurencyLabel = true;
+        }
+
+
         currency.formattedDate = new Moment(currency.date).format('LL');
       });
 
       // @TODO Method for selecting primary exchange
       vm.primaryExchange = vm.currencies[0];
+
     })
     .catch(Notify.handleError);
 

--- a/client/src/modules/home/home.html
+++ b/client/src/modules/home/home.html
@@ -65,7 +65,18 @@
           <div class="panel-body text-center">
             <div class="segment-title" translate>TABLE.COLUMNS.EXCHANGE_RATE</div>
             <div class="ui huge ima-blue statistic" title="{{ HomeCtrl.primaryExchange.rate}} ({{ HomeCtrl.primaryExchange.symbol }})">
-              <div class="value">{{ HomeCtrl.primaryExchange.rate | limitTo:HomeCtrl.EXCHANGE_RATE_DISPLAY_SIZE }}({{ HomeCtrl.primaryExchange.symbol }})</div>
+
+              <div class="value" ng-show ='!HomeCtrl.isFirstCurencyLabel'>
+                {{ HomeCtrl.primaryExchange.rate | limitTo:HomeCtrl.EXCHANGE_RATE_DISPLAY_SIZE }}({{ HomeCtrl.primaryExchange.symbol }})</div>
+
+                <div class="value" style='font-size:45px !important; padding-top:16px' ng-show ='HomeCtrl.isFirstCurencyLabel'>
+
+               1{{HomeCtrl.primaryExchange.symbol}} = {{ HomeCtrl.primaryExchange.rate | limitTo:HomeCtrl.EXCHANGE_RATE_DISPLAY_SIZE }}({{ HomeCtrl.enterprise.currencySymbol }})
+
+              </div>
+
+
+
               <div class="uilabel"><span translate>HOME.EXCHANGE_SET</span> {{ HomeCtrl.primaryExchange.formattedDate }}</div>
             </div>
           </div>


### PR DESCRIPTION
This PR solves the problem we had at #1936  abaut making the exchange rate display human-readable

The result looks like this
![screem_short](https://user-images.githubusercontent.com/25838121/29919744-757ecf46-8e42-11e7-8f2b-292084ab74fd.PNG)

Instead of
![screem2](https://user-images.githubusercontent.com/25838121/29919912-17bb77aa-8e43-11e7-8ea3-6c3cbec520ea.PNG)
