### PR TITLE
Feature:  bhReceiptComponent for displaying receipts

### DIFF
--- a/client/src/js/components/bhReceipt.js
+++ b/client/src/js/components/bhReceipt.js
@@ -21,7 +21,7 @@ function bhReceiptController(ReceiptModal, $log) {
     // make sure the receipt type exists before it is clicked
     var hasCallbackFn = ReceiptModal[$ctrl.type];
     if (!hasCallbackFn) {
-      $log.warn('Warning: Cannot find '
+      $log.error('Warning: Cannot find '
         .concat($ctrl.type)
         .concat(' in ReceiptModalService.'));
     }

--- a/client/src/js/components/bhReceipt.js
+++ b/client/src/js/components/bhReceipt.js
@@ -1,0 +1,34 @@
+var bhReceiptTemplate =
+  '<a ng-click="$ctrl.open()" href="">{{ $ctrl.displayValue }}</a>';
+
+angular.module('bhima.components')
+  .component('bhReceipt', {
+    template : bhReceiptTemplate,
+    controller  : bhReceiptController,
+    bindings    : {
+      value : '<',
+      displayValue : '<',
+      type : '@',
+    },
+  });
+
+bhReceiptController.$inject = ['ReceiptModal', '$log'];
+
+function bhReceiptController(ReceiptModal, $log) {
+  var $ctrl = this;
+
+  $ctrl.$onInit = function $onInit() {
+    // make sure the receipt type exists before it is clicked
+    var hasCallbackFn = ReceiptModal[$ctrl.type];
+    if (!hasCallbackFn) {
+      $log.warn('Warning: Cannot find '
+        .concat($ctrl.type)
+        .concat(' in ReceiptModalService.'));
+    }
+  };
+
+  $ctrl.open = function open() {
+    ReceiptModal[$ctrl.type]($ctrl.value);
+  };
+}
+

--- a/client/src/modules/cash/payments/registry.js
+++ b/client/src/modules/cash/payments/registry.js
@@ -4,7 +4,7 @@ angular.module('bhima.controllers')
 // dependencies injection
 CashPaymentRegistryController.$inject = [
   'CashService', 'bhConstants', 'NotifyService', 'SessionService', 'uiGridConstants',
-  'ReceiptModal', 'ModalService', 'GridSortingService', '$state', 'FilterService',
+  'ModalService', 'GridSortingService', '$state', 'FilterService',
   'GridColumnService', 'GridStateService', 'ModalService',
 ];
 
@@ -15,8 +15,8 @@ CashPaymentRegistryController.$inject = [
  * print and search utilities for the registry.`j
  */
 function CashPaymentRegistryController(
-  Cash, bhConstants, Notify, Session, uiGridConstants, Receipt, Modal, Sorting,
-  $state, Filters, Columns, GridState, Modals
+  Cash, bhConstants, Notify, Session, uiGridConstants, Modal, Sorting, $state,
+  Filters, Columns, GridState, Modals
 ) {
   var vm = this;
 
@@ -34,9 +34,6 @@ function CashPaymentRegistryController(
   // global variables
   vm.enterprise = Session.enterprise;
   vm.bhConstants = bhConstants;
-
-  // bind the cash payments receipt
-  vm.openReceiptModal = Receipt.cash;
 
   // expose to the view
   vm.search = search;
@@ -79,7 +76,7 @@ function CashPaymentRegistryController(
     // @TODO(jniles): This is temporary, as it doesn't take into account USD payments
     aggregationType : uiGridConstants.aggregationTypes.sum,
     aggregationHideLabel : true,
-    footerCellClass: 'text-right',
+    footerCellClass : 'text-right',
   }, {
     field : 'cashbox_label',
     displayName : 'TABLE.COLUMNS.CASHBOX',

--- a/client/src/modules/cash/payments/templates/reference.html
+++ b/client/src/modules/cash/payments/templates/reference.html
@@ -1,5 +1,3 @@
-<div class="ui-grid-cell-contents text-action">
-  <a ng-click="grid.appScope.openReceiptModal(row.entity.uuid)" href>
-    {{ row.entity.reference }}
-  </a>
+<div class="ui-grid-cell-contents">
+  <bh-receipt value="row.entity.uuid" display-value="row.entity.reference" type="cash">
 </div>

--- a/client/src/modules/invoices/registry/registry.js
+++ b/client/src/modules/invoices/registry/registry.js
@@ -5,7 +5,7 @@ InvoiceRegistryController.$inject = [
   'PatientInvoiceService', 'bhConstants', 'NotifyService', 'SessionService',
   'ReceiptModal', 'uiGridConstants', 'ModalService', 'CashService',
   'GridSortingService', 'GridColumnService', 'GridStateService', '$state',
-  'ModalService'
+  'ModalService', 'ReceiptModal',
 ];
 
 /**
@@ -15,7 +15,7 @@ InvoiceRegistryController.$inject = [
  */
 function InvoiceRegistryController(
   Invoices, bhConstants, Notify, Session, Receipt, uiGridConstants,
-  ModalService, Cash, Sorting, Columns, GridState, $state, Modals
+  ModalService, Cash, Sorting, Columns, GridState, $state, Modals, Receipts
 ) {
   var vm = this;
 
@@ -29,13 +29,13 @@ function InvoiceRegistryController(
   var state;
 
   vm.search = search;
-  vm.openReceiptModal = Receipt.invoice;
   vm.creditNoteReceipt = Receipt.creditNote;
   vm.onRemoveFilter = onRemoveFilter;
   vm.creditNote = creditNote;
   vm.bhConstants = bhConstants;
   vm.download = Invoices.download;
   vm.deleteInvoice = deleteInvoiceWithConfirmation;
+  vm.Receipts = Receipts;
 
   // track if module is making a HTTP request for invoices
   vm.loading = false;

--- a/client/src/modules/invoices/registry/templates/action.cell.html
+++ b/client/src/modules/invoices/registry/templates/action.cell.html
@@ -8,7 +8,7 @@
   <ul data-row-menu="{{ row.entity.reference }}" class="dropdown-menu-right" uib-dropdown-menu>
     <li class="dropdown-header">{{row.entity.reference}}</li>
     <li>
-      <a data-method="receipt" href ng-click="grid.appScope.openReceiptModal(row.entity.uuid, false)">
+      <a data-method="receipt" href ng-click="grid.appScope.Receipts.invoice(row.entity.uuid)">
         <i class="fa fa-file-pdf-o"></i> <span translate>REPORT.VIEW_RECEIPT</span>
       </a>
     </li>

--- a/client/src/modules/invoices/registry/templates/reference.html
+++ b/client/src/modules/invoices/registry/templates/reference.html
@@ -1,5 +1,3 @@
-<div class="ui-grid-cell-contents text-action">
-  <a ng-click="grid.appScope.openReceiptModal(row.entity.uuid)" href>
-    {{ row.entity.reference }}
-  </a>
+<div class="ui-grid-cell-contents">
+  <bh-receipt value="row.entity.uuid" display-value="row.entity.reference" type="invoice">
 </div>

--- a/client/src/modules/purchases/list/list.js
+++ b/client/src/modules/purchases/list/list.js
@@ -2,9 +2,8 @@ angular.module('bhima.controllers')
   .controller('PurchaseListController', PurchaseListController);
 
 PurchaseListController.$inject = [
-  '$state', 'PurchaseOrderService', 'NotifyService', 'ReceiptModal',
-  'uiGridConstants', 'GridColumnService',
-  'GridStateService', 'SessionService', 'ModalService',
+  '$state', 'PurchaseOrderService', 'NotifyService', 'uiGridConstants',
+  'GridColumnService', 'GridStateService', 'SessionService', 'ModalService',
 ];
 
 /**
@@ -12,8 +11,10 @@ PurchaseListController.$inject = [
  *
  * This module is responsible for the management of Purchase Order Registry.
  */
-function PurchaseListController($state, PurchaseOrder, Notify, Receipts, uiGridConstants,
-  Columns, GridState, Session, Modal) {
+function PurchaseListController(
+  $state, PurchaseOrder, Notify, uiGridConstants, Columns, GridState, Session,
+  Modal
+) {
   var vm = this;
 
   var cacheKey = 'PurchaseRegistry';
@@ -26,7 +27,6 @@ function PurchaseListController($state, PurchaseOrder, Notify, Receipts, uiGridC
   vm.onRemoveFilter = onRemoveFilter;
   vm.download = PurchaseOrder.download;
 
-  vm.getDocument = getDocument;
   vm.editStatus = editStatus;
 
   // track if module is making a HTTP request for purchase order
@@ -106,11 +106,6 @@ function PurchaseListController($state, PurchaseOrder, Notify, Receipts, uiGridC
     Notify.handleError(error);
   }
 
-  // get document
-  function getDocument(uuid) {
-    Receipts.purchase(uuid);
-  }
-
   // edit status
   function editStatus(purchase) {
     Modal.openPurchaseOrderStatus(purchase)
@@ -122,7 +117,7 @@ function PurchaseListController($state, PurchaseOrder, Notify, Receipts, uiGridC
 
   /** load purchase orders */
   function load(filters) {
-    // flush error and loading states    
+    // flush error and loading states
     vm.hasError = false;
     toggleLoadingIndicator();
 

--- a/client/src/modules/purchases/templates/uuid.tmpl.html
+++ b/client/src/modules/purchases/templates/uuid.tmpl.html
@@ -1,5 +1,3 @@
 <div class="ui-grid-cell-contents">
-  <a href ng-click="grid.appScope.getDocument(row.entity.uuid)">
-    {{ row.entity.reference }}
-  </a>
+  <bh-receipt value="row.entity.uuid" display-value="row.entity.reference" type="purchase">
 </div>

--- a/client/src/modules/vouchers/templates/uuid.tmpl.html
+++ b/client/src/modules/vouchers/templates/uuid.tmpl.html
@@ -1,5 +1,3 @@
 <div class="ui-grid-cell-contents">
-  <a href ng-click="grid.appScope.showReceipt(row.entity.uuid)">
-    {{ row.entity.reference }}
-  </a>
+  <bh-receipt value="row.entity.uuid" display-value="row.entity.reference" type="voucher">
 </div>

--- a/client/src/modules/vouchers/voucher-registry.ctrl.js
+++ b/client/src/modules/vouchers/voucher-registry.ctrl.js
@@ -4,7 +4,7 @@ angular.module('bhima.controllers')
 // dependencies injection
 VoucherController.$inject = [
   'VoucherService', 'NotifyService', 'uiGridGroupingConstants',
-  'TransactionTypeService', 'uiGridConstants', 'bhConstants', 'ReceiptModal',
+  'TransactionTypeService', 'uiGridConstants', 'bhConstants',
   'GridSortingService', 'GridColumnService', 'GridStateService', '$state',
   'ModalService',
 ];
@@ -19,7 +19,7 @@ VoucherController.$inject = [
  */
 function VoucherController(
   Vouchers, Notify, uiGridGroupingConstants, TransactionTypes, uiGridConstants,
-  bhConstants, Receipts, Sorting, Columns, GridState, $state, Modals
+  bhConstants, Sorting, Columns, GridState, $state, Modals
 ) {
   var vm = this;
 
@@ -110,8 +110,6 @@ function VoucherController(
   gridColumns = new Columns(vm.gridOptions, cacheKey);
   state = new GridState(vm.gridOptions, cacheKey);
 
-  // expose function
-  vm.showReceipt = showReceipt;
   vm.bhConstants = bhConstants;
 
   // search voucher
@@ -126,11 +124,6 @@ function VoucherController(
 
         return load(Vouchers.filters.formatHTTP(true));
       });
-  }
-
-  // showReceipt
-  function showReceipt(uuid) {
-    Receipts.voucher(uuid);
   }
 
   function load(filters) {


### PR DESCRIPTION
This PR implements a receipt-rendering component that opens the receipt modal when a link is clicked.  It supports three values:
 1. value - the ID or UUID for the receipt
 2. displayValue - whatever you would like to show.
 3. type - a string denoting what kind of receipt it is.  This will call the corresponding method in the ReceiptModal service.


With the bhReceipt component on the financial registries, there is no need to import the ReceiptModal into every single controller.  I've updated the vouchers, purchases, invoices, and cash payments accordingly.