### PR TITLE
chore: enable strict component bindings

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -171,6 +171,8 @@ function compileConfig($compileProvider) {
     $compileProvider.commentDirectivesEnabled(false);
     $compileProvider.cssClassDirectivesEnabled(false);
   }
+
+  $compileProvider.strictComponentBindingsEnabled(true);
 }
 
 /**


### PR DESCRIPTION
This commit turns on parsing-time checks for bindings that are required
by angular components but not provided.  These checks ensure that a
component's API is respected.  Since they provide a slight performance
hit in production, they probably can be turned off in releases.

Closes #2223.