### PR TITLE
fix(inventory) : refresh correctly the grid after an update

### DIFF
--- a/client/src/modules/inventory/inventory.routes.js
+++ b/client/src/modules/inventory/inventory.routes.js
@@ -1,56 +1,61 @@
 angular.module('bhima.routes')
-  .config(['$stateProvider', function ($stateProvider) {
-    $stateProvider
-      .state('inventoryConfiguration', {
-        url : '/inventory/configuration',
-        views : {
-          '' : {
-            templateUrl : 'modules/inventory/configuration/configuration.html',
-          },
-          'groups@inventoryConfiguration' : {
-            templateUrl : 'modules/inventory/configuration/groups/groups.html',
-            controller : 'InventoryGroupsController as GroupsCtrl',
-          },
-          'types@inventoryConfiguration' : {
-            templateUrl : 'modules/inventory/configuration/types/types.html',
-            controller : 'InventoryTypesController as TypesCtrl',
-          },
-          'units@inventoryConfiguration' : {
-            templateUrl : 'modules/inventory/configuration/units/units.html',
-            controller : 'InventoryUnitsController as UnitsCtrl',
-          },
-        },
-      })
-      .state('inventory', {
-        abstract : true,
-        url : '/inventory',
-        controller : 'InventoryListController as InventoryCtrl',
-        templateUrl : 'modules/inventory/list/list.html',
-      })
-      .state('inventory.create', {
-        url : '/create',
-        params : {
-          creating : { value : true },
-        },
-        onEnter : ['$state', 'ModalService', onEnterFactory('create')],
-        onExit : ['$uibModalStack', closeModal],
-      })
-      .state('inventory.update', {
-        url : '/:uuid/update',
-        onEnter : ['$state', 'ModalService', onEnterFactory('update')],
-        onExit : ['$uibModalStack', closeModal],
-      })
-      .state('inventory.list', {
-        url : '/:uuid',
-        params : {
-          uuid : { squash : true, value : null },
-          created : false, // default for transitioning from child states
-          updated : false, // default for transitioning from child states
-          filters : [],
-        },
-      });
-  }]);
+  .config(['$stateProvider', inventoryStateProvider]);
 
+function inventoryStateProvider($stateProvider) {
+  $stateProvider
+    .state('inventoryConfiguration', {
+      url : '/inventory/configuration',
+      views : {
+        '' : {
+          templateUrl : 'modules/inventory/configuration/configuration.html',
+        },
+        'groups@inventoryConfiguration' : {
+          templateUrl : 'modules/inventory/configuration/groups/groups.html',
+          controller : 'InventoryGroupsController as GroupsCtrl',
+        },
+        'types@inventoryConfiguration' : {
+          templateUrl : 'modules/inventory/configuration/types/types.html',
+          controller : 'InventoryTypesController as TypesCtrl',
+        },
+        'units@inventoryConfiguration' : {
+          templateUrl : 'modules/inventory/configuration/units/units.html',
+          controller : 'InventoryUnitsController as UnitsCtrl',
+        },
+      },
+    })
+    .state('inventory', {
+      abstract : true,
+      url : '/inventory',
+      controller : 'InventoryListController as InventoryCtrl',
+      templateUrl : 'modules/inventory/list/list.html',
+    })
+    .state('inventory.create', {
+      url : '/create',
+      params : {
+        creating : { value : true },
+        filters : [],
+      },
+      onEnter : ['$state', 'ModalService', onEnterFactory('create')],
+      onExit : ['$uibModalStack', closeModal],
+    })
+    .state('inventory.update', {
+      url : '/:uuid/update',
+      onEnter : ['$state', 'ModalService', onEnterFactory('update')],
+      onExit : ['$uibModalStack', closeModal],
+      params : {
+        filters : [],
+      },
+    })
+    .state('inventory.list', {
+      url : '/:uuid',
+      params : {
+        uuid : { squash : true, value : null },
+        created : false, // default for transitioning from child states
+        updated : false, // default for transitioning from child states
+        filters : [],
+      },
+    });
+}
 
 function closeModal($uibModalStack) {
   $uibModalStack.dismissAll();
@@ -63,8 +68,8 @@ function onEnterFactory(stateType) {
   return function onEnter($state, Modal) {
     var instance = Modal.openInventoryListActions();
     instance
-      .then(function (uuid) {
-        var params = { uuid : uuid };
+      .then(function handleOnEnter(_uuid) {
+        var params = { uuid : _uuid };
 
         if (isCreateState) {
           params.created = true;
@@ -74,8 +79,8 @@ function onEnterFactory(stateType) {
 
         $state.go('^.list', params, { reload : true });
       })
-      .catch(function (error) {
-        $state.go('^.list', { uuid : $state.params.id }, {notify : false });
+      .catch(function handleError() {
+        $state.go('^.list', { uuid : $state.params.id }, { notify : false });
       });
   };
 }

--- a/client/src/modules/inventory/list/modals/actions.modal.js
+++ b/client/src/modules/inventory/list/modals/actions.modal.js
@@ -68,13 +68,13 @@ function InventoryListActionsModalController(
       message = vm.isCreateState ? 'FORM.INFO.CREATE_SUCCESS' : 'FORM.INFO.UPDATE_SUCCESS';
 
       $rootScope.$broadcast('INVENTORY_UPDATED');
-      
+
       Notify.success(message);
 
       // if we are supposed to create another item, just refresh the state
       if (vm.createAnotherItem) {
         vm.item = {};
-        form.$submitted = false;
+        form.$setPristine();
         return;
       }
 


### PR DESCRIPTION
This PR fix the refresh issue on the inventory grid after the creation of a new inventory (with the option add other activated)

Close #2377 