### PR TITLE
refactor(reports): remove browser.refresh()

### DIFF
--- a/test/end-to-end/reports/aged_creditors/aged_creditors.spec.js
+++ b/test/end-to-end/reports/aged_creditors/aged_creditors.spec.js
@@ -1,5 +1,3 @@
-/* global browser, element, by */
-
 const chai = require('chai');
 const helpers = require('../../shared/helpers');
 
@@ -7,7 +5,7 @@ helpers.configure(chai);
 
 const ReportCreditorsPage = require('./aged_creditors.page');
 
-describe('Aged Creditors Report ::', () => {
+describe('Aged Creditors Report', () => {
   let Page;
   const key = 'aged_creditors';
 
@@ -18,12 +16,11 @@ describe('Aged Creditors Report ::', () => {
     renderer : 'PDF',
     period_1 : 'juin 2016',
     period_2 : 'mai 2015',
-  };  
+  };
 
   before(() => {
     helpers.navigate(`#!/reports/${key}`);
     Page = new ReportCreditorsPage(key);
-    browser.refresh();
   });
 
   it('preview a new Aged Creditors Report', () => {

--- a/test/end-to-end/reports/aged_debtors/aged_debtors.spec.js
+++ b/test/end-to-end/reports/aged_debtors/aged_debtors.spec.js
@@ -1,5 +1,3 @@
-/* global browser, element, by */
-
 const chai = require('chai');
 const helpers = require('../../shared/helpers');
 
@@ -7,7 +5,7 @@ helpers.configure(chai);
 
 const ReportDebtorsPage = require('./aged_debtors.page');
 
-describe('Aged Debtors Report ::', () => {
+describe('Aged Debtors Report', () => {
   let Page;
   const key = 'aged_debtors';
 
@@ -23,7 +21,6 @@ describe('Aged Debtors Report ::', () => {
   before(() => {
     helpers.navigate(`#!/reports/${key}`);
     Page = new ReportDebtorsPage(key);
-    browser.refresh();
   });
 
   it('preview a new Aged Debtors Report', () => {

--- a/test/end-to-end/reports/balance_report/balance_report.page.js
+++ b/test/end-to-end/reports/balance_report/balance_report.page.js
@@ -12,7 +12,6 @@ const components = require('../../shared/components');
 class BalanceReportPage {
   constructor(key) {
     this.page = new ReportPage(key);
-    browser.refresh();
   }
 
   // preview an account report

--- a/test/end-to-end/reports/balance_sheet/balance_sheet_report.spec.js
+++ b/test/end-to-end/reports/balance_sheet/balance_sheet_report.spec.js
@@ -1,5 +1,3 @@
-/* global browser, element, by */
-
 const chai = require('chai');
 const helpers = require('../../shared/helpers');
 
@@ -7,7 +5,7 @@ helpers.configure(chai);
 
 const ReportBalanceSheetPage = require('./balance_sheet_report.page');
 
-describe('BalanceSheets report ::', () => {
+describe('Balance Sheet Report', () => {
   let Page;
   const key = 'balance_sheet_report';
 
@@ -21,7 +19,6 @@ describe('BalanceSheets report ::', () => {
   before(() => {
     helpers.navigate(`#!/reports/${key}`);
     Page = new ReportBalanceSheetPage(key);
-    browser.refresh();    
   });
 
   it('preview a new balanceSheet report', () => {

--- a/test/end-to-end/reports/cashflow/cashflow.spec.js
+++ b/test/end-to-end/reports/cashflow/cashflow.spec.js
@@ -1,5 +1,3 @@
-/* global browser, element, by */
-
 const chai = require('chai');
 const helpers = require('../../shared/helpers');
 
@@ -7,7 +5,7 @@ helpers.configure(chai);
 
 const ReportCashflowPage = require('./cashflow.page');
 
-describe('Cashflow Report ::', () => {
+describe('Cashflow Report', () => {
   let Page;
   const key = 'cashflow';
 
@@ -26,7 +24,6 @@ describe('Cashflow Report ::', () => {
   before(() => {
     helpers.navigate(`#!/reports/${key}`);
     Page = new ReportCashflowPage(key);
-    browser.refresh();
   });
 
   it('preview a new Cashflow Report', () => {

--- a/test/end-to-end/reports/cashflow_by_service/cashflow_by_service.spec.js
+++ b/test/end-to-end/reports/cashflow_by_service/cashflow_by_service.spec.js
@@ -1,5 +1,3 @@
-/* global browser, element, by */
-
 const chai = require('chai');
 const helpers = require('../../shared/helpers');
 
@@ -7,7 +5,7 @@ helpers.configure(chai);
 
 const ReportCashflowPage = require('./cashflow_by_service.page');
 
-describe('Cashflow By Service Report ::', () => {
+describe('Cashflow By Service Report', () => {
   let Page;
   const key = 'cashflowByService';
 
@@ -23,7 +21,6 @@ describe('Cashflow By Service Report ::', () => {
   before(() => {
     helpers.navigate(`#!/reports/${key}`);
     Page = new ReportCashflowPage(key);
-    browser.refresh();
   });
 
   it('preview a new Cashflow By Service Report', () => {

--- a/test/end-to-end/reports/clients_report/clients_report.spec.js
+++ b/test/end-to-end/reports/clients_report/clients_report.spec.js
@@ -1,5 +1,3 @@
-/* global browser, element, by */
-
 const chai = require('chai');
 const helpers = require('../../shared/helpers');
 
@@ -7,7 +5,7 @@ helpers.configure(chai);
 
 const ReportClientsPage = require('./clients_report.page');
 
-describe('Clients report ::', () => {
+describe('Clients Report', () => {
   let Page;
   const key = 'clients_report';
 
@@ -16,20 +14,19 @@ describe('Clients report ::', () => {
     end_date : '31/12/2016',
     clients : ['First Test Debtor Group'],
     report_name : 'Clients Report Saved by E2E',
-    renderer : 'PDF'
+    renderer : 'PDF',
   };
 
   before(() => {
     helpers.navigate(`#!/reports/${key}`);
     Page = new ReportClientsPage(key);
-    browser.refresh();    
   });
 
   it('preview a new clients report', () => {
     Page.showClientsReportPreview(dataset.start_date, dataset.end_date);
   });
 
-  it('close the previewed report', () => { 
+  it('close the previewed report', () => {
     Page.closeClientsReportPreview();
   });
 

--- a/test/end-to-end/reports/income_expense/IncomeExpense.spec.js
+++ b/test/end-to-end/reports/income_expense/IncomeExpense.spec.js
@@ -1,5 +1,3 @@
-/* global browser, element, by */
-
 const chai = require('chai');
 const helpers = require('../../shared/helpers');
 
@@ -7,7 +5,7 @@ helpers.configure(chai);
 
 const ReportIncomeExpensePage = require('./income_expense.page');
 
-describe('Income Expense report ::', () => {
+describe('Income Expense Report', () => {
   let Page;
   const key = 'income_expense';
 
@@ -23,7 +21,6 @@ describe('Income Expense report ::', () => {
   before(() => {
     helpers.navigate(`#!/reports/${key}`);
     Page = new ReportIncomeExpensePage(key);
-    browser.refresh();
   });
 
   it('preview a new income expense report', () => {
@@ -35,7 +32,14 @@ describe('Income Expense report ::', () => {
   });
 
   it('save a previewed report', () => {
-    Page.saveIncomeExpenseReport(dataset.fiscal_id, dataset.periodFrom_id, dataset.periodTo_id, dataset.type, dataset.report_name, dataset.renderer);
+    Page.saveIncomeExpenseReport(
+      dataset.fiscal_id,
+      dataset.periodFrom_id,
+      dataset.periodTo_id,
+      dataset.type,
+      dataset.report_name,
+      dataset.renderer
+    );
   });
 
   it('report has been saved into archive', () => {

--- a/test/end-to-end/reports/open_debtors/open_debtors.spec.js
+++ b/test/end-to-end/reports/open_debtors/open_debtors.spec.js
@@ -1,5 +1,3 @@
-/* global browser */
-
 const chai = require('chai');
 const helpers = require('../../shared/helpers');
 
@@ -20,7 +18,6 @@ describe('Open Debtors Report', () => {
   before(() => {
     helpers.navigate(`#!/reports/${key}`);
     Page = new ReportOpenDebtorsPage(key);
-    browser.refresh();
   });
 
   it(`preview a new Open Debtors report - order by ${dataset.order}`, () => {


### PR DESCRIPTION
This commit removes all browser.refresh() calls in the reports end to end tests.  This ensures that the tests behave consistently and do not need a reset.  It also fractionally decreases the execution time since the browser does not need to load and parse all the JS code and recompute layouts multiple times.

Closes #1884.