### PR TITLE
fix(login): remove untranslated Notify.warn()

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -59,11 +59,6 @@ function startupConfig($rootScope, $state, $uibModalStack, SessionService, amMom
     // to the login page.
     } else if (!isLoggedIn && !isLoginState) {
       event.preventDefault();
-
-      if (!isRootState) {
-        Notify.warn('AUTH.UNAUTHENTICATED');
-      }
-
       $state.go('login');
     }
 

--- a/test/end-to-end/login/login.spec.js
+++ b/test/end-to-end/login/login.spec.js
@@ -70,19 +70,6 @@ describe('Login Page', () => {
     expect(defaultProject).to.not.be.empty;
   });
 
-  it('prevents navigation to other pages with a growl notification', () => {
-    // assert that we are on the login page with no notifications present on the page
-    expect(helpers.getCurrentPath()).to.eventually.equal('#!/login');
-    FU.exists(by.css('[data-bh-growl-notification]'), false);
-
-    // attempt to navigate to the settings page
-    helpers.navigate(settings);
-
-    // assert that we are still on the login page with a notification
-    expect(helpers.getCurrentPath()).to.eventually.equal('#!/login');
-    components.notification.hasWarn();
-  });
-
   it('allows a valid user to log in to the application', () => {
     FU.input('LoginCtrl.credentials.username', 'superuser');
     FU.input('LoginCtrl.credentials.password', 'superuser');


### PR DESCRIPTION
This commit removes an annoying `Notify.warn()` call that happens when the user is trying to access a substate of the application, but is not logged in.  Because it is one of the first things loaded, it can never
be translated correctly, making the application look broken.