### PR TITLE
fix(vouchers): sort receipt items

### DIFF
--- a/server/controllers/finance/vouchers.js
+++ b/server/controllers/finance/vouchers.js
@@ -95,7 +95,8 @@ function lookupVoucher(vUuid) {
     JOIN account a ON a.id = vi.account_id
     LEFT JOIN entity_map ON entity_map.uuid = vi.entity_uuid
     LEFT JOIN document_map ON document_map.uuid = vi.document_uuid
-    WHERE vi.voucher_uuid = ?;
+    WHERE vi.voucher_uuid = ?
+    ORDER BY vi.account_id DESC, vi.debit DESC, vi.credit ASC, entity_reference;
   `;
 
   return db.one(sql, [db.bid(vUuid)])


### PR DESCRIPTION
This commit fixes the voucher receipt by sorting the lines first by account, then by amounts, and finally by the entity affected.  This should ensure a fairly stable appearance to all receipts, no matter how the accountant ordered the transaction initially or in what order the database decided to enter them.

Closes #2221.

**Unordered Voucher Items (prior to this change)**
![unorderedvouchers](https://user-images.githubusercontent.com/896472/32049987-263725a6-ba47-11e7-94fa-65e9a40132cd.png)

**Ordered Voucher Items (after this change)**
![orderedvouchers](https://user-images.githubusercontent.com/896472/32050008-335b08b0-ba47-11e7-94ee-3800bc14e55d.png)
