### PR TITLE
feat(patient registration) correct message for date of birth input

### DIFF
--- a/client/src/modules/patients/registration/registration.js
+++ b/client/src/modules/patients/registration/registration.js
@@ -24,7 +24,7 @@ function PatientRegistrationController(Patients, Session, util, Notify,
   vm.submit = submit;
   vm.toggleFullDate = toggleFullDate;
   vm.calculateYOB = calculateYOB;
-  vm.dateIndicatorLabel = 'FORM.LABELS.ENTER_BIRTH_DAY';
+  vm.dateIndicatorLabel = 'FORM.LABELS.ENTER_BIRTH_YEAR';
   vm.dateComponentLabel = 'FORM.LABELS.DOB';
 
 


### PR DESCRIPTION
When first rendered in the patient registration page, the Year of Birth option does not say "Enter only Year of Birth" . this PR solves that problem.
closes  #2336