### PR TITLE
fix(stock): improve movements registry

### DIFF
--- a/client/src/modules/stock/lots/registry.js
+++ b/client/src/modules/stock/lots/registry.js
@@ -124,9 +124,10 @@ function StockLotsController(Stock, Notify,
 
     if($state.params.filters) {
       var changes = [{ key : $state.params.filters.key, value : $state.params.filters.value }]
-      stockLotFilters.replaceFilters(changes);		
+      stockLotFilters.replaceFilters(changes);
       Stock.cacheFilters(filterKey);
     }
+
     load(stockLotFilters.formatHTTP(true));
     vm.latestViewFilters = stockLotFilters.formatView();
   }
@@ -160,14 +161,14 @@ function StockLotsController(Stock, Notify,
     toggleLoadingIndicator();
 
     Stock.lots.read(null, filters)
-    .then(function(lots){
-      vm.gridOptions.data = lots;
-      vm.grouping.unfoldAllGroups();
-    })
-    .catch(errorHandler)
-    .finally(function (){
-      toggleLoadingIndicator();     
-    });
+      .then(function (lots) {
+        vm.gridOptions.data = lots;
+        vm.grouping.unfoldAllGroups();
+      })
+      .catch(errorHandler)
+      .finally(function (){
+        toggleLoadingIndicator();
+      });
   }
 
   // remove a filter with from the filter object, save the filters and reload

--- a/client/src/modules/stock/movements/modals/search.modal.html
+++ b/client/src/modules/stock/movements/modals/search.modal.html
@@ -20,13 +20,13 @@
             <bh-clear on-clear="$ctrl.clear('is_exit')"></bh-clear>
             <div class="radio">
               <label>
-                <input type="radio" name="is_exit" value="0" ng-model="$ctrl.searchQueries.is_exit"> 
+                <input type="radio" name="is_exit" value="0" ng-model="$ctrl.searchQueries.is_exit">
                 <span translate>STOCK.INPUT</span>
               </label>
             </div>
             <div class="radio">
               <label>
-                <input type="radio" name="is_exit" value="0" ng-model="$ctrl.searchQueries.is_exit"> 
+                <input type="radio" name="is_exit" value="1" ng-model="$ctrl.searchQueries.is_exit">
                 <span translate>STOCK.OUTPUT</span>
               </label>
             </div>
@@ -59,27 +59,16 @@
           <div class="form-group">
             <label class="control-label" translate>STOCK.FLUX</label>
             <bh-clear on-clear="$ctrl.clear('flux_id')"></bh-clear>
-            
+
             <ui-select name="inventory" ng-model="$ctrl.searchQueries.flux_id">
               <ui-select-match>
                 <span translate>{{$select.selected.label}}</span>
               </ui-select-match>
-              <ui-select-choices ui-select-focus-patch repeat="flux as flux in $ctrl.fluxes | filter:{ 'label': $select.search }">
+              <ui-select-choices ui-select-focus-patch repeat="flux.id as flux in $ctrl.fluxes | filter:{ 'label': $select.search }">
                 <span ng-bind-html="flux.label | translate | highlight:$select.search"></span>
               </ui-select-choices>
             </ui-select>
           </div>
-
-          <!-- date -->
-          <fieldset>
-            <legend translate>FORM.LABELS.DATE</legend>
-            <bh-date-interval
-              date-id="date" 
-              date-from="$ctrl.searchQueries.dateFrom" 
-              date-to="$ctrl.searchQueries.dateTo" 
-              mode="clean">
-            </bh-date-interval>
-          </fieldset>
         </div>
       </uib-tab>
       <uib-tab index="1" heading="{{ 'FORM.LABELS.DEFAULTS' | translate }}" data-default-filter-tab>
@@ -91,7 +80,7 @@
 
           <div class="form-group" ng-class="{ 'has-error' : ModalForm.limit.$invalid }">
             <label class="control-label" translate>FORM.LABELS.LIMIT</label>
-            <input 
+            <input
               name="limit"
               type="number"
               bh-integer
@@ -105,14 +94,14 @@
           </div>
         </div>
       </uib-tab>
-    </uib-tabset>    
+    </uib-tabset>
   </div>
 
   <div class="modal-footer">
-    <button type="button" class="btn btn-default" ng-click="$ctrl.cancel()" data-method="cancel" translate> 
+    <button type="button" class="btn btn-default" ng-click="$ctrl.cancel()" data-method="cancel" translate>
       FORM.BUTTONS.CLOSE
     </button>
-    <button type="submit" class="btn btn-primary" data-method="submit" translate> 
+    <button type="submit" class="btn btn-primary" data-method="submit" translate>
       FORM.BUTTONS.SUBMIT
     </button>
   </div>

--- a/client/src/modules/stock/movements/modals/search.modal.js
+++ b/client/src/modules/stock/movements/modals/search.modal.js
@@ -1,32 +1,32 @@
 angular.module('bhima.controllers')
-.controller('SearchMovementsModalController', SearchMovementsModalController);
+  .controller('SearchMovementsModalController', SearchMovementsModalController);
 
 SearchMovementsModalController.$inject = [
-  'data', 'NotifyService', '$uibModalInstance', 'FluxService', 
-  '$translate', 'PeriodService', 'Store', 'util'
+  'data', 'NotifyService', '$uibModalInstance', 'FluxService',
+  '$translate', 'PeriodService', 'Store', 'util',
 ];
 
 function SearchMovementsModalController(data, Notify, Instance, Flux, $translate, Periods, Store, util) {
   var vm = this;
-  var changes = new Store({ identifier : 'key'});
+  var changes = new Store({ identifier : 'key' });
+
+  var searchQueryOptions = [
+    'is_exit', 'depot_uuid', 'inventory_uuid', 'label', 'flux_id', 'dateFrom', 'dateTo',
+  ];
 
   vm.filters = data;
   vm.searchQueries = {};
   vm.defaultQueries = {};
 
-  var searchQueryOptions = [
-    'is_exit', 'depot_uuid', 'inventory_uuid', 'label', 'flux_id', 'dateFrom', 'dateTo'
-  ];
-
-  // load flux 
+  // load flux
   Flux.read()
-  .then(function (rows) {
+    .then(function (rows) {
       vm.fluxes = rows.map(function (row) {
         row.label = $translate.instant(row.label);
         return row;
       });
-  })
-  .catch(Notify.handleError);
+    })
+    .catch(Notify.handleError);
 
   // default filter period - directly write to changes list
   vm.onSelectPeriod = function onSelectPeriod(period) {
@@ -50,7 +50,7 @@ function SearchMovementsModalController(data, Notify, Instance, Flux, $translate
   // assign already defined custom filters to searchQueries object
   vm.searchQueries = util.maskObjectFromKeys(data, searchQueryOptions);
 
-  if(data.limit) {
+  if (data.limit) {
     vm.defaultQueries.limit = data.limit;
   }
 
@@ -58,11 +58,11 @@ function SearchMovementsModalController(data, Notify, Instance, Flux, $translate
   vm.onSelectLimit = function onSelectLimit(value) {
     // input is type value, this will only be defined for a valid number
     if (angular.isDefined(value)) {
-      changes.post({ key: 'limit', value: value });
+      changes.post({ key : 'limit', value : value });
     }
   };
 
-  // deletes a filter from the custom filter object, 
+  // deletes a filter from the custom filter object,
   // this key will no longer be written to changes on exit
   vm.clear = function clear(key) {
     delete vm.searchQueries[key];
@@ -70,16 +70,16 @@ function SearchMovementsModalController(data, Notify, Instance, Flux, $translate
 
   vm.cancel = function cancel() { Instance.close(); };
 
-  vm.submit = function submit(form) {
+  vm.submit = function submit() {
     // push all searchQuery values into the changes array to be applied
     angular.forEach(vm.searchQueries, function (value, key) {
       if (angular.isDefined(value)) {
-        changes.post({ key: key, value: value });
+        changes.post({ key : key, value : value });
       }
     });
 
     var loggedChanges = changes.getAll();
-    
+
     return Instance.close(loggedChanges);
   };
 }

--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -4,7 +4,7 @@ angular.module('bhima.controllers')
 StockMovementsController.$inject = [
   'StockService', 'NotifyService', 'uiGridConstants', '$translate',
   'StockModalService', 'LanguageService', 'SessionService', 'FluxService',
-  'ReceiptModal', 'GridGroupingService', '$state', 'GridColumnService', 'GridStateService'
+  'ReceiptModal', 'GridGroupingService', '$state', 'GridColumnService', 'GridStateService',
 ];
 
 /**
@@ -21,129 +21,114 @@ function StockMovementsController(Stock, Notify,
   var state;
   var gridColumns;
 
-  vm.gridApi = {};
-
   // bind flux id with receipt
   var mapFlux = {
-    1: { receipt: ReceiptModal.stockEntryPurchaseReceipt },
-    2: { receipt: ReceiptModal.stockEntryDepotReceipt },
-    3: { receipt: ReceiptModal.stockAdjustmentReceipt },
-    8: { receipt: ReceiptModal.stockExitDepotReceipt },
-    9: { receipt: ReceiptModal.stockExitPatientReceipt },
-    10: { receipt: ReceiptModal.stockExitServiceReceipt },
-    11: { receipt: ReceiptModal.stockExitLossReceipt },
-    12: { receipt: ReceiptModal.stockAdjustmentReceipt },
-    13: { receipt: ReceiptModal.stockEntryIntegrationReceipt },
+    1 : { receipt : ReceiptModal.stockEntryPurchaseReceipt },
+    2 : { receipt : ReceiptModal.stockEntryDepotReceipt },
+    3 : { receipt : ReceiptModal.stockAdjustmentReceipt },
+    8 : { receipt : ReceiptModal.stockExitDepotReceipt },
+    9 : { receipt : ReceiptModal.stockExitPatientReceipt },
+    10 : { receipt : ReceiptModal.stockExitServiceReceipt },
+    11 : { receipt : ReceiptModal.stockExitLossReceipt },
+    12 : { receipt : ReceiptModal.stockAdjustmentReceipt },
+    13 : { receipt : ReceiptModal.stockEntryIntegrationReceipt },
   };
 
   // grouping box
   vm.groupingBox = [
-    { label: 'STOCK.INVENTORY', value: 'text' },
-    { label: 'STOCK.IO', value: 'io' },
-    { label: 'STOCK.LOT', value: 'label' },
+    { label : 'STOCK.INVENTORY', value : 'text' },
+    { label : 'STOCK.IO', value : 'io' },
+    { label : 'STOCK.LOT', value : 'label' },
   ];
+
+  vm.gridApi = {};
 
   // global variables
   vm.enterprise = Session.enterprise;
 
   // grid columns
-  var columns = [
-    {
-      field: 'depot_text',
-      displayName: 'STOCK.DEPOT',
-      headerCellFilter: 'translate',
-      aggregationType: uiGridConstants.aggregationTypes.count
-    },
-
-    {
-      field: 'io',
-      displayName: 'STOCK.IO',
-      headerCellFilter: 'translate',
-      cellTemplate: 'modules/stock/movements/templates/io.cell.html'
-    },
-
-    {
-      field: 'text',
-      displayName: 'STOCK.INVENTORY',
-      headerCellFilter: 'translate'
-    },
-
-    {
-      field: 'label',
-      displayName: 'STOCK.LOT',
-      headerCellFilter: 'translate'
-    },
-
-    {
-      field: 'quantity',
-      displayName: 'STOCK.QUANTITY',
-      headerCellFilter: 'translate',
-      aggregationType: uiGridConstants.aggregationTypes.sum,
-      cellClass: 'text-right',
-      footerCellClass: 'text-right'
-    },
-
-    {
-      field: 'unit_type',
-      width: 75,
-      displayName: 'TABLE.COLUMNS.UNIT',
-      headerCellFilter: 'translate',
-      cellTemplate: 'modules/stock/inventories/templates/unit.tmpl.html'
-    },
-
-    {
-      field: 'unit_cost',
-      displayName: 'STOCK.UNIT_COST',
-      headerCellFilter: 'translate',
-      cellFilter: 'currency:grid.appScope.enterprise.currency_id',
-      cellClass: 'text-right'
-    },
-
-    {
-      field: 'cost',
-      displayName: 'STOCK.COST',
-      headerCellFilter: 'translate',
-      aggregationType: totalCost,
-      cellClass: 'text-right',
-      cellTemplate: 'modules/stock/movements/templates/cost.cell.html',
-      footerCellFilter: 'currency:grid.appScope.enterprise.currency_id',
-      footerCellClass: 'text-right'
-    },
-
-    {
-      field: 'date',
-      displayName: 'FORM.LABELS.DATE',
-      headerCellFilter: 'translate',
-      cellFilter: 'date',
-      cellClass: 'text-right'
-    },
-
-    {
-      field: 'flux_id',
-      displayName: 'STOCK.FLUX',
-      headerCellFilter: 'translate',
-      cellTemplate: 'modules/stock/movements/templates/flux.cell.html'
-    },
-
-    {
-      field: 'action',
-      displayName: '',
-      enableFiltering: false,
-      enableSorting: false,
-      cellTemplate: 'modules/stock/movements/templates/action.cell.html'
-    },
-  ];
+  var columns = [{
+    field : 'depot_text',
+    displayName : 'STOCK.DEPOT',
+    headerCellFilter : 'translate',
+    aggregationType : uiGridConstants.aggregationTypes.count,
+    aggregationHideLabel : true,
+  }, {
+    field : 'io',
+    displayName : 'STOCK.IO',
+    headerCellFilter : 'translate',
+    cellTemplate : 'modules/stock/movements/templates/io.cell.html',
+  }, {
+    field : 'text',
+    displayName : 'STOCK.INVENTORY',
+    headerCellFilter : 'translate',
+  }, {
+    field : 'label',
+    displayName : 'STOCK.LOT',
+    headerCellFilter : 'translate',
+  }, {
+    field : 'quantity',
+    type: 'number',
+    displayName : 'STOCK.QUANTITY',
+    headerCellFilter : 'translate',
+    aggregationType : uiGridConstants.aggregationTypes.sum,
+    aggregationHideLabel : true,
+    cellClass : 'text-right',
+    footerCellClass : 'text-right',
+  }, {
+    field : 'unit_type',
+    width : 75,
+    displayName : 'TABLE.COLUMNS.UNIT',
+    headerCellFilter : 'translate',
+    cellTemplate : 'modules/stock/inventories/templates/unit.tmpl.html',
+  }, {
+    field : 'unit_cost',
+    type : 'number',
+    displayName : 'STOCK.UNIT_COST',
+    headerCellFilter : 'translate',
+    cellFilter : 'currency:grid.appScope.enterprise.currency_id',
+    cellClass : 'text-right',
+  }, {
+    field : 'cost',
+    type : 'number',
+    displayName : 'STOCK.COST',
+    headerCellFilter : 'translate',
+    aggregationType : totalCost,
+    aggregationHideLabel : true,
+    cellFilter : 'currency:grid.appScope.enterprise.currency_id',
+    cellClass : 'text-right',
+    footerCellFilter : 'currency:grid.appScope.enterprise.currency_id',
+    footerCellClass : 'text-right',
+  }, {
+    field : 'date',
+    type: 'date',
+    displayName : 'FORM.LABELS.DATE',
+    headerCellFilter : 'translate',
+    cellFilter : 'date',
+    cellClass : 'text-right',
+  }, {
+    field : 'flux_id',
+    displayName : 'STOCK.FLUX',
+    headerCellFilter : 'translate',
+    cellTemplate : 'modules/stock/movements/templates/flux.cell.html',
+  }, {
+    field : 'action',
+    displayName : '',
+    enableFiltering : false,
+    enableSorting : false,
+    cellTemplate : 'modules/stock/movements/templates/action.cell.html',
+  }];
 
   // options for the UI grid
   vm.gridOptions = {
-    appScopeProvider: vm,
-    enableColumnMenus: false,
-    columnDefs: columns,
-    enableSorting: true,
-    showColumnFooter: true,
-    onRegisterApi: onRegisterApi,
-    fastWatch: true,
-    flatEntityAccess: true,
+    appScopeProvider : vm,
+    enableColumnMenus : false,
+    columnDefs : columns,
+    enableSorting : true,
+    showColumnFooter : true,
+    onRegisterApi : onRegisterApi,
+    fastWatch : true,
+    flatEntityAccess : true,
   };
 
   vm.grouping = new Grouping(vm.gridOptions, true, 'depot_text', vm.grouped, true);
@@ -215,35 +200,41 @@ function StockMovementsController(Stock, Notify,
     // column configuration has direct access to the grid API to alter the current
     // state of the columns - this will be saved if the user saves the grid configuration
     gridColumns.openConfigurationModal();
-  };
+  }
 
   vm.saveGridState = state.saveGridState;
 
   function clearGridState() {
     state.clearGridState();
     $state.reload();
-  };
+  }
 
   // load stock lots in the grid
   function load(filters) {
     vm.hasError = false;
     vm.loading = true;
 
-    Stock.movements.read(null, filters).then(function (rows) {
-      // set flux name
-      rows.forEach(function (row) {
-        row.fluxName = getFluxName(row.flux_id);
+    Stock.movements.read(null, filters)
+      .then(function (rows) {
+        // preprocess data
+        rows.forEach(function (row) {
+
+          // compute the fluxName from its ID
+          row.fluxName = getFluxName(row.flux_id);
+
+          // compute the row cost
+          row.cost = row.quantity * row.unit_cost;
+        });
+
+        vm.gridOptions.data = rows;
+
+        // force expand grid
+        vm.grouping.unfoldAllGroups();
+      })
+      .catch(Notify.handleError)
+      .finally(function () {
+        vm.loading = false;
       });
-
-      vm.gridOptions.data = rows;
-
-      // force expand grid
-      vm.grouping.unfoldAllGroups();
-    })
-    .catch(Notify.handleError)
-    .finally(function () {
-      vm.loading = false;
-    });
   }
 
   // search modal
@@ -267,10 +258,9 @@ function StockMovementsController(Stock, Notify,
 
   // initialize module
   function startup() {
-
-    if($state.params.filters) {
+    if ($state.params.filters) {
       var changes = [{ key : $state.params.filters.key, value : $state.params.filters.value }]
-      stockMovementFilters.replaceFilters(changes);		
+      stockMovementFilters.replaceFilters(changes);
       Stock.cacheFilters(filterKey);
     }
 

--- a/client/src/modules/stock/movements/templates/action.cell.html
+++ b/client/src/modules/stock/movements/templates/action.cell.html
@@ -1,4 +1,4 @@
-<div class="ui-grid-cell-contents text-action" uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
+<div class="ui-grid-cell-contents text-action" uib-dropdown dropdown-append-to-body uib-dropdown-toggle ng-if="!row.groupHeader">
   <a href>
     <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>

--- a/client/src/modules/stock/movements/templates/cost.cell.html
+++ b/client/src/modules/stock/movements/templates/cost.cell.html
@@ -1,3 +1,0 @@
-<div class="ui-grid-cell-contents">
-    {{ row.entity.unit_cost * row.entity.quantity | currency: grid.appScope.enterprise.currency_id }}
-</div>

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -42,7 +42,7 @@ const snis = require('../controllers/medical/snis');
 const medicalReports = require('../controllers/medical/reports');
 const diagnoses = require('../controllers/medical/diagnoses');
 
-// humaine ressource route
+// human resources routes
 const employees = require('../controllers/payroll/employees');
 const employeeReports = require('../controllers/payroll/reports');
 
@@ -175,12 +175,12 @@ exports.configure = function configure(app) {
   // API for journal
   app.get('/journal', journal.list);
   app.get('/journal/count', journal.count);
- 
+
   app.get('/journal/:record_uuid', journal.getTransaction);
   app.post('/journal/:record_uuid/edit', journal.editTransaction);
   app.post('/journal/:uuid/reverse', journal.reverse);
 
-  
+
 
   // API for general ledger
   app.get('/general_ledger', generalLedger.list);
@@ -318,7 +318,7 @@ exports.configure = function configure(app) {
 
   // interface for linking entities, it renders a report for a particular entity
   app.get('/refenceLookup/:codeRef/:language', refenceLookup.getEntity);
-  
+
   // interface for employee report
   app.get('/reports/payroll/employees', employeeReports.employeeRegistrations);
 

--- a/test/end-to-end/stock/stock.movements.spec.js
+++ b/test/end-to-end/stock/stock.movements.spec.js
@@ -1,7 +1,6 @@
 const FU = require('../shared/FormUtils');
 const GU = require('../shared/GridUtils');
 const helpers = require('../shared/helpers');
-const components = require('../shared/components');
 const SearchModal = require('../shared/search.page');
 const Filters = require('../shared/components/bhFilters');
 
@@ -39,11 +38,11 @@ function StockMovementsRegistryTests() {
     GU.expectRowCount(gridId, 15 + (2 * depotGroupingRow));
   });
 
-  it('find exit movements', () => {
+  it('filters by entry/exit', () => {
     // for Exit
     modal.setEntryExit(1);
     modal.submit();
-    GU.expectRowCount(gridId, 16 + depotGroupingRow);
+    GU.expectRowCount(gridId, 8 + depotGroupingRow);
   });
 
   it('find movements by depot', () => {
@@ -67,54 +66,42 @@ function StockMovementsRegistryTests() {
 
   it('find by lots reasons for purchase order', () => {
     // FIX ME: reasons must not depend on translations
-    //selection with `id` works but it is not completed
+    // selection with `id` works but it is not completed
     modal.setMovementReason('Commande d\'achat');
     modal.submit();
-    GU.expectRowCount(gridId, 24 + depotGroupingRow);
+    GU.expectRowCount(gridId, 8 + depotGroupingRow);
   });
 
   it('find by lots reasons for distribution to patient', () => {
-     // to patient
+    // to patient
     modal.setMovementReason('Vers un patient');
     modal.submit();
-    GU.expectRowCount(gridId, 24 + depotGroupingRow);    
+    GU.expectRowCount(gridId, 2 + depotGroupingRow);
   });
 
   it('find by lots reasons for distribution to depot', () => {
     modal.setMovementReason('Vers un depot');
     modal.submit();
-    GU.expectRowCount(gridId, 24 + depotGroupingRow);
+    GU.expectRowCount(gridId, 2 + depotGroupingRow);
   });
 
   it('find by lots reasons for distribution from depot', () => {
     // from depot
     modal.setMovementReason('En provenance d\'un depot');
     modal.submit();
-    GU.expectRowCount(gridId, 24 + depotGroupingRow);
+    GU.expectRowCount(gridId, 1 + depotGroupingRow);
   });
 
   it('find by lots reasons for positive adjustement', () => {
     modal.setMovementReason('Ajustement (Positif)');
     modal.submit();
-    GU.expectRowCount(gridId, 24 + depotGroupingRow);
+    GU.expectRowCount(gridId, 1 + depotGroupingRow);
   });
 
   it('find by lots reasons for negative adjustement', () => {
     modal.setMovementReason('Ajustement (Negatif)');
     modal.submit();
-    GU.expectRowCount(gridId, 24 + depotGroupingRow);
-  });  
-
-  it('find lots by date - Fev 2017', () => {
-    modal.setdateInterval('02/02/2017', '02/02/2017', 'date');
-    modal.submit();
-    GU.expectRowCount(gridId, 8 + depotGroupingRow);
-  });
-
-  it('find zero lot by date - january 2015', () => {
-    modal.setdateInterval('01/01/2015', '30/01/2015', 'date');
-    modal.submit();
-    GU.expectRowCount(gridId, 0);
+    GU.expectRowCount(gridId, 1 + depotGroupingRow);
   });
 }
 


### PR DESCRIPTION
This commit fixes a number of bugs on the movements registry.
 1. The input/output search parameter now actually filters correctly.
 2. The "reason" ui-select actually filters the registry.
 3. The "actions" column does not present a dropdown on header rows.
 4. The date and unit cost columns sort properly.
 5. The grid footer no longer gives untranslated english text in the
 footer.

It also improves the performance of the registry by pre-computing costs
in the same way that it pre-computes the flux mappings.

Closes #2073.  Closes #2072.

---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through eslint.
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the online review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
