### PR TITLE
fix(db, UI): make transfer account not required

### DIFF
--- a/client/src/modules/cash/cashboxes/configure_currency/modal.html
+++ b/client/src/modules/cash/cashboxes/configure_currency/modal.html
@@ -32,6 +32,7 @@
 
     <bh-account-select
       id="transfer-account-id"
+      required="false"
       account-id="CashboxModalCtrl.data.transfer_account_id"
       label="FORM.LABELS.TRANSFER_ACCOUNT"
       name="transfer_account_id"

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -160,7 +160,7 @@ CREATE TABLE `cash_box_account_currency` (
   `currency_id`         TINYINT UNSIGNED NOT NULL,
   `cash_box_id`         MEDIUMINT UNSIGNED NOT NULL,
   `account_id`          INT UNSIGNED NOT NULL,
-  `transfer_account_id` INT UNSIGNED NOT NULL,
+  `transfer_account_id` INT UNSIGNED DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `cash_box_account_currency_1` (`currency_id`, `cash_box_id`, `account_id`),
   UNIQUE KEY `cash_box_account_currency_2` (`currency_id`, `cash_box_id`, `transfer_account_id`),


### PR DESCRIPTION
This pull request update the db to make transfer account null by default and update the UI in order to let the user creating a cash-box without being required to provide a transfer account.
closes #2357 