### PR TITLE
feat(journal): add showFullTransaction filter

### DIFF
--- a/client/src/i18n/en/posting_journal.json
+++ b/client/src/i18n/en/posting_journal.json
@@ -11,6 +11,8 @@
     "SAVE_TRANSACTION" : "Save Transaction",
     "SAVE_TRANSACTION_SUCCESS" : "Transaction record was updated successfully.",
     "TRANSACTION" : "Transaction",
+    "SHOW_FULL_TRANSACTION_RECORDS" : "Show Full Transactions",
+    "SHOW_FULL_TRANSACTION_RECORDS_HELP" : "Enabling this option will make this server return all rows in a transaction matching any of the filter values.  It may slow down performance of Journal slightly.",
     "VIEWING" : "Viewing",
     "OUTDATED_DATA_MESSAGE_1" : "The data displayed may have changed since it was loaded.",
     "OUTDATED_DATA_MESSAGE_2" : "the latest data.",

--- a/client/src/i18n/fr/posting_journal.json
+++ b/client/src/i18n/fr/posting_journal.json
@@ -10,6 +10,8 @@
     "SAVE_TRANSACTION" : "Sauvegarder la transaction",
     "TITLE" : "Journal de Saisie",
     "TRANSACTION" : "Transaction",
+    "SHOW_FULL_TRANSACTION_RECORDS" : "Afficher les Transactions Complètes",
+    "SHOW_FULL_TRANSACTION_RECORDS_HELP" : "Si vous activez cette option, ce serveur retournera toutes les lignes d'une transaction correspondant à l'une des valeurs de filtre. Cela peut ralentir légèrement les performances du Journal.",
     "CLICK_HERE_TO_RELOAD" : "Cliquez ici pour recharger les données",
     "EDITING" : "Édition",
     "VIEWING" : "Voir",

--- a/client/src/modules/journal/journal.service.js
+++ b/client/src/modules/journal/journal.service.js
@@ -97,6 +97,9 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants) {
 
   // default filters will always be applied
   journalFilters.registerDefaultFilters(bhConstants.defaultFilters);
+  journalFilters.registerDefaultFilters([
+    { key : 'showFullTransactions', label : 'POSTING_JOURNAL.SHOW_FULL_TRANSACTION_RECORDS' },
+  ]);
 
   // custom filters can be optionally applied
   journalFilters.registerCustomFilters([
@@ -134,6 +137,10 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants) {
     // assign default limit filter
     if (assignedKeys.indexOf('limit') === -1) {
       journalFilters.assignFilter('limit', 100);
+    }
+
+    if (assignedKeys.indexOf('showFullTransactions') === -1) {
+      journalFilters.assignFilter('showFullTransactions', 0);
     }
   }
 
@@ -214,7 +221,6 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants) {
     return service.$http.get(url)
       .then(service.util.unwrapHttpResponse);
   }
-
 
   return service;
 }

--- a/client/src/modules/journal/modals/search.modal.html
+++ b/client/src/modules/journal/modals/search.modal.html
@@ -54,7 +54,7 @@
         <bh-transaction-type-select
           on-change="ModalCtrl.onTransactionTypesChange(transactionTypes)"
           transaction-type-ids="ModalCtrl.searchQueries.origin_id">
-        </bh-transaction-type-select>        
+        </bh-transaction-type-select>
 
         <!-- description fuzzy search -->
         <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.description.$invalid }">
@@ -101,7 +101,11 @@
 
       <uib-tab index="1" heading="{{ 'FORM.LABELS.DEFAULTS' | translate }}">
         <div class="tab-body">
-          <!-- hasDefaultAccount is used to set a default account selection behavior -->
+
+          <!--
+            hasDefaultAccount is used to set a default account selection
+            behavior in the Account Statement Module.
+          -->
           <div ng-if="ModalCtrl.hasDefaultAccount">
             <bh-account-select
               account-id="ModalCtrl.defaultQueries.account_id"
@@ -110,6 +114,25 @@
               exclude-title-accounts="true"
               required="0">
             </bh-account-select>
+          </div>
+
+          <!-- Full Transaction applies to the Journal, not the Account Statement -->
+          <div ng-if="!ModalCtrl.hasDefaultAccount">
+            <div class="radio">
+              <p class="control-label" style="margin-bottom:5px;">
+                <strong translate>POSTING_JOURNAL.SHOW_FULL_TRANSACTION_RECORDS</strong>
+              </p>
+              <label class="radio-inline">
+                <input type="radio" name="showFullTransactions" ng-value="1" ng-model="ModalCtrl.defaultQueries.showFullTransactions" ng-click="ModalCtrl.toggleFullTransaction(ModalCtrl.defaultQueries.showFullTransactions)">
+                <span translate>FORM.LABELS.YES</span>
+              </label>
+              <label class="radio-inline">
+                <input type="radio" name="showFullTransactions" ng-value="0" ng-model="ModalCtrl.defaultQueries.showFullTransactions" ng-click="ModalCtrl.toggleFullTransaction(ModalCtrl.defaultQueries.showFullTransactions)">
+                <span translate>FORM.LABELS.NO</span>
+              </label>
+            </div>
+
+            <span class="help-block" translate>POSTING_JOURNAL.SHOW_FULL_TRANSACTION_RECORDS_HELP</span>
           </div>
 
           <!-- period selection -->

--- a/client/src/modules/journal/modals/search.modal.js
+++ b/client/src/modules/journal/modals/search.modal.js
@@ -38,8 +38,6 @@ function JournalSearchModalController(Instance, Notify,
   // assign already defined custom filters to searchQueries object
   vm.searchQueries = util.maskObjectFromKeys(filters, searchQueryOptions);
 
-  window.search = vm.searchQueries;
-
   /**
    * hasDefaultAccount is used to set a default account selection behavior
    * if the search modal need to set account selection in default query panel we can send it
@@ -52,13 +50,17 @@ function JournalSearchModalController(Instance, Notify,
   if (options.hasDefaultAccount) {
     vm.hasDefaultAccount = true;
   }
-  
+
   // assign default filters
   if (filters.limit) {
     vm.defaultQueries.limit = filters.limit;
   }
 
-  // assing default account
+  if (angular.isDefined(filters.showFullTransactions)) {
+    vm.defaultQueries.showFullTransactions = filters.showFullTransactions;
+  }
+
+  // assign default account
   if (filters.account_id) {
     vm.defaultQueries.account_id = filters.account_id;
   }
@@ -122,6 +124,13 @@ function JournalSearchModalController(Instance, Notify,
     // input is type value, this will only be defined for a valid number
     if (angular.isDefined(value)) {
       changes.post({ key : 'limit', value : value });
+    }
+  };
+
+  // default filter to show full transactions
+  vm.toggleFullTransaction = function toggleFullTransaction(value) {
+    if (angular.isDefined(value)) {
+      changes.post({ key : 'showFullTransactions', value : value });
     }
   };
 

--- a/test/integration/journal.js
+++ b/test/integration/journal.js
@@ -29,7 +29,7 @@ describe('(/journal) API endpoint', () => {
       .catch(helpers.handler)
   );
 
-  it('GET /journal/:record_id : it returns an error message and 404 code if the transaction does not exist ', () =>
+  it('GET /journal/:record_uuid : it returns an error message and 404 code if the transaction does not exist ', () =>
     agent.get(`/journal/${MISSING_RECORD_UUID}`)
       .then((res) => {
         helpers.api.errored(res, 404);
@@ -72,6 +72,24 @@ function SearchTests() {
       .query({ account_id })
       .then((res) => {
         helpers.api.listed(res, NUM_MATCHES);
+      })
+      .catch(helpers.handler);
+  });
+
+  it(`GET /journal?account_id=${account_id}&showFullTransaction=1 should find complete transactions`, () => {
+    const NUM_MATCHES = 7;
+    const NUM_TXNS = 3;
+    return agent.get('/journal')
+      .query({ account_id, showFullTransactions : 1 })
+      .then((res) => {
+        helpers.api.listed(res, NUM_MATCHES);
+
+        // make sure that even though we return more rows, the transactions are unique.
+        const uniqueTransactions = res.body
+          .map(row => row.record_uuid)
+          .filter((record, idx, arr) => arr.indexOf(record) === idx);
+
+        expect(uniqueTransactions).to.have.length(NUM_TXNS);
       })
       .catch(helpers.handler);
   });


### PR DESCRIPTION
The journal filters have been extended with the option to show the entire transaction following a search on the Journal. This extension gives the user the ability to not only find an account view, but also a
full transaction view of all the data in the journal.

Note that the implementation is quite heavy (requires two passes on the Journal).  A warning message has been placed underneath the option to make the user aware of this.

Closes #2266.

![showfulltransactionoption](https://user-images.githubusercontent.com/896472/32417106-c7d08084-c25c-11e7-9c35-cf52175d98f0.png)
_Fig 1: The modal for selecting transactions_

![showfulltransactiongrid](https://user-images.githubusercontent.com/896472/32417105-c7138790-c25c-11e7-91ea-6a892db1fa16.png)
_Fig 2: After filtering, the full transactions containing the query are shown_


