### PR TITLE
Fix: Inventory group item links

### DIFF
--- a/client/src/modules/inventory/configuration/groups/groups.html
+++ b/client/src/modules/inventory/configuration/groups/groups.html
@@ -37,7 +37,9 @@
           <td>{{ group.code }}</td>
           <td>{{ group.name }}</td>
           <td>
-            <a ui-sref="inventory.list({ filters : { group_uuid : group.uuid }})" href>
+            <a
+              ui-sref="inventory.list({ filters : [{ key : \'group_uuid\', value : groud.uuid, displayValue: group.name }] })"
+              href>
               {{ group.inventory_counted }} <span class="text-lowercase" translate> INVENTORY.ELEMENT</span>(s)
             </a>
           </td>

--- a/client/src/modules/inventory/configuration/groups/groups.html
+++ b/client/src/modules/inventory/configuration/groups/groups.html
@@ -37,9 +37,7 @@
           <td>{{ group.code }}</td>
           <td>{{ group.name }}</td>
           <td>
-            <a
-              ui-sref="inventory.list({ filters : [{ key : \'group_uuid\', value : groud.uuid, displayValue: group.name }] })"
-              href>
+            <a ui-sref="inventory.list({ filters : [{ key : 'group_uuid', value : group.uuid, displayValue: group.name }] })" href>
               {{ group.inventory_counted }} <span class="text-lowercase" translate> INVENTORY.ELEMENT</span>(s)
             </a>
           </td>

--- a/client/src/modules/inventory/configuration/groups/groups.js
+++ b/client/src/modules/inventory/configuration/groups/groups.js
@@ -18,12 +18,6 @@ function InventoryGroupsController($translate, InventoryGroup, Account, Notify, 
   vm.created = false;
   vm.updated = false;
 
-  /** paths in the headercrumb */
-  vm.bcPaths = [
-    { label : 'TREE.INVENTORY' },
-    { label : 'TREE.INVENTORY_GROUP' }
-  ];
-
   // expose to the view
   vm.editInventoryGroup = editInventoryGroup;
   vm.addInventoryGroup = addInventoryGroup;
@@ -84,10 +78,10 @@ function InventoryGroupsController($translate, InventoryGroup, Account, Notify, 
 
     // initializes inventory group list with associate accounts
     Account.read()
-    .then(handleAccountList)
-    .then(readInventoryGroup)
-    .then(handleGroupList)
-    .catch(Notify.handleError);
+      .then(handleAccountList)
+      .then(readInventoryGroup)
+      .then(handleGroupList)
+      .catch(Notify.handleError);
 
     // handle the list of accounts
     function handleAccountList(list) {

--- a/client/src/modules/inventory/inventory.routes.js
+++ b/client/src/modules/inventory/inventory.routes.js
@@ -45,17 +45,11 @@ angular.module('bhima.routes')
         url : '/:uuid',
         params : {
           uuid : { squash : true, value : null },
-          created : false,  // default for transitioning from child states
-          updated : false,  // default for transitioning from child states
-          filters : null,
+          created : false, // default for transitioning from child states
+          updated : false, // default for transitioning from child states
+          filters : [],
         },
       });
-      // @TODO IMPLEMENT THEM
-      // .state('/inventory/types',  {
-      //   url : '/inventory/types',
-      //   controller : 'InventoryTypesController as InventoryCtrl',
-      //   templateUrl : 'modules/inventory/types/types.html'
-      // })
   }]);
 
 

--- a/client/src/modules/inventory/inventory.service.js
+++ b/client/src/modules/inventory/inventory.service.js
@@ -2,63 +2,86 @@ angular.module('bhima.services')
   .service('InventoryService', InventoryService);
 
 InventoryService.$inject = [
-  'PrototypeApiService', 'InventoryGroupService', 'InventoryUnitService', 'InventoryTypeService', '$uibModal'
+  'PrototypeApiService', 'InventoryGroupService', 'InventoryUnitService', 'InventoryTypeService', '$uibModal',
+  'FilterService', 'appcache',
 ];
 
-function InventoryService(Api, Groups, Units, Types, $uibModal) {
+function InventoryService(Api, Groups, Units, Types, $uibModal, Filters, AppCache) {
   var service = new Api('/inventory/metadata/');
+
+  var inventoryFilters = new Filters();
+  var filterCache = new AppCache('inventory-filters');
 
   // expose inventory services through a nicer API
   service.Groups = Groups;
   service.Units = Units;
   service.Types = Types;
   service.openSearchModal = openSearchModal;
-  service.formatFilterParameters = formatFilterParameters;
+  service.filters = inventoryFilters;
 
   /**
    * @method openSearchModal
    *
-   * @param {Object} params - an object of filter parameters to be passed to
+   * @param {Object} filters - an object of filter parameters to be passed to
    *   the modal.
    * @returns {Promise} modalInstance
    */
-  function openSearchModal(params) {
+  function openSearchModal(filters) {
     return $uibModal.open({
       templateUrl : 'modules/inventory/list/modals/search.modal.html',
       size : 'md',
       keyboard : false,
       animation : false,
       backdrop : 'static',
-      controller : 'InventoryServiceModalController as ModalCtrl',
+      controller : 'InventorySearchModalController as ModalCtrl',
       resolve : {
-        params : function paramsProvider() { return params; }
+        filters : function filtersProvider() { return filters; },
       },
     }).result;
   }
 
-  /**
-   * This function prepares the headers inventory properties which were filtered,
-   * Special treatment occurs when processing data related to the date
-   * @todo - this might be better in it's own service
-   */
-  function formatFilterParameters(params) {
-    var columns = [
-      { field : 'group_uuid', displayName : 'FORM.LABELS.GROUP' },
-      { field : 'text', displayName : 'FORM.LABELS.LABEL' },
+  inventoryFilters.registerDefaultFilters([
+    { key : 'limit', label : 'FORM.LABELS.LIMIT' },
+  ]);
 
-    ];
-    // returns columns from filters
-    return columns.filter(function (column) {
-      var value = params[column.field];
+  inventoryFilters.registerCustomFilters([
+    { key : 'group_uuid', label : 'FORM.LABELS.GROUP' },
+    { key : 'code', label : 'FORM.LABELS.CODE' },
+    { key : 'consumable', label : 'FORM.LABELS.CONSUMABLE' },
+    { key : 'text', label : 'FORM.LABELS.LABEL' },
+    { key : 'type_id', label : 'FORM.LABELS.TYPE' },
+    { key : 'price', label : 'FORM.LABELS.PRICE' },
+  ]);
 
-      if (angular.isDefined(value)) {
-        column.value = value;
-        return true;
-      }
-      return false;
-    });
+  if (filterCache.filters) {
+    // load cached filter definition if it exists
+    inventoryFilters.loadCache(filterCache.filters);
   }
 
+  assignDefaultFilters();
+
+  function assignDefaultFilters() {
+    // get the keys of filters already assigned - on initial load this will be empty
+    var assignedKeys = Object.keys(inventoryFilters.formatHTTP());
+
+    // assign default limit filter
+    if (assignedKeys.indexOf('limit') === -1) {
+      inventoryFilters.assignFilter('limit', 100);
+    }
+  }
+
+  service.removeFilter = function removeFilter(key) {
+    inventoryFilters.resetFilterState(key);
+  };
+
+  // load filters from cache
+  service.cacheFilters = function cacheFilters() {
+    filterCache.filters = inventoryFilters.formatCache();
+  };
+
+  service.loadCachedFilters = function loadCachedFilters() {
+    inventoryFilters.loadCache(filterCache.filters || {});
+  };
 
   return service;
 }

--- a/client/src/modules/inventory/list/list.html
+++ b/client/src/modules/inventory/list/list.html
@@ -58,19 +58,17 @@
           <i class="fa fa-filter"></i>
         </button>
 
-        <a
-          class="btn btn-default text-capitalize"
-          ui-sref="inventory.create"
-          data-method="create">
-          <i class="fa fa-plus"></i> <span translate>INVENTORY.ADD_METADATA</span>
+        <a class="btn btn-default text-capitalize" ui-sref="inventory.create" data-method="create">
+          <i class="fa fa-plus"></i> <span class="hidden-xs" translate>INVENTORY.ADD_METADATA</span>
         </a>
 
         <button
           ng-click="InventoryCtrl.research()"
+          type="button"
           data-method="research"
           class="btn btn-default"
           id="research">
-          <i class="fa fa-search"></i> <span translate>FORM.BUTTONS.SEARCH</span>
+          <i class="fa fa-search"></i> <span class="hidden-xs" translate>FORM.BUTTONS.SEARCH</span>
         </button>
       </div>
     </div>
@@ -78,9 +76,8 @@
   </div>
 </div>
 
-<div class="flex-util bh-filter-bar" ng-if="InventoryCtrl.hasCustomFilters">
+<div class="flex-util bh-filter-bar">
   <bh-filters
-    style="max-width:90%"
     filters="InventoryCtrl.latestViewFilters"
     on-remove-filter="InventoryCtrl.onRemoveFilter(filter)">
   </bh-filters>
@@ -104,7 +101,6 @@
         empty-state="InventoryCtrl.gridOptions.data.length === 0"
         error-state="InventoryCtrl.hasError">
       </bh-grid-loading-indicator>
-
     </div>
   </div>
 </div>

--- a/client/src/modules/inventory/list/list.js
+++ b/client/src/modules/inventory/list/list.js
@@ -181,8 +181,8 @@ function InventoryListController(
 
   function startup() {
     // if parameters are passed through the $state object, use them.
-    if ($state.params.filters.length) {
-      Inventory.filters.replaceFilters(angular.copy($state.params.filters));
+    if ($state.params.filters.length > 0) {
+      Inventory.filters.replaceFilters($state.params.filters);
     }
 
     load(Inventory.filters.formatHTTP(true));

--- a/client/src/modules/inventory/list/modals/search.modal.html
+++ b/client/src/modules/inventory/list/modals/search.modal.html
@@ -1,7 +1,4 @@
-<form
-  name="ModalForm"
-  ng-submit="ModalCtrl.submit(ModalForm)"
-  novalidate>
+<form name="ModalForm" ng-submit="ModalCtrl.submit(ModalForm)" novalidate>
 
   <div class="modal-header">
     <ol class="headercrumb">
@@ -10,106 +7,109 @@
     </ol>
   </div>
 
-  <div class="modal-body">
+  <div class="modal-body search-modal">
+    <uib-tabset>
+      <uib-tab index="0" heading="{{ 'FORM.LABELS.SEARCH_QUERRIES' | translate }}" data-custom-filter-tab>
+        <div class="tab-body">
 
-    <fieldset>
-      <div class="form-group">
-        <label class="control-label" translate>
-          FORM.LABELS.GROUP
-        </label>
-        <bh-clear on-clear="ModalCtrl.clear('group_uuid')"></bh-clear>
+          <div class="form-group">
+            <label class="control-label" translate>
+              FORM.LABELS.GROUP
+            </label>
+            <bh-clear on-clear="ModalCtrl.clear('group_uuid')"></bh-clear>
 
-        <!-- @todo make data driven selects components to handle loading and error states -->
-        <ui-select
-          name="group_uuid"
-          ng-model="ModalCtrl.params.group_uuid">
-          <ui-select-match placeholder="{{ 'FORM.SELECT.INVENTORY_GROUP' | translate }}"><span>{{$select.selected.name}}</span></ui-select-match>
-          <ui-select-choices ui-select-focus-patch repeat="group.uuid as group in (ModalCtrl.inventoryGroups | filter:$select.search | orderBy:'name') track by group.uuid">
-            <span ng-bind-html="group.name | highlight:$select.search"></span>
-          </ui-select-choices>
-        </ui-select>
+            <!-- @todo make data driven selects components to handle loading and error states -->
+            <ui-select
+              name="group_uuid"
+              ng-model="ModalCtrl.searchQueries.group_uuid">
+              <ui-select-match placeholder="{{ 'FORM.SELECT.INVENTORY_GROUP' | translate }}"><span>{{$select.selected.name}}</span></ui-select-match>
+              <ui-select-choices ui-select-focus-patch repeat="group.uuid as group in (ModalCtrl.inventoryGroups | filter:$select.search | orderBy:'name')">
+                <span ng-bind-html="group.name | highlight:$select.search"></span>
+              </ui-select-choices>
+            </ui-select>
 
-      </div>
+          </div>
 
-      <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.text.$invalid }">
-        <label class="control-label" translate>
-          FORM.LABELS.LABEL
-        </label>
-        <bh-clear on-clear="ModalCtrl.clear('text')"></bh-clear>
+          <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.text.$invalid }">
+            <label class="control-label" translate>
+              FORM.LABELS.LABEL
+            </label>
+            <bh-clear on-clear="ModalCtrl.clear('text')"></bh-clear>
 
-        <input type="text" class="form-control" name="text" ng-model="ModalCtrl.params.text">
-        <div class="help-block" ng-messages="ModalForm.text.$error" ng-show="ModalForm.$submitted">
-          <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            <input type="text" class="form-control" name="text" ng-model="ModalCtrl.searchQueries.text">
+            <div class="help-block" ng-messages="ModalForm.text.$error" ng-show="ModalForm.$submitted">
+              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            </div>
+          </div>
+
+          <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.code.$invalid }">
+            <label class="control-label" translate>
+              FORM.LABELS.CODE
+            </label>
+            <bh-clear on-clear="ModalCtrl.clear('code')"></bh-clear>
+
+            <input type="text" class="form-control" name="code" ng-model="ModalCtrl.searchQueries.code">
+            <div class="help-block" ng-messages="ModalForm.code.$error" ng-show="ModalForm.$submitted">
+              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            </div>
+          </div>
+
+          <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.price.$invalid }">
+            <label class="control-label" translate>
+              FORM.LABELS.UNIT_PRICE
+            </label>
+            <bh-clear on-clear="ModalCtrl.clear('price')"></bh-clear>
+
+            <input type="number" class="form-control" name="price" ng-model="ModalCtrl.searchQueries.price">
+            <div class="help-block" ng-messages="ModalForm.price.$error" ng-show="ModalForm.$submitted">
+              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            </div>
+          </div>
+
+          <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.type_id.$invalid }">
+            <label class="control-label" translate>FORM.LABELS.TYPE</label>
+            <bh-clear on-clear="ModalCtrl.clear('type_id')"></bh-clear>
+            <select
+              class="form-control"
+              name="type_id"
+              ng-model="ModalCtrl.searchQueries.type_id"
+              ng-options="type.id as type.text for type in ModalCtrl.types">
+              <option value="" translate>FORM.SELECT.INVENTORY_TYPE</option>
+            </select>
+            <div class="help-block" ng-messages="ModalForm.type_id.$error" ng-show="ModalForm.$submitted">
+              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            </div>
+          </div>
+
+          <div class="radio" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.consumable.$invalid }">
+            <bh-clear on-clear="ModalCtrl.clear('consumable')"></bh-clear>
+
+            <label class="radio-inline">
+              <input type="radio" value='1' name="consumable" ng-model="ModalCtrl.searchQueries.consumable">
+              <span translate>FORM.LABELS.CONSUMABLE</span>
+            </label>
+
+            <label class="radio-inline">
+              <input type="radio" value='0' name="consumable" ng-model="ModalCtrl.searchQueries.consumable">
+              <span translate>FORM.LABELS.UNCONSUMABLE</span>
+            </label>
+          </div>
         </div>
-      </div>
+      </uib-tab>
 
-      <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.code.$invalid }">
-        <label class="control-label" translate>
-          FORM.LABELS.CODE
-        </label>
-        <bh-clear on-clear="ModalCtrl.clear('code')"></bh-clear>
+      <uib-tab index="1" heading="{{ 'FORM.LABELS.DEFAULTS' | translate }}" data-default-filter-tab>
+        <div class="tab-body">
+          <div class="form-group" ng-class="{ 'has-error' : ModalForm.limit.$invalid }">
+            <label class="control-label" translate>FORM.LABELS.LIMIT</label>
+            <input name="limit" type="number" bh-integer class="form-control" ng-model="ModalCtrl.defaultQueries.limit" ng-change="ModalCtrl.onSelectLimit(ModalCtrl.defaultQueries.limit)">
 
-        <input type="text" class="form-control" name="code" ng-model="ModalCtrl.params.code">
-        <div class="help-block" ng-messages="ModalForm.code.$error" ng-show="ModalForm.$submitted">
-          <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            <div class="help-block" ng-messages="ModalForm.limit.$error">
+              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            </div>
+          </div>
         </div>
-      </div>
-
-
-
-      <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.price.$invalid }">
-        <label class="control-label" translate>
-          FORM.LABELS.UNIT_PRICE
-        </label>
-        <bh-clear on-clear="ModalCtrl.clear('price')"></bh-clear>
-
-        <input type="number" class="form-control" name="price" ng-model="ModalCtrl.params.price">
-        <div class="help-block" ng-messages="ModalForm.price.$error" ng-show="ModalForm.$submitted">
-          <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-        </div>
-      </div>
-
-
-
-    <div class="form-group"
-      ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.type_id.$invalid }">
-      <label class="control-label" translate>FORM.LABELS.TYPE</label>
-      <bh-clear on-clear="ModalCtrl.clear('type_id')"></bh-clear>
-      <select
-        class="form-control"
-        name="type_id"
-        ng-model="ModalCtrl.params.type_id"
-        ng-options="type.id as type.text for type in ModalCtrl.types"
-        >
-        <option value=""  translate>FORM.SELECT.INVENTORY_TYPE</option>
-      </select>
-      <div class="help-block" ng-messages="ModalForm.type_id.$error" ng-show="ModalForm.$submitted">
-        <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-      </div>
-    </div>
-
-
-      <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.consumable.$invalid }">
-         <bh-clear on-clear="ModalCtrl.clear('consumable')"></bh-clear>
-
-         <input type="radio" value='1' name="consumable" ng-model="ModalCtrl.params.consumable"/>
-
-         <label class="control-label" translate>
-          FORM.LABELS.CONSUMABLE
-        </label>
-
-        <br/>
-
-        <input type="radio" value='0' name="consumable" ng-model="ModalCtrl.params.consumable"/>
-
-        <label class="control-label" translate>
-          FORM.LABELS.UNCONSUMABLE
-        </label>
-
-
-        </div>
-
-    </fieldset>
+      </uib-tab>
+    </uib-tabset>
   </div>
 
   <div class="modal-footer">

--- a/client/src/modules/patients/registry/registry.js
+++ b/client/src/modules/patients/registry/registry.js
@@ -185,10 +185,9 @@ function PatientRegistryController($state, Patients, Notify, AppCache,
 
   // startup function. Checks for cached filters and loads them.  This behavior could be changed.
   function startup() {
-
     if($state.params.filters) {
       var changes = [{ key : $state.params.filters.key, value : $state.params.filters.value }]
-      Patients.filters.replaceFilters(changes);		
+      Patients.filters.replaceFilters(changes);
       Patients.cacheFilters();
     }
 

--- a/client/src/modules/patients/registry/search.modal.js
+++ b/client/src/modules/patients/registry/search.modal.js
@@ -19,7 +19,6 @@ function PatientRegistryModalController(ModalInstance, filters, bhConstants, mom
   var changes = new Store({ identifier : 'key' });
   vm.filters = filters;
 
-
   vm.today = new Date();
   vm.defaultQueries = {};
   vm.searchQueries = {};
@@ -45,11 +44,11 @@ function PatientRegistryModalController(ModalInstance, filters, bhConstants, mom
 
   vm.onSelectDebtor = function onSelectDebtor(debtorGroup) {
     vm.searchQueries.debtor_group_uuid = debtorGroup.uuid;
-  }
+  };
 
   vm.onSelectPatientGroup = function onSelectPatientGroup(patientGroup) {
     vm.searchQueries.patient_group_uuid = patientGroup.uuid;
-  }
+  };
 
   // custom filter user_id - assign the value to the searchQueries object
   vm.onSelectUser = function onSelectUser(user) {

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -110,8 +110,8 @@ function getIds() {
 * @return {Promise} Returns a database query promise
 */
 function getItemsMetadata(params) {
-  db.convert(params, ['inventory_uuids']);
-  const filters = new FilterParser(params, { tableAlias : 'inventory' });
+  db.convert(params, ['inventory_uuids', 'uuid', 'group_uuid']);
+  const filters = new FilterParser(params, { tableAlias : 'inventory', autoParseStatements : false });
 
   const sql =
     `SELECT BUID(inventory.uuid) as uuid, inventory.code, inventory.text AS label, inventory.price, iu.text AS unit,
@@ -125,8 +125,19 @@ function getItemsMetadata(params) {
       inventory.unit_id = iu.id`;
 
   filters.fullText('text', 'text', 'inventory');
+
+  filters.equals('uuid');
+  filters.equals('group_uuid');
+  filters.equals('unit_id');
+  filters.equals('type_id');
+  filters.equals('code');
+  filters.equals('price');
+  filters.equals('consumable');
+  filters.equals('label');
+
   filters.custom('inventory_uuids', 'inventory.uuid IN (?)', params.inventory_uuids);
   filters.setOrder('ORDER BY inventory.code ASC');
+
   const query = filters.applyQuery(sql);
   const parameters = filters.parameters();
   return db.exec(query, parameters);

--- a/test/end-to-end/inventory/list.spec.js
+++ b/test/end-to-end/inventory/list.spec.js
@@ -1,4 +1,4 @@
-/* global element, by, browser */
+/* global element, by */
 
 const chai = require('chai');
 const GU = require('../shared/GridUtils');
@@ -9,7 +9,6 @@ const components = require('../shared/components');
 helpers.configure(chai);
 
 describe('Inventory List', () => {
-
   // navigate to the page
   before(() => helpers.navigate('#/inventory'));
 
@@ -81,7 +80,7 @@ describe('Inventory List', () => {
   it(`should find one Inventory with Label "${metadataSearch.label}"`, () => {
     element(by.id('research')).click();
 
-    FU.input('ModalCtrl.params.text', metadataSearch.label);
+    FU.input('ModalCtrl.searchQueries.text', metadataSearch.label);
     FU.modal.submit();
 
     GU.expectRowCount('inventoryListGrid', 1);


### PR DESCRIPTION
This commit completely refreshes the inventory list fixing many small bugs.  These bugs include, but are not limited to:
 1. Filters are now cached and loaded correctly. Filters can be linked  from $states.
 2. There are no more column menus.
 3. The filter now uses FilterParser on the server side.
 4. Unit Prices are rendered in the enterprise currency.

This commit fixes the inventory registry by linking the inventory groups to the inventory registry.

Closes #2122.