### PR TITLE
refactor: use bhConstants.defaultFilters

### DIFF
--- a/client/src/js/services/FilterService.js
+++ b/client/src/js/services/FilterService.js
@@ -1,9 +1,7 @@
 angular.module('bhima.services')
   .service('FilterService', FilterService);
 
-FilterService.$inject = ['Store'];
-
-function FilterService(Store) {
+function FilterService() {
   function FilterList() {
     // initialise internal state
     this._defaultFilters = [];
@@ -34,10 +32,11 @@ function FilterService(Store) {
       if (filterDefinition.defaultValue) {
         filter.setValue(filterDefinition.defaultValue);
       }
+
       return filter;
     });
 
-    // udpate index
+    // update index
     this._indexList(this._filterIndex, formattedFilters);
     this._defaultFilters = this._defaultFilters.concat(formattedFilters);
   };
@@ -49,7 +48,7 @@ function FilterService(Store) {
       return filter;
     });
 
-    // udpate index
+    // update index
     this._indexList(this._filterIndex, formattedFilters);
     this._customFilters = this._customFilters.concat(formattedFilters);
   };
@@ -156,7 +155,7 @@ function FilterService(Store) {
 
     Object.keys(this._filterIndex).forEach(function (key) {
       var filter = this._filterIndex[key];
-      
+
       if (filter._value !== null && filter._value !== undefined && filter._value.length !== '') {
         filtered.push(angular.copy(filter));
       }

--- a/client/src/modules/account_statement/account_statement.service.js
+++ b/client/src/modules/account_statement/account_statement.service.js
@@ -1,16 +1,19 @@
 angular.module('bhima.services')
-.service('AccountStatementService', AccountStatementService);
+  .service('AccountStatementService', AccountStatementService);
 
-// DI
 AccountStatementService.$inject = [
-  '$uibModal', '$http', 'util',
-  'AppCache', 'FilterService', 'PeriodService',
+  '$uibModal', '$http', 'util', 'AppCache', 'FilterService', 'PeriodService',
+  'bhConstants',
 ];
 
 /**
- * AccountStatementService
+ * @overview AccountStatementService
+ *
+ * @description
+ * This service powers the backend for the Account Statement report, giving an
+ * overview of all accounts by period for the entire fiscal year.
  */
-function AccountStatementService(Modal, $http, util, AppCache, Filters, Periods) {
+function AccountStatementService(Modal, $http, util, AppCache, Filters, Periods, bhConstants) {
   var service = this;
   var baseUrl = '/general_ledger/';
   var filterCache = new AppCache('account-statement-filters');
@@ -54,13 +57,11 @@ function AccountStatementService(Modal, $http, util, AppCache, Filters, Periods)
   service.cacheFilters = cacheFilters;
   service.loadCachedFilters = loadCachedFilters;
 
-  // default filtes will always be applied
+  // default filters will always be applied
+  accountStatementFilters.registerDefaultFilters(bhConstants.defaultFilters);
   accountStatementFilters.registerDefaultFilters([
     { key : 'account_id', label : 'TABLE.COLUMNS.ACCOUNT' },
-    { key : 'period', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
-    { key : 'custom_period_start', label : 'PERIODS.START', valueFilter : 'date' },
-    { key : 'custom_period_end', label : 'PERIODS.END', valueFilter : 'date' },
-    { key : 'limit', label : 'FORM.LABELS.LIMIT' }]);
+  ]);
 
   // custom filters can be optionally applied
   accountStatementFilters.registerCustomFilters([

--- a/client/src/modules/cash/cash.service.js
+++ b/client/src/modules/cash/cash.service.js
@@ -4,7 +4,7 @@ angular.module('bhima.services')
 CashService.$inject = [
   '$uibModal', 'PrototypeApiService', 'ExchangeRateService', 'SessionService',
   'moment', '$translate', 'FilterService', 'appcache', 'PeriodService',
-  'LanguageService', '$httpParamSerializer',
+  'LanguageService', '$httpParamSerializer', 'bhConstants',
 ];
 
 /**
@@ -16,7 +16,7 @@ CashService.$inject = [
  */
 function CashService(
   Modal, Api, Exchange, Session, moment, $translate, Filters, AppCache, Periods,
-  Languages, $httpParamSerializer
+  Languages, $httpParamSerializer, bhConstants
 ) {
   var service = new Api('/cash/');
   var urlCheckin = '/cash/checkin/';
@@ -142,11 +142,7 @@ function CashService(
     return disabledCurrencyIds;
   }
 
-  cashFilters.registerDefaultFilters([
-    { key : 'period', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
-    { key : 'custom_period_start', label : 'PERIODS.START', valueFilter : 'date', comparitor : '>' },
-    { key : 'custom_period_end', label : 'PERIODS.END', valueFilter : 'date', comparitor : '<' },
-    { key : 'limit', label : 'FORM.LABELS.LIMIT' }]);
+  cashFilters.registerDefaultFilters(bhConstants.defaultFilters);
 
   cashFilters.registerCustomFilters([
     { key : 'is_caution', label : 'FORM.LABELS.CAUTION' },

--- a/client/src/modules/invoices/patientInvoice.service.js
+++ b/client/src/modules/invoices/patientInvoice.service.js
@@ -3,7 +3,7 @@ angular.module('bhima.services')
 
 PatientInvoiceService.$inject = [
   '$uibModal', 'SessionService', 'PrototypeApiService', 'FilterService', 'appcache', 'PeriodService',
-  '$httpParamSerializer', 'LanguageService',
+  '$httpParamSerializer', 'LanguageService', 'bhConstants',
 ];
 
 /**
@@ -14,7 +14,10 @@ PatientInvoiceService.$inject = [
  * This service wraps the /invoices URL and all CRUD on the underlying tables
  * takes place through this service.
  */
-function PatientInvoiceService(Modal, Session, Api, Filters, AppCache, Periods, $httpParamSerializer, Languages) {
+function PatientInvoiceService(
+  Modal, Session, Api, Filters, AppCache, Periods, $httpParamSerializer,
+  Languages, bhConstants
+) {
   var service = new Api('/invoices/');
 
   var invoiceFilters = new Filters();
@@ -118,11 +121,7 @@ function PatientInvoiceService(Modal, Session, Api, Filters, AppCache, Periods, 
     }, true).result;
   }
 
-  invoiceFilters.registerDefaultFilters([
-    { key : 'period', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
-    { key : 'custom_period_start', label : 'PERIODS.START', valueFilter : 'date', comparitor : '>' },
-    { key : 'custom_period_end', label : 'PERIODS.END', valueFilter : 'date', comparitor : '<' },
-    { key : 'limit', label : 'FORM.LABELS.LIMIT' }]);
+  invoiceFilters.registerDefaultFilters(bhConstants.defaultFilters);
 
   invoiceFilters.registerCustomFilters([
     { key : 'service_id', label : 'FORM.LABELS.SERVICE' },

--- a/client/src/modules/journal/journal.service.js
+++ b/client/src/modules/journal/journal.service.js
@@ -1,14 +1,19 @@
 angular.module('bhima.services')
   .service('JournalService', JournalService);
 
-// Dependencies injection
-JournalService.$inject = [ 'PrototypeApiService', 'AppCache', 'FilterService', 'PeriodService', '$uibModal'];
+JournalService.$inject = [
+  'PrototypeApiService', 'AppCache', 'FilterService', 'PeriodService',
+  '$uibModal', 'bhConstants',
+];
 
 /**
  * Journal Service
- * This service is responsible of all process with the posting journal
+ *
+ * @description
+ * This service is responsible for powering the Posting/Posted Journal grid.  It
+ * also includes methods to open associated modals.
  */
-function JournalService(Api, AppCache, Filters, Periods, Modal) {
+function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants) {
   var URL = '/journal/';
   var service = new Api(URL);
 
@@ -73,7 +78,6 @@ function JournalService(Api, AppCache, Filters, Periods, Modal) {
 
   function sanitiseNewRows(rows) {
     rows.data.forEach(function (row) {
-
       // delete view data required by journal grid
       delete row.transaction;
       delete row.hrRecord;
@@ -91,26 +95,21 @@ function JournalService(Api, AppCache, Filters, Periods, Modal) {
 
   service.filters = journalFilters;
 
-  // default filtes will always be applied
-  journalFilters.registerDefaultFilters([
-    { key : 'period', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
-    { key : 'custom_period_start', label : 'PERIODS.START', valueFilter : 'date' },
-    { key : 'custom_period_end', label : 'PERIODS.END', valueFilter : 'date' },
-    { key : 'limit', label : 'FORM.LABELS.LIMIT' }]);
-    // { key : 'transactions', label : 'FORM.LABELS.TRANSACTIONS', defaultValue : true },
+  // default filters will always be applied
+  journalFilters.registerDefaultFilters(bhConstants.defaultFilters);
 
   // custom filters can be optionally applied
   journalFilters.registerCustomFilters([
-      { key : 'trans_id', label : 'FORM.LABELS.TRANS_ID' },
-      { key : 'record_uuid', label : 'FORM.LABELS.TRANS_ID' },
-      { key : 'reference', label : 'FORM.LABELS.REFERENCE' },
-      { key : 'user_id', label : 'FORM.LABELS.USER' },
-      { key : 'account_id', label : 'FORM.LABELS.ACCOUNT' },
-      { key : 'amount', label : 'FORM.LABELS.AMOUNT' },
-      { key : 'project_id', label : 'FORM.LABELS.PROJECT' },
-      { key : 'description', label : 'FORM.LABELS.DESCRIPTION' },
-      { key : 'includeNonPosted', label : 'TRANSACTIONS.INCLUDE_POSTED_TRANSACTIONS_SHORT' },
-      { key : 'origin_id', label : 'FORM.LABELS.TRANSACTION_TYPE' }]);
+    { key : 'trans_id', label : 'FORM.LABELS.TRANS_ID' },
+    { key : 'record_uuid', label : 'FORM.LABELS.TRANS_ID' },
+    { key : 'reference', label : 'FORM.LABELS.REFERENCE' },
+    { key : 'user_id', label : 'FORM.LABELS.USER' },
+    { key : 'account_id', label : 'FORM.LABELS.ACCOUNT' },
+    { key : 'amount', label : 'FORM.LABELS.AMOUNT' },
+    { key : 'project_id', label : 'FORM.LABELS.PROJECT' },
+    { key : 'description', label : 'FORM.LABELS.DESCRIPTION' },
+    { key : 'includeNonPosted', label : 'TRANSACTIONS.INCLUDE_POSTED_TRANSACTIONS_SHORT' },
+    { key : 'origin_id', label : 'FORM.LABELS.TRANSACTION_TYPE' }]);
 
   if (filterCache.filters) {
     // load cached filter definition if it exists

--- a/client/src/modules/patients/patients.service.js
+++ b/client/src/modules/patients/patients.service.js
@@ -1,9 +1,10 @@
 angular.module('bhima.services')
-.service('PatientService', PatientService);
+  .service('PatientService', PatientService);
 
 PatientService.$inject = [
-  '$http', 'util', 'SessionService', '$uibModal',
-  'DocumentService', 'VisitService', 'FilterService', 'appcache', 'PeriodService', 'PrototypeApiService', '$httpParamSerializer', 'LanguageService'
+  'SessionService', '$uibModal', 'DocumentService', 'VisitService',
+  'FilterService', 'appcache', 'PeriodService', 'PrototypeApiService',
+  '$httpParamSerializer', 'LanguageService', 'bhConstants',
 ];
 
 /**
@@ -21,14 +22,16 @@ PatientService.$inject = [
  *   Patients.create(medicalDetails, financeDetails).then(callback);
  *  }
  */
-function PatientService($http, util, Session, $uibModal,
-  Documents, Visits, Filters, AppCache, Periods, Api, $httpParamSerializer, Languages) {
+function PatientService(
+  Session, $uibModal, Documents, Visits, Filters, AppCache, Periods, Api,
+  $httpParamSerializer, Languages, bhConstants
+) {
   var baseUrl = '/patients/';
   var service = new Api(baseUrl);
 
   var patientFilters = new Filters();
   var filterCache = new AppCache('patient-filters');
-    
+
   service.filters = patientFilters;
   service.create = create;
   service.groups = groups;
@@ -47,43 +50,32 @@ function PatientService($http, util, Session, $uibModal,
   service.download = download;
 
 
-
   /**
+   * @method latest
    *
-   * @method read
+   * @description
+   * This method returns the latest invoice that was billed to a patient.
    *
-   * This method returns information on a patient given the patients UUID. This
-   * route provides almost all of the patients attributes.
-   * Uses query strings to generically search for patients.   
-   * @param {object} options - a JSON of options to be parsed by Angular's
-   * paramSerializer
-   *
-   * @param {String|Null} uuid   The patient's UUID  (could be null)
-   * @return {Object}       Promise object that will return patient details
+   * @param {String} uuid The patient's UUID
    */
-  function read(uuid, parameters) {
-    parameters = angular.copy(parameters || {});
-    var target = baseUrl.concat(uuid || '');
-
-    return $http.get(target, { params : parameters })
-      .then(util.unwrapHttpResponse);
-  }
-
-
   function latest(uuid) {
     var path = 'patients/:uuid/invoices/latest';
-    return $http.get(path.replace(':uuid', uuid))
-      .then(util.unwrapHttpResponse);
+    return service.$http.get(path.replace(':uuid', uuid))
+      .then(service.util.unwrapHttpResponse);
   }
 
   /**
-   * This method returns the patient balance
+   * @method balance
+   *
+   * @description
+   * This method returns the balance of a patient's account.
+   *
    * @param {String} uuid The patient's UUID
    */
   function balance(uuid) {
     var path = 'patients/:uuid/finance/balance';
-    return $http.get(path.replace(':uuid', uuid))
-     .then(util.unwrapHttpResponse);
+    return service.$http.get(path.replace(':uuid', uuid))
+      .then(service.util.unwrapHttpResponse);
   }
 
   /**
@@ -98,19 +90,14 @@ function PatientService($http, util, Session, $uibModal,
   function create(medical, finance) {
     var formatPatientRequest = {
       medical : medical,
-      finance : finance
+      finance : finance,
     };
 
     // Assign implicit information
     formatPatientRequest.medical.project_id = Session.project.id;
 
-    return $http.post(baseUrl, formatPatientRequest)
-      .then(util.unwrapHttpResponse);
-  }
-
-  function update(uuid, definition) {
-    return $http.put(baseUrl.concat(uuid), definition)
-      .then(util.unwrapHttpResponse);
+    return service.$http.post(baseUrl, formatPatientRequest)
+      .then(service.util.unwrapHttpResponse);
   }
 
   /**
@@ -128,13 +115,12 @@ function PatientService($http, util, Session, $uibModal,
     if (angular.isDefined(patientUuid)) {
       path = baseUrl.concat(patientUuid, '/groups');
     } else {
-
       // no Patient ID is specified - return a list of all patient groups
       path = baseUrl.concat('groups');
     }
 
-    return $http.get(path)
-      .then(util.unwrapHttpResponse);
+    return service.$http.get(path)
+      .then(service.util.unwrapHttpResponse);
   }
 
   /**
@@ -151,17 +137,17 @@ function PatientService($http, util, Session, $uibModal,
     var options = formatGroupOptions(subscribedGroups);
     var path = baseUrl.concat(uuid, '/groups');
 
-    return $http.post(path, options)
-      .then(util.unwrapHttpResponse);
+    return service.$http.post(path, options)
+      .then(service.util.unwrapHttpResponse);
   }
 
   function searchByName(options) {
-    options = angular.copy(options || {});
+    var opts = angular.copy(options || {});
 
     var target = baseUrl.concat('search/name');
 
-    return $http.get(target, { params : options })
-      .then(util.unwrapHttpResponse);
+    return service.$http.get(target, { params : opts })
+      .then(service.util.unwrapHttpResponse);
   }
 
   /**
@@ -173,8 +159,8 @@ function PatientService($http, util, Session, $uibModal,
    */
   function billingServices(patientUuid) {
     var path = patientAttributePath('services', patientUuid);
-    return $http.get(path)
-      .then(util.unwrapHttpResponse);
+    return service.$http.get(path)
+      .then(service.util.unwrapHttpResponse);
   }
 
   /**
@@ -185,8 +171,8 @@ function PatientService($http, util, Session, $uibModal,
    */
   function subsidies(patientUuid) {
     var path = patientAttributePath('subsidies', patientUuid);
-    return $http.get(path)
-      .then(util.unwrapHttpResponse);
+    return service.$http.get(path)
+      .then(service.util.unwrapHttpResponse);
   }
 
   /* ----------------------------------------------------------------- */
@@ -196,13 +182,12 @@ function PatientService($http, util, Session, $uibModal,
     var groupUuids = Object.keys(groupFormOptions);
 
     var formatted = groupUuids.filter(function (groupUuid) {
-
       // Filter out UUIDs without a true subscription
       return groupFormOptions[groupUuid];
     });
 
     return {
-      assignments : formatted
+      assignments : formatted,
     };
   }
 
@@ -219,26 +204,21 @@ function PatientService($http, util, Session, $uibModal,
     return root.concat(patientUuid, '/', path);
   }
 
-
-  patientFilters.registerDefaultFilters([
-    { key : 'period', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
-    { key : 'custom_period_start', label : 'PERIODS.START', valueFilter : 'date', comparitor : '>'},
-    { key : 'custom_period_end', label : 'PERIODS.END', valueFilter : 'date', comparitor: '<'},
-    { key : 'limit', label : 'FORM.LABELS.LIMIT' }]);
+  patientFilters.registerDefaultFilters(bhConstants.defaultFilters);
 
   patientFilters.registerCustomFilters([
     { key : 'display_name', label : 'FORM.LABELS.NAME' },
     { key : 'sex', label : 'FORM.LABELS.GENDER' },
     { key : 'hospital_no', label : 'FORM.LABELS.HOSPITAL_NO' },
     { key : 'reference', label : 'FORM.LABELS.REFERENCE' },
-    { key : 'dateBirthFrom', label : 'FORM.LABELS.DOB', comparitor: '>', valueFilter:'date' },
-    { key : 'dateBirthTo', label : 'FORM.LABELS.DOB', comparitor: '<', valueFilter:'date' },
-    { key : 'dateRegistrationFrom', label: 'FORM.LABELS.DATE_REGISTRATION', comparitor: '>', valueFilter:'date' },
-    { key : 'dateRegistrationTo', label: 'FORM.LABELS.DATE_REGISTRATION', comparitor: '<', valueFilter:'date' },
-    { key : 'debtor_group_uuid', label: 'FORM.LABELS.DEBTOR_GROUP' },
-    { key : 'patient_group_uuid', label: 'PATIENT_GROUP.PATIENT_GROUP' },
-    { key : 'user_id', label: 'FORM.LABELS.USER' },
-    { key : 'defaultPeriod', label : 'TABLE.COLUMNS.PERIOD'},
+    { key : 'dateBirthFrom', label : 'FORM.LABELS.DOB', comparitor: '>', valueFilter : 'date' },
+    { key : 'dateBirthTo', label : 'FORM.LABELS.DOB', comparitor: '<', valueFilter : 'date' },
+    { key : 'dateRegistrationFrom', label : 'FORM.LABELS.DATE_REGISTRATION', comparitor: '>', valueFilter : 'date' },
+    { key : 'dateRegistrationTo', label : 'FORM.LABELS.DATE_REGISTRATION', comparitor: '<', valueFilter : 'date' },
+    { key : 'debtor_group_uuid', label : 'FORM.LABELS.DEBTOR_GROUP' },
+    { key : 'patient_group_uuid', label : 'PATIENT_GROUP.PATIENT_GROUP' },
+    { key : 'user_id', label : 'FORM.LABELS.USER' },
+    { key : 'defaultPeriod', label : 'TABLE.COLUMNS.PERIOD' },
   ]);
 
   if (filterCache.filters) {
@@ -289,29 +269,28 @@ function PatientService($http, util, Session, $uibModal,
    */
   function openSearchModal(params) {
     return $uibModal.open({
-      templateUrl: 'modules/patients/registry/search.modal.html',
-      size: 'md',
-      keyboard: false,
-      animation: false,
-      backdrop: 'static',
-      controller: 'PatientRegistryModalController as $ctrl',
+      templateUrl : 'modules/patients/registry/search.modal.html',
+      size : 'md',
+      keyboard : false,
+      animation : false,
+      backdrop : 'static',
+      controller : 'PatientRegistryModalController as $ctrl',
       resolve : {
-        filters : function paramsProvider() { return params; }
-      }
+        filters : function paramsProvider() { return params; },
+      },
     }).result;
   }
 
   function download(type) {
     var filterOpts = patientFilters.formatHTTP();
     var defaultOpts = { renderer : type, lang : Languages.key };
-    
+
     // combine options
     var options = angular.merge(defaultOpts, filterOpts);
 
     // return  serialized options
     return $httpParamSerializer(options);
   }
-
 
   return service;
 }

--- a/client/src/modules/purchases/purchases.service.js
+++ b/client/src/modules/purchases/purchases.service.js
@@ -1,9 +1,10 @@
 angular.module('bhima.services')
-.service('PurchaseOrderService', PurchaseOrderService);
+  .service('PurchaseOrderService', PurchaseOrderService);
 
 PurchaseOrderService.$inject = [
-  '$http', 'util', '$uibModal', 'FilterService', 'appcache', 'PeriodService', 'PrototypeApiService', 
-  '$httpParamSerializer', 'LanguageService'
+  '$http', 'util', '$uibModal', 'FilterService', 'appcache', 'PeriodService',
+  'PrototypeApiService', '$httpParamSerializer', 'LanguageService',
+  'bhConstants',
 ];
 
 /**
@@ -13,15 +14,16 @@ PurchaseOrderService.$inject = [
  * @description
  * Connects client controllers with the purchase order backend.
  */
-function PurchaseOrderService($http, util, $uibModal, Filters, AppCache, Periods, Api, 
-  $httpParamSerializer, Languages) {
-  
+function PurchaseOrderService(
+  $http, util, $uibModal, Filters, AppCache, Periods, Api, $httpParamSerializer,
+  Languages, bhConstants
+) {
   var baseUrl = '/purchases/';
   var service = new Api(baseUrl);
 
   var purchaseFilters = new Filters();
   var filterCache = new AppCache('purchases-filters');
-    
+
   service.filters = purchaseFilters;
   service.openSearchModal = openSearchModal;
 
@@ -34,18 +36,13 @@ function PurchaseOrderService($http, util, $uibModal, Filters, AppCache, Periods
   service.stockBalance = stockBalance;
   service.purchaseState = purchaseState;
 
-
-  purchaseFilters.registerDefaultFilters([
-    { key : 'period', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
-    { key : 'custom_period_start', label : 'PERIODS.START', valueFilter : 'date', comparitor : '>'},
-    { key : 'custom_period_end', label : 'PERIODS.END', valueFilter : 'date', comparitor: '<'},
-    { key : 'limit', label : 'FORM.LABELS.LIMIT' }]);
+  purchaseFilters.registerDefaultFilters(bhConstants.defaultFilters);
 
   purchaseFilters.registerCustomFilters([
     { key : 'reference', label : 'FORM.LABELS.REFERENCE' },
-    { key : 'user_id', label: 'FORM.LABELS.USER' },
-    { key : 'supplier_uuid', label: 'FORM.LABELS.SUPPLIER' },  
-    { key : 'status_id', label: 'PURCHASES.ORDER' },
+    { key : 'user_id', label : 'FORM.LABELS.USER' },
+    { key : 'supplier_uuid', label : 'FORM.LABELS.SUPPLIER' },
+    { key : 'status_id', label : 'PURCHASES.ORDER' },
     { key : 'defaultPeriod', label : 'TABLE.COLUMNS.PERIOD', ngFilter : 'translate' },
   ]);
 
@@ -94,7 +91,6 @@ function PurchaseOrderService($http, util, $uibModal, Filters, AppCache, Periods
    * Preprocesses purchase order data for submission to the server
    */
   function create(data) {
-
     // loop through the items ensuring that they are properly formatted for
     // inserting into the database.  We only want to send minimal information
     // to the server.
@@ -128,36 +124,6 @@ function PurchaseOrderService($http, util, $uibModal, Filters, AppCache, Periods
     return Api.read.call(service, url);
   }
 
-  /* ----------------------------------------------------------------- */
-  /** Utility Methods */
-  /* ----------------------------------------------------------------- */
-  function formatGroupOptions(groupFormOptions) {
-    var groupUuids = Object.keys(groupFormOptions);
-
-    var formatted = groupUuids.filter(function (groupUuid) {
-
-      // Filter out UUIDs without a true subscription
-      return groupFormOptions[groupUuid];
-    });
-
-    return {
-      assignments : formatted
-    };
-  }
-
-  /**
-   * Combine and return the purchase entity with a service/attribute - returns a
-   * correctly formatted path.
-   *
-   * @param   {String} path   Entity path (e.g 'services')
-   * @param   {String} uuid   UUID of purchase to format services request
-   * @return  {String}        Formatted URL for purchase service
-   */
-  function purchaseAttributePath(path, purchaseUuid) {
-    var root = '/purchases/';
-    return root.concat(purchaseUuid, '/', path);
-  }
-
   /**
    * @method openSearchModal
    *
@@ -167,22 +133,22 @@ function PurchaseOrderService($http, util, $uibModal, Filters, AppCache, Periods
    */
   function openSearchModal(params) {
     return $uibModal.open({
-      templateUrl: 'modules/purchases/modals/search.tmpl.html',
-      size: 'md',
-      keyboard: false,
-      animation: false,
-      backdrop: 'static',
-      controller: 'SearchPurchaseOrderModalController as $ctrl',
+      templateUrl : 'modules/purchases/modals/search.tmpl.html',
+      size : 'md',
+      keyboard : false,
+      animation : false,
+      backdrop : 'static',
+      controller : 'SearchPurchaseOrderModalController as $ctrl',
       resolve : {
-        params : function paramsProvider() { return params; }
-      }
+        params : function paramsProvider() { return params; },
+      },
     }).result;
   }
 
   function download(type) {
     var filterOpts = purchaseFilters.formatHTTP();
     var defaultOpts = { renderer : type, lang : Languages.key };
-    
+
     // combine options
     var options = angular.merge(defaultOpts, filterOpts);
 

--- a/client/src/modules/vouchers/vouchers.service.js
+++ b/client/src/modules/vouchers/vouchers.service.js
@@ -2,8 +2,9 @@ angular.module('bhima.services')
   .service('VoucherService', VoucherService);
 
 VoucherService.$inject = [
-  'PrototypeApiService', '$http', 'TransactionTypeStoreService', '$uibModal', 'FilterService',
-  'PeriodService', 'LanguageService', '$httpParamSerializer', 'appcache',
+  'PrototypeApiService', 'TransactionTypeStoreService', '$uibModal',
+  'FilterService', 'PeriodService', 'LanguageService', '$httpParamSerializer',
+  'appcache', 'bhConstants',
 ];
 
 /**
@@ -15,8 +16,8 @@ VoucherService.$inject = [
  * includes some utilities that are useful for voucher pages.
  */
 function VoucherService(
-  Api, $http, TransactionTypeStore, Modal, Filters, Periods, Languages,
-  $httpParamSerializer, AppCache
+  Api, TransactionTypeStore, Modal, Filters, Periods, Languages,
+  $httpParamSerializer, AppCache, bhConstants
 ) {
   var service = new Api('/vouchers/');
   var voucherFilters = new Filters();
@@ -37,11 +38,7 @@ function VoucherService(
   service.loadCachedFilters = loadCachedFilters;
   service.download = download;
 
-  voucherFilters.registerDefaultFilters([
-    { key : 'period', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
-    { key : 'custom_period_start', label : 'PERIODS.START', comparitor : '>', valueFilter : 'date' },
-    { key : 'custom_period_end', label : 'PERIODS.END', comparitor : '<', valueFilter : 'date' },
-    { key : 'limit', label : 'FORM.LABELS.LIMIT' }]);
+  voucherFilters.registerDefaultFilters(bhConstants.defaultFilters);
 
   voucherFilters.registerCustomFilters([
     { key : 'user_id', label : 'FORM.LABELS.USER' },
@@ -50,7 +47,7 @@ function VoucherService(
     { key : 'description', label : 'FORM.LABELS.DESCRIPTION' },
     { key : 'entity_uuid', label : 'FORM.LABELS.ENTITY' },
     { key : 'cash_uuid', label : 'FORM.INFO.PAYMENT' },
-    { key : 'invoice_uuid', label : 'FORM.LABELS.INVOICE' },    
+    { key : 'invoice_uuid', label : 'FORM.LABELS.INVOICE' },
     { key : 'type_ids', label : 'FORM.LABELS.TRANSACTION_TYPE' }]);
 
 
@@ -148,7 +145,7 @@ function VoucherService(
    * debits and credits switched.
    */
   function reverse(creditNote) {
-    return $http.post(baseUrl.concat(creditNote.uuid, '/reverse'), creditNote)
+    return service.$http.post(baseUrl.concat(creditNote.uuid, '/reverse'), creditNote)
       .then(service.util.unwrapHttpResponse);
   }
 


### PR DESCRIPTION
This commit replaces all instances of hand-defined default filters with
the shared instance found in `bhConstants`.  This allows a significant
reduction in code for all services that use the FilterService to limit
records.

Additionally, a few typos were fixed in the affected services, as well
as pruning functions that are never called.  Where appropriate, further
documenting comments were added.

Closes #2133.