### PR TITLE
ci: add CircleCi Build Matrix config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,80 @@
+version: 2.0
+
+# NOTE
+# Each job listed below is identical save for their MySQL version
+# This sets up the opportunity to run tests against a different database
+# version on each change.
+jobs:
+  "mysql-5.5":
+    docker:
+      - image: circleci/mysql:5.5
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - run:
+          name: Build Database
+          command: './sh/travis.sh'
+      - run:
+          name: Fetch Dependencies
+          command: './sh/dependencies.sh'
+      - run:
+          name: Run Integration Tests
+          command: 'npm run test:integration'
+
+  "mysql-5.6":
+    docker:
+      - image: circleci/mysql:5.6
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - run:
+          name: Build Database
+          command: './sh/travis.sh'
+      - run:
+          name: Fetch Dependencies
+          command: './sh/dependencies.sh'
+      - run:
+          name: Run Integration Tests
+          command: 'npm run test:integration'
+
+  "mysql-5.7":
+    docker:
+      - image: circleci/mysql:5.7
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - run:
+          name: Build Database
+          command: './sh/travis.sh'
+      - run:
+          name: Fetch Dependencies
+          command: './sh/dependencies.sh'
+      - run:
+          name: Run Integration Tests
+          command: 'npm run test:integration'
+
+  "mysql-latest (8+)":
+    docker:
+      - image: circleci/mysql:latest
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - run:
+          name: Build Database
+          command: './sh/travis.sh'
+      - run:
+          name: Fetch Dependencies
+          command: './sh/dependencies.sh'
+      - run:
+          name: Run Integration Tests
+          command: 'npm run test:integration'
+
+# create a build matrix that tests the latest NodeJS against all planned versions of MySQL.
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "mysql-5.5"
+      - "mysql-5.6"
+      - "mysql-5.7"
+        # - "mysql-latest (8+)"


### PR DESCRIPTION
This commit implements the CircleCI configuration to build a test matrix
as described in #2090.  The test matrix will test the integration tests
against all MySQL versions available.

Closes #2090.