### PR TITLE
chore: add fiscal year error i18n translations

### DIFF
--- a/client/src/i18n/en/errors.json
+++ b/client/src/i18n/en/errors.json
@@ -5,6 +5,7 @@
     "ERR_INTERNET_DISCONNECTED" : "You are not connected to the network.",
     "MISSING_INVENTORY_ACCOUNTS" : "Some selected inventories doesn't have stock accounts associated",
     "NO_EXCHANGE_RATE" : "No Exchange rate defined",
+    "NO_FISCAL_YEAR" : "You are missing a fiscal year for that date!",
     "NOT_ALLOWED" : "You are not allowed to perform this action",
     "NOT_FOUND" : "This record could not be found",
     "NO_PERMISSIONS" : "The login succeeded, but you have no permissions. Please see a system administrator.",

--- a/client/src/i18n/fr/errors.json
+++ b/client/src/i18n/fr/errors.json
@@ -9,6 +9,7 @@
     "NOT_FOUND" : "Cet enregistrement n'a pas pu être trouvé",
     "NO_PERMISSIONS" : "La connexion a réussi, mais vous n'avez aucune autorisation. Veuillez contacter un administrateur système.",
     "NO_PROJECT" : "Aucune autorisation pour ce projet, Veuillez contacter un administrateur système",
+    "NO_FISCAL_YEAR" : "Aucune année fiscale pour cette date!",
     "UNAUTHORIZED" : "Vous avez soumis un mauvais nom ou mot de passe.  Entrez un nom ou un mot de passe valid pour continuer.",
     "UNKNOWN" : "Une erreur est survenue.",
     "OVERPAID_INVOICE" : "Vous avez payé trop aux factures.",


### PR DESCRIPTION
This commit adds a translated message for the error thrown when the server cannot find a fiscal year.