### PR TITLE
fix(accounts): standardize button sizes

### DIFF
--- a/client/src/modules/accounts/edit/accounts.edit.modal.html
+++ b/client/src/modules/accounts/edit/accounts.edit.modal.html
@@ -50,21 +50,21 @@
     <!-- @TODO Re-disable account type editing after accounts are stable -->
     <!-- Account type read only -->
      <div ng-if="!AccountEditCtrl.isCreateState" class="form-group">
-       <label class="control-label">{{ "FORM.LABELS.ACCOUNT_TYPE" | translate }}</label> 
-       <p class="form-control-static" ng-if="AccountEditCtrl.account" id="type-static" translate>{{::AccountEditCtrl.getTypeTitle(AccountEditCtrl.account.type_id)}}</p> 
-    </div> 
+       <label class="control-label">{{ "FORM.LABELS.ACCOUNT_TYPE" | translate }}</label>
+       <p class="form-control-static" ng-if="AccountEditCtrl.account" id="type-static" translate>{{::AccountEditCtrl.getTypeTitle(AccountEditCtrl.account.type_id)}}</p>
+    </div>
 
     <!-- TODO(@jniles): can this just use ng-options? -->
-    <div 
+    <div
         class="form-group"
         ng-if="AccountEditCtrl.isCreateState"
-        ng-class="{'has-error' : (AccountForm.type_id.$invalid && AccountForm.$submitted) || AccountEditCtrl.invalidTitleAccount}">         
+        ng-class="{'has-error' : (AccountForm.type_id.$invalid && AccountForm.$submitted) || AccountEditCtrl.invalidTitleAccount}">
       <label class="control-label" translate>FORM.LABELS.ACCOUNT_TYPE</label>
       <select
         class="form-control"
         ng-model="AccountEditCtrl.account.type_id"
         ng-change="AccountEditCtrl.titleChangedValidation(AccountEditCtrl.account.type_id)"
-        name="type_id"        
+        name="type_id"
         required>
         <option value="" disabled translate>FORM.SELECT.ACCOUNT_TYPE</option>
         <option ng-repeat="entry in AccountEditCtrl.types" value="{{entry.id}}" data-key="{{entry.translation_key}}" translate>{{entry.translation_key}}</option>
@@ -130,7 +130,7 @@
   <button
     type="button"
     ng-if="!AccountEditCtrl.isCreateState"
-    class="btn btn-danger btn-sm"
+    class="btn btn-danger"
     data-method="delete"
     ng-click="AccountEditCtrl.deleteAccount(AccountEditCtrl.account)">
     <span translate>ACCOUNT.SUBMIT_DELETE</span>


### PR DESCRIPTION
This commit increases the button size on the accounts edit modal.  They are now all `btn` instead of a mix of `btn` and `btn-sm`.

![accountsmodalbefore](https://user-images.githubusercontent.com/896472/32417252-36bb0dd2-c25f-11e7-8b71-ad3854e37773.PNG)
_Fig 1: Accounts Modal Before_

![accountsmodal](https://user-images.githubusercontent.com/896472/32417244-108b491a-c25f-11e7-87e5-e819160b8b47.png)
_Fig 2: Accounts Modal After_