### PR TITLE
fix(i18n): clarify cash receipt balance text

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -239,6 +239,7 @@
             "DEBTOR_GROUP_FORM": "Form debtor group record",
             "DEFINE_UNTIL_DATE": "Define a limit date",
             "DEFAULT_QUANTITY": "Default Quantity",
+            "DEBTOR_BALANCE_REMAINING": "Debtor's Remaining Balance",
             "DEPOT": "Depot",
             "DESCRIPTION": "Description",
             "DESIGNATION": "Designation",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -239,6 +239,7 @@
             "DEBTOR_GROUP_FORM": "Formulaire d'enregistrement de groupe débiteur",
             "DEBTOR_CREDITOR": "Débiteur/Créditeur",
             "DEFINE_UNTIL_DATE": "Définir une date limite",
+            "DEBTOR_BALANCE_REMAINING": "Solde Restant du Débiteur",
             "DEPOT": "Depot",
             "DESCRIPTION": "Description",
             "DETAILS": "Details",

--- a/server/controllers/finance/reports/cash/receipt.handlebars
+++ b/server/controllers/finance/reports/cash/receipt.handlebars
@@ -95,7 +95,7 @@
       <!-- the balance only makes sense to show if the debtor is paying an invoice -->
       {{#unless payment.is_caution}}
         <tr>
-          <th colspan="2">{{translate "FORM.LABELS.TOTAL_BALANCE_REMAINING"}}</th>
+          <th colspan="2">{{translate "FORM.LABELS.DEBTOR_BALANCE_REMAINING"}}</th>
           <th class="text-right">{{currency debtorTotalBalance enterprise.currency_id}}</th>
         </tr>
       {{/unless }}


### PR DESCRIPTION
This commit makes sure that the cash receipt properly labels the balance
as the debtor's balance instead of simply "Total Balance".  The previous
form was ambiguous about what balance it was referring to.

Closes #1931.

![fixdebtorremainingbalance](https://user-images.githubusercontent.com/896472/29997252-9e2bdb00-8fdc-11e7-9c9b-aa1a7e13bf20.png)
_Fig 1: New Text for Debtor's Remaining Balance_


---

Thank you for contributing!

Before submitting this pull request, please verify that you have:
 - [x] Run your code through eslint.
 - [x] Run integration tests.
 - [x] Run end-to-end tests.
 - [x] Accurately described the changes your are making in this pull request.

For a more detailed checklist, [see the online review checklist](https://docs.google.com/document/d/1nupLVLRXgSZJQo_acLgrwvPnN8RukfSiwRhSToj81uU/pub) that this PR will be evaluated against.

Ensuring that the above checkboxes are completed will help speed the review process and help build a stronger application.  Thanks!
