### PR TITLE
tests: remove multiple element warnings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,10 +15,10 @@
     "src"
   ],
   "dependencies": {
-    "angular": "1.6.5",
-    "angular-animate": "1.6.5",
-    "angular-sanitize": "1.6.5",
-    "angular-messages": "1.6.5",
+    "angular": "1.6.6",
+    "angular-animate": "1.6.6",
+    "angular-sanitize": "1.6.6",
+    "angular-messages": "1.6.6",
     "angular-bootstrap": "2.5.0",
     "angular-ui-router": "1.0.0-rc.1",
     "angular-ui-grid": "4.0.4",
@@ -28,22 +28,22 @@
     "jquery": "3.2.1",
     "ng-file-upload": "12.2.13",
     "bootstrap": "3.3.7",
-    "angular-moment": "1.0.1",
-    "moment": "2.18.1",
+    "angular-moment": "1.1.0",
+    "moment": "2.19.1",
     "angular-dynamic-locale": "0.1.32",
     "ngstorage": "0.3.11",
     "Chart.js": "2.5.0",
     "angular-chart.js": "1.1.1",
     "components-font-awesome": "4.7.0",
     "angular-ui-select": "0.17.1",
-    "JsBarcode": "jsbarcode#3.5.9",
-    "angular-touch": "1.6.5",
+    "JsBarcode": "jsbarcode#3.8.0",
+    "angular-touch": "1.6.6",
     "angular-growl-notifications": "2.5.0"
   },
   "devDependencies": {
-    "angular-mocks": "1.6.5"
+    "angular-mocks": "1.6.6"
   },
   "resolutions": {
-    "angular": "1.6.5"
+    "angular": "1.6.6"
   }
 }

--- a/client/src/modules/users/templates/grid/action.cell.html
+++ b/client/src/modules/users/templates/grid/action.cell.html
@@ -25,14 +25,14 @@
 
     <li class="divider"></li>
     <li ng-if="!row.entity.deactivated">
-      <a data-method="activated" ng-click="grid.appScope.activatePermissions(row.entity, 1, 'FORM.DIALOGS.CONFIRM_DEACTIVATION')" href>
+      <a data-method="deactivate" ng-click="grid.appScope.activatePermissions(row.entity, 1, 'FORM.DIALOGS.CONFIRM_DEACTIVATION')" href>
         <span class="text-danger">
           <i class="fa fa-lock"></i> <span translate>FORM.LABELS.DEACTIVATE</span>
         </span>
       </a>
     </li>
     <li ng-if="row.entity.deactivated">
-      <a data-method="activated" ng-click="grid.appScope.activatePermissions(row.entity, 0, 'FORM.DIALOGS.CONFIRM_ACTIVATION')" href>
+      <a data-method="activate" ng-click="grid.appScope.activatePermissions(row.entity, 0, 'FORM.DIALOGS.CONFIRM_ACTIVATION')" href>
         <span class="text-danger">
           <i class="fa fa-unlock"></i><span translate>FORM.LABELS.ACTIVATE</span>
         </span>

--- a/test/end-to-end/creditor_groups/creditor_groups.spec.js
+++ b/test/end-to-end/creditor_groups/creditor_groups.spec.js
@@ -1,9 +1,9 @@
-/* global browser, element, by */
+/* global element, by */
 const chai = require('chai');
 const helpers = require('../shared/helpers');
 
 helpers.configure(chai);
-const expect = chai.expect;
+const { expect } = chai;
 
 const components = require('../shared/components');
 const FU = require('../shared/FormUtils');
@@ -13,7 +13,6 @@ describe('Creditor Groups Management', () => {
   before(() => helpers.navigate(path));
 
   const INITIAL_GROUP = 2;
-  const USED_CREDITOR_GROUP = 'Personnel [Creditor Group Test]';
 
   const currentDate = new Date();
   const uniqueIdentifier = currentDate.getTime().toString();
@@ -25,7 +24,7 @@ describe('Creditor Groups Management', () => {
     account      : '41001',
   };
 
-  it('Get initial list of creditor groups', () => {
+  it(`has an initial list of ${INITIAL_GROUP} creditor groups`, () => {
     expect(element.all(by.css('[data-group-entry]')).count()).to.eventually.equal(INITIAL_GROUP);
   });
 
@@ -50,23 +49,23 @@ describe('Creditor Groups Management', () => {
     components.notification.hasSuccess();
   });
 
-  it('Delete a creditor group', () => {
+  it('deletes a creditor group', () => {
     element(by.css(`[data-update="${group.updated_name}"]`)).click();
-    
+
     // click the "delete" button
     FU.buttons.delete();
 
-    FU.buttons.submit();
+    FU.modal.submit();
     components.notification.hasSuccess();
   });
 
-  it('Cannot delete a used creditor group', () => {
+  it('blocks deletion of a creditor group used in a transaction', () => {
     element(by.css(`[data-update="${group.delete_name}"]`)).click();
 
     // click the "delete" button
     FU.buttons.delete();
 
-    FU.buttons.submit();
+    FU.modal.submit();
     components.notification.hasError();
   });
 });

--- a/test/end-to-end/employees/registration.page.js
+++ b/test/end-to-end/employees/registration.page.js
@@ -3,144 +3,142 @@
 /**
  * This class is represents an employee registration page
  * behaviour so it is an employee page object
- **/
+ */
 
 const FU = require('../shared/FormUtils');
 const components = require('../shared/components');
 
 class RegistrationPage {
-    //simulate the create employee button click
-     createEmployee () {
-        FU.buttons.submit();
-    }
+  createEmployee() {
+    FU.buttons.submit();
+  }
 
-    // set display name
-    setDisplayName(displayName){
-        FU.input('EmployeeCtrl.employee.display_name', displayName);
-    }
+  // set display name
+  setDisplayName(displayName) {
+    FU.input('EmployeeCtrl.employee.display_name', displayName);
+  }
 
-    // set dob
-    setDob (dob){
-        FU.input('EmployeeCtrl.employee.dob', dob);
-    }
+  // set dob
+  setDob(dob) {
+    FU.input('EmployeeCtrl.employee.dob', dob);
+  }
 
-    // set sex
-    setSex (sex){
-        const position = sex === 'M' ? 0 : 1;
-        FU.radio('EmployeeCtrl.employee.sex', position);
-    }
+  // set sex
+  setSex(sex) {
+    const id = (sex === 'M') ? 'male' : 'female';
+    $(`[id="${id}"]`).click();
+  }
 
-    // set number of spouse
-    setNumberSpouse (nbSpouse){
-        FU.input('EmployeeCtrl.employee.nb_spouse', nbSpouse);
-    }
+  // set number of spouse
+  setNumberSpouse(nbSpouse) {
+    FU.input('EmployeeCtrl.employee.nb_spouse', nbSpouse);
+  }
 
-    // set number of spouse
-    setNumberChild (nbEnfant){
-        FU.input('EmployeeCtrl.employee.nb_enfant', nbEnfant);
-    }
+  // set number of spouse
+  setNumberChild(nbEnfant) {
+    FU.input('EmployeeCtrl.employee.nb_enfant', nbEnfant);
+  }
 
-    // set hiring date
-    setHiringDate (hiringDate){
-        FU.input('EmployeeCtrl.employee.date_embauche', hiringDate);
-    }
+  // set hiring date
+  setHiringDate(hiringDate) {
+    FU.input('EmployeeCtrl.employee.date_embauche', hiringDate);
+  }
 
-    // set the employee code
-    setCode (code){
-        FU.input('EmployeeCtrl.employee.code', code);
-    }
+  // set the employee code
+  setCode(code) {
+    FU.input('EmployeeCtrl.employee.code', code);
+  }
 
-    //set service
-    setService (service){
-        FU.uiSelect('EmployeeCtrl.employee.service_id', service);
-    }
+  // set service
+  setService(service) {
+    FU.uiSelect('EmployeeCtrl.employee.service_id', service);
+  }
 
-    // set grade
-    setGrade (grade){
-        FU.uiSelect('EmployeeCtrl.employee.grade_uuid', grade);
-    }
+  // set grade
+  setGrade(grade) {
+    FU.uiSelect('EmployeeCtrl.employee.grade_uuid', grade);
+  }
 
-    // set fonction
-    setFonction (fonction){
-        FU.uiSelect('EmployeeCtrl.employee.fonction_id', fonction);
-    }
+  // set fonction
+  setFonction(fonction) {
+    FU.uiSelect('EmployeeCtrl.employee.fonction_id', fonction);
+  }
 
-    // set Medical Staff
-    setIsMedical (){
-        element(by.model('EmployeeCtrl.employee.is_medical')).click();
-    }
+  // set Medical Staff
+  setIsMedical() {
+    element(by.model('EmployeeCtrl.employee.is_medical')).click();
+  }
 
-    // set email
-    setEmail (email){
-        FU.input('EmployeeCtrl.employee.email', email);
-    }
+  // set email
+  setEmail(email) {
+    FU.input('EmployeeCtrl.employee.email', email);
+  }
 
-    // set address
-    setAddress (address){
-        FU.input('EmployeeCtrl.employee.adresse', address);
-    }
+  // set address
+  setAddress(address) {
+    FU.input('EmployeeCtrl.employee.adresse', address);
+  }
 
-    // set hospital Number
-    setHospitalNumber(hn){
-        FU.input('EmployeeCtrl.employee.hospital_no', hn);
-    }
+  // set hospital Number
+  setHospitalNumber(hn) {
+    FU.input('EmployeeCtrl.employee.hospital_no', hn);
+  }
 
-    // set debtor group
-    setDebtorGroup (dg){
-        components.debtorGroupSelect.set(dg);
-    }
+  // set debtor group
+  setDebtorGroup(dg) {
+    components.debtorGroupSelect.set(dg);
+  }
 
-    // set creditor group
-    setCreditorGroup (cg){
-        FU.uiSelect('EmployeeCtrl.employee.creditor_group_uuid', cg);
-    }
+  // set creditor group
+  setCreditorGroup(cg) {
+    FU.uiSelect('EmployeeCtrl.employee.creditor_group_uuid', cg);
+  }
 
-    // set bank
-    setBank (bank){
-        FU.input('EmployeeCtrl.employee.bank', bank);
-    }
+  // set bank
+  setBank(bank) {
+    FU.input('EmployeeCtrl.employee.bank', bank);
+  }
 
-    // set bank account
-    setBankAccount (bankAccount){
-        FU.input('EmployeeCtrl.employee.bank_account', bankAccount);
-    }
+  // set bank account
+  setBankAccount(bankAccount) {
+    FU.input('EmployeeCtrl.employee.bank_account', bankAccount);
+  }
 
-    // set origin location
-    setOriginLocation(locations){
-        components.locationSelect.set(locations, 'origin-location-id');
-    }
+  // set origin location
+  setOriginLocation(locations) {
+    components.locationSelect.set(locations, 'origin-location-id');
+  }
 
-    // set current location
-    setCurrentLocation(locations){
-        components.locationSelect.set(locations, 'current-location-id');
-    }
+  // set current location
+  setCurrentLocation(locations) {
+    components.locationSelect.set(locations, 'current-location-id');
+  }
 
-    isEmpoyeeCreated (resp){
-        return FU.exists(by.id('receipt-confirm-created'), resp);
-    }
+  isEmpoyeeCreated(resp) {
+    return FU.exists(by.id('receipt-confirm-created'), resp);
+  }
 
-    requiredFIeldErrored (){
-        FU.validation.error('EmployeeCtrl.employee.display_name');
-        FU.validation.error('EmployeeCtrl.employee.sex');
-        FU.validation.error('EmployeeCtrl.employee.code');
-        FU.validation.error('EmployeeCtrl.employee.grade_uuid');
-        FU.validation.error('EmployeeCtrl.employee.creditor_group_uuid');
-        FU.validation.error('$ctrl.debtorGroupUuid');
-        FU.validation.error('EmployeeCtrl.employee.dob');
-        FU.validation.error('EmployeeCtrl.employee.hospital_no');
-    }
+  requiredFieldErrored() {
+    FU.validation.error('EmployeeCtrl.employee.display_name');
+    FU.validation.error('EmployeeCtrl.employee.code');
+    FU.validation.error('EmployeeCtrl.employee.grade_uuid');
+    FU.validation.error('EmployeeCtrl.employee.creditor_group_uuid');
+    FU.validation.error('$ctrl.debtorGroupUuid');
+    FU.validation.error('EmployeeCtrl.employee.dob');
+    FU.validation.error('EmployeeCtrl.employee.hospital_no');
+  }
 
-    noRequiredFieldOk(){
-        FU.validation.ok('EmployeeCtrl.employee.nb_spouse');
-        FU.validation.ok('EmployeeCtrl.employee.nb_enfant');
-        FU.validation.ok('EmployeeCtrl.employee.phone');
-        FU.validation.ok('EmployeeCtrl.employee.email');
-        FU.validation.ok('EmployeeCtrl.employee.bank');
-        FU.validation.ok('EmployeeCtrl.employee.bank_account');
-        FU.validation.ok('EmployeeCtrl.employee.service_id');
-        FU.validation.ok('EmployeeCtrl.employee.fonction_id');
-        FU.validation.ok('EmployeeCtrl.employee.adresse');
-    }
+  noRequiredFieldOk() {
+    FU.validation.ok('EmployeeCtrl.employee.nb_spouse');
+    FU.validation.ok('EmployeeCtrl.employee.nb_enfant');
+    FU.validation.ok('EmployeeCtrl.employee.phone');
+    FU.validation.ok('EmployeeCtrl.employee.email');
+    FU.validation.ok('EmployeeCtrl.employee.bank');
+    FU.validation.ok('EmployeeCtrl.employee.bank_account');
+    FU.validation.ok('EmployeeCtrl.employee.service_id');
+    FU.validation.ok('EmployeeCtrl.employee.fonction_id');
+    FU.validation.ok('EmployeeCtrl.employee.adresse');
+  }
 }
 
 module.exports = RegistrationPage;

--- a/test/end-to-end/employees/registration.spec.js
+++ b/test/end-to-end/employees/registration.spec.js
@@ -1,8 +1,8 @@
-/* global element, by, browser */
+/* global browser */
 const chai = require('chai');
 const helpers = require('../shared/helpers');
 
-const expect = chai.expect;
+const { expect } = chai;
 const RegistrationPage = require('./registration.page.js');
 
 helpers.configure(chai);
@@ -32,7 +32,7 @@ describe('Employees', () => {
     expect(helpers.getCurrentPath()).to.eventually.equal(path);
 
     registrationPage.createEmployee();
-    registrationPage.requiredFIeldErrored();
+    registrationPage.requiredFieldErrored();
     registrationPage.noRequiredFieldOk();
   });
 
@@ -78,7 +78,6 @@ describe('Employees', () => {
   //   components.notification.hasSuccess();
   // });
 
-  // FIXME: skip throws an error
   // it.skip('unlocks an employee', () => {
   //   element(by.id(`employee-upd-${employeeId}`)).click();
   //   element(by.id('bhima-employee-locked')).click();

--- a/test/end-to-end/employees/registry.page.js
+++ b/test/end-to-end/employees/registry.page.js
@@ -1,9 +1,7 @@
-/* global element, by */
-
 /**
  * This class represents an employee registry page
  * behaviour so it is an employee page object
- **/
+ */
 
 const FU = require('../shared/FormUtils');
 const grid = require('../shared/GridUtils');

--- a/test/end-to-end/employees/registry.spec.js
+++ b/test/end-to-end/employees/registry.spec.js
@@ -1,4 +1,3 @@
-/* global element, by, browser */
 const chai = require('chai');
 const helpers = require('../shared/helpers');
 
@@ -25,7 +24,8 @@ describe('Employees Registry', () => {
 
   it('list all registered employees', () => {
     employeeRegistryPage.employeeCount(
-        employeeCount, `The number of registered employee should be ${employeeCount}`
+      employeeCount,
+      `The number of registered employee should be ${employeeCount}`
     );
   });
 
@@ -49,7 +49,7 @@ describe('Employees Registry', () => {
 
   it('should find no female employee registered in the last year.', () => {
     employeeRegistryPage.search();
-    searchModalPage.setDateRange('year');
+    searchModalPage.setRegistrationDateRange('year');
     searchModalPage.selectSex('female');
     searchModalPage.submit();
 
@@ -72,11 +72,10 @@ describe('Employees Registry', () => {
 
     searchModalPage.selectService('Administration');
     searchModalPage.selectFonction('Infirmier');
-    searchModalPage.selectGrade('1.1');        
+    searchModalPage.selectGrade('1.1');
     searchModalPage.submit();
 
     employeeRegistryPage.employeeCount(1, `The number of filtered employee should be 1`);
     employeeRegistryPage.clearFilter();
   });
-
 });

--- a/test/end-to-end/employees/searchModal.page.js
+++ b/test/end-to-end/employees/searchModal.page.js
@@ -1,44 +1,41 @@
-/* global element */
+/* global element, by */
 
 /**
  * This class represents a modal search page
  * behaviour so it is a modal search page object
- **/
+ */
 
 const FU = require('../shared/FormUtils');
 const components = require('../shared/components');
-const grid = require('../shared/GridUtils');
 
-class SearchModalPage{
-
+class SearchModalPage {
   setDisplayName(displayName) {
     FU.input('ModalCtrl.searchQueries.display_name', displayName);
   }
 
-  submit () {
+  submit() {
     FU.modal.submit();
   }
 
-  selectSex (sex) {
+  selectSex(sex) {
     return element(by.id(`${sex}`)).click();
   }
 
-  setDateRange (range) {
-    return $(`[data-date-range="${range}"]`).click();
+  setRegistrationDateRange(range) {
+    return $('[date-id="embauche-date"]').$(`[data-date-range="${range}"]`).click();
   }
 
-  selectService (service) {
+  selectService(service) {
     components.serviceSelect.set(service);
   }
 
-  selectGrade (grade) {
+  selectGrade(grade) {
     components.gradeSelect.set(grade);
   }
 
-  selectFonction (fonction) {
+  selectFonction(fonction) {
     components.fonctionSelect.set(fonction);
   }
-
 }
 
 module.exports = SearchModalPage;

--- a/test/end-to-end/patient/record.spec.js
+++ b/test/end-to-end/patient/record.spec.js
@@ -51,7 +51,7 @@ describe('Patient Record', () => {
   });
 
   it('admits a patient', () => {
-    const diagnosisLabel = 'dio';
+    const diagnosisLabel = 'Melioidose a';
     element(by.id('submit-visit')).click();
 
     FU.typeahead('AdmitCtrl.visit.diagnosis', diagnosisLabel);
@@ -62,7 +62,7 @@ describe('Patient Record', () => {
   });
 
   it('dicharges a patient with a new diagnosis', () => {
-    const diagnosisLabel = 'iod';
+    const diagnosisLabel = 'Melioidose a';
     element(by.id('submit-visit')).click();
 
     FU.typeahead('AdmitCtrl.visit.diagnosis', diagnosisLabel);

--- a/test/end-to-end/patient/registration.spec.js
+++ b/test/end-to-end/patient/registration.spec.js
@@ -4,11 +4,10 @@ const FU = require('../shared/FormUtils');
 const components = require('../shared/components');
 const helpers = require('../shared/helpers');
 
-const expect = chai.expect;
+const { expect } = chai;
 helpers.configure(chai);
 
-describe('Patient Registration', function () {
-
+describe('Patient Registration', () => {
   const path = '#!/patients/register';
   beforeEach(() => helpers.navigate(path));
 
@@ -20,10 +19,7 @@ describe('Patient Registration', function () {
     hospital_no  : 120,
   };
 
-  const uniqueHospitalNumber = 1020;
-
-  it('registers a valid patient', function () {
-
+  it('registers a valid patient', () => {
     // patient name
     FU.input('PatientRegCtrl.medical.display_name', mockPatient.display_name);
 
@@ -49,13 +45,11 @@ describe('Patient Registration', function () {
 
   // This test group assumes the previous mock patient has been successfully registered
   // with the system
-  describe('form validation', function () {
-
+  describe('form validation', () => {
     // refresh the page to make sure previous data is cleared
     before(() => browser.refresh());
 
-    it('blocks invalid form submission with relevent error classes', function () {
-
+    it('blocks invalid form submission with relevent error classes', () => {
       // submit the patient registration form
       FU.buttons.submit();
 
@@ -73,7 +67,7 @@ describe('Patient Registration', function () {
       components.notification.hasDanger();
     });
 
-    it('alerts for minimum and maximum dates', function () {
+    it('alerts for minimum and maximum dates', () => {
       const testMaxYear = '01/01/9000';
       const validYear = '01/01/2000';
       const testMinYear = '01/01/1000';

--- a/test/end-to-end/user/user.page.js
+++ b/test/end-to-end/user/user.page.js
@@ -1,23 +1,21 @@
-/* global element, by, browser */
+/* global element, by */
 
 /**
  * This class is represents a user page in term of structure and
  * behaviour so it is a user page object
- **/
+ */
 
-/** loading grid actions **/
+/* loading grid actions */
 const GA = require('../shared/GridAction');
 
 function UserPage() {
-  'use strict';
-
   const page = this;
 
   var userGrid = element(by.id('users-grid'));
   var addUserButon = element(by.css('[data-method="create"]'));
   var actionLinkColumn = 2;
 
-  /** send back the number of user in the grid**/
+  /* send back the number of user in the grid */
   function getUserCount() {
     return userGrid
       .element(by.css('.ui-grid-render-container-body'))
@@ -27,45 +25,49 @@ function UserPage() {
 
   /**
    * simulate the add user button click to show the dialog of creation
-   **/
-  function createUser () {
+   */
+  function createUser() {
     return addUserButon.click();
   }
 
   /**
    * simulate a click to a link tailed to the user
    *  listed in the grid to show the dialog for an editing
-   **/
+   */
   function editUser(n) {
     GA.clickOnMethod(n, actionLinkColumn, 'edit', 'users-grid');
   }
 
   /**
-   * simulte a link clicking on the grid to show permission dialog
-   **/
+   * simulate a link clicking on the grid to show permission dialog
+   */
   function editUserPermission(n) {
     GA.clickOnMethod(n, actionLinkColumn, 'permission', 'users-grid');
   }
 
   /**
-   * simulte a link clicking on the grid to show depot dialog
-   **/
+   * simulate a link clicking on the grid to show depot dialog
+   */
   function editUserDepot(n) {
     GA.clickOnMethod(n, actionLinkColumn, 'depot', 'users-grid');
   }
 
   /**
-   * simulte a link clicking on the grid to show cashbox dialog
-   **/
+   * simulate a link clicking on the grid to show cashbox dialog
+   */
   function editUserCashbox(n) {
     GA.clickOnMethod(n, actionLinkColumn, 'cashbox', 'users-grid');
   }
 
   /**
-   * simulte a link clicking on the grid to show activation dialog
-   **/
+   * simulate a link clicking on the grid to show activation dialog
+   */
   function activateUser(n) {
-    GA.clickOnMethod(n, actionLinkColumn, 'activated', 'users-grid');
+    GA.clickOnMethod(n, actionLinkColumn, 'activate', 'users-grid');
+  }
+
+  function deactivateUser(n) {
+    GA.clickOnMethod(n, actionLinkColumn, 'deactivate', 'users-grid');
   }
 
   page.getUserCount = getUserCount;
@@ -75,6 +77,7 @@ function UserPage() {
   page.editUserDepot = editUserDepot;
   page.editUserCashbox = editUserCashbox;
   page.activateUser = activateUser;
+  page.deactivateUser = deactivateUser;
 }
 
 module.exports = UserPage;

--- a/test/end-to-end/user/user.spec.js
+++ b/test/end-to-end/user/user.spec.js
@@ -1,24 +1,20 @@
-/* global browser, element, by */
-
-/** loading chai and helpers **/
+/* loading chai and helpers */
 const chai = require('chai');
 const helpers = require('../shared/helpers');
 const components = require('../shared/components');
 const FU = require('../shared/FormUtils');
 
-/** loading pages **/
+/* loading pages */
 const UserPage = require('./user.page.js');
 const UserCreateUpdatePage = require('./userCU.page.js');
 const EditPasswordPage = require('./edit.password.page.js');
 
-/** configuring helpers**/
+/* configuring helpers */
 helpers.configure(chai);
 
-const expect = chai.expect;
+const { expect } = chai;
 
-describe('User Management Page', function () {
-  'use strict';
-
+describe('User Management Page', () => {
   const path = '#/users';
   const userPage = new UserPage();
   const userCreateUpdatePage = new UserCreateUpdatePage();
@@ -29,30 +25,28 @@ describe('User Management Page', function () {
     email : 'test@bhima.org',
     project : 'Test Project A',
     password : 'testtest134@IMA',
-    passwordConfirm : 'testtest134@IMA'
+    passwordConfirm : 'testtest134@IMA',
   };
   const mockUserEdit = {
     userName : 'User test edit',
     login : 'Login test edit',
     email : 'test_edit@bhima.org',
     project : 'Test Project C',
-    password : 'testtestedit1233@D'
+    password : 'testtestedit1233@D',
   };
   const userCount = 4;
 
-  const cashbox = { 
-    text : 'Test Aux Cashbox B'
+  const cashbox = {
+    text : 'Test Aux Cashbox B',
   };
 
-  before(function () {
-    return helpers.navigate(path);
-  });
+  before(() => helpers.navigate(path));
 
-  it('displays all users loaded from the database', function () {
+  it('displays all users loaded from the database', () => {
     expect(userPage.getUserCount()).to.eventually.equal(userCount);
   });
 
-  it('creates a user successfully', function () {
+  it('creates a user successfully', () => {
     userPage.createUser();
     userCreateUpdatePage.setUserName(mockUserCreate.userName);
     userCreateUpdatePage.setLogin(mockUserCreate.login);
@@ -64,7 +58,7 @@ describe('User Management Page', function () {
     expect(userPage.getUserCount()).to.eventually.equal(userCount + 1);
   });
 
-  it('edits a user successfully without changing the password', function () {
+  it('edits a user successfully without changing the password', () => {
     userPage.editUser(4);
     userCreateUpdatePage.setUserName(mockUserEdit.userName);
     userCreateUpdatePage.setLogin(mockUserEdit.login);
@@ -77,11 +71,12 @@ describe('User Management Page', function () {
      * TODO : Use the page object correctly for the login page
      * to help us access the application with the edited user information
      * from this test
-     **/
-    expect(userCreateUpdatePage.isDisplayed()).to.eventually.equal(false); //if every thing is good, the modal should disappear
+     */
+    // if every thing is ok, the modal should disappear
+    expect(userCreateUpdatePage.isDisplayed()).to.eventually.equal(false);
   });
 
-  it('edits a user password successfully', function () {
+  it('edits a user password successfully', () => {
     userPage.editUser(4);
     userCreateUpdatePage.editPassword();
     editPasswordPage.setPassword(mockUserEdit.password);
@@ -91,27 +86,27 @@ describe('User Management Page', function () {
      * TODO : Use the page object correctly for the login page
      * to help us access the application with the edited user information
      * from this test
-     **/
-    expect(editPasswordPage.isDisplayed()).to.eventually.equal(false); //if every thing is good, the modal should disappear
+     */
+    expect(editPasswordPage.isDisplayed()).to.eventually.equal(false); // if every thing is ok, the modal should disappear
     userCreateUpdatePage.close();
   });
 
-  it('Deactivate user system access successfully', function () {
-    userPage.activateUser(4);
+  it('deactivate user system access successfully', () => {
+    userPage.deactivateUser(4);
     // submit the confirmation modal
     FU.modal.submit();
 
     components.notification.hasSuccess();
   });
 
-  it('refuses to update a user when no changes have been made', function () {
+  it('refuses to update a user when no changes have been made', () => {
     userPage.editUser(3);
     userCreateUpdatePage.submitUser();
     expect(userCreateUpdatePage.isSameUser()).to.eventually.equal(true);
     userCreateUpdatePage.close();
   });
 
-  it('validates from on editing password', function () {
+  it('validates from on editing password', () => {
     userPage.editUser(3);
 
     // check that an empty form is not allowed
@@ -134,13 +129,13 @@ describe('User Management Page', function () {
   it(`Set Cashbox ${cashbox.text} Manage Right to RegularUser `, () => {
     userPage.editUserCashbox(1);
     components.multipleCashBoxSelect.set([cashbox.text]);
-    
+
     // submit the modal
     FU.modal.submit();
     components.notification.hasSuccess();
   });
 
-  it('validates form on creation', function () {
+  it('validates form on creation', () => {
     userPage.createUser();
     userCreateUpdatePage.submitUser();
     expect(userCreateUpdatePage.isUserNameInvalid()).to.eventually.equal(true);

--- a/test/end-to-end/vouchers/complex.spec.js
+++ b/test/end-to-end/vouchers/complex.spec.js
@@ -147,7 +147,7 @@ describe('Complex Vouchers', () => {
 
     const detail = {
       tool            : 'Convention - Paiement factures',
-      cashbox         : '$',
+      cashbox         : 'Test Primary Cashbox A',
       convention      : 'Second Test',
       invoices        : [0, 1],
       description     : 'Convention payment with journal voucher',


### PR DESCRIPTION
This commit addresses as many duplicate element warnings as possible. There remains warnings on the open debtors report, since the uiSelect uses an icon to differentiate the sort order, which cannot be selected upon easily.

Closes #2193.