### PR TITLE
feat(invetory item) add currency symbol next to the price label

### DIFF
--- a/client/src/modules/inventory/list/modals/actions.modal.js
+++ b/client/src/modules/inventory/list/modals/actions.modal.js
@@ -2,20 +2,21 @@ angular.module('bhima.controllers')
   .controller('InventoryListActionsModalController', InventoryListActionsModalController);
 
 InventoryListActionsModalController.$inject = [
-  'AccountService', 'InventoryService','NotifyService',
-  '$uibModalInstance', '$state', 'util', 'appcache'
+  'AccountService', 'InventoryService', 'NotifyService',
+  '$uibModalInstance', '$state', 'util', 'appcache', 'SessionService',
 ];
 
-function InventoryListActionsModalController(Account, Inventory, Notify, Instance, $state, util, AppCache) {
+function InventoryListActionsModalController(Account, Inventory, Notify, Instance, $state, util, AppCache, SessionService) {
   var vm = this;
   var cache = AppCache('InventoryList');
 
   // this is the model
   vm.item = {};
   vm.stateParams = {};
+  vm.currencySymbol = SessionService.enterprise.currencySymbol;
 
   vm.stateParams = cache.stateParams = $state.params;
-  if($state.params.uuid || $state.params.creating){
+  if ($state.params.uuid || $state.params.creating) {
     vm.stateParams = cache.stateParams = $state.params;
   } else {
     vm.stateParams = cache.stateParams;
@@ -46,7 +47,7 @@ function InventoryListActionsModalController(Account, Inventory, Notify, Instanc
     if (util.isEmptyObject(record)) {
       return cancel();
     }
- 
+
     var promise = vm.isCreateState ?
       Inventory.create(record) :
       Inventory.update(vm.identifier, record);
@@ -78,7 +79,6 @@ function InventoryListActionsModalController(Account, Inventory, Notify, Instanc
 
   /** startup */
   function startup() {
-
     // Inventory Group
     Inventory.Groups.read()
       .then(function (groups) {
@@ -108,6 +108,5 @@ function InventoryListActionsModalController(Account, Inventory, Notify, Instanc
         })
         .catch(Notify.handleError);
     }
-
   }
 }

--- a/client/src/modules/inventory/list/modals/actions.tmpl.html
+++ b/client/src/modules/inventory/list/modals/actions.tmpl.html
@@ -59,7 +59,7 @@
 
     <div class="form-group"
       ng-class="{ 'has-error' : ActionForm.$submitted && ActionForm.price.$invalid }">
-      <label class="control-label" translate>FORM.LABELS.PRICE</label>
+      <label class="control-label"><span translate>FORM.LABELS.PRICE </span> ({{$ctrl.currencySymbol}})</label>
       <input class="form-control"
         type="number"
         ng-min="0"


### PR DESCRIPTION
For more understanding, the currency symbol should be display some where in the inventory item registration. So this PR helps to do it.
You can see, at the bellow picture, how the modal looks like now
![symbolecurrency](https://user-images.githubusercontent.com/25838121/33701923-6f0bc750-db21-11e7-9b32-ac014e62a149.PNG)

closes #2341 