### PR TITLE
chore: use uniform interface for $state filters

### DIFF
--- a/client/src/modules/cash/cash.routes.js
+++ b/client/src/modules/cash/cash.routes.js
@@ -7,8 +7,7 @@ angular.module('bhima.routes')
         controller  : 'CashPaymentRegistryController as CPRCtrl',
         templateUrl : 'modules/cash/payments/registry.html',
         params      : {
-          filters : null,
-          display : null,
+          filters : [],
         },
       })
 

--- a/client/src/modules/cash/payments/registry.js
+++ b/client/src/modules/cash/payments/registry.js
@@ -185,13 +185,12 @@ function CashPaymentRegistryController(
   }
 
   function startup() {
-    if ($state.params.filters) {
-      // fix me, generate change dynamically
-      var change = [{ key : $state.params.filters.key, value : $state.params.filters.value }];
-
-      Cash.filters.replaceFilters(change);
+    if ($state.params.filters.length) {
+      Cash.filters.replaceFiltersFromState($state.params.filters);
       Cash.cacheFilters();
     }
+
+    vm.latestViewFilters = Cash.filters.formatView();
 
     load(Cash.filters.formatHTTP(true));
     vm.latestViewFilters = Cash.filters.formatView();

--- a/client/src/modules/debtors/groups.list.html
+++ b/client/src/modules/debtors/groups.list.html
@@ -40,7 +40,7 @@
             <div class="row">
               <div class="col-md-6">
                 <h4 style="margin-top : 0px;">
-                  <i class="fa fa-circle" style="color: {{ debtorGroup.color }}"></i> <b>{{debtorGroup.name}}</b> 
+                  <i class="fa fa-circle" style="color: {{ debtorGroup.color }}"></i> <b>{{debtorGroup.name}}</b>
                   <span ng-if="debtorGroup.locked" class="fa fa-lock text-danger"></span>
                 </h4>
                 <h5 style="margin-top : 0px;"></span><span translate> FORM.LABELS.ACCOUNT_NUMBER </span> : <b>{{debtorGroup.account_number}}</b></h5>
@@ -58,7 +58,7 @@
                   </div>
 
                   <div class="col-md-6">
-                    <a ui-sref="patientRegistry({ filters : { key : 'debtor_group_uuid', value : debtorGroup.uuid }})"><span class="fa fa-bars" aria-hidden="true"></span> <b>{{debtorGroup.total_debtors}}</b> <span translate> DEBTOR_GROUP.DEBTOR.SUBSCRIBED </span></a>
+                    <a ui-sref="patientRegistry({ filters : [{ key : 'debtor_group_uuid', value : debtorGroup.uuid, displayValue: debtorGroup.name }]})"><span class="fa fa-bars" aria-hidden="true"></span> <b>{{debtorGroup.total_debtors}}</b> <span translate> DEBTOR_GROUP.DEBTOR.SUBSCRIBED </span></a>
                   </div>
                 </div>
               </div>

--- a/client/src/modules/employees/employees.routes.js
+++ b/client/src/modules/employees/employees.routes.js
@@ -6,11 +6,12 @@ angular.module('bhima.routes')
         controller  : 'EmployeeController as EmployeeCtrl',
         templateUrl : 'modules/employees/registration/employees.html',
       })
-
       .state('employeeRegistry', {
         url         : '/employees',
         controller  : 'EmployeeRegistryController as EmployeeRegistryCtrl',
         templateUrl : '/modules/employees/registry/registry.html',
-        params      : {filters : null},
+        params      : {
+          filters : [],
+        },
       });
   }]);

--- a/client/src/modules/employees/registry/registry.js
+++ b/client/src/modules/employees/registry/registry.js
@@ -4,19 +4,21 @@ angular.module('bhima.controllers')
 EmployeeRegistryController.$inject = [
   '$state', 'EmployeeService', 'NotifyService', 'AppCache',
   'util', 'ReceiptModal', 'uiGridConstants', 'GridColumnService', 'bhConstants',
-  'GridStateService', 'LanguageService', 'ExportService'];
+  'GridStateService',
+];
 
 /**
  * Employee Registry Controller
  *
  * This module is responsible for the management of Employe Registry.
  */
-function EmployeeRegistryController($state, Employees, Notify, AppCache,
-  util, Receipts, uiGridConstants, Columns, bhConstants, GridState, Languages, Export) {
+function EmployeeRegistryController(
+  $state, Employees, Notify, AppCache, util, Receipts, uiGridConstants, Columns,
+  bhConstants, GridState
+) {
   var vm = this;
 
   var cacheKey = 'EmployeeRegistry';
-  var cache = AppCache(cacheKey);
   var state;
 
   vm.search = search;
@@ -45,7 +47,7 @@ function EmployeeRegistryController($state, Employees, Notify, AppCache,
       displayName      : 'FORM.LABELS.MEDICAL_STAFF',
       headerCellFilter : 'translate',
       cellTemplate     : '/modules/employees/templates/medical.cell.html',
-    },    
+    },
     { field            : 'sex',
       displayName      : 'TABLE.COLUMNS.GENDER',
       headerCellFilter : 'translate',
@@ -121,8 +123,8 @@ function EmployeeRegistryController($state, Employees, Notify, AppCache,
     },
     { name          : 'actions',
       displayName   : '',
-      cellTemplate  : '/modules/employees/templates/action.cell.html'
-    }
+      cellTemplate  : '/modules/employees/templates/action.cell.html',
+    },
   ];
 
   /** TODO manage column : last_transaction */
@@ -143,7 +145,7 @@ function EmployeeRegistryController($state, Employees, Notify, AppCache,
   vm.clearGridState = function clearGridState() {
     state.clearGridState();
     $state.reload();
-  }
+  };
 
   // error handler
   function handler(error) {
@@ -165,12 +167,12 @@ function EmployeeRegistryController($state, Employees, Notify, AppCache,
     // hook the returned employeess up to the grid.
     Employees.read(null, parameters)
       .then(function (employees) {
-          employees.forEach(function (employee) {
-            employee.employeeAge = util.getMomentAge(employee.dob, 'years');
-          });
+        employees.forEach(function (employee) {
+          employee.employeeAge = util.getMomentAge(employee.dob, 'years');
+        });
 
-          // put data in the grid
-          vm.uiGridOptions.data = employees;
+        // put data in the grid
+        vm.uiGridOptions.data = employees;
       })
       .catch(handler)
       .finally(function () {
@@ -215,9 +217,8 @@ function EmployeeRegistryController($state, Employees, Notify, AppCache,
 
   // startup function. Checks for cached filters and loads them.  This behavior could be changed.
   function startup() {
-    if($state.params.filters) {
-      var changes = [{ key : $state.params.filters.key, value : $state.params.filters.value }]
-      Employees.filters.replaceFilters(changes);
+    if ($state.params.filters.length) {
+      Employees.filters.replaceFiltersFromState($state.params.filters);
       Employees.cacheFilters();
     }
 

--- a/client/src/modules/employees/templates/action.cell.html
+++ b/client/src/modules/employees/templates/action.cell.html
@@ -5,7 +5,7 @@
   </a>
 
   <ul data-action="{{ rowRenderIndex}}"  class="dropdown-menu-right" uib-dropdown-menu>
-    <li class="dropdown-header">{{row.entity.code}}</li>    
+    <li class="dropdown-header">{{row.entity.code}}</li>
     <li>
       <a data-method="edit" href>
         <span class="fa fa-edit"></span> <span translate>TABLE.COLUMNS.EDIT</span>
@@ -23,7 +23,7 @@
       </a>
     </li>
     <li>
-    <a data-method="payment" href>
+      <a data-method="payment" href>
         <span class="fa fa-money"></span> <span translate>PATIENT_REGISTRY.PAYMENTS</span>
       </a>
     </li>

--- a/client/src/modules/inventory/list/list.js
+++ b/client/src/modules/inventory/list/list.js
@@ -3,9 +3,9 @@ angular.module('bhima.controllers')
 
 // dependencies injection
 InventoryListController.$inject = [
-  'InventoryService', 'NotifyService', 'uiGridConstants', 'ModalService', '$state', 'FilterService',
-  'appcache', 'GridColumnService', 'GridStateService', 'GridExportService', 'LanguageService',
-  'SessionService',
+  'InventoryService', 'NotifyService', 'uiGridConstants', 'ModalService',
+  '$state', 'FilterService', 'appcache', 'GridColumnService', 'GridStateService',
+  'GridExportService', 'LanguageService', 'SessionService',
 ];
 
 /**
@@ -181,15 +181,14 @@ function InventoryListController(
 
   function startup() {
     // if parameters are passed through the $state object, use them.
-    if ($state.params.filters.length > 0) {
-      Inventory.filters.replaceFilters($state.params.filters);
+    if ($state.params.filters.length) {
+      Inventory.filters.replaceFiltersFromState($state.params.filters);
     }
 
     load(Inventory.filters.formatHTTP(true));
     vm.latestViewFilters = Inventory.filters.formatView();
 
     // load the cached inline filter state
-    vm.filterEnabled = cache.filterEnabled || false;
     vm.gridOptions.enableFiltering = vm.filterEnabled;
   }
 

--- a/client/src/modules/inventory/list/templates/action.cell.html
+++ b/client/src/modules/inventory/list/templates/action.cell.html
@@ -17,7 +17,7 @@
 
     <li class="divider"></li>
     <li>
-      <a data-method="invoice" ui-sref="invoiceRegistry({ filters : { key : 'inventory_uuid', value : row.entity.uuid, displayValue: row.entity.label }})" href>
+      <a data-method="invoice" ui-sref="invoiceRegistry({ filters : [{ key : 'inventory_uuid', value : row.entity.uuid, displayValue: row.entity.label }]})" href>
         <span class="fa fa-file-text-o"></span> <span translate>PATIENT_REGISTRY.INVOICES</span>
       </a>
     </li>

--- a/client/src/modules/invoices/invoices.routes.js
+++ b/client/src/modules/invoices/invoices.routes.js
@@ -6,8 +6,7 @@ angular.module('bhima.routes')
         controller  : 'InvoiceRegistryController as InvoiceRegistryCtrl',
         templateUrl : '/modules/invoices/registry/registry.html',
         params      : {
-          filters : null,
-          display : null,
+          filters : [],
         },
       })
       .state('patientInvoice', {

--- a/client/src/modules/invoices/registry/registry.js
+++ b/client/src/modules/invoices/registry/registry.js
@@ -123,19 +123,20 @@ function InvoiceRegistryController(
     request = Invoices.read(null, filters);
 
     // hook the returned patients up to the grid.
-    request.then(function (invoices) {
-      invoices.forEach(function (invoice) {
-        invoice._backgroundColor = invoice.reversed ? reversedBackgroundColor : regularBackgroundColor;
-        invoice._is_cancelled = invoice.reversed;
-      });
+    request
+      .then(function (invoices) {
+        invoices.forEach(function (invoice) {
+          invoice._backgroundColor = invoice.reversed ? reversedBackgroundColor : regularBackgroundColor;
+          invoice._is_cancelled = invoice.reversed;
+        });
 
-      // put data in the grid
-      vm.uiGridOptions.data = invoices;
-    })
-    .catch(handler)
-    .finally(function () {
-      toggleLoadingIndicator();
-    });
+        // put data in the grid
+        vm.uiGridOptions.data = invoices;
+      })
+      .catch(handler)
+      .finally(function () {
+        toggleLoadingIndicator();
+      });
   }
 
   // search and filter data in Invoice Registry
@@ -163,11 +164,8 @@ function InvoiceRegistryController(
 
   // startup function. Checks for cached filters and loads them.  This behavior could be changed.
   function startup() {
-    if ($state.params.filters) {
-      // Fix me, generate change dynamically
-      var change = [{ key : $state.params.filters.key, value : $state.params.filters.value, displayValue : $state.params.filters.displayValue }];
-
-      Invoices.filters.replaceFilters(change);
+    if ($state.params.filters.length) {
+      Invoices.filters.replaceFiltersFromState($state.params.filters);
       Invoices.cacheFilters();
     }
 

--- a/client/src/modules/invoices/registry/templates/action.cell.html
+++ b/client/src/modules/invoices/registry/templates/action.cell.html
@@ -17,12 +17,12 @@
 
     <!-- view linked records -->
     <li>
-      <a data-method="view-patient" href ui-sref="patientRegistry({ filters : { key : 'display_name', value : row.entity.patientName }})">
+      <a data-method="view-patient" href ui-sref="patientRegistry({ filters : [{ key : 'display_name', value : row.entity.patientName }]})">
         <i class="fa fa-user"></i> <span translate>REPORT.VIEW_PATIENT</span>
       </a>
     </li>
     <li>
-      <a data-method="view-payment" href ui-sref="cashRegistry({ filters : { key : 'invoice_uuid', value : row.entity.uuid, displayValue: row.entity.reference }})">
+      <a data-method="view-payment" href ui-sref="cashRegistry({ filters : [{ key : 'invoice_uuid', value : row.entity.uuid, displayValue: row.entity.reference }]})">
         <span class="fa fa-money"></span> <span translate>REPORT.VIEW_PAYMENTS</span>
       </a>
     </li>

--- a/client/src/modules/patients/groups/groups.html
+++ b/client/src/modules/patients/groups/groups.html
@@ -44,7 +44,7 @@
                   <a class="btn btn-xs btn-default" ng-click="PatientGroupCtrl.update(group.uuid)" id="group-{{group.uuid}}">
                     <span class="glyphicon glyphicon-pencil"></span>
                   </a>
-                  <a class="btn btn-xs btn-default" ui-sref="patientRegistry({ filters : { key : 'patient_group_uuid', value : group.uuid }})">
+                  <a class="btn btn-xs btn-default" ui-sref="patientRegistry({ filters : [{ key : 'patient_group_uuid', value : group.uuid, displayValue: group.name }]})">
                     <span class="fa fa-list"></span> <span translate> FORM.LABELS.PATIENT_LIST </span>
                   </a>
                 </td>

--- a/client/src/modules/patients/patients.routes.js
+++ b/client/src/modules/patients/patients.routes.js
@@ -1,6 +1,5 @@
 angular.module('bhima.routes')
   .config(['$stateProvider', function ($stateProvider) {
-
     $stateProvider
       .state('patientsRegister', {
         url         : '/patients/register',
@@ -24,7 +23,9 @@ angular.module('bhima.routes')
         url         : '/patients',
         controller  : 'PatientRegistryController as PatientRegistryCtrl',
         templateUrl : '/modules/patients/registry/registry.html',
-        params      : { filters: null },
+        params      : {
+          filters: [],
+        },
       })
       .state('patientGroups', {
         url         : '/patients/groups',

--- a/client/src/modules/patients/registry/registry.js
+++ b/client/src/modules/patients/registry/registry.js
@@ -134,18 +134,19 @@ function PatientRegistryController($state, Patients, Notify, AppCache,
     var request = Patients.read(null, filters);
 
     // hook the returned patients up to the grid.
-    request.then(function (patients) {
-      patients.forEach(function (patient) {
-        patient.patientAge = util.getMomentAge(patient.dob, 'years');
-      });
+    request
+    .then(function (patients) {
+        patients.forEach(function (patient) {
+          patient.patientAge = util.getMomentAge(patient.dob, 'years');
+        });
 
-      // put data in the grid
-      vm.uiGridOptions.data = patients;
-    })
-    .catch(handler)
-    .finally(function () {
-      toggleLoadingIndicator();
-    });
+        // put data in the grid
+        vm.uiGridOptions.data = patients;
+      })
+      .catch(handler)
+      .finally(function () {
+        toggleLoadingIndicator();
+      });
   }
 
   function search() {
@@ -185,9 +186,8 @@ function PatientRegistryController($state, Patients, Notify, AppCache,
 
   // startup function. Checks for cached filters and loads them.  This behavior could be changed.
   function startup() {
-    if($state.params.filters) {
-      var changes = [{ key : $state.params.filters.key, value : $state.params.filters.value }]
-      Patients.filters.replaceFilters(changes);
+    if ($state.params.filters.length) {
+      Patients.filters.replaceFiltersFromState($state.params.filters);
       Patients.cacheFilters();
     }
 

--- a/client/src/modules/patients/templates/action.cell.html
+++ b/client/src/modules/patients/templates/action.cell.html
@@ -7,7 +7,7 @@
   <ul data-action="{{ rowRenderIndex}}"  class="dropdown-menu-right" uib-dropdown-menu>
     <li class="dropdown-header">{{row.entity.reference}}</li>
     <li>
-      <a data-method="record" ui-sref="patientRecord.details({patientID : row.entity.uuid})" href>
+      <a data-method="record" ui-sref="patientRecord.details({ patientID : row.entity.uuid })" href>
         <span class="fa fa-book"></span> <span translate>PATIENT_REGISTRY.RECORD</span>
       </a>
     </li>
@@ -29,12 +29,12 @@
     </li>
     <li class="divider"></li>
     <li>
-      <a data-method="invoice" ui-sref="invoiceRegistry({ filters : { key : 'patientReference', value : row.entity.reference }})" href>
+      <a data-method="invoice" ui-sref="invoiceRegistry({ filters : [{ key : 'patientReference', value : row.entity.reference }]})" href>
         <span class="fa fa-file-text-o"></span> <span translate>PATIENT_REGISTRY.INVOICES</span>
       </a>
     </li>
     <li>
-      <a data-method="payment" ui-sref="cashRegistry({ filters : { key : 'patientReference', value : row.entity.reference }})" href>
+      <a data-method="payment" ui-sref="cashRegistry({ filters : [{ key : 'patientReference', value : row.entity.reference }]})" href>
         <span class="fa fa-money"></span> <span translate>PATIENT_REGISTRY.PAYMENTS</span>
       </a>
     </li>

--- a/client/src/modules/stock/inventories/registry.js
+++ b/client/src/modules/stock/inventories/registry.js
@@ -100,7 +100,7 @@ function StockInventoriesController(
   ];
 
   vm.enterprise = Session.enterprise;
-  vm.gridApi = {};  
+  vm.gridApi = {};
 
   vm.gridOptions = {
     appScopeProvider  : vm,
@@ -186,19 +186,18 @@ function StockInventoriesController(
     var filtersSnapshot = stockInventoryFilters.formatHTTP();
 
     Modal.openSearchInventories(filtersSnapshot)
-    .then(function (changes) {
-      stockInventoryFilters.replaceFilters(changes);
-      Stock.cacheFilters(filterKey);
-      vm.latestViewFilters = stockInventoryFilters.formatView();
-      
-      return load(stockInventoryFilters.formatHTTP(true));
-    });
+      .then(function (changes) {
+        stockInventoryFilters.replaceFilters(changes);
+        Stock.cacheFilters(filterKey);
+        vm.latestViewFilters = stockInventoryFilters.formatView();
+
+        load(stockInventoryFilters.formatHTTP(true));
+      });
   }
 
-  function startup (){
-    if ($state.params.filters) {
-      var changes = [{ key : $state.params.filters.key, value : $state.params.filters.value }]
-      stockMovementFilters.replaceFilters(changes);
+  function startup() {
+    if ($state.params.filters.length) {
+      stockInventoryFilters.replaceFiltersFromState($state.params.filters);
       Stock.cacheFilters(filterKey);
     }
 

--- a/client/src/modules/stock/lots/registry.js
+++ b/client/src/modules/stock/lots/registry.js
@@ -121,10 +121,8 @@ function StockLotsController(Stock, Notify,
 
   // initialize module
   function startup() {
-
-    if($state.params.filters) {
-      var changes = [{ key : $state.params.filters.key, value : $state.params.filters.value }]
-      stockLotFilters.replaceFilters(changes);
+    if ($state.params.filters.length) {
+      stockLotFilters.replaceFiltersFromState($state.params.filters);
       Stock.cacheFilters(filterKey);
     }
 

--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -255,8 +255,7 @@ function StockMovementsController(Stock, Notify,
         stockMovementFilters.replaceFilters(changes);
         Stock.cacheFilters(filterKey);
         vm.latestViewFilters = stockMovementFilters.formatView();
-        return load(stockMovementFilters.formatHTTP(true));
-
+        load(stockMovementFilters.formatHTTP(true));
       });
   }
 
@@ -267,9 +266,8 @@ function StockMovementsController(Stock, Notify,
 
   // initialize module
   function startup() {
-    if ($state.params.filters) {
-      var changes = [{ key : $state.params.filters.key, value : $state.params.filters.value }]
-      stockMovementFilters.replaceFilters(changes);
+    if ($state.params.filters.length) {
+      stockMovementFilters.replaceFiltersFromState($state.params.filters);
       Stock.cacheFilters(filterKey);
     }
 

--- a/client/src/modules/stock/stock.routes.js
+++ b/client/src/modules/stock/stock.routes.js
@@ -5,18 +5,27 @@ angular.module('bhima.routes')
         url         : '/stock/lots',
         controller  : 'StockLotsController as StockLotsCtrl',
         templateUrl : 'modules/stock/lots/registry.html',
+        params : {
+          filters : [],
+        },
       })
 
       .state('stockMovements', {
         url         : '/stock/movements',
         controller  : 'StockMovementsController as StockCtrl',
         templateUrl : 'modules/stock/movements/registry.html',
+        params : {
+          filters : [],
+        },
       })
 
       .state('stockInventories', {
         url         : '/stock/inventories',
         controller  : 'StockInventoriesController as StockCtrl',
         templateUrl : 'modules/stock/inventories/registry.html',
+        params : {
+          filters : [],
+        },
       })
 
       .state('stockExit', {

--- a/client/src/modules/vouchers/voucher-registry.ctrl.js
+++ b/client/src/modules/vouchers/voucher-registry.ctrl.js
@@ -195,12 +195,8 @@ function VoucherController(
 
   // initialize module
   function startup() {
-    var changes;
-
     if ($state.params.filters.length) {
-      changes = angular.copy($state.params.filters);
-
-      Vouchers.filters.replaceFilters(changes);
+      Vouchers.filters.replaceFiltersFromState($state.params.filters);
       Vouchers.cacheFilters();
     }
 


### PR DESCRIPTION
This commit implements the recommendations of #1935 on all registries. This allows all linked registries to send multiple filters through $state parameters as necessary.

Closes #1935.