### PR TITLE
fix(bhPeriodSelect): remove custom submit btn

### DIFF
--- a/client/src/modules/templates/bhPeriodSelect.tmpl.html
+++ b/client/src/modules/templates/bhPeriodSelect.tmpl.html
@@ -110,15 +110,6 @@
       <div class="help-block" ng-messages="DateIntervalForm.dateTo.$error" ng-show="$ctrl.validationTrigger && DateIntervalForm.dateTo.$invalid">
         <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
       </div>
-
-      </div>
-
-
-    </div>
-
-    <div class="row" style="margin-top : 5px">
-      <div class="col-md-12">
-        <button type="button" class="btn btn-default" ng-click="$ctrl.selectCustomPeriod($ctrl.customSelection)"><span translate>PERIODS.SUBMIT_CUSTOM_PERIOD</span></button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This commit remove the custom submit button required to register a custom period.  With the button removed, it is no longer required or possible to click the button to put in a custom period.  This applies
across all registries.

Closes #1946.