### PR TITLE
Block Inventory Items from being Invoiced

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -341,6 +341,7 @@
             "LAST_PAGE": "Last Page Visited",
             "LOCATION_REGISTER": "Location Register",
             "LOCKED": "Locked",
+            "UNLOCKED": "Unlocked",
             "LOGIN": "Login",
             "LOSS_ACCOUNT": "Loss Account",
             "LIMIT": "Limit",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -342,6 +342,7 @@
             "LAST_PAGE": "La dernière page visitée",
             "LOCATION_REGISTER": "Enregistrer une localisation",
             "LOCKED": "Bloqué(e)",
+            "UNLOCKED": "Non Bloqué(e)",
             "LOGIN": "Login",
             "LOSS_ACCOUNT": "Compte perte",
             "LIMIT": "Limite",

--- a/client/src/modules/inventory/inventory.service.js
+++ b/client/src/modules/inventory/inventory.service.js
@@ -48,6 +48,7 @@ function InventoryService(Api, Groups, Units, Types, $uibModal, Filters, AppCach
     { key : 'group_uuid', label : 'FORM.LABELS.GROUP' },
     { key : 'code', label : 'FORM.LABELS.CODE' },
     { key : 'consumable', label : 'FORM.LABELS.CONSUMABLE' },
+    { key : 'locked', label : 'FORM.LABELS.LOCKED' },
     { key : 'text', label : 'FORM.LABELS.LABEL' },
     { key : 'type_id', label : 'FORM.LABELS.TYPE' },
     { key : 'price', label : 'FORM.LABELS.PRICE' },

--- a/client/src/modules/inventory/list/modals/actions.tmpl.html
+++ b/client/src/modules/inventory/list/modals/actions.tmpl.html
@@ -50,6 +50,13 @@
       </label>
     </div>
 
+    <div class="checkbox" ng-if="$ctrl.isUpdateState">
+      <label>
+        <input type="checkbox" name="locked" ng-true-value="1" ng-false-value="0" ng-model="$ctrl.item.locked">
+        <span translate>FORM.LABELS.LOCKED</span>
+      </label>
+    </div>
+
     <div class="form-group"
       ng-class="{ 'has-error' : ActionForm.$submitted && ActionForm.price.$invalid }">
       <label class="control-label" translate>FORM.LABELS.PRICE</label>

--- a/client/src/modules/inventory/list/modals/search.modal.html
+++ b/client/src/modules/inventory/list/modals/search.modal.html
@@ -94,6 +94,20 @@
               <span translate>FORM.LABELS.UNCONSUMABLE</span>
             </label>
           </div>
+
+          <div class="radio" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.locked.$invalid }">
+            <bh-clear on-clear="ModalCtrl.clear('locked')"></bh-clear>
+
+            <label class="radio-inline">
+              <input type="radio" value='1' name="locked" ng-model="ModalCtrl.searchQueries.locked">
+              <span translate>FORM.LABELS.LOCKED</span>
+            </label>
+
+            <label class="radio-inline">
+              <input type="radio" value='0' name="locked" ng-model="ModalCtrl.searchQueries.locked">
+              <span translate>FORM.LABELS.UNLOCKED</span>
+            </label>
+          </div>
         </div>
       </uib-tab>
 

--- a/client/src/modules/inventory/list/modals/search.modal.js
+++ b/client/src/modules/inventory/list/modals/search.modal.js
@@ -18,7 +18,7 @@ function InventorySearchModalController(ModalInstance, Notify, filters, Inventor
 
   // @TODO ideally these should be passed in when the modal is initialised these are known when the filter service is defined
   var searchQueryOptions = [
-    'code', 'group_uuid', 'consumable', 'label', 'type_id', 'price',
+    'code', 'group_uuid', 'consumable', 'locked', 'label', 'type_id', 'price',
   ];
 
   var changes = new Store({ identifier : 'key' });

--- a/client/src/modules/invoices/patientInvoiceForm.service.js
+++ b/client/src/modules/invoices/patientInvoiceForm.service.js
@@ -102,7 +102,7 @@ function PatientInvoiceFormService(Patients, PriceLists, Inventory, AppCache, St
       }.bind(this));
 
     // set up the inventory
-    Inventory.read(null, { detailed: 1 })
+    Inventory.read(null, { detailed: 1, locked : 0 })
       .then(function (data) {
 
         // make sure both the label and code is searchable

--- a/client/src/modules/stock/inventories/registry.html
+++ b/client/src/modules/stock/inventories/registry.html
@@ -68,7 +68,6 @@
 
 <div class="flex-content">
   <div class="container-fluid">
-
     <div
       id="stock-inventory-grid"
       class="grid-full-height-with-filters"

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -115,7 +115,7 @@ function getItemsMetadata(params) {
 
   const sql =
     `SELECT BUID(inventory.uuid) as uuid, inventory.code, inventory.text AS label, inventory.price, iu.text AS unit,
-      it.text AS type, ig.name AS groupName, BUID(ig.uuid) AS group_uuid, inventory.consumable, inventory.stock_min,
+      it.text AS type, ig.name AS groupName, BUID(ig.uuid) AS group_uuid, inventory.consumable,inventory.locked, inventory.stock_min,
       inventory.stock_max, inventory.created_at AS timestamp, inventory.type_id, inventory.unit_id,
       inventory.unit_weight, inventory.unit_volume, ig.sales_account, ig.stock_account, ig.donation_account,
       ig.cogs_account, inventory.default_quantity
@@ -133,6 +133,7 @@ function getItemsMetadata(params) {
   filters.equals('code');
   filters.equals('price');
   filters.equals('consumable');
+  filters.equals('locked');
   filters.equals('label');
 
   filters.custom('inventory_uuids', 'inventory.uuid IN (?)', params.inventory_uuids);
@@ -155,7 +156,7 @@ function getItemsMetadata(params) {
 function getItemsMetadataById(uid) {
   const sql =
     `SELECT BUID(i.uuid) as uuid, i.code, i.text AS label, i.price, iu.text AS unit,
-      it.text AS type, ig.name AS groupName, BUID(ig.uuid) AS group_uuid, i.consumable, i.stock_min,
+      it.text AS type, ig.name AS groupName, BUID(ig.uuid) AS group_uuid, i.consumable, i.locked, i.stock_min,
       i.stock_max, i.created_at AS timestamp, i.type_id, i.unit_id, i.unit_weight, i.unit_volume,
       ig.sales_account, i.default_quantity, i.avg_consumption, i.delay, i.purchase_interval
     FROM inventory AS i JOIN inventory_type AS it

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -855,6 +855,7 @@ CREATE TABLE `inventory` (
   `stock_min` INT(10) UNSIGNED NOT NULL DEFAULT 0,
   `type_id` TINYINT(3) UNSIGNED NOT NULL DEFAULT 0,
   `consumable` TINYINT(1) NOT NULL DEFAULT 0,
+  `locked` TINYINT(1) NOT NULL DEFAULT 0,
   `delay` INT(10) UNSIGNED NOT NULL DEFAULT 1 COMMENT 'Delai de livraison',
   `avg_consumption` DECIMAL(10,4) UNSIGNED NOT NULL DEFAULT 1 COMMENT 'Consommation moyenne' ,
   `purchase_interval` DECIMAL(10,4) UNSIGNED NOT NULL DEFAULT 1 COMMENT 'Intervalle de commande' ,

--- a/test/data.sql
+++ b/test/data.sql
@@ -241,9 +241,9 @@ INSERT INTO `inventory_group` VALUES
   (HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'),'Test inventory group','INVGRP',3636,3636,3636,3636);
 
 INSERT INTO `inventory` VALUES
-  (1, HUID('cf05da13-b477-11e5-b297-023919d3d5b0'), 'INV0', 'First Test Inventory Item', 25.0, 1, HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'), 2, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, CURRENT_TIMESTAMP, NULL),
-  (1, HUID('289cc0a1-b90f-11e5-8c73-159fdc73ab02'), 'INV1', 'Second Test Inventory Item', 10.0, 20, HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'), 2, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, CURRENT_TIMESTAMP, NULL),
-  (1, HUID('c48a3c4b-c07d-4899-95af-411f7708e296'), 'INV2', 'Third Test Inventory Item', 105.0, 1, HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'), 2, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, CURRENT_TIMESTAMP, NULL);
+  (1, HUID('cf05da13-b477-11e5-b297-023919d3d5b0'), 'INV0', 'First Test Inventory Item', 25.0, 1, HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'), 2, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, CURRENT_TIMESTAMP, NULL),
+  (1, HUID('289cc0a1-b90f-11e5-8c73-159fdc73ab02'), 'INV1', 'Second Test Inventory Item', 10.0, 20, HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'), 2, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, CURRENT_TIMESTAMP, NULL),
+  (1, HUID('c48a3c4b-c07d-4899-95af-411f7708e296'), 'INV2', 'Third Test Inventory Item', 105.0, 1, HUID('1410dfe0-b478-11e5-b297-023919d3d5b0'), 2, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, CURRENT_TIMESTAMP, NULL);
 
 INSERT INTO `debtor_group` VALUES
   (1,HUID('4de0fe47-177f-4d30-b95f-cff8166400b4'),'First Test Debtor Group',3631,HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'),NULL,NULL,NULL,0,10,0,NULL,1,1,1, '#ff0000', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),


### PR DESCRIPTION
This P.R addresses #2140 

It add the functionality of invoicing only unlocked inventory and let user filter inventory based on the inventory locked state.
The enventory can be locked during the editing phase.

closes #2140 