### PR TITLE
feat(reports): additional opts for Account Report

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -10,7 +10,7 @@ DB_NAME='bhima_test'
 # session variables
 SESS_SECRET='XopEn BlowFISH'
 
-DEBUG=app
+DEBUG=app,db:errors
 
 # Amazon S3 Creds
 S3_ACCESS_KEY_ID=""

--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -130,6 +130,13 @@
       "PREVIEW": "Preview",
       "VIEW_ARCHIVE": "Archives",
       "EMAIL_HELP_TXT" : "The email above will receive the report as an attachment.  The server must have an internet connection for the email to be successfully delivered."
+    },
+    "OPTIONS" : {
+      "MORE_OPTIONS" : "More Options",
+      "USE_ORIGINAL_TRANSACTION_CURRENCY" : "Display original transaction currency?",
+      "USE_ORIGINAL_TRANSACTION_CURRENCY_HELP" : "If yes, the report will show the recorded currency of the transaction instead of the value in the enterprise's currency.",
+      "TOTALS_CURRENCY" : "Select Totals Currency",
+      "TOTALS_CURRENCY_HELP" : "This options lets you view the totals in the selected currency by exchanging the totals into the selected currency using today's exchange rate."
     }
   }
 }

--- a/client/src/i18n/en/tree.json
+++ b/client/src/i18n/en/tree.json
@@ -65,7 +65,7 @@
     "REFERENCE_GROUP": "Reference Group",
     "REGISTER_SUPPLIER": "Supplier",
     "REPORTS": "Reports",
-    "REPORT_ACCOUNTS": "Report accounts",
+    "REPORT_ACCOUNTS": "Account Statement Report",
     "ROOT": "Root",
     "RUBRIC_MANAGEMENT": "Rubrics Management",
     "INVOICES": "Invoices",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -133,6 +133,13 @@
       "PREVIEW":"Aperçu",
       "VIEW_ARCHIVE":"Archives",
       "EMAIL_HELP_TXT" : "L'e-mail ci-dessus recevra le rapport en pièce jointe. Le serveur doit avoir une connexion Internet pour que l'e-mail soit livré avec succès."
+    },
+    "OPTIONS" : {
+      "MORE_OPTIONS" : "Plus d'options",
+      "USE_ORIGINAL_TRANSACTION_CURRENCY" : "Afficher la devise de transaction originale?",
+      "USE_ORIGINAL_TRANSACTION_CURRENCY_HELP" : "Si oui, le rapport affichera la devise de la transaction au lieu de la valeur dans la devise de l'entreprise.",
+      "TOTALS_CURRENCY" : "Sélectionnez la Devise des Totaux",
+      "TOTALS_CURRENCY_HELP" : "Cette option vous permet d'afficher les totaux dans la devise sélectionnée en échangeant les totaux dans la devise sélectionnée en utilisant le taux de change du jour."
     }
   }
 }

--- a/client/src/js/components/bhCurrencySelect.js
+++ b/client/src/js/components/bhCurrencySelect.js
@@ -6,8 +6,9 @@ angular.module('bhima.components')
     bindings    : {
       currencyId        : '=',
       validationTrigger : '<',
+      onChange          : '&',
+      label             : '@?',
       disableIds        : '<?',
-      onChange          : '&?',
       cashboxId         : '<?',
     },
   });
@@ -56,8 +57,7 @@ bhCurrencySelect.$inject = ['CurrencyService'];
  *   currency-id="ParentCtrl.model.currencyId"
  *   on-change="ParentCtrl.currencyChangeEvent()"
  *   disable-ids="ParentCtrl.disabledIds"
- *   validation-trigger="ParentForm.$submitted"
- *   >
+ *   validation-trigger="ParentForm.$submitted">
  * </bh-currency-select>
  *
  * @requires services/CurrencyService
@@ -80,6 +80,8 @@ function bhCurrencySelect(Currencies) {
 
     $ctrl.valid = true;
 
+    $ctrl.label = $ctrl.label || 'FORM.LABELS.CURRENCY';
+
     // default to noop() if an onChange() method was not passed in
     $ctrl.onChange = $ctrl.onChange || angular.noop;
   };
@@ -89,6 +91,7 @@ function bhCurrencySelect(Currencies) {
       digestDisableIds(changes.disableIds.currentValue);
     }
 
+    // FIXME - why is this needed?
     if (changes.onChange) {
       $ctrl.onChange = changes.onChange.currentValue;
     }

--- a/client/src/modules/reports/generate/account_report/account_report.config.js
+++ b/client/src/modules/reports/generate/account_report/account_report.config.js
@@ -3,17 +3,24 @@ angular.module('bhima.controllers')
 
 AccountReportConfigController.$inject = [
   '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData',
-  '$state', 'moment'
+  '$state', 'moment', 'SessionService',
 ];
 
-function AccountReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Moment) {
+function AccountReportConfigController(
+  $sce, Notify, SavedReports, AppCache, reportData, $state,
+  Moment, Session
+) {
   var vm = this;
   var cache = new AppCache('configure_account_report');
   var reportUrl = 'reports/finance/account_report';
 
   vm.previewGenerated = false;
-  vm.reportDetails = {};
-  vm.dateInterval=1;
+
+  vm.reportDetails = {
+    currency_id : Session.enterprise.currency_id,
+  };
+
+  vm.dateInterval = 1;
 
   checkCachedConfiguration();
 
@@ -30,11 +37,16 @@ function AccountReportConfigController($sce, Notify, SavedReports, AppCache, rep
     vm.previewResult = null;
   };
 
+  vm.setCurrency = function (currencyId) {
+    vm.reportDetails.currency_id = currencyId;
+  };
+
   vm.requestSaveAs = function requestSaveAs() {
+    var options;
     parseDateInterval(vm.reportDetails);
 
     // @FIXME
-    var options = {
+    options = {
       url : reportUrl,
       report : reportData,
       reportOptions : sanitiseDateStrings(vm.reportDetails),
@@ -51,7 +63,6 @@ function AccountReportConfigController($sce, Notify, SavedReports, AppCache, rep
     if (form.$invalid) { return; }
 
     parseDateInterval(vm.reportDetails);
-
 
     // update cached configuration
     cache.reportDetails = angular.copy(vm.reportDetails);
@@ -78,7 +89,8 @@ function AccountReportConfigController($sce, Notify, SavedReports, AppCache, rep
   // @TODO validation on dates - this should be done through a 'period select' component
   function parseDateInterval(reportDetails) {
     if (!vm.dateInterval) {
-      reportDetails.dateTo = reportDetails.dateFrom = null;
+      delete reportDetails.dateTo;
+      delete reportDetails.dateFrom;
     }
   }
 

--- a/client/src/modules/reports/generate/account_report/account_report.html
+++ b/client/src/modules/reports/generate/account_report/account_report.html
@@ -25,7 +25,7 @@
 
             <bh-account-select
               id="account-id"
-              account-id="ReportConfigCtrl.account"
+              account-id="ReportConfigCtrl.reportDetails.account_id"
               label="FORM.SELECT.ACCOUNT"
               name="account"
               on-select-callback="ReportConfigCtrl.selectAccount(account)"
@@ -34,16 +34,64 @@
               validation-trigger="ConfigForm.$submitted">
             </bh-account-select>
 
-            <!-- included Date interval  -->
-
             <!-- Date interval  -->
             <!-- @TODO this should use a component that callback with well defined dates -->
             <bh-date-interval
-            date-from="ReportConfigCtrl.reportDetails.dateFrom"
-            date-to="ReportConfigCtrl.reportDetails.dateTo"
-            required="true"
-            validation-trigger="ConfigForm.$submitted">
-          </bh-date-interval>
+              date-from="ReportConfigCtrl.reportDetails.dateFrom"
+              date-to="ReportConfigCtrl.reportDetails.dateTo"
+              required="true"
+              validation-trigger="ConfigForm.$submitted">
+            </bh-date-interval>
+
+            <bh-hidden-field
+              show-text="REPORT.OPTIONS.MORE_OPTIONS"
+              hide-text="REPORT.OPTIONS.MORE_OPTIONS">
+
+              <div class="radio" ng-class="{ 'has-error': ConfigForm.$submitted && ConfigForm.useOriginalTransactionCurrency.$invalid }">
+                <p class="control-label" style="margin-bottom:5px;">
+                  <strong translate>REPORT.OPTIONS.USE_ORIGINAL_TRANSACTION_CURRENCY</strong>
+                </p>
+
+                <label
+                  class="radio-inline"
+                  translate-attr="{ title : 'FORM.LABELS.YES' }">
+                  <input
+                    name="useOriginalTransactionCurrency"
+                    type="radio"
+                    ng-model="ReportConfigCtrl.reportDetails.useOriginalTransactionCurrency"
+                    ng-value="true"
+                    required>
+                  <span translate>FORM.LABELS.YES</span>
+                </label>
+
+                <label
+                  class="radio-inline"
+                  translate-attr="{ title : 'FORM.LABELS.NO' }">
+                  <input
+                    name="useOriginalTransactionCurrency"
+                    type="radio"
+                    ng-model="ReportConfigCtrl.reportDetails.useOriginalTransactionCurrency"
+                    ng-value="false"
+                    required>
+                  <span translate>FORM.LABELS.NO</span>
+                </label>
+
+                <div class="help-block" ng-messages="ConfigForm.$error" ng-show="ConfigForm.$submitted">
+                  <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+                </div>
+
+                <p class="help-block" translate>REPORT.OPTIONS.USE_ORIGINAL_TRANSACTION_CURRENCY_HELP</p>
+              </div>
+
+              <!-- the currency to be used in the footer -->
+              <bh-currency-select
+                label="REPORT.OPTIONS.TOTALS_CURRENCY"
+                currency-id="ReportConfigCtrl.reportDetails.currency_id"
+                on-change="ReportConfigCtrl.setCurrency(currency)"
+                validation-trigger="ConfigForm.$submitted">
+              </bh-currency-select>
+              <p class="help-block" translate>REPORT.OPTIONS.TOTALS_CURRENCY_HELP</p>
+            </bh-hidden-field>
 
             <bh-loading-button loading-state="ConfigForm.$loading">
               <span translate>REPORT.UTIL.PREVIEW</span>

--- a/client/src/modules/templates/bhCurrencySelect.tmpl.html
+++ b/client/src/modules/templates/bhCurrencySelect.tmpl.html
@@ -1,7 +1,7 @@
 <ng-form name="$ctrl.form">
   <div class="radio" ng-class="{ 'has-error' : ($ctrl.validationTrigger && $ctrl.form.$invalid) || !$ctrl.valid }" data-bh-currency-select>
     <p class="control-label" style="margin-bottom:5px;">
-      <strong translate>FORM.LABELS.CURRENCY</strong>
+      <strong translate>{{ $ctrl.label }}</strong>
     </p>
 
     <ng-transclude></ng-transclude>

--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -154,6 +154,7 @@ function find(options) {
   filters.fullText('description');
   filters.period('period', 'date');
 
+  // TODO - re-write these use document maps and entity maps
   const referenceStatement = `CONCAT_WS('.', '${CASH_KEY}', project.abbr, cash.reference) = ?`;
   filters.custom('reference', referenceStatement);
 

--- a/server/controllers/finance/reports/generalLedger/index.js
+++ b/server/controllers/finance/reports/generalLedger/index.js
@@ -48,7 +48,7 @@ function renderReport(req, res, next) {
   const fiscalYearId = options.fiscal_year_id;
 
   return Fiscal.getPeriodByFiscal(fiscalYearId)
-    .then((rows) => {
+    .then(rows => {
       return GeneralLedger.getlistAccounts(rows);
     })
     .then((rows) => {
@@ -71,9 +71,11 @@ function renderReport(req, res, next) {
  * GET reports/finance/general_ledger/:account_id
  *
  * @method accountSlip
+ *
+ * FIXME(@jniles) - rewrite this.
  */
 function renderAccountSlip(req, res, next) {
-  const params = req.params;
+  const { params } = req;
   const options = _.extend(req.query, {
     filename : 'GENERAL_LEDGER.ACCOUNT_SLIP',
     csvKey   : 'transactions',
@@ -93,7 +95,7 @@ function renderAccountSlip(req, res, next) {
 
       report = new ReportManager(ACCOUNT_SLIP_TEMPLATE, req.session, options);
 
-      return AccountReport.getAccountTransactions(params.account_id, GENERAL_LEDGER_SOURCE);
+      return AccountReport.getAccountTransactions(params, GENERAL_LEDGER_SOURCE);
     })
     .then((result) => {
       _.extend(data, { transactions : result.transactions, sum : result.sum });

--- a/server/controllers/finance/reports/reportAccounts/report.handlebars
+++ b/server/controllers/finance/reports/reportAccounts/report.handlebars
@@ -27,9 +27,9 @@
           <th>{{translate "TABLE.COLUMNS.TRANSACTION" }}</th>
           <th>{{translate "TABLE.COLUMNS.DOCUMENT" }}</th>
           <th>{{translate "TABLE.COLUMNS.DESCRIPTION" }}</th>
-          <th style="width:12%">{{translate "TABLE.COLUMNS.DEBIT" }}</th>
-          <th style="width:12%">{{translate "TABLE.COLUMNS.CREDIT" }}</th>
-          <th style="width:12%">{{translate "TABLE.COLUMNS.BALANCE" }}</th>
+          <th style="min-width:12%">{{translate "TABLE.COLUMNS.DEBIT" }}</th>
+          <th style="min-width:12%">{{translate "TABLE.COLUMNS.CREDIT" }}</th>
+          <th style="min-width:12%">{{translate "TABLE.COLUMNS.BALANCE" }}</th>
         </tr>
       </thead>
       <tbody>
@@ -40,13 +40,13 @@
           <th colspan="3">{{translate "REPORT.OPENING_BALANCE"}}</th>
 
           <th class="text-right">
-            {{#unless openingBalance.isCreditBalance}} {{currency openingBalance.balance metadata.enterprise.currency_id}} {{/unless}}
+            {{currency openingBalance.debit metadata.enterprise.currency_id}}
           </th>
           <th class="text-right">
-            {{#if openingBalance.isCreditBalance}} {{currency openingBalance.balance metadata.enterprise.currency_id}} {{/if}}
+            {{currency openingBalance.credit metadata.enterprise.currency_id}}
           </th>
-          <th class="text-right">{{currency openingBalance.balance metadata.enterprise.currency_id}}</th>
 
+          <th class="text-right">{{currency openingBalance.balance metadata.enterprise.currency_id}}</th>
         </tr>
 
         {{#each transactions}}
@@ -56,52 +56,74 @@
             <td>{{this.document_reference}}</td>
             <td style="max-width : 200px; white-space : nowrap; overflow : hidden; text-overflow : ellipsis;">{{this.description}}</td>
             <td class="text-right">
-              {{#if this.debit}}
-                {{currency this.debit ../metadata.enterprise.currency_id}}
+              {{#if ../useOriginalTransactionCurrency}}
+                {{#if this.debit}}
+                  {{currency this.debit this.currency_id}}
+                  {{#if this.rate}} (&#64; {{this.rate}}){{/if}}
+                {{/if}}
+              {{else}}
+                {{#if this.debit_equiv}}
+                  {{currency this.debit_equiv ../metadata.enterprise.currency_id}}
+                {{/if}}
               {{/if}}
             </td>
             <td class="text-right">
-              {{#if this.credit}}
-                {{currency this.credit ../metadata.enterprise.currency_id}}
+              {{#if ../useOriginalTransactionCurrency}}
+                {{#if this.credit}}
+                  {{currency this.credit this.currency_id}}
+                  {{#if this.rate}} (&#64; {{this.rate}}){{/if}}
+                {{/if}}
+              {{else}}
+                {{#if this.credit_equiv}}
+                  {{currency this.credit_equiv ../metadata.enterprise.currency_id}}
+                {{/if}}
               {{/if}}
             </td>
+
             <td class="text-right">
-                {{currency this.cumsum ../metadata.enterprise.currency_id}}
+              {{currency this.cumsum ../metadata.enterprise.currency_id}}
             </td>
           </tr>
         {{else}}
           {{> emptyTable columns=7}}
         {{/each}}
 
-        {{#if transactions}} 
-          <tr>
-            <td><strong>{{date params.dateTo}}</strong></th>
-            <td colspan="3"><strong>{{translate "FORM.LABELS.PERIOD_TOTAL"}}</strong></td>
-            <td class="text-right"><strong>{{currency sum.period.debit metadata.enterprise.currency_id}}</strong></td>
-            <td class="text-right"><strong>{{currency sum.period.credit metadata.enterprise.currency_id}}</strong></td>
-            <td class="text-right"><strong>{{currency sum.period.balance metadata.enterprise.currency_id}}</strong></td>
-          </tr>
-        {{/if}}
+        {{!  This contains the grid totals }}
+        <tr>
+          <td><strong>{{date sum.footer.date}}</strong></th>
+          <td colspan="3"><strong>{{translate "FORM.LABELS.TOTAL"}}</strong></td>
+          <td class="text-right"><strong>{{currency sum.footer.exchangedDebit sum.footer.currency_id}}</strong></td>
+          <td class="text-right"><strong>{{currency sum.footer.exchangedCredit sum.footer.currency_id}}</strong></td>
+          <td></td>
+        </tr>
       </tbody>
       <tfoot>
+        {{! This contains the period totals (opening balance + grid totals }}
         <tr style="background-color: #ddd;">
-          <td colspan="4"><strong>{{translate "FORM.LABELS.TOTAL" }}</strong></td>
-        
+          <td colspan="4"><strong>{{translate "FORM.LABELS.PERIOD_TOTAL" }}</strong></td>
           <th class="text-right">
-            {{#unless sum.isCreditBalance}} {{currency sum.balance metadata.enterprise.currency_id}} {{/unless}}
+            {{currency sum.period.exchangedDebit sum.period.currency_id}}
           </th>
           <th class="text-right">
-            {{#if sum.isCreditBalance}} {{currency sum.balance metadata.enterprise.currency_id}} {{/if}}
+            {{currency sum.period.exchangedCredit sum.period.currency_id}}
           </th>
-          <th class="text-right">{{currency sum.balance metadata.enterprise.currency_id}}</th>
-
+          <th class="text-right">
+            {{currency sum.period.exchangedBalance sum.period.currency_id}}
+          </th>
         </tr>
       </tfoot>
     </table>
     <table class="table table-condensed">
-      <tr>
-        <th colspan="5" class="text-right">
-          <strong>{{translate "FORM.LABELS.BALANCE" }} ({{date params.dateTo }}) {{currency sum.balance metadata.enterprise.currency_id}}</strong>
+      {{#if sum.period.showExchangeRate }}
+        <tr>
+          <th colspan="5" class="text-right" style="padding-bottom:0;">
+            {{translate "FORM.LABELS.EXCHANGE_RATE"}} ({{date sum.period.exchangedDate}}) {{currency sum.period.inverted_rate metadata.enterprise.currency_id}} 
+          </th>
+        </tr>
+      {{/if}}
+      <tr style="border-top: none;">
+        <th colspan="5" class="text-right" style="border-top: none;">
+          <strong>{{translate "FORM.LABELS.BALANCE" }} ({{date params.dateTo }}) {{currency sum.period.exchangedBalance sum.period.currency_id}}</strong>
         </th>
       </tr>
     </table>

--- a/server/models/functions.sql
+++ b/server/models/functions.sql
@@ -59,6 +59,7 @@ BEGIN
 END $$
 
 
+
 /*
   GenerateTransactionId(projectId)
 

--- a/test/integration/reports/finance/account_report.js
+++ b/test/integration/reports/finance/account_report.js
@@ -9,21 +9,12 @@ describe(`(${target}) Report Account`, () => {
     account_id : 171, // 41111000 - SNEL
     dateFrom : '2016-01-01',
     dateTo : '2016-12-31',
+    currency_id : 1,
   };
 
   const BAD_REQUEST = 'ERRORS.BAD_REQUEST';
 
   const clone = (object) => JSON.parse(JSON.stringify(object));
-
-  it(`GET ${target} should return a BAD_REQUEST response`, () => {
-    return agent.get(target)
-      .then(res => {
-        expect(res).to.have.status(400);
-        expect(res).to.be.json;
-        expect(res.body.code).to.equal(BAD_REQUEST);
-      })
-      .catch(helpers.handler);
-  });
 
   it(`GET ${target} should return HTML data for HTML rendering target`, () => {
     const copy = clone(parameters);


### PR DESCRIPTION
This commit adds a series of additional options for the account reports.
It also improves the code clarity on the server slightly.

The following options are now supported:
 1. Show Original Transaction Currency - This renders the values in the
 currency of the transaction.  Basically, it uses `debit` instead of
 `debit_equiv` and so forth. The opening balances and running totals are
 still in the enterprise currency, however.
 2. Select Total Currency - This allows a user to set a different
 currency to render in the totals footer.  The values are exchanged on
 the date of the report creation.

Together, this allows a very flexible view of the transactions in an
account.

I've also improved the totalling so that the following values are
available:
 1. Opening Balances
 2. Grid Balance (sum of rows)
 3. Grand total (Opening Balances + Grid Balances).

These enhancements strengthen the utility of the account statement and
it is now ready for prime-time.