### PR TITLE
deps: replace node-uuid with uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,11 +68,12 @@
     "morgan": "^1.6.1",
     "multer": "^1.1.0",
     "mysql": "^2.14.0",
-    "node-uuid": "^1.4.7",
     "q": "~1.5.0",
     "snyk": "^1.41.1",
     "stream-to-promise": "^2.2.0",
     "use-strict": "^1.0.1",
+    "uuid": "^3.1.0",
+    "uuid-parse": "^1.0.0",
     "winston": "^2.1.1",
     "wkhtmltopdf": "^0.3.3"
   },

--- a/server/controllers/admin/grades.js
+++ b/server/controllers/admin/grades.js
@@ -5,7 +5,7 @@
  * This controller exposes an API to the client for reading and writing Grade
  **/
 const db = require('../../lib/db');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const NotFound = require('../../lib/errors/NotFound');
 
 // GET /Grade
@@ -56,16 +56,17 @@ function detail(req, res, next) {
 // POST /grade
 function create(req, res, next) {
   const data = req.body;
+  const recordUuid = data.uuid || uuid();
 
   // Provide UUID if the client has not specified
-  data.uuid = db.bid(data.uuid || uuid.v4());
+  data.uuid = db.bid(recordUuid);
 
   const sql =
     'INSERT INTO grade SET ? ';
 
   db.exec(sql, [data])
     .then(() => {
-      res.status(201).json({ uuid : uuid.unparse(data.uuid) });
+      res.status(201).json({ uuid : recordUuid });
     })
     .catch(next)
     .done();
@@ -97,16 +98,16 @@ function del(req, res, next) {
     'DELETE FROM grade WHERE uuid = ?;';
 
   db.exec(sql, [db.bid(req.params.uuid)])
-  .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-    if (row.affectedRows === 0) {
-      throw new NotFound(`Could not find a Grade with uuid ${db.bid(req.params.uuid)}`);
-    }
+    .then((row) => {
+      // if nothing happened, let the client know via a 404 error
+      if (row.affectedRows === 0) {
+        throw new NotFound(`Could not find a Grade with uuid ${db.bid(req.params.uuid)}`);
+      }
 
-    res.status(204).json();
-  })
-  .catch(next)
-  .done();
+      res.status(204).json();
+    })
+    .catch(next)
+    .done();
 }
 
 

--- a/server/controllers/admin/locations.js
+++ b/server/controllers/admin/locations.js
@@ -16,7 +16,7 @@
 
 
 const db = require('../../lib/db');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const Topic = require('../../lib/topic');
 
 exports.lookupVillage = lookupVillage;
@@ -299,7 +299,7 @@ exports.create = {};
  */
 exports.create.country = function createCountry(req, res, next) {
   // create a UUID if not provided
-  req.body.uuid = req.body.uuid || uuid.v4();
+  req.body.uuid = req.body.uuid || uuid();
 
   const sql =
     `INSERT INTO country (uuid, name) VALUES (?, ?);`;
@@ -334,7 +334,7 @@ exports.create.province = function createProvince(req, res, next) {
   ]);
 
   // create a UUID if not provided
-  data.uuid = data.uuid || uuid.v4();
+  data.uuid = data.uuid || uuid();
 
   const sql =
     'INSERT INTO province (uuid, name, country_uuid) VALUES (?);';
@@ -368,7 +368,7 @@ exports.create.sector = function createSector(req, res, next) {
   const data = db.convert(req.body, ['province_uuid']);
 
   // create a UUID if not provided
-  data.uuid = data.uuid || uuid.v4();
+  data.uuid = data.uuid || uuid();
 
   const sql =
     `INSERT INTO sector (uuid, name, province_uuid) VALUES (?);`;
@@ -401,7 +401,7 @@ exports.create.village = function createVillage(req, res, next) {
   const data = db.convert(req.body, ['sector_uuid']);
 
   // create a UUID if not provided
-  data.uuid = data.uuid || uuid.v4();
+  data.uuid = data.uuid || uuid();
 
   const sql =
     `INSERT INTO village (uuid, name, sector_uuid) VALUES (?);`;

--- a/server/controllers/admin/services.js
+++ b/server/controllers/admin/services.js
@@ -7,7 +7,7 @@
  * @description
  * This controller is responsible for implementing all crud and others custom request
  * on the services table through the `/services` endpoint. *
- * @requires node-uuid
+ * @requires uuid/v4
  * @requires db
  * @requires NotFound
  * @requires BadRequest
@@ -15,7 +15,7 @@
  */
 
 
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const db = require('../../lib/db');
 const NotFound = require('../../lib/errors/NotFound');
 const Topic = require('../../lib/topic');
@@ -67,7 +67,7 @@ function create(req, res, next) {
   delete record.id;
 
   // service unique uuid as entity uuid
-  record.uuid = db.bid(uuid.v4());
+  record.uuid = db.bid(uuid());
 
   db.exec(sql, [record])
     .then((result) => {

--- a/server/controllers/admin/suppliers.js
+++ b/server/controllers/admin/suppliers.js
@@ -8,7 +8,7 @@
 
 
 const db = require('../../lib/db');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const Topic = require('../../lib/topic');
 
 function lookupSupplier(uid) {
@@ -84,10 +84,10 @@ function create(req, res, next) {
   const data = req.body;
 
   // provide uuid if the client has not specified
-  const recordUuid = data.uuid || uuid.v4();
+  const recordUuid = data.uuid || uuid();
   const transaction = db.transaction();
 
-  const creditorUuid = db.bid(uuid.v4());
+  const creditorUuid = db.bid(uuid());
   const creditorGroupUuid = db.bid(data.creditor_group_uuid);
 
   delete data.creditor_group_uuid;

--- a/server/controllers/finance/creditorGroups.js
+++ b/server/controllers/finance/creditorGroups.js
@@ -6,7 +6,7 @@
  */
 const db = require('../../lib/db');
 const BadRequest = require('../../lib/errors/BadRequest');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 // GET /creditor_groups
 function lookupCreditorGroup(Uuid) {
@@ -68,7 +68,8 @@ function create(req, res, next) {
   const data = req.body;
 
   // provide UUID if the client has not specified
-  data.uuid = db.bid(data.uuid || uuid.v4());
+  const creditorGroupUuid = data.uuid || uuid();
+  data.uuid = db.bid(creditorGroupUuid);
   data.enterprise_id = req.session.enterprise.id;
 
   const sql =
@@ -76,7 +77,7 @@ function create(req, res, next) {
 
   db.exec(sql, [data])
     .then(() => {
-      res.status(201).json({ uuid : uuid.unparse(data.uuid) });
+      res.status(201).json({ uuid : creditorGroupUuid });
     })
     .catch(next)
     .done();

--- a/server/controllers/finance/debtors/groups/index.js
+++ b/server/controllers/finance/debtors/groups/index.js
@@ -8,13 +8,13 @@
 * @module finance/debtors/groups
 *
 * @requires q
-* @requires node-uuid
+* @requires uuid/v4
 * @requires lib/db
 * @requires lib/util
 * @requires lib/errors/NotFound
 */
 
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const db = require('../../../../lib/db');
 const NotFound = require('../../../../lib/errors/NotFound');
 const BadRequest = require('../../../../lib/errors/BadRequest');
@@ -127,11 +127,12 @@ function create(req, res, next) {
   const data = db.convert(req.body, ['price_list_uuid', 'location_id']);
 
   // generate a uuid if one doesn't exist, and convert to binary
-  data.uuid = db.bid(data.uuid || uuid.v4());
+  const recordUuid = data.uuid || uuid();
+  data.uuid = db.bid(recordUuid);
 
   db.exec(sql, data)
     .then(() => {
-      res.status(201).json({ uuid : uuid.unparse(data.uuid) });
+      res.status(201).json({ uuid : recordUuid });
     })
     .catch(next)
     .done();

--- a/server/controllers/finance/debtors/index.js
+++ b/server/controllers/finance/debtors/index.js
@@ -15,7 +15,6 @@
 * @requires lib/errors/BadRequest
 */
 
-const uuid = require('node-uuid');
 const db = require('../../../lib/db');
 const NotFound = require('../../../lib/errors/NotFound');
 
@@ -36,7 +35,7 @@ function list(req, res, next) {
   const sql = `
     SELECT BUID(d.uuid) AS uuid, BUID(d.group_uuid) AS group_uuid,
       d.text, map.text as hr_entity
-    FROM debtor d 
+    FROM debtor d
     JOIN entity_map map ON map.uuid = d.uuid;
   `;
 
@@ -51,9 +50,7 @@ function list(req, res, next) {
  * Detail of debtors
  */
 function detail(req, res, next) {
-  const uid = db.bid(req.params.uuid);
-
-  lookupDebtor(uid)
+  lookupDebtor(req.params.uuid)
     .then((debtor) => {
       res.status(200).json(debtor);
     })
@@ -79,7 +76,7 @@ function update(req, res, next) {
   }
 
   db.exec(sql, [req.body, uid])
-    .then(() => lookupDebtor(uid))
+    .then(() => lookupDebtor(req.params.uuid))
     .then((debtor) => {
       res.status(200).json(debtor);
     })
@@ -103,7 +100,7 @@ function lookupDebtor(uid) {
   return db.exec(sql, [db.bid(uid)])
     .then((rows) => {
       if (!rows.length) {
-        throw new NotFound(`Could not find a debtor with uuid ${uuid.unparse(uid)}`);
+        throw new NotFound(`Could not find a debtor with uuid ${uid}`);
       }
       return rows[0];
     });
@@ -145,8 +142,7 @@ function invoices(req, res, next) {
 /**
  * This function sends back a list of invoices uuids
  * which belong to a particular debtor
- **/
-
+ */
 function getDebtorInvoices(debtorUuid) {
   const debtorUid = db.bid(debtorUuid);
   const reversalVoucherType = 10;

--- a/server/controllers/finance/fiscal.js
+++ b/server/controllers/finance/fiscal.js
@@ -11,7 +11,7 @@
 
 const q = require('q');
 const _ = require('lodash');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const db = require('../../lib/db');
 const Transaction = require('../../lib/db/transaction');
 const NotFound = require('../../lib/errors/NotFound');
@@ -528,7 +528,7 @@ function closing(req, res, next) {
       const transaction = db.transaction();
 
       voucher = {
-        uuid : db.bid(uuid.v4()),
+        uuid : db.bid(uuid()),
         date : fiscal.end_date,
         project_id : projectId,
         currency_id : currencyId,
@@ -538,7 +538,7 @@ function closing(req, res, next) {
         amount : 0, // not necessary
       };
 
-      const voucherDocumentUuid = db.bid(uuid.v4());
+      const voucherDocumentUuid = db.bid(uuid());
 
       // insert voucher
       transaction.addQuery('INSERT INTO voucher SET ?', voucher);
@@ -553,7 +553,7 @@ function closing(req, res, next) {
         const credit = value >= 0 ? 0 : Math.abs(value);
 
         const profitParams = [
-          db.bid(uuid.v4()),
+          db.bid(uuid()),
           item.id,
           debit,
           credit,
@@ -574,7 +574,7 @@ function closing(req, res, next) {
         const credit = value > 0 ? Math.abs(value) : 0;
 
         const chargeParams = [
-          db.bid(uuid.v4()),
+          db.bid(uuid()),
           item.id,
           debit,
           credit,
@@ -595,7 +595,7 @@ function closing(req, res, next) {
         const credit = value >= 0 ? Math.abs(value) : 0;
 
         const resultParams = [
-          db.bid(uuid.v4()),
+          db.bid(uuid()),
           accountId,
           debit,
           credit,

--- a/server/controllers/finance/invoice/patientInvoice.create.js
+++ b/server/controllers/finance/invoice/patientInvoice.create.js
@@ -12,7 +12,7 @@
  * into a prepared statement
  */
 const db = require('../../../lib/db');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const util = require('../../../lib/util');
 const _ = require('lodash');
 
@@ -47,7 +47,7 @@ module.exports = createInvoice;
  */
 function createInvoice(invoiceDetails) {
   const transaction = db.transaction();
-  const invoiceUuid = db.bid(invoiceDetails.uuid || uuid.v4());
+  const invoiceUuid = db.bid(invoiceDetails.uuid || uuid());
 
   const billingServices = processBillingServices(invoiceUuid, invoiceDetails.billingServices);
   const subsidies = processSubsidies(invoiceUuid, invoiceDetails.subsidies);
@@ -140,7 +140,7 @@ function processInvoiceItems(invoiceUuid, invoiceItems) {
 
   // make sure that invoice items have their uuids
   items.forEach((item) => {
-    item.uuid = db.bid(item.uuid || uuid.v4());
+    item.uuid = db.bid(item.uuid || uuid());
     item.invoice_uuid = invoiceUuid;
 
     // should every item have an inventory uuid?

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -8,7 +8,7 @@
  *
  * @requires q
  * @requires lodash
- * @requires node-uuid
+ * @requires uuid/v4
  * @requires lib/db
  * @requires lib/filter
  * @requires lib/errors/NotFound
@@ -17,7 +17,7 @@
 
 const q = require('q');
 const _ = require('lodash');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 // module dependencies
 const db = require('../../../lib/db');
@@ -288,7 +288,7 @@ function editTransaction(req, res, next) {
       // record the transaction history once the transaction has been updated.
       const row = _transactionToEdit[0];
       const transactionHistory = {
-        uuid : db.bid(uuid.v4()),
+        uuid : db.bid(uuid()),
         record_uuid : db.bid(row.record_uuid),
         user_id : req.session.user.id,
       };
@@ -478,7 +478,7 @@ function transformColumns(rows, newRecord, transactionToEdit, setFiscalData) {
  * POST /journal/:uuid/reverse
  */
 function reverse(req, res, next) {
-  const voucherUuid = uuid.v4();
+  const voucherUuid = uuid();
   const recordUuid = db.bid(req.params.uuid);
   const params = [
     recordUuid,

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -7,7 +7,7 @@
  * billing services infrastructure
  */
 
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const identifiers = require('../../config/identifiers');
 const db = require('../../lib/db');
 const barcode = require('../../lib/barcode');
@@ -182,10 +182,14 @@ function create(req, res, next) {
     return;
   }
 
+  // cache the uuid to avoid parsing later
+  const invoiceUuid = invoice.uuid || uuid();
+  invoice.uuid = invoiceUuid;
+
   const preparedTransaction = createInvoice(invoice);
   preparedTransaction.execute()
     .then(() => {
-      res.status(201).json({ uuid : uuid.unparse(invoice.uuid) });
+      res.status(201).json({ uuid : invoiceUuid });
     })
     .catch(next)
     .done();

--- a/server/controllers/finance/priceList.js
+++ b/server/controllers/finance/priceList.js
@@ -14,7 +14,7 @@
  */
 
 const db = require('../../lib/db');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 /**
  * Lists all price lists in the database
@@ -152,7 +152,7 @@ function formatPriceListItems(priceListUuid, items) {
     var inventoryId = item.inventory_uuid ? db.bid(item.inventory_uuid) : null;
 
     return [
-      db.bid(item.uuid || uuid.v4()),
+      db.bid(item.uuid || uuid()),
       inventoryId,
       priceListUuid,
       item.label,
@@ -180,7 +180,8 @@ exports.create = function create(req, res, next) {
     label, value, is_percentage) VALUES ?;`;
 
   // generate a UUID if not provided
-  data.uuid = db.bid(data.uuid || uuid.v4());
+  const priceListUuid = data.uuid || uuid();
+  data.uuid = db.bid(priceListUuid);
   // if the client didn't send price list items, do not create them.
   if (data.items) {
     items = formatPriceListItems(data.uuid, data.items);
@@ -200,7 +201,7 @@ exports.create = function create(req, res, next) {
   trans.execute()
     .then(() => {
       // respond to the client with a 201 CREATED
-      res.status(201).json({ uuid : uuid.unparse(data.uuid) });
+      res.status(201).json({ uuid : priceListUuid });
     })
     .catch(next)
     .done();

--- a/server/controllers/finance/purchases.js
+++ b/server/controllers/finance/purchases.js
@@ -5,13 +5,13 @@
  * This module provides an API interface for the Purchase API, responsible for
  * making purchase orders and quotes.
  *
- * @requires node-uuid
+ * @requires uuid/v4
  * @requires db
  * @requires NotFound
  * @requires BadRequest
  */
 
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 const db = require('../../lib/db');
 const BadRequest = require('../../lib/errors/BadRequest');
@@ -69,7 +69,7 @@ function linkPurchaseItems(items, purchaseUuid) {
   // loop through each item, making sure we have escapes and orderings correct
   return items.map((item) => {
     // make sure that each item has a uuid by generate
-    item.uuid = db.bid(item.uuid || uuid.v4());
+    item.uuid = db.bid(item.uuid || uuid());
     item.purchase_uuid = purchaseUuid;
     item.inventory_uuid = db.bid(item.inventory_uuid);
 
@@ -146,7 +146,7 @@ function create(req, res, next) {
   }
 
   // default to a new uuid if the client did not provide one
-  const puid = data.uuid || uuid.v4();
+  const puid = data.uuid || uuid();
   data.uuid = db.bid(puid);
 
   data = db.convert(data, ['supplier_uuid']);

--- a/server/controllers/finance/vouchers.js
+++ b/server/controllers/finance/vouchers.js
@@ -7,7 +7,7 @@
  * against the `voucher` table.
  *
  * @requires lodash
- * @requires node-uuid
+ * @requires uuid/v4
  * @requires lib/util
  * @requires lib/db
  * @requires lib/ReportManager
@@ -16,7 +16,7 @@
  */
 
 const _ = require('lodash');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 const util = require('../../lib/util');
 const db = require('../../lib/db');
@@ -208,14 +208,14 @@ function create(req, res, next) {
   voucher.project_id = req.session.project.id;
 
   // make sure the voucher has an id
-  const vuid = voucher.uuid || uuid.v4();
+  const vuid = voucher.uuid || uuid();
   voucher.uuid = db.bid(vuid);
 
   // preprocess the items so they have uuids as required
   items.forEach((value) => {
     let item = value;
     // if the item doesn't have a uuid, create one for it.
-    item.uuid = item.uuid || uuid.v4();
+    item.uuid = item.uuid || uuid();
 
     // make sure the items reference the voucher correctly
     item.voucher_uuid = item.voucher_uuid || voucher.uuid;

--- a/server/controllers/inventory/depots/distributions.js
+++ b/server/controllers/inventory/depots/distributions.js
@@ -16,7 +16,7 @@
 */
 
 const db = require('../../../lib/db');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const q = require('q');
 
 // @fixme remove this file

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -5,7 +5,7 @@
 * handling.
 */
 
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const db = require('../../../lib/db');
 const FilterParser = require('../../../lib/filter');
 
@@ -53,7 +53,8 @@ exports.errorHandler = errorHandler;
 */
 function createItemsMetadata(record, session) {
   record.enterprise_id = session.enterprise.id;
-  record.uuid = db.bid(record.uuid || uuid.v4());
+  const recordUuid = record.uuid || uuid();
+  record.uuid = db.bid(recordUuid);
   record.group_uuid = db.bid(record.group_uuid);
 
   const sql = 'INSERT INTO inventory SET ?;';
@@ -62,7 +63,7 @@ function createItemsMetadata(record, session) {
    * in the main controller (inventory.js)
    */
   return db.exec(sql, [record])
-  .then(() => uuid.unparse(record.uuid));
+    .then(() => recordUuid);
 }
 
 /**

--- a/server/controllers/inventory/inventory/groups.js
+++ b/server/controllers/inventory/inventory/groups.js
@@ -4,7 +4,7 @@
  */
 
 // requirements
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const db = require('../../../lib/db');
 
 // expose module's methods
@@ -28,7 +28,8 @@ function details(identifier) {
 
 /** create new inventory group */
 function create(record) {
-  record.uuid = db.bid(record.uuid || uuid.v4());
+  const recordUuid = record.uuid || uuid();
+  record.uuid = db.bid(recordUuid);
 
   const sql = 'INSERT INTO inventory_group SET ?;';
   /*
@@ -36,7 +37,7 @@ function create(record) {
    * in the main controller (inventory.js)
    */
   return db.exec(sql, [record])
-    .then(() => uuid.unparse(record.uuid));
+    .then(() => recordUuid);
 }
 
 /** update an existing inventory group */

--- a/server/controllers/medical/patientGroups.js
+++ b/server/controllers/medical/patientGroups.js
@@ -8,14 +8,14 @@
  * The /patient_groups HTTP API endpoint
  *
  * @requires db
- * @requires node-uuid
+ * @requires uuid/v4
  * @requires NotFound
  * @requires Topic
  */
 
 
 const db = require('../../lib/db');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const NotFound = require('../../lib/errors/NotFound');
 const Topic = require('../../lib/topic');
 
@@ -61,7 +61,7 @@ function create(req, res, next) {
   const sql = 'INSERT INTO patient_group SET ?';
 
   // provide UUID if the client has not specified
-  const uid = record.uuid || uuid.v4();
+  const uid = record.uuid || uuid();
   record.uuid = db.bid(uid);
 
   db.exec(sql, [record])

--- a/server/controllers/medical/patients/documents.js
+++ b/server/controllers/medical/patients/documents.js
@@ -11,13 +11,13 @@
  * in the application.
  *
  * @requires db
- * @requires node-uuid
+ * @requires uuid/v4
  * @requires BadRequest
  * @requires NotFound
  */
 
 
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 const db = require('../../../lib/db');
 const Topic = require('../../../lib/topic');
@@ -68,21 +68,21 @@ function create(req, res, next) {
   });
 
   db.exec(sql, [records])
-  .then(() => {
-    // publish a patient update event
-    Topic.publish(Topic.channels.MEDICAL, {
-      event : Topic.events.UPDATE,
-      entity : Topic.entities.PATIENT,
-      user_id : req.session.user.id,
-      id : req.params.uuid,
-    });
+    .then(() => {
+      // publish a patient update event
+      Topic.publish(Topic.channels.MEDICAL, {
+        event : Topic.events.UPDATE,
+        entity : Topic.entities.PATIENT,
+        user_id : req.session.user.id,
+        id : req.params.uuid,
+      });
 
-    res.status(201).json({
-      uuids : records.map(row => uuid.unparse(row[0])),
-    });
-  })
-  .catch(next)
-  .done();
+      res.status(201).json({
+        uuids : req.files.map(file => file.filename),
+      });
+    })
+    .catch(next)
+    .done();
 }
 
 

--- a/server/controllers/medical/patients/groups.js
+++ b/server/controllers/medical/patients/groups.js
@@ -8,7 +8,7 @@
  *
  * @requires lodash
  * @requires lib/db
- * @requires lib/node-uuid
+ * @requires lib/uuid/v4
  * @requires lib/errors/BadRequest
  * @requires lib/errors/NotFound
  * @requires Topic
@@ -16,7 +16,7 @@
 
 const _ = require('lodash');
 const db = require('../../../lib/db');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const BadRequest = require('../../../lib/errors/BadRequest');
 const NotFound = require('../../../lib/errors/NotFound');
 const Topic = require('../../../lib/topic');
@@ -97,7 +97,7 @@ function update(req, res, next) {
   // inserted into the database
   const assignmentData = req.body.assignments.map(patientGroupId => {
     return [
-      db.bid(uuid.v4()),
+      db.bid(uuid()),
       patientId,
       db.bid(patientGroupId),
     ];

--- a/server/controllers/medical/patients/visits.js
+++ b/server/controllers/medical/patients/visits.js
@@ -9,12 +9,12 @@
  * It is responsible for reading and writing to the `patient_visit` database table as well as responding to HTTP
  * requests.
  *
- * @requires  node-uuid
+ * @requires  uuid/v4
  * @requires  lib/db
  * @requires  lib/errors/BadRequest
  */
 
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const db = require('../../../lib/db');
 const BadRequest = require('../../../lib/errors/BadRequest');
 const NotFound = require('../../../lib/errors/NotFound');
@@ -185,7 +185,7 @@ function listByPatient(req, res, next) {
 function admission(req, res, next) {
   const data = req.body;
 
-  const visitUuid = uuid.v4();
+  const visitUuid = uuid();
   data.uuid = db.bid(visitUuid);
   data.patient_uuid = req.params.uuid;
 

--- a/server/controllers/payroll/employees/index.js
+++ b/server/controllers/payroll/employees/index.js
@@ -17,7 +17,7 @@
  */
 
 
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 const db = require('./../../../lib/db');
 const topic = require('../../../lib/topic');
@@ -261,9 +261,9 @@ function update(req, res, next) {
 function create(req, res, next) {
   // cast as data object and add unique ids
   const data = req.body;
-  const patientID = uuid.v4();
-  data.creditor_uuid = uuid.v4();
-  data.debtor_uuid = uuid.v4();
+  const patientID = uuid();
+  data.creditor_uuid = uuid();
+  data.debtor_uuid = uuid();
   data.patient_uuid = patientID;
 
   // convert uuids to binary uuids as necessary

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -7,12 +7,12 @@
  *
  * This module is responsible for handling all crud operations relatives to stocks
  * and define all stock API functions
- * @requires lib/node-uuid
+ * @requires lib/uuid/v4
  * @requires lib/db
  * @requires stock/core
  */
 
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const db = require('../../lib/db');
 const core = require('./core');
 
@@ -43,7 +43,7 @@ function createStock(req, res, next) {
   const params = req.body;
   const transaction = db.transaction();
   const document = {
-    uuid: uuid.v4(),
+    uuid: uuid(),
     date: new Date(params.date),
     user: req.session.user.id,
     depot_uuid: params.depot_uuid,
@@ -66,7 +66,7 @@ function createStock(req, res, next) {
 
     // the lot object to insert
     createLotObject = {
-      uuid: db.bid(uuid.v4()),
+      uuid: db.bid(uuid()),
       label: lot.label,
       initial_quantity: lot.quantity,
       quantity: lot.quantity,
@@ -82,7 +82,7 @@ function createStock(req, res, next) {
 
     // the movement object to insert
     createMovementObject = {
-      uuid: db.bid(uuid.v4()),
+      uuid: db.bid(uuid()),
       lot_uuid: createLotObject.uuid,
       depot_uuid: db.bid(document.depot_uuid),
       document_uuid: db.bid(document.uuid),
@@ -126,8 +126,8 @@ function createStock(req, res, next) {
 function createIntegration(req, res, next) {
   const transaction = db.transaction();
   const params = req.body;
-  const identifier = uuid.v4();
-  const documentUuid = uuid.v4();
+  const identifier = uuid();
+  const documentUuid = uuid();
 
   const integration = {
     uuid: db.bid(identifier),
@@ -140,7 +140,7 @@ function createIntegration(req, res, next) {
   transaction.addQuery(sql, [integration]);
 
   params.lots.forEach((lot) => {
-    let lotUuid = uuid.v4();
+    let lotUuid = uuid();
 
     // adding a lot insertion query into the transaction
     transaction.addQuery(`INSERT INTO lot SET ?`, {
@@ -157,7 +157,7 @@ function createIntegration(req, res, next) {
 
     // adding a movement insertion query into the transaction
     transaction.addQuery(`INSERT INTO stock_movement SET ?`, {
-      uuid: db.bid(uuid.v4()),
+      uuid: db.bid(uuid()),
       lot_uuid: db.bid(lotUuid),
       depot_uuid: db.bid(params.movement.depot_uuid),
       document_uuid: db.bid(documentUuid),
@@ -195,7 +195,7 @@ function createMovement(req, res, next) {
   const params = req.body;
 
   const document = {
-    uuid: params.document_uuid || uuid.v4(),
+    uuid: params.document_uuid || uuid(),
     date: new Date(params.date),
     user: req.session.user.id,
   };
@@ -237,7 +237,7 @@ function normalMovement(document, params, metadata) {
   parameters.lots.forEach((lot) => {
     createMovementQuery = 'INSERT INTO stock_movement SET ?';
     createMovementObject = {
-      uuid: db.bid(uuid.v4()),
+      uuid: db.bid(uuid()),
       lot_uuid: db.bid(lot.uuid),
       depot_uuid: db.bid(parameters.depot_uuid),
       document_uuid: db.bid(document.uuid),
@@ -298,7 +298,7 @@ function depotMovement(document, params) {
       entity_uuid: entityUuid,
       is_exit: isExit,
       flux_id: fluxId,
-      uuid: db.bid(uuid.v4()),
+      uuid: db.bid(uuid()),
       lot_uuid: db.bid(lot.uuid),
       document_uuid: db.bid(document.uuid),
       quantity: lot.quantity,

--- a/server/lib/ReportManager.js
+++ b/server/lib/ReportManager.js
@@ -14,7 +14,7 @@
  * @requires path
  * @requires fs
  * @requires q
- * @requires node-uuid
+ * @requires uuid/v4
  * @requires lib/helpers/translate
  * @requires lib/errors/BadRequest
  * @requires lib/errors/InternalServerError
@@ -25,7 +25,7 @@ const _ = require('lodash');
 const path = require('path');
 const fs = require('fs');
 const q = require('q');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 const translateHelper = require('./helpers/translate');
 
 const BadRequest = require('./errors/BadRequest');
@@ -184,7 +184,7 @@ class ReportManager {
     }
 
     // generate a unique id for the report name
-    const reportId = uuid.v4();
+    const reportId = uuid();
     const options = this.options;
 
     // make the report name using the

--- a/server/lib/db/index.js
+++ b/server/lib/db/index.js
@@ -2,7 +2,7 @@
 const q = require('q');
 const mysql = require('mysql');
 const winston = require('winston');
-const uuid = require('node-uuid');
+const uuidParse = require('uuid-parse');
 const Transaction = require('./transaction');
 
 const BadRequest = require('../errors/BadRequest');
@@ -20,12 +20,9 @@ const NotFound = require('../errors/NotFound');
  * @requires q
  * @requires mysql
  * @requires winston
- * @requires node-uuid
  * @requires Transaction
  */
 class DatabaseConnector {
-
-  /** @constructor */
   constructor() {
     const params = {
       host     : process.env.DB_HOST,
@@ -161,7 +158,7 @@ class DatabaseConnector {
       return hexUuid;
     }
 
-    return new Buffer(uuid.parse(hexUuid));
+    return new Buffer(uuidParse.parse(hexUuid));
   }
 
   /**
@@ -202,7 +199,7 @@ class DatabaseConnector {
       }
 
       // the key exists on the object and value is an array
-      if(data[key] && Array.isArray(data[key])) { 
+      if (data[key] && Array.isArray(data[key])) {
         // Every item should be converted to binary
         data[key] = data[key].map(this.bid);
       }
@@ -220,8 +217,6 @@ class DatabaseConnector {
   escape(key) {
     return mysql.escape(key);
   }
-
-
 }
 
 module.exports = new DatabaseConnector();

--- a/server/lib/uploader.js
+++ b/server/lib/uploader.js
@@ -19,7 +19,7 @@
  * @requires mkdirp
  * @requires multer
  * @requires winston
- * @requires node-uuid
+ * @requires uuid/v4
  *
  * @todo
  *  1) Ensure that a max-size is properly handled with error codes
@@ -30,7 +30,7 @@ const path = require('path');
 const mkdirp = require('mkdirp');
 const multer = require('multer');
 const winston = require('winston');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 // configure the uploads directory based on global process variables
 const defaultDir = 'uploads';                     // note: this must be a relative path
@@ -74,7 +74,7 @@ function Uploader(prefix, fields) {
       mkdirp(folder, err => cb(err, folder));
     },
     filename : (req, file, cb) => {
-      const id = uuid.v4();
+      const id = uuid();
 
       // ensure that a link is passed to the req.file object
       file.link = `${directory}${id}`;

--- a/test/integration/creditorGroups.js
+++ b/test/integration/creditorGroups.js
@@ -1,7 +1,7 @@
 /* global expect, chai, agent */
 
 const helpers = require('./helpers');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 /*
  * The /creditors/groups API endpoint
@@ -13,7 +13,7 @@ describe('(/creditors/groups) Creditor Groups', function () {
   // creditor group we will add during this test suite.
   var creditorGroup = {
     enterprise_id : 1,
-    uuid          : uuid.v4(),
+    uuid          : uuid(),
     name          : 'Creditor Test',
     account_id    : 3645,
     locked        : 0

--- a/test/integration/debtorGroups.js
+++ b/test/integration/debtorGroups.js
@@ -2,14 +2,14 @@
 'use strict';
 
 const helpers = require('./helpers');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 describe('(/debtor_groups) The debtor groups API', function () {
   const numDebtorGroups = 7;
 
   const debtorGroup = {
     enterprise_id : 1,
-    uuid : uuid.v4(),
+    uuid : uuid(),
     name : 'New Debtor Group (Test)',
     account_id : 3638,
     location_id : '1f162a10-9f67-4788-9eff-c1fea42fcc9b',
@@ -45,7 +45,7 @@ describe('(/debtor_groups) The debtor groups API', function () {
 
   const lockedGroup = {
     enterprise_id : 1,
-    uuid : uuid.v4(),
+    uuid : uuid(),
     name : 'Locked Debtor Group (Test)',
     account_id : 3638,
     location_id : '1f162a10-9f67-4788-9eff-c1fea42fcc9b',
@@ -63,7 +63,7 @@ describe('(/debtor_groups) The debtor groups API', function () {
 
   const conventionGroup = {
     enterprise_id : 1,
-    uuid : uuid.v4(),
+    uuid : uuid(),
     name : 'Convention Debtor Group (Test)',
     account_id : 3638,
     location_id : '1f162a10-9f67-4788-9eff-c1fea42fcc9b',
@@ -81,7 +81,7 @@ describe('(/debtor_groups) The debtor groups API', function () {
 
   const lockedConventionGroup = {
     enterprise_id : 1,
-    uuid : uuid.v4(),
+    uuid : uuid(),
     name : 'Locked Convention Debtor Group (Test)',
     account_id : 3638,
     location_id : '1f162a10-9f67-4788-9eff-c1fea42fcc9b',

--- a/test/integration/depots.js
+++ b/test/integration/depots.js
@@ -1,13 +1,13 @@
 /* global expect, chai, agent */
 
 const helpers = require('./helpers');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 // The /depots API endpoint
 describe('(/depots) The depots API ', () => {
   // new depot object
   var newDepot = {
-    uuid : uuid.v4(),
+    uuid : uuid(),
     // the reference column is auto increment by a trigger
     text : 'New Depot',
     enterprise_id : 1,
@@ -30,7 +30,7 @@ describe('(/depots) The depots API ', () => {
 
   // update depot
   var editDepot = {
-    uuid : uuid.v4(),
+    uuid : uuid(),
     text : 'Edited Depot',
     is_warehouse : 1,
     allow_entry_purchase : 1,
@@ -45,7 +45,7 @@ describe('(/depots) The depots API ', () => {
 
   // removable depot
   var removableDepot = {
-    uuid : uuid.v4(),
+    uuid : uuid(),
     text : 'Removable Depot',
     enterprise_id : 1,
     is_warehouse : 1,

--- a/test/integration/grades.js
+++ b/test/integration/grades.js
@@ -1,7 +1,7 @@
 /* global expect, chai, agent */
 
 const helpers = require('./helpers');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 /*
  * The /grades API endpoint
@@ -12,7 +12,7 @@ describe('(/grades) API endpoint', function () {
 
   // grade we will add during this test suite.
   var grade = {
-    uuid : uuid.v4(),
+    uuid : uuid(),
     code : 'G2',
     text : 'Grade 2',
     basic_salary : 150

--- a/test/integration/inventory.js
+++ b/test/integration/inventory.js
@@ -2,13 +2,13 @@
 'use strict';
 
 const helpers = require('./helpers');
-const uuid    = require('node-uuid');
+const uuid    = require('uuid/v4');
 
 describe('(/inventory) The Inventory HTTP API', () => {
   let inventoryList;
 
   let inventoryGroup = {
-    uuid : uuid.v4(),
+    uuid : uuid(),
     code : '10',
     name : 'Test Inventory Group 2',
     stock_account : 3635,
@@ -228,7 +228,7 @@ describe('(/inventory) The Inventory HTTP API', () => {
 
   // inventory list items
   let metadata = {
-    uuid : uuid.v4(),
+    uuid : uuid(),
     code : '1000012', // code must be unique
     text : '[IT] Inventory Article',
     price : 5,

--- a/test/integration/locations.js
+++ b/test/integration/locations.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const helpers = require('./helpers');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 const _ = require('lodash');
 
@@ -144,24 +144,24 @@ describe('(/locations) Locations Interface', function () {
   /* CREATE methods */
 
   const country = {
-    uuid : uuid.v4(),
+    uuid : uuid(),
     name : 'Test Country'
   };
 
   const province = {
-    uuid : uuid.v4(),
+    uuid : uuid(),
     name : 'Test Province',
     country_uuid : country.uuid
   };
 
   const sector = {
-    uuid : uuid.v4(),
+    uuid : uuid(),
     name : 'Test Sector',
     province_uuid : province.uuid
   };
 
   const village = {
-    uuid: uuid.v4(),
+    uuid: uuid(),
     name: 'Test Village',
     sector_uuid: sector.uuid
   };
@@ -214,7 +214,7 @@ describe('(/locations) Locations Interface', function () {
   it('POST /locations/villages should create the same village name in a different sector', function () {
     let copy = _.clone(village);
     copy.sector_uuid = sectorUuid;
-    copy.uuid = uuid.v4();
+    copy.uuid = uuid();
 
     return agent.post('/locations/villages')
       .send(copy)

--- a/test/integration/priceList.js
+++ b/test/integration/priceList.js
@@ -1,7 +1,7 @@
 /* global expect, chai, agent */
 
 const helpers = require('./helpers');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 /*
  * The /prices API endpoint
@@ -84,7 +84,7 @@ describe('(/prices ) Price List', function () {
   };
 
   const duplicatesPriceList = {
-    uuid : uuid.v4(),
+    uuid : uuid(),
     label : 'This list contains duplicate labels',
     description : 'The list has a tone of items.',
     items : priceListItemsWithDuplicates,

--- a/test/integration/suppliers.js
+++ b/test/integration/suppliers.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const helpers = require('./helpers');
-const uuid    = require('node-uuid');
+const uuid    = require('uuid/v4');
 
 /*
  * The /supplier API endpoint
@@ -14,7 +14,7 @@ describe('(/suppliers) The supplier API endpoint', function () {
 
   // supplier we will add during this test suite.
   let supplier = {
-    uuid : uuid.v4(),
+    uuid : uuid(),
     creditor_group_uuid : '8bedb6df-6b08-4dcf-97f7-0cfbb07cf9e2',
     display_name : 'SUPPLIER TEST A',
     address_1 : null,

--- a/test/integration/vouchers.js
+++ b/test/integration/vouchers.js
@@ -1,7 +1,7 @@
 /* global expect, agent */
 
 const helpers = require('./helpers');
-const uuid = require('node-uuid');
+const uuid = require('uuid/v4');
 
 /*
  * The /vouchers API endpoint
@@ -26,11 +26,11 @@ describe('(/vouchers) The vouchers HTTP endpoint', () => {
     description : 'Voucher Transaction',
     user_id     : 1,
     items       : [{
-      uuid          : uuid.v4(),
+      uuid          : uuid(),
       account_id    : 3631,
       debit         : 10,
       credit        : 0,
-      document_uuid : uuid.v4(),
+      document_uuid : uuid(),
       voucher_uuid  : vUuid,
     }, {
       account_id   : 3628,
@@ -42,8 +42,8 @@ describe('(/vouchers) The vouchers HTTP endpoint', () => {
 
   // NOTE: this voucher does not have any uuids
   const items = [
-    { account_id : 3631, debit : 11, credit : 0, document_uuid : uuid.v4(), entity_uuid : uuid.v4() },
-    { account_id : 3637, debit : 0, credit : 11, document_uuid : uuid.v4(), entity_uuid : uuid.v4() },
+    { account_id : 3631, debit : 11, credit : 0, document_uuid : uuid(), entity_uuid : uuid() },
+    { account_id : 3637, debit : 0, credit : 11, document_uuid : uuid(), entity_uuid : uuid() },
     { account_id : 3631, debit : 0, credit : 12 },
     { account_id : 3628, debit : 12, credit : 0 },
   ];
@@ -61,13 +61,13 @@ describe('(/vouchers) The vouchers HTTP endpoint', () => {
   // only one item - bad transaction
   const badVoucher = {
     date,
-    uuid        : uuid.v4(),
+    uuid        : uuid(),
     project_id  : 1,
     currency_id : helpers.data.USD,
     amount      : 10,
     description : 'Voucher Transaction',
     items       : [{
-      uuid       : uuid.v4(),
+      uuid       : uuid(),
       account_id : 3631,
       debit      : 10,
       credit     : 0,
@@ -76,7 +76,7 @@ describe('(/vouchers) The vouchers HTTP endpoint', () => {
 
   // this voucher will not have an exchange rate
   const predatedVoucher = {
-    uuid        : uuid.v4(),
+    uuid        : uuid(),
     date        : new Date('2000-01-01'),
     project_id  : 1,
     currency_id : helpers.data.FC,
@@ -84,12 +84,12 @@ describe('(/vouchers) The vouchers HTTP endpoint', () => {
     description : 'Voucher Transaction',
     user_id     : 1,
     items       : [{
-      uuid       : uuid.v4(),
+      uuid       : uuid(),
       account_id : 3627,
       debit      : 10,
       credit     : 0,
     }, {
-      uuid       : uuid.v4(),
+      uuid       : uuid(),
       account_id : 3637,
       debit      : 0,
       credit     : 10,
@@ -118,7 +118,7 @@ describe('(/vouchers) The vouchers HTTP endpoint', () => {
   });
 
   it('POST /vouchers doesn\'t register when missing data', () => {
-    const uid = uuid.v4();
+    const uid = uuid();
     mockVoucher = {
       date,
       uuid          : uid,
@@ -126,7 +126,7 @@ describe('(/vouchers) The vouchers HTTP endpoint', () => {
       currency_id   : 1,
       amount        : 10,
       description   : 'Bad Voucher Transaction',
-      document_uuid : uuid.v4(), // technically, this should reference something..
+      document_uuid : uuid(), // technically, this should reference something..
       user_id       : 1,
       items         : [{
         account_id   : 3631,
@@ -147,7 +147,7 @@ describe('(/vouchers) The vouchers HTTP endpoint', () => {
   it('POST /vouchers will reject a voucher will less than two records', () => {
     // attempt 1 - missing items completely + bad voucher
     return agent.post('/vouchers')
-      .send({ voucher: { uuid: uuid.v4() } })
+      .send({ voucher: { uuid: uuid() } })
       .then((res) => {
         helpers.api.errored(res, 400);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4180,10 +4180,6 @@ node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
 
-node-uuid@^1.4.7:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
-
 node-zip@1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/node-zip/-/node-zip-1.1.1.tgz#94d1ad674a3cd46a1588dd736f4a9a78c757eb62"
@@ -6312,6 +6308,10 @@ util@^0.10.3:
 utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
+
+uuid-parse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/uuid-parse/-/uuid-parse-1.0.0.tgz#f4657717624b0e4b88af36f98d89589a5bbee569"
 
 uuid@^2.0.1:
   version "2.0.3"


### PR DESCRIPTION
This commit replaces the deprecated node-uuid with the uuid npm module. The uuid library is supported through the community, and has much smaller implementation.  It removes support for `parse()` and
`unparse()` methods, which are now implemented in the `uuid-parse` library.  Since we use these methods upon occasion ( e.g. `db.bid()`), I have added that as a dependency as well.

Closes #1395.