### PR TITLE
fix(vouchers): undo reversals on delete

### DIFF
--- a/server/controllers/finance/vouchers.js
+++ b/server/controllers/finance/vouchers.js
@@ -160,7 +160,7 @@ function find(options) {
   filters.custom('account_id', 'v.uuid IN (SELECT DISTINCT voucher_uuid FROM voucher_item WHERE account_id = ?)');
 
   filters.custom('invoice_uuid', REFERENCE_SQL, [options.invoice_uuid, options.invoice_uuid]);
-  filters.custom('cash_uuid', REFERENCE_SQL, [options.invoice_uuid, options.invoice_uuid]);
+  filters.custom('cash_uuid', REFERENCE_SQL, [options.cash_uuid, options.cash_uuid]);
 
   // @TODO Support ordering query (reference support for limit)?
   filters.setOrder('ORDER BY v.date DESC');
@@ -302,11 +302,15 @@ function safelyDeleteVoucher(guid) {
 
       transaction
         .addQuery(DELETE_TRANSACTION, binaryUuid)
-        .addQuery(DELETE_TRANSACTION_HISTORY, binaryUuid)
-        .addQuery(DELETE_VOUCHER, binaryUuid)
-        .addQuery(DELETE_DOCUMENT_MAP, binaryUuid)
+
+        // note that we have to delete the toggles before removing the voucher
+        // wholesale.
         .addQuery(TOGGLE_INVOICE_REVERSAL, binaryUuid)
-        .addQuery(TOGGLE_CASH_REVERSAL, binaryUuid);
+        .addQuery(TOGGLE_CASH_REVERSAL, binaryUuid)
+
+        .addQuery(DELETE_VOUCHER, binaryUuid)
+        .addQuery(DELETE_TRANSACTION_HISTORY, binaryUuid)
+        .addQuery(DELETE_DOCUMENT_MAP, binaryUuid);
 
       return transaction.execute();
     });

--- a/server/models/procedures/voucher.sql
+++ b/server/models/procedures/voucher.sql
@@ -92,6 +92,13 @@ BEGIN
       FROM general_ledger AS gl WHERE gl.record_uuid = uuid
     ) AS zz;
 
+  -- update the "amount" with the sum of the voucher_items.  We could choose either
+  -- debits or credits to sum here ... they should be equivalent.
+  UPDATE voucher SET amount = (
+    SELECT SUM(vi.debit) FROM (
+      SELECT * FROM voucher_item) AS vi WHERE vi.voucher_uuid = voucher.uuid
+    ) WHERE voucher.uuid = voucher_uuid;
+
   -- make sure we update the invoice with the fact that it got reversed.
   IF isInvoice THEN
     UPDATE invoice SET reversed = 1 WHERE invoice.uuid = uuid;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1397,7 +1397,7 @@ CREATE TABLE `purchase` (
   `user_id`         SMALLINT(5) UNSIGNED NOT NULL,
   `payment_method`  TEXT,
   `note`            TEXT,
-  `status_id`       TINYINT(3) UNSIGNED NOT NULL,   
+  `status_id`       TINYINT(3) UNSIGNED NOT NULL,
   PRIMARY KEY (`uuid`),
   UNIQUE KEY `purchase_1` (`project_id`, `reference`),
   KEY `project_id` (`project_id`),

--- a/test/end-to-end/verificationLinks/verificationLinks.spec.js
+++ b/test/end-to-end/verificationLinks/verificationLinks.spec.js
@@ -62,7 +62,7 @@ describe('Check Inter-Registry Links', () => {
   it('Checks the link between Cash Registry -> Voucher Registry', () => {
     helpers.navigate('#!/payments');
     filters.resetFilters();
-    const row = new GridRow('CP.TPA.1');
+    const row = new GridRow('CP.TPA.3');
     row.dropdown().click();
     row.goToVoucher().click();
 


### PR DESCRIPTION
This commit updates the voucher delete method to undo the "reversal"
flag on the reversed record if the voucher has been removed.  It is
currently a naive method - simply attempt to remove the value if it is
present.  This can be improved in the future by checking the transaction
types first.

Closes #2207.