### PR TITLE
Fix findReference modal for Complex Vouchers

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -57,6 +57,7 @@
             "SUBMIT_CHANGES": "Submit Changes",
             "SUBMIT_CREDIT_NOTE": "Submit Credit Note",
             "SUSPEND": "Suspend",
+            "SHOW_ALL_RECORDS": "Show All Records",
             "THIS_WEEK": "This Week",
             "THIS_MONTH": "This Month",
             "THIS_YEAR": "This Year",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -53,6 +53,7 @@
             "CLEAR_GRID_CONFIGURATION": "Effacer la configuration",
             "SEARCH": "Rechercher",
             "SELECT_INVOICES": "Sélectionner la(les) Facture(s)",
+            "SHOW_ALL_RECORDS": "Télécharger toutes les lignes",
             "SUBMIT": "Soumettre",
             "SUBMIT_CREDIT_NOTE": "Soumettre la note de crédit",
             "SUBMIT_CHANGES": "Soumettre des changements",

--- a/client/src/modules/templates/modals/findEntity.modal.js
+++ b/client/src/modules/templates/modals/findEntity.modal.js
@@ -1,8 +1,8 @@
 angular.module('bhima.controllers')
-.controller('FindEntityModalController', FindEntityModalController);
+  .controller('FindEntityModalController', FindEntityModalController);
 
 FindEntityModalController.$inject = [
-  '$uibModalInstance','DebtorService', 'CreditorService', '$timeout',
+  '$uibModalInstance', 'DebtorService', 'CreditorService', '$timeout',
 ];
 
 /**
@@ -10,7 +10,7 @@ FindEntityModalController.$inject = [
  *
  * This controller provides bindings for the find entity modal.
  */
-function FindEntityModalController(Instance, Debtor, Creditor, $timeout) {
+function FindEntityModalController(Instance, Debtors, Creditors, $timeout) {
   var vm = this;
 
   vm.result = {};
@@ -28,15 +28,15 @@ function FindEntityModalController(Instance, Debtor, Creditor, $timeout) {
   vm.cancel = cancel;
   vm.refresh = refresh;
 
-  Debtor.read()
-  .then(function (list) {
-    vm.debtorList = list;
-  });
+  Debtors.read()
+    .then(function (debtors) {
+      vm.debtorList = debtors;
+    });
 
-  Creditor.read()
-  .then(function (list) {
-    vm.creditorList = list;
-  });
+  Creditors.read()
+    .then(function (creditors) {
+      vm.creditorList = creditors;
+    });
 
   function selectEntity(item) {
     vm.result = {
@@ -64,14 +64,14 @@ function FindEntityModalController(Instance, Debtor, Creditor, $timeout) {
 
   function submit() {
     // the $timeout fix the $digest error
-    $timeout(function() {
+    $timeout(function () {
       Instance.close(vm.result);
     }, 0, false);
   }
 
   function cancel() {
     // the $timeout fix the $digest error
-    $timeout(function() {
+    $timeout(function () {
       Instance.close();
     }, 0, false);
   }

--- a/client/src/modules/templates/modals/findReference.modal.html
+++ b/client/src/modules/templates/modals/findReference.modal.html
@@ -12,9 +12,9 @@
     <div class="toolbar">
       <div class="toolbar-item">
         <button type="button"
-          ng-click="$ctrl.toggleFilter()"
+          ng-click="$ctrl.toggleInlineFilter()"
           class="btn btn-default"
-          ng-class="{ 'btn-info' : $ctrl.filterEnabled }">
+          ng-class="{ 'btn-info' : $ctrl.gridOptions.enableFiltering }">
           <span class="fa fa-filter"></span>
         </button>
 
@@ -28,7 +28,7 @@
   </div>
 </div>
 
-<div class="modal-body clearfix">
+<div class="modal-body">
 
   <!-- select document type  -->
   <div ng-hide="$ctrl.documentTypeSelected">
@@ -67,24 +67,37 @@
     </div>
   </div>
 
-  <!-- select references  -->
-  <div class="row" ng-show="$ctrl.documentTypeSelected">
-    <div class="col-xs-12">
-      <div
-        id="referenceGrid"
-        class="journalGrid"
-        ui-grid="$ctrl.gridOptions"
-        ui-grid-auto-resize
-        ui-grid-resize-columns
-        ui-grid-selection>
+  <!-- select references -->
+
+
+  <section ng-if="$ctrl.documentTypeSelected">
+    <div class="row">
+      <div class="col-xs-12">
+        <div
+          id="referenceGrid"
+          class="journalGrid"
+          ui-grid="$ctrl.gridOptions"
+          ui-grid-auto-resize
+          ui-grid-resize-columns
+          ui-grid-selection>
+        </div>
+        <bh-grid-loading-indicator
+          loading-state="$ctrl.loading"
+          empty-state="$ctrl.gridOptions.data.length === 0"
+          error-state="$ctrl.hasError">
+        </bh-grid-loading-indicator>
       </div>
-      <bh-grid-loading-indicator
-        loading-state="$ctrl.loading"
-        empty-state="$ctrl.gridOptions.data.length === 0"
-        error-state="$ctrl.hasError">
-      </bh-grid-loading-indicator>
     </div>
-  </div>
+
+    <div class="row">
+      <div class="col-xs-12">
+        <p style="margin:0.25em 0;" ng-show="$ctrl.gridOptions.data.length === $ctrl.DEFAULT_DOWNLOAD_LIMIT">
+          <span>({{ $ctrl.gridOptions.data.length }})</span> <span translate>FORM.LABELS.RECORDS</span>
+          <a href ng-click="$ctrl.showAllRecords()" translate>FORM.BUTTONS.SHOW_ALL_RECORDS</a>
+        </p>
+      </div>
+    </div>
+  </section>
 </div>
 
 <div class="modal-footer text-right" data-reference-modal>

--- a/client/src/modules/templates/modals/findReference.modal.js
+++ b/client/src/modules/templates/modals/findReference.modal.js
@@ -3,16 +3,20 @@ angular.module('bhima.controllers')
 
 FindReferenceModalController.$inject = [
   '$uibModalInstance', 'VoucherService', 'CashService', 'GridFilteringService',
-  'entity', 'PatientInvoiceService', 'uiGridConstants', 'NotifyService'
+  'entity', 'PatientInvoiceService', 'uiGridConstants', 'NotifyService',
+  'bhConstants',
 ];
 
 /**
  * Find Reference Modal Controller
  *
  * This controller provides bindings for the find references modal.
- * @todo Implement the Cash Payment Data list for the references
+ * TODO Implement the Cash Payment Data list for the references
  */
-function FindReferenceModalController(Instance, Voucher, Cash, Filtering, Entity, Invoices, uiGridConstants, Notify) {
+function FindReferenceModalController(
+  Instance, Voucher, Cash, GridFilter, entity, Invoices, uiGridConstants,
+  Notify, bhConstants
+) {
   var vm = this;
 
   vm.result = {};
@@ -20,34 +24,39 @@ function FindReferenceModalController(Instance, Voucher, Cash, Filtering, Entity
   vm.loading = false;
 
   vm.documentType = {
-    'patient_invoice' : {
+    patient_invoice : {
       label : 'VOUCHERS.COMPLEX.PATIENT_INVOICE',
-      action : referencePatientInvoice
+      action : referencePatientInvoice,
     },
-    'cash_payment' : {
+    cash_payment : {
       label : 'VOUCHERS.COMPLEX.CASH_PAYMENT',
-      action : referenceCashPayment
+      action : referenceCashPayment,
     },
-    'voucher' : {
+    voucher : {
       label : 'VOUCHERS.COMPLEX.VOUCHER',
-      action : referenceVoucher
-    }
+      action : referenceVoucher,
+    },
   };
 
   vm.selectDocType = selectDocType;
-  vm.submit  = submit;
-  vm.cancel  = cancel;
+  vm.submit = submit;
+  vm.cancel = cancel;
   vm.refresh = refresh;
 
   /* ======================= Grid configurations ============================ */
   vm.filterEnabled = false;
+
+  // TODO - make this a default options extensible by many different
   vm.gridOptions = {};
 
-  var filtering  = new Filtering(vm.gridOptions);
+  var filtering = new GridFilter(vm.gridOptions);
 
-  vm.gridOptions.multiSelect     = false;
+  vm.gridOptions.multiSelect = false;
   vm.gridOptions.enableFiltering = vm.filterEnabled;
-  vm.gridOptions.onRegisterApi   = onRegisterApi;
+  vm.gridOptions.onRegisterApi = onRegisterApi;
+  vm.gridOptions.fastWatch = true;
+  vm.gridOptions.flatEntityAccess = true;
+  vm.gridOptions.enableColumnMenus = false;
   vm.toggleFilter = toggleFilter;
 
   function onRegisterApi(gridApi) {
@@ -87,16 +96,16 @@ function FindReferenceModalController(Instance, Voucher, Cash, Filtering, Entity
           { field : 'reference', displayName : 'TABLE.COLUMNS.REFERENCE', headerCellFilter: 'translate' },
           {
             field : 'date',
-            cellFilter:'date',
+            cellFilter : 'date:"'.concat(bhConstants.dates.format, '"'),
             filter : { condition : filtering.filterByDate },
             displayName : 'TABLE.COLUMNS.BILLING_DATE',
             headerCellFilter : 'translate',
-            sort : { priority : 0, direction : 'desc'}
+            sort : { priority : 0, direction : 'desc' },
           },
-          { field : 'patientNames', displayName : 'TABLE.COLUMNS.PATIENT', headerCellFilter : 'translate' },
+          { field : 'patientName', displayName : 'TABLE.COLUMNS.PATIENT', headerCellFilter : 'translate' },
           { field : 'cost', displayName : 'TABLE.COLUMNS.COST', headerCellFilter : 'translate', cellTemplate: costTemplate },
-          { field : 'serviceName', displayName : 'TABLE.COLUMNS.SERVICE', headerCellFilter : 'translate'  },
-          { field : 'display_name', displayName : 'TABLE.COLUMNS.BY', headerCellFilter : 'translate' }
+          { field : 'serviceName', displayName : 'TABLE.COLUMNS.SERVICE', headerCellFilter : 'translate' },
+          { field : 'display_name', displayName : 'TABLE.COLUMNS.BY', headerCellFilter : 'translate' },
         ];
 
         vm.gridOptions.data = list;
@@ -119,11 +128,12 @@ function FindReferenceModalController(Instance, Voucher, Cash, Filtering, Entity
           { field : 'reference', displayName : 'TABLE.COLUMNS.REFERENCE', headerCellFilter: 'translate' },
           {
             field : 'date',
-            cellFilter:'date',
+            cellFilter : 'date:"'.concat(bhConstants.dates.format, '"'),
+            type : 'date',
             filter : { condition : filtering.filterByDate },
             displayName : 'TABLE.COLUMNS.BILLING_DATE',
             headerCellFilter : 'translate',
-            sort : { priority : 0, direction : 'desc'}
+            sort : { priority : 0, direction : 'desc' }
           },
           { field : 'description', displayName : 'TABLE.COLUMNS.DESCRIPTION', headerCellFilter : 'translate' },
           { field : 'amount', displayName : 'TABLE.COLUMNS.COST', headerCellFilter : 'translate', cellTemplate: costTemplate }
@@ -145,16 +155,16 @@ function FindReferenceModalController(Instance, Voucher, Cash, Filtering, Entity
             '{{ row.entity.amount | currency: grid.appScope.enterprise.currency_id }}' +
           '</div>';
 
-        vm.gridOptions.columnDefs  = [
-          { field : 'reference', displayName : 'Reference'},
+        vm.gridOptions.columnDefs = [
+          { field : 'reference', displayName : 'Reference' },
           {
             field : 'date',
             displayName : 'Date',
-            cellFilter : 'date:"mediumDate"',
+            cellFilter : 'date:"'.concat(bhConstants.dates.format, '"'),
             filter : { condition : filtering.filterByDate },
-            sort : { priority : 0, direction : 'desc'}
+            sort : { priority : 0, direction : 'desc' }
           },
-          { field : 'description', displayName : 'Description'},
+          { field : 'description', displayName : 'Description' },
           { field : 'amount', displayName : 'Amount', cellTemplate: amountTemplate }
         ];
 
@@ -165,7 +175,7 @@ function FindReferenceModalController(Instance, Voucher, Cash, Filtering, Entity
             reference     : item.reference,
             date          : item.date,
             description   : item.description,
-            amount        : item.amount
+            amount        : item.amount,
           };
         });
         vm.gridOptions.data = data;
@@ -182,6 +192,7 @@ function FindReferenceModalController(Instance, Voucher, Cash, Filtering, Entity
 
   function refresh() {
     vm.documentTypeSelected = false;
+    vm.gridOptions.data = [];
   }
 
   function submit() {
@@ -193,7 +204,7 @@ function FindReferenceModalController(Instance, Voucher, Cash, Filtering, Entity
   }
 
   function startup() {
-    vm.selectedEntity = Entity || {};
+    vm.selectedEntity = entity || {};
   }
 
   function toggleLoadingIndicator() {

--- a/client/src/modules/templates/modals/findReference.modal.js
+++ b/client/src/modules/templates/modals/findReference.modal.js
@@ -4,20 +4,27 @@ angular.module('bhima.controllers')
 FindReferenceModalController.$inject = [
   '$uibModalInstance', 'VoucherService', 'CashService', 'GridFilteringService',
   'entity', 'PatientInvoiceService', 'uiGridConstants', 'NotifyService',
-  'bhConstants',
+  'bhConstants', 'SessionService',
 ];
 
 /**
  * Find Reference Modal Controller
  *
+ * @description
  * This controller provides bindings for the find references modal.
- * TODO Implement the Cash Payment Data list for the references
+ *
+ * TODO(@jniles) - rewrite this entire file.  There is no need to use objects,
+ * just call the methods from the HTML itself.
  */
 function FindReferenceModalController(
   Instance, Voucher, Cash, GridFilter, entity, Invoices, uiGridConstants,
-  Notify, bhConstants
+  Notify, bhConstants, Session
 ) {
   var vm = this;
+  var filtering;
+  var SHARED_COLUMN_DEFNS;
+  var DEFAULT_DOWNLOAD_LIMIT = 250;
+  vm.DEFAULT_DOWNLOAD_LIMIT = DEFAULT_DOWNLOAD_LIMIT;
 
   vm.result = {};
 
@@ -42,131 +49,112 @@ function FindReferenceModalController(
   vm.submit = submit;
   vm.cancel = cancel;
   vm.refresh = refresh;
+  vm.showAllRecords = showAllRecords;
 
   /* ======================= Grid configurations ============================ */
-  vm.filterEnabled = false;
 
   // TODO - make this a default options extensible by many different
   vm.gridOptions = {};
 
-  var filtering = new GridFilter(vm.gridOptions);
-
   vm.gridOptions.multiSelect = false;
-  vm.gridOptions.enableFiltering = vm.filterEnabled;
+  vm.gridOptions.enableFiltering = false;
   vm.gridOptions.onRegisterApi = onRegisterApi;
   vm.gridOptions.fastWatch = true;
   vm.gridOptions.flatEntityAccess = true;
   vm.gridOptions.enableColumnMenus = false;
-  vm.toggleFilter = toggleFilter;
+
+  filtering = new GridFilter(vm.gridOptions);
 
   function onRegisterApi(gridApi) {
     vm.gridApi = gridApi;
-    vm.gridApi.selection.on.rowSelectionChanged(null, rowSelectionCallback);
   }
 
-  function rowSelectionCallback(row) {
-    vm.selectedRow = row.entity;
-
-    // update to selected document type
-    vm.selectedRow.document_type = vm.documentTypeLabel;
-  }
-
-  /** toggle filter */
-  function toggleFilter() {
-    vm.filterEnabled = !vm.filterEnabled;
-    vm.gridOptions.enableFiltering = vm.filterEnabled;
+  // FIXME(@jniles) - by some quirk of UI grid, this doesn't work.
+  vm.toggleInlineFilter = function toggleInlineFilter() {
+    vm.gridOptions.enableFiltering = !vm.gridOptions.enableFiltering;
     vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
-  }
+  };
+
   /* ======================= End Grid configurations ======================== */
 
   // startup the modal
   startup();
 
-  function referencePatientInvoice() {
+  SHARED_COLUMN_DEFNS = [{
+    field : 'reference',
+    displayName : 'TABLE.COLUMNS.REFERENCE',
+    headerCellFilter : 'translate',
+  }, {
+    field : 'date',
+    cellFilter : 'date:"'.concat(bhConstants.dates.format, '"'),
+    filter : { condition : filtering.filterByDate },
+    displayName : 'TABLE.COLUMNS.DATE',
+    headerCellFilter : 'translate',
+    sort : { priority : 0, direction : 'desc' },
+  }, {
+    field : 'amount',
+    displayName : 'TABLE.COLUMNS.COST',
+    headerCellFilter : 'translate',
+    cellFilter: 'currency:'.concat(Session.enterprise.currency_id),
+    cellClass : 'text-right',
+  }];
+
+  // this function extends the columns list by splicing in the accounts
+  // at the second position.
+  function substitute(columns) {
+    var cloned = SHARED_COLUMN_DEFNS.slice();
+    Array.prototype.splice.apply(cloned, [1, 0].concat(columns));
+    return cloned;
+  }
+
+  function referencePatientInvoice(limit) {
     toggleLoadingIndicator();
 
-    Invoices.read()
+    Invoices.read(null, { limit : limit })
       .then(function (list) {
-        var costTemplate =
-          '<div class="ui-grid-cell-contents text-right">' +
-            '{{ row.entity.cost | currency: grid.appScope.enterprise.currency_id }}' +
-          '</div>';
-
-        vm.gridOptions.columnDefs = [
-          { field : 'reference', displayName : 'TABLE.COLUMNS.REFERENCE', headerCellFilter: 'translate' },
-          {
-            field : 'date',
-            cellFilter : 'date:"'.concat(bhConstants.dates.format, '"'),
-            filter : { condition : filtering.filterByDate },
-            displayName : 'TABLE.COLUMNS.BILLING_DATE',
-            headerCellFilter : 'translate',
-            sort : { priority : 0, direction : 'desc' },
-          },
+        vm.gridOptions.columnDefs = substitute([
           { field : 'patientName', displayName : 'TABLE.COLUMNS.PATIENT', headerCellFilter : 'translate' },
-          { field : 'cost', displayName : 'TABLE.COLUMNS.COST', headerCellFilter : 'translate', cellTemplate: costTemplate },
           { field : 'serviceName', displayName : 'TABLE.COLUMNS.SERVICE', headerCellFilter : 'translate' },
           { field : 'display_name', displayName : 'TABLE.COLUMNS.BY', headerCellFilter : 'translate' },
-        ];
+        ]);
+
+        // map the cost to the "amount" field
+        list.forEach(function (row) {
+          row.amount = row.cost;
+        });
 
         vm.gridOptions.data = list;
+
+        vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.ALL);
       })
       .catch(handler)
       .finally(toggleLoadingIndicator);
   }
 
-  function referenceCashPayment() {
+  function referenceCashPayment(limit) {
     toggleLoadingIndicator();
 
-    Cash.read()
+    Cash.read(null, { limit : limit })
       .then(function (list) {
-        var costTemplate =
-          '<div class="ui-grid-cell-contents text-right">' +
-            '{{ row.entity.amount | currency: grid.appScope.enterprise.currency_id }}' +
-          '</div>';
-
-        vm.gridOptions.columnDefs = [
-          { field : 'reference', displayName : 'TABLE.COLUMNS.REFERENCE', headerCellFilter: 'translate' },
-          {
-            field : 'date',
-            cellFilter : 'date:"'.concat(bhConstants.dates.format, '"'),
-            type : 'date',
-            filter : { condition : filtering.filterByDate },
-            displayName : 'TABLE.COLUMNS.BILLING_DATE',
-            headerCellFilter : 'translate',
-            sort : { priority : 0, direction : 'desc' }
-          },
+        vm.gridOptions.columnDefs = substitute([
           { field : 'description', displayName : 'TABLE.COLUMNS.DESCRIPTION', headerCellFilter : 'translate' },
-          { field : 'amount', displayName : 'TABLE.COLUMNS.COST', headerCellFilter : 'translate', cellTemplate: costTemplate }
-        ];
+        ]);
 
         vm.gridOptions.data = list;
+        vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.ALL);
       })
       .catch(handler)
       .finally(toggleLoadingIndicator);
   }
 
-  function referenceVoucher() {
+  function referenceVoucher(limit) {
     toggleLoadingIndicator();
 
-    Voucher.read()
+    Voucher.read(null, { limit : limit })
       .then(function (list) {
-        var amountTemplate =
-          '<div class="ui-grid-cell-contents text-right">' +
-            '{{ row.entity.amount | currency: grid.appScope.enterprise.currency_id }}' +
-          '</div>';
-
-        vm.gridOptions.columnDefs = [
-          { field : 'reference', displayName : 'Reference' },
-          {
-            field : 'date',
-            displayName : 'Date',
-            cellFilter : 'date:"'.concat(bhConstants.dates.format, '"'),
-            filter : { condition : filtering.filterByDate },
-            sort : { priority : 0, direction : 'desc' }
-          },
-          { field : 'description', displayName : 'Description' },
-          { field : 'amount', displayName : 'Amount', cellTemplate: amountTemplate }
-        ];
+        vm.gridOptions.columnDefs = substitute([
+          { field : 'description', displayName : 'TABLE.COLUMNS.DESCRIPTION', headerCellFilter : 'translate' },
+        ]);
 
         // format data for the grid
         var data = list.map(function (item) {
@@ -178,16 +166,26 @@ function FindReferenceModalController(
             amount        : item.amount,
           };
         });
+
         vm.gridOptions.data = data;
+
+        vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.ALL);
       })
       .catch(handler)
       .finally(toggleLoadingIndicator);
   }
 
+
   function selectDocType(type) {
+    vm.docType = type;
     vm.documentTypeLabel = vm.documentType[type].label;
-    vm.documentType[type].action();
+    vm.documentType[type].action(DEFAULT_DOWNLOAD_LIMIT);
     vm.documentTypeSelected = true;
+  }
+
+  function showAllRecords() {
+    // use a very, very large limit.
+    vm.documentType[vm.docType].action(10000000);
   }
 
   function refresh() {
@@ -196,7 +194,10 @@ function FindReferenceModalController(
   }
 
   function submit() {
-    Instance.close(vm.selectedRow);
+    var row = vm.gridApi.selection.getSelectedRows();
+    var e = row[0];
+    e.document_type = vm.documentTypeLabel;
+    Instance.close(e);
   }
 
   function cancel() {

--- a/client/src/modules/vouchers/complex-voucher.ctrl.js
+++ b/client/src/modules/vouchers/complex-voucher.ctrl.js
@@ -4,24 +4,25 @@ angular.module('bhima.controllers')
 ComplexJournalVoucherController.$inject = [
   'VoucherService', 'CurrencyService', 'SessionService',
   'FindEntityService', 'FindReferenceService', 'NotifyService',
-  'VoucherToolkitService', 'ReceiptModal', 'bhConstants', 'GridAggregatorService',
-  'uiGridConstants', 'VoucherForm', '$timeout',
+  'VoucherToolkitService', 'ReceiptModal', 'bhConstants', 'uiGridConstants',
+  'VoucherForm', '$timeout',
 ];
 
 /**
- * Complex Journal Vouchers
+ * @overview ComplexJournalVoucherController
  *
+ * @description
  * This module implements complex journal vouchers. It allows users to quickly create transactions by
  * specifying two or more lines of transactions and all relative document references
  *
  * @constructor
  *
- * @todo - Implement caching mechanism for incomplete forms (via AppCache)
- * @todo/@fixme - this error notification system needs serious refactor.
+ * TODO - Implement caching mechanism for incomplete forms (via AppCache)
+ * TODO/FIXME - this error notification system needs serious refactor.
  */
 function ComplexJournalVoucherController(
-  Vouchers, Currencies, Session, FindEntity, FindReference, Notify, Toolkit, Receipts, bhConstants,
-  GridAggregators, uiGridConstants, VoucherForm, $timeout
+  Vouchers, $translate, Currencies, Session, FindEntity, FindReference, Notify,
+  Toolkit, Receipts, bhConstants, uiGridConstants, VoucherForm, $timeout
 ) {
   var vm = this;
 
@@ -111,7 +112,7 @@ function ComplexJournalVoucherController(
    * @param {object} result
    */
   function updateView(result) {
-    $timeout(function () {
+    $timeout(function update() {
       // transaction type
       vm.Voucher.details.type_id = result.type_id || vm.Voucher.details.type_id;
 
@@ -132,7 +133,7 @@ function ComplexJournalVoucherController(
    */
   function removeNullRows() {
     var gridData = JSON.parse(JSON.stringify(vm.gridOptions.data));
-    gridData.forEach(function (item) {
+    gridData.forEach(function removeItems(item) {
       if (!item.account_id) {
         vm.Voucher.store.remove(item.uuid);
       }
@@ -168,8 +169,8 @@ function ComplexJournalVoucherController(
   /** Reference modal */
   function openReferenceModal(row) {
     FindReference.openModal(row.entity)
-      .then(function (document) {
-        row.configure({ document: document });
+      .then(function (doc) {
+        row.configure({ document: doc });
       });
   }
 

--- a/client/src/modules/vouchers/complex-voucher.ctrl.js
+++ b/client/src/modules/vouchers/complex-voucher.ctrl.js
@@ -2,10 +2,9 @@ angular.module('bhima.controllers')
   .controller('ComplexJournalVoucherController', ComplexJournalVoucherController);
 
 ComplexJournalVoucherController.$inject = [
-  'VoucherService', 'CurrencyService', 'SessionService',
-  'FindEntityService', 'FindReferenceService', 'NotifyService',
-  'VoucherToolkitService', 'ReceiptModal', 'bhConstants', 'uiGridConstants',
-  'VoucherForm', '$timeout',
+  'VoucherService', 'CurrencyService', 'SessionService', 'FindEntityService',
+  'FindReferenceService', 'NotifyService', 'VoucherToolkitService',
+  'ReceiptModal', 'bhConstants', 'uiGridConstants', 'VoucherForm', '$timeout',
 ];
 
 /**
@@ -21,8 +20,8 @@ ComplexJournalVoucherController.$inject = [
  * TODO/FIXME - this error notification system needs serious refactor.
  */
 function ComplexJournalVoucherController(
-  Vouchers, $translate, Currencies, Session, FindEntity, FindReference, Notify,
-  Toolkit, Receipts, bhConstants, uiGridConstants, VoucherForm, $timeout
+  Vouchers, Currencies, Session, FindEntity, FindReference, Notify, Toolkit,
+  Receipts, bhConstants, uiGridConstants, VoucherForm, $timeout
 ) {
   var vm = this;
 

--- a/client/src/modules/vouchers/templates/reference.grid.tmpl.html
+++ b/client/src/modules/vouchers/templates/reference.grid.tmpl.html
@@ -1,5 +1,4 @@
-<div class="ui-grid-cell-contents"
-  ng-class="{'bg-info': row.entity.document.uuid}">
+<div class="ui-grid-cell-contents" ng-class="{ 'bg-info': row.entity.document.uuid }">
   <a class="text-action"
     ng-click="grid.appScope.openReferenceModal(row.entity)"
     data-reference-button>

--- a/client/src/modules/vouchers/toolkit/convention_payment/convention_payment.js
+++ b/client/src/modules/vouchers/toolkit/convention_payment/convention_payment.js
@@ -9,7 +9,8 @@ ConventionPaymentKitController.$inject = [
 // Import transaction rows for a convention payment
 function ConventionPaymentKitController(
   Instance, DebtorGroup, Notify, Cashboxes,
-  Session, bhConstants, $translate, ToolKits) {
+  Session, bhConstants, $translate, ToolKits
+) {
   var vm = this;
 
   var MAX_DECIMAL_PRECISION = bhConstants.precision.MAX_DECIMAL_PRECISION;


### PR DESCRIPTION
This commit improves the performance and usability of the FindReference
modal on the complex vouchers page.  The dates now render in the format
DD/MM/YYYY, and the grid is cleared every time the user refreshes the
selection.  Additionally, the options for fastWatching and
flatEntityAccess have been put in place.

This commit cleans up the findReference modal's controller by
centralising the column definitions and limiting the data downloaded by
default.  Currently, the modal fetches 250 rows at maximum.  If the
limit is reached, it gives a link to load the full record set.

Closes #1138.