### PR TITLE
fix(employee): rename grade_id to grade_uuid

### DIFF
--- a/client/src/modules/employees/employee.service.js
+++ b/client/src/modules/employees/employee.service.js
@@ -33,7 +33,7 @@ function EmployeeService(Filters, $uibModal, Api, AppCache, Languages, $httpPara
       { key : 'dateBirthTo', label : 'FORM.LABELS.DOB', comparitor: '<', valueFilter:'date' },
       { key : 'dateEmbaucheFrom', label : 'FORM.LABELS.DATE_EMBAUCHE', comparitor: '>', valueFilter:'date' },
       { key : 'dateEmbaucheTo', label : 'FORM.LABELS.DATE_EMBAUCHE', comparitor: '<', valueFilter:'date' },
-      { key : 'grade_id', label : 'FORM.LABELS.GRADE' },
+      { key : 'grade_uuid', label : 'FORM.LABELS.GRADE' },
       { key : 'fonction_id', label : 'FORM.LABELS.FUNCTION' },
       { key : 'service_id', label : 'FORM.LABELS.SERVICE' },
       { key : 'is_medical', label : 'FORM.LABELS.MEDICAL_STAFF' }

--- a/client/src/modules/employees/registration/employees.html
+++ b/client/src/modules/employees/registration/employees.html
@@ -124,7 +124,7 @@
                     <div class="col-md-9">
                       <ui-select
                         name="grade"
-                        ng-model="EmployeeCtrl.employee.grade_id"
+                        ng-model="EmployeeCtrl.employee.grade_uuid"
                         required>
                         <ui-select-match placeholder="{{ 'FORM.SELECT.GRADE' | translate }}">
                           <span>{{$select.selected.format}}</span>

--- a/client/src/modules/employees/registry/search.modal.html
+++ b/client/src/modules/employees/registry/search.modal.html
@@ -67,9 +67,9 @@
           </div>
 
           <bh-grade-select
-            grade-uuid="ModalCtrl.searchQueries.grade_id"
+            grade-uuid="ModalCtrl.searchQueries.grade_uuid"
             on-select-callback="ModalCtrl.onSelectGrade(grade)">
-            <bh-clear on-clear="ModalCtrl.clear('grade_id')"></bh-clear>
+            <bh-clear on-clear="ModalCtrl.clear('grade_uuid')"></bh-clear>
           </bh-grade-select>
 
           <bh-fonction-select

--- a/client/src/modules/employees/registry/search.modal.js
+++ b/client/src/modules/employees/registry/search.modal.js
@@ -35,7 +35,7 @@ function EmployeeRegistryModalController(ModalInstance, bhConstants, moment, Ser
   // these properties will be used to filter employee data form the client
   var searchQueryOptions = [
     'display_name', 'sex', 'code', 'dateBirthFrom', 'dateBirthTo', 'dateEmbaucheFrom',
-    'dateEmbaucheTo', 'grade_id', 'fonction_id', 'service_id', 'is_medical',
+    'dateEmbaucheTo', 'grade_uuid', 'fonction_id', 'service_id', 'is_medical',
   ];
 
   // assign already defined custom filters to searchQueries object
@@ -58,10 +58,10 @@ function EmployeeRegistryModalController(ModalInstance, bhConstants, moment, Ser
     vm.searchQueries.service_id = service.id;
   };
 
-  // custom filter grade_id - assign the value to the searchQueries object
+  // custom filter grade_uuid - assign the value to the searchQueries object
   vm.onSelectGrade = function onSelectGrade(grade) {
-    displayValues.grade_id = grade.text;
-    vm.searchQueries.grade_id = grade.uuid;
+    displayValues.grade_uuid = grade.text;
+    vm.searchQueries.grade_uuid = grade.uuid;
   };
 
   // custom filter fonction_id - assign the value to the searchQueries object

--- a/server/controllers/finance/reports/shared.js
+++ b/server/controllers/finance/reports/shared.js
@@ -46,7 +46,7 @@ const filters = [
   { field : 'dateBirthTo', displayName : 'FORM.LABELS.DOB', comparitor : '<', isDate : true },
   { field : 'dateEmbaucheFrom', displayName : 'FORM.LABELS.DATE_EMBAUCHE', comparitor : '>', isDate : true },
   { field : 'dateEmbaucheTo', displayName : 'FORM.LABELS.DATE_EMBAUCHE', comparitor : '<', isDate : true },
-  { field : 'grade_id', displayName : 'FORM.LABELS.GRADE' },
+  { field : 'grade_uuid', displayName : 'FORM.LABELS.GRADE' },
   { field : 'fonction_id', displayName : 'FORM.LABELS.FUNCTION' },
   { field : 'type_ids', displayName : 'FORM.LABELS.TRANSACTION_TYPE' },
 

--- a/server/controllers/payroll/employees/index.js
+++ b/server/controllers/payroll/employees/index.js
@@ -130,7 +130,7 @@ function lookupEmployee(id) {
     SELECT 
       employee.id, employee.code AS code_employee, employee.display_name, employee.sex, 
       employee.dob, employee.date_embauche, employee.service_id,
-      employee.nb_spouse, employee.nb_enfant, BUID(employee.grade_id) as grade_id,
+      employee.nb_spouse, employee.nb_enfant, BUID(employee.grade_uuid) as grade_uuid,
       employee.locked, employee.is_medical, grade.text, grade.basic_salary,
       fonction.id AS fonction_id, fonction.fonction_txt, service.name AS service_txt,
       employee.phone, employee.email, employee.adresse, employee.bank, employee.bank_account,
@@ -139,7 +139,7 @@ function lookupEmployee(id) {
       BUID(creditor.uuid) as creditor_uuid, creditor.text AS creditor_text,
       BUID(creditor.group_uuid) as creditor_group_uuid, creditor_group.account_id
     FROM employee
-      JOIN grade ON employee.grade_id = grade.uuid
+      JOIN grade ON employee.grade_uuid = grade.uuid
       LEFT JOIN fonction ON employee.fonction_id = fonction.id
       JOIN patient ON patient.uuid = employee.patient_uuid
       JOIN debtor ON patient.debtor_uuid = debtor.uuid
@@ -175,7 +175,7 @@ function detail(req, res, next) {
  */
 function update(req, res, next) {
   const employee = db.convert(req.body, [
-    'grade_id', 'debtor_group_uuid', 'creditor_group_uuid', 'creditor_uuid', 'debtor_uuid',
+    'grade_uuid', 'debtor_group_uuid', 'creditor_group_uuid', 'creditor_uuid', 'debtor_uuid',
   ]);
 
   if (employee.dob) {
@@ -206,7 +206,7 @@ function update(req, res, next) {
     service_id : employee.service_id,
     nb_spouse : employee.nb_spouse,
     nb_enfant : employee.nb_enfant,
-    grade_id : employee.grade_id,
+    grade_uuid : employee.grade_uuid,
     locked : employee.locked,
     fonction_id : employee.fonction_id,
     phone : employee.phone,
@@ -268,7 +268,7 @@ function create(req, res, next) {
 
   // convert uuids to binary uuids as necessary
   const employee = db.convert(data, [
-    'grade_id', 'debtor_group_uuid', 'creditor_group_uuid', 'creditor_uuid',
+    'grade_uuid', 'debtor_group_uuid', 'creditor_group_uuid', 'creditor_uuid',
     'debtor_uuid', 'current_location_id', 'origin_location_id', 'patient_uuid',
   ]);
 
@@ -327,7 +327,7 @@ function create(req, res, next) {
 
   transaction.execute()
     .then(results => {
-      // @todo - why is this not a UUID, but grade_id is a uuid?
+      // @todo - why is this not a UUID, but grade_uuid is a uuid?
       const employeeId = results[3].insertId;
 
       topic.publish(topic.channels.ADMIN, {
@@ -386,7 +386,7 @@ function find(options) {
     `SELECT 
       employee.id, employee.code AS code, employee.display_name, employee.sex, 
       employee.dob, employee.date_embauche, employee.service_id, employee.nb_spouse, 
-      employee.nb_enfant, BUID(employee.grade_id) as grade_id, employee.locked,
+      employee.nb_enfant, BUID(employee.grade_uuid) as grade_uuid, employee.locked,
       grade.text, grade.basic_salary, fonction.id AS fonction_id, fonction.fonction_txt,
       employee.phone, employee.email, employee.adresse, employee.bank, employee.bank_account,
       employee.daily_salary, employee.is_medical, grade.code AS code_grade, BUID(debtor.uuid) as debtor_uuid,
@@ -395,7 +395,7 @@ function find(options) {
       BUID(creditor.group_uuid) as creditor_group_uuid, creditor_group.account_id,
       service.name as service_name
     FROM employee
-     JOIN grade ON employee.grade_id = grade.uuid
+     JOIN grade ON employee.grade_uuid = grade.uuid
      LEFT JOIN fonction ON employee.fonction_id = fonction.id
      JOIN patient ON patient.uuid = employee.patient_uuid
      JOIN debtor ON patient.debtor_uuid = debtor.uuid
@@ -404,7 +404,7 @@ function find(options) {
      LEFT JOIN service ON service.id = employee.service_id
   `;
   // ensure epected options are parsed appropriately as binary
-  db.convert(options, ['grade_id', 'creditor_uuid', 'patient_uuid']);
+  db.convert(options, ['grade_uuid', 'creditor_uuid', 'patient_uuid']);
 
   const filters = new FilterParser(options, { tableAlias : 'employee' });
 
@@ -417,7 +417,7 @@ function find(options) {
   filters.equals('code', 'code', 'employee');
   filters.equals('service_id', 'service_id', 'employee');
   filters.equals('fonction_id', 'fonction_id', 'employee');
-  filters.equals('grade_id', 'grade_id', 'employee');
+  filters.equals('grade_uuid', 'grade_uuid', 'employee');
   filters.equals('is_medical', 'is_medical', 'employee');
 
   // @TODO Support ordering query

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -614,7 +614,7 @@ CREATE TABLE `employee` (
   `sex`           VARCHAR(1) NOT NULL,
   `dob`           DATETIME NOT NULL,
   `date_embauche` DATETIME DEFAULT NULL,
-  `grade_id`      BINARY(16) NOT NULL,
+  `grade_uuid`      BINARY(16) NOT NULL,
   `nb_spouse`     INT(2) DEFAULT 0,
   `nb_enfant`     INT(3) DEFAULT 0,
   `daily_salary`  FLOAT DEFAULT 0,
@@ -634,12 +634,12 @@ CREATE TABLE `employee` (
   KEY `fonction_id` (`fonction_id`),
   KEY `service_id` (`service_id`),
   KEY `creditor_uuid` (`creditor_uuid`),
-  KEY `grade_id` (`grade_id`),
+  KEY `grade_uuid` (`grade_uuid`),
   KEY `patient_uuid` (`patient_uuid`),
   FOREIGN KEY (`fonction_id`) REFERENCES `fonction` (`id`),
   FOREIGN KEY (`service_id`) REFERENCES `service` (`id`),
   FOREIGN KEY (`creditor_uuid`) REFERENCES `creditor` (`uuid`),
-  FOREIGN KEY (`grade_id`) REFERENCES `grade` (`uuid`),
+  FOREIGN KEY (`grade_uuid`) REFERENCES `grade` (`uuid`),
   FOREIGN KEY (`patient_uuid`) REFERENCES `patient` (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/test/end-to-end/employees/registration.page.js
+++ b/test/end-to-end/employees/registration.page.js
@@ -57,7 +57,7 @@ class RegistrationPage {
 
     // set grade
     setGrade (grade){
-        FU.uiSelect('EmployeeCtrl.employee.grade_id', grade);
+        FU.uiSelect('EmployeeCtrl.employee.grade_uuid', grade);
     }
 
     // set fonction
@@ -123,7 +123,7 @@ class RegistrationPage {
         FU.validation.error('EmployeeCtrl.employee.display_name');
         FU.validation.error('EmployeeCtrl.employee.sex');
         FU.validation.error('EmployeeCtrl.employee.code');
-        FU.validation.error('EmployeeCtrl.employee.grade_id');
+        FU.validation.error('EmployeeCtrl.employee.grade_uuid');
         FU.validation.error('EmployeeCtrl.employee.creditor_group_uuid');
         FU.validation.error('$ctrl.debtorGroupUuid');
         FU.validation.error('EmployeeCtrl.employee.dob');

--- a/test/integration/employee.js
+++ b/test/integration/employee.js
@@ -26,7 +26,7 @@ describe('(/employees) the employees API endpoint', function () {
     date_embauche : embaucheDate,
     nb_spouse : 0,
     nb_enfant : 0,
-    grade_id : '9ee06e4a-7b59-48e6-812c-c0f8a00cf7d3',
+    grade_uuid : '9ee06e4a-7b59-48e6-812c-c0f8a00cf7d3',
     daily_salary : 50,
     bank : 'BIAC',
     bank_account : '00-99-88-77',
@@ -50,7 +50,7 @@ describe('(/employees) the employees API endpoint', function () {
     date_embauche : embaucheDate,
     nb_spouse : 0,
     nb_enfant : 0,
-    grade_id : '9ee06e4a-7b59-48e6-812c-c0f8a00cf7d3',
+    grade_uuid : '9ee06e4a-7b59-48e6-812c-c0f8a00cf7d3',
     daily_salary : 50,
     bank : 'BIAC',
     bank_account : '00-99-88-77',
@@ -173,7 +173,7 @@ describe('(/employees) the employees API endpoint', function () {
         var expected = [
           'nb_spouse', 'nb_enfant', 'daily_salary', 'bank', 'bank_account',
           'adresse', 'phone', 'email', 'fonction_id', 'fonction_txt',
-          'grade_id', 'basic_salary', 'service_id',
+          'grade_uuid', 'basic_salary', 'service_id',
           'creditor_uuid', 'locked'
         ];
 


### PR DESCRIPTION
This commit renames the "grade_id" column to "grade_uuid" in reflection
of it's underlying uuid representation.  The three commands that were run
were:
```sh
find ./client/ -type f | xargs sed -i  's/grade_id/grade_uuid/g'
find ./server/ -type f | xargs sed -i  's/grade_id/grade_uuid/g'
find ./test/ -type f | xargs sed -i  's/grade_id/grade_uuid/g'
```

Partially addressed #342.

Closes #2208.