### PR TITLE
fix(db): recompute period totals on build

### DIFF
--- a/sh/build-database.sh
+++ b/sh/build-database.sh
@@ -52,4 +52,7 @@ echo "[build] recomputing mappings"
 mysql -u $DB_USER -p$DB_PASS $DB_NAME -e "Call zRecomputeEntityMap();" &> /dev/null
 mysql -u $DB_USER -p$DB_PASS $DB_NAME -e "Call zRecomputeDocumentMap();" &> /dev/null
 
+echo "[build] recalculating period totals"
+mysql -u $DB_USER -p$DB_PASS $DB_NAME -e "Call zRecalculatePeriodTotals();" &> /dev/null
+
 echo "[/build]"

--- a/test/integration/trialBalance.js
+++ b/test/integration/trialBalance.js
@@ -1,5 +1,4 @@
 /* global expect, agent */
-
 const helpers = require('./helpers');
 
 /*
@@ -54,11 +53,11 @@ describe('(/journal/trialbalance) API endpoint', () => {
         expect(res.body.errors).to.have.length(0);
 
         // The transactions TRANS1, TRANS2 hit 2 accounts and should have the following profiles
-        const summary = res.body.summary;
+        const { summary } = res.body;
         expect(summary).to.have.length(2);
 
         // all accounts have 0 balance before
-        expect(summary[0].balance_before).to.equal(25);
+        expect(summary[0].balance_before).to.equal(50);
         expect(summary[1].balance_before).to.equal(-25);
 
         expect(summary[0].debit_equiv).to.equal(75);
@@ -67,7 +66,7 @@ describe('(/journal/trialbalance) API endpoint', () => {
         expect(summary[0].credit_equiv).to.equal(0);
         expect(summary[1].credit_equiv).to.equal(75);
 
-        expect(summary[0].balance_final).to.equal(100);
+        expect(summary[0].balance_final).to.equal(125);
         expect(summary[1].balance_final).to.equal(-100);
       })
       .catch(helpers.handler);


### PR DESCRIPTION
This commit ensures that we operate with the correct period totals by
recomputing them after the database is built.  This should have been
done all along.
