### PR TITLE
fix(currency): use decimal point 1000s place FC

### DIFF
--- a/client/src/i18n/currency/fc.json
+++ b/client/src/i18n/currency/fc.json
@@ -1,7 +1,7 @@
 {
   "CURRENCY_SYM": "Fc",
   "DECIMAL_SEP": ",",
-  "GROUP_SEP": "\u00a0",
+  "GROUP_SEP": ".",
   "PATTERNS": [
     {
       "gSize": 3,


### PR DESCRIPTION
This commit uses a decimal point instead of white space to separate the
FCs thousands place.  It makes the currency much more readable on the
client.

Closes #2371.