### PR TITLE
feat: implement bhHiddenField

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -1,6 +1,5 @@
 {
   "REPORT": {
-    "CLIENTS" : "Rapport Clients",
     "ACCOUNT": "Account Statement",
     "AGED_CREDITORS":{
      "TITLE":"Aged Creditors",
@@ -30,8 +29,11 @@
     },
     "CASH_INCOME":"Incomes",
     "CHART_OF_ACCOUNTS": "Chart of Accounts",
+    "CLIENTS" : "Clients Report",
     "CLIENTS_REPORT": {
       "TITLE": "Clients Report",
+      "ADD_IGNORED_CLIENTS" : "Skip Certain Clients",
+      "HIDE_IGNORED_CLIENTS" : "Skip Certain Clients",
       "CURRENT_MVT": "Current Movement",
       "PREVIOUS_MVT": "From Beginning To :",
       "DESCRIPTION": "This report displays all the debtor groups, their account balances at the beginning of the fiscal year, the current balances, and their ending balances."

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -100,6 +100,8 @@
     "CLIENTS_REPORT" : {
       "TITLE" : "Rapport Clients",
       "CURRENT_MVT" : "Mouvement Courant",
+      "ADD_IGNORED_CLIENTS" : "Sauter Certains Clients",
+      "HIDE_IGNORED_CLIENTS" : "Sauter Certains Clients",
       "PREVIOUS_MVT" : "Du debut Au :",
       "DESCRIPTION" : "Ce rapport affiche tous les groupes de debiteurs, leurs situations precedent l'annee en cours, leurs situations de l'annee en cours ainsi que la balance finale"
     },

--- a/client/src/js/components/bhHiddenField.js
+++ b/client/src/js/components/bhHiddenField.js
@@ -1,0 +1,42 @@
+/**
+ * @overview bhHiddenField
+ *
+ * @description
+ * This component allows a programmer to optionally hide a field in a form at
+ * startup that may toggled open by the user if they need it.
+ */
+
+var template =
+ '<p>' +
+   '<a ng-click="$ctrl.toggleVisibility()" bh-hidden-field-toggle href>' +
+      '<span ng-hide="$ctrl.visible"> + <span translate>{{ $ctrl.showText }}</span></span>' +
+      '<span ng-show="$ctrl.visible"> - <span translate>{{ $ctrl.hideText }}</span></span>' +
+   '</a>' +
+ '</p>' +
+ '<div ng-if="$ctrl.visible">' +
+  '<ng-transclude></ng-transclude>' +
+ '</div>';
+
+
+angular.module('bhima.components')
+  .component('bhHiddenField', {
+    template : template,
+    transclude : true,
+    controller : bhHiddenFieldController,
+    bindings : {
+      showText : '@',
+      hideText : '@',
+    },
+  });
+
+function bhHiddenFieldController() {
+  var $ctrl = this;
+
+  $ctrl.$onInit = function onInit() {
+    $ctrl.visible = false;
+  };
+
+  $ctrl.toggleVisibility = function toggleVisibility() {
+    $ctrl.visible = !$ctrl.visible;
+  };
+}

--- a/client/src/js/components/bhHiddenField.js
+++ b/client/src/js/components/bhHiddenField.js
@@ -5,22 +5,9 @@
  * This component allows a programmer to optionally hide a field in a form at
  * startup that may toggled open by the user if they need it.
  */
-
-var template =
- '<p>' +
-   '<a ng-click="$ctrl.toggleVisibility()" bh-hidden-field-toggle href>' +
-      '<span ng-hide="$ctrl.visible"> + <span translate>{{ $ctrl.showText }}</span></span>' +
-      '<span ng-show="$ctrl.visible"> - <span translate>{{ $ctrl.hideText }}</span></span>' +
-   '</a>' +
- '</p>' +
- '<div ng-if="$ctrl.visible">' +
-  '<ng-transclude></ng-transclude>' +
- '</div>';
-
-
 angular.module('bhima.components')
   .component('bhHiddenField', {
-    template : template,
+    templateUrl : 'modules/templates/bhHiddenField.html',
     transclude : true,
     controller : bhHiddenFieldController,
     bindings : {

--- a/client/src/modules/reports/generate/clients_report/clients_report.html
+++ b/client/src/modules/reports/generate/clients_report/clients_report.html
@@ -46,11 +46,15 @@
             </div>
 
             <!-- Client to ignore  -->
-            <bh-multiple-debtor-group-select
-              label="FORM.LABELS.CLIENT_TO_IGNORE"
-              on-select-callback="ReportConfigCtrl.onDebtorGroupSelected(debtorGroups)"
-              on-remove-callback="ReportConfigCtrl.onDebtorGroupRemoved(debtorGroups)">
-            </bh-multiple-debtor-group-select>
+            <bh-hidden-field
+              show-text="REPORT.CLIENTS_REPORT.ADD_IGNORED_CLIENTS"
+              hide-text="REPORT.CLIENTS_REPORT.HIDE_IGNORED_CLIENTS">
+              <bh-multiple-debtor-group-select
+                label="FORM.LABELS.CLIENT_TO_IGNORE"
+                on-select-callback="ReportConfigCtrl.onDebtorGroupSelected(debtorGroups)"
+                on-remove-callback="ReportConfigCtrl.onDebtorGroupRemoved(debtorGroups)">
+              </bh-multiple-debtor-group-select>
+            </bh-hidden-field>
 
             <bh-loading-button loading-state="ConfigForm.$loading">
               <span translate>REPORT.UTIL.PREVIEW</span>

--- a/client/src/modules/templates/bhHiddenField.html
+++ b/client/src/modules/templates/bhHiddenField.html
@@ -1,0 +1,9 @@
+<p>
+  <a ng-click="$ctrl.toggleVisibility()" bh-hidden-field-toggle href>
+    <span ng-hide="$ctrl.visible"> + <span translate>{{ $ctrl.showText }}</span></span>
+    <span ng-show="$ctrl.visible"> - <span translate>{{ $ctrl.hideText }}</span></span>
+  </a>
+</p>
+<div ng-if="$ctrl.visible" bh-hidden-field-transclude>
+  <ng-transclude></ng-transclude>
+</div>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,8 +9,7 @@ module.exports = function (config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha', 'chai-spies', 'chai'],
-
+    frameworks: ['mocha', 'chai-spies', 'chai-dom', 'chai'],
 
     // list of files / patterns to load in the browser
     files: [

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "gulp-util": "^3.0.7",
     "karma": "^1.1.2",
     "karma-chai": "^0.1.0",
+    "karma-chai-dom": "^1.1.0",
     "karma-chai-spies": "^0.1.4",
     "karma-chrome-launcher": "^2.2.0",
     "karma-mocha": "^1.2.0",

--- a/server/controllers/finance/reports/clientsReport/report_complex.handlebars
+++ b/server/controllers/finance/reports/clientsReport/report_complex.handlebars
@@ -51,6 +51,8 @@
               <td class='text-right'> {{currency this.currentBalance ../enterprise.currency_id}} </td>
               <td class='text-right'> {{currency this.finalBalance ../enterprise.currency_id}} </td>
             </tr>
+          {{else}}
+            {{>emptyTable columns=7}}
           {{/each}}
         </tbody>
         <tfoot>

--- a/test/client-unit/components/bhHiddenField.spec.js
+++ b/test/client-unit/components/bhHiddenField.spec.js
@@ -1,0 +1,72 @@
+/* global inject, expect */
+
+describe('bhHiddenField', bhHiddenFieldTests);
+
+function bhHiddenFieldTests() {
+  const template = `
+    <bh-hidden-field show-text="OPEN" hide-text="CLOSE">
+      <p id="test">TEST</p>
+    </bh-hidden-field>
+  `;
+
+  // make sure the
+  beforeEach(module('pascalprecht.translate', 'bhima.services', 'bhima.components', 'templates'));
+
+  let $scope;
+  let $compile;
+  let element;
+
+  beforeEach(inject((_$rootScope_, _$compile_) => {
+    $scope = _$rootScope_.$new();
+    $compile = _$compile_;
+
+    element = angular.element(template);
+    $compile(element)($scope);
+    $scope.$digest();
+  }));
+
+  // jqLite's "find" only looks at class names.  Mock a better find.
+  const find = (elm, selector) => elm[0].querySelector(selector);
+
+  it('should hide the hidden field by default', () => {
+    const transclusion = find(element, '[bh-hidden-field-transclude]');
+    expect(transclusion).not.to.exist;
+  });
+
+  it('should show the hidden field when toggled', () => {
+    const toggle = find(element, '[bh-hidden-field-toggle]');
+    angular.element(toggle).click();
+
+    $scope.$digest();
+
+    const transclusion = find(element, '[bh-hidden-field-transclude]');
+    expect(transclusion).to.exist;
+
+    const content = find(element, '#test');
+    expect(content).to.exist;
+    expect(content).to.contain.text('TEST');
+  });
+
+  it('should hide the data again when clicked twice', () => {
+
+    // click to show data!
+    const toggle = find(element, '[bh-hidden-field-toggle]');
+    angular.element(toggle).click();
+
+    $scope.$digest();
+
+    let transclusion = find(element, '[bh-hidden-field-transclude]');
+    expect(transclusion).to.exist;
+
+    const content = find(element, '#test');
+    expect(content).to.exist;
+    expect(content).to.contain.text('TEST');
+
+    // click to hide data!
+    angular.element(toggle).click();
+    $scope.$digest();
+
+    transclusion = find(element, '[bh-hidden-field-transclude]');
+    expect(transclusion).not.to.exist;
+  });
+}

--- a/test/end-to-end/reports/clients_report/clients_report.page.js
+++ b/test/end-to-end/reports/clients_report/clients_report.page.js
@@ -19,7 +19,7 @@ class ClientsReportPage {
     components.dateInterval.range(start_date, end_date);
     if (clients) {
       components.multipleDebtorGroupSelect.set(clients);
-    }    
+    }
     this.page.preview();
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -616,6 +616,10 @@ chai-datetime@^1.5.0:
   dependencies:
     chai ">1.9.0"
 
+chai-dom@*:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/chai-dom/-/chai-dom-1.6.0.tgz#9539de3114c1391e945824f1c093f138ae91990b"
+
 chai-http@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/chai-http/-/chai-http-1.0.0.tgz#87d4407aa342db0b6e8d67bf68731a42095b3d10"
@@ -3418,6 +3422,12 @@ jszip@^3.1.3:
     lie "~3.1.0"
     pako "~1.0.2"
     readable-stream "~2.0.6"
+
+karma-chai-dom@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/karma-chai-dom/-/karma-chai-dom-1.1.0.tgz#1b36514822cbb5fa749d007de76e4221ae34cfa4"
+  dependencies:
+    chai-dom "*"
 
 karma-chai-spies@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
This commit implements the `bhHiddenField` component which hides any transcluded HTML behind a toggle and lets the user decide when to show it and to hide it after.  The use case is for option fields in forms that do not need to be considered by default.  For example, many reports have complex options that should not be presented on the outset, but can instead by added in later.

Closes #933.

![clientsreportclosed](https://user-images.githubusercontent.com/896472/32426507-81521b88-c2c3-11e7-957f-bc9240fafa0d.PNG)
_Fig 1: Closed Hidden Field_

![clientsreportopen](https://user-images.githubusercontent.com/896472/32426508-82157466-c2c3-11e7-877f-009598a09204.PNG)
_Fig 2: Open Hidden Field_