### PR TITLE
fix: links to patient registry

### DIFF
--- a/client/src/modules/debtors/groups.list.html
+++ b/client/src/modules/debtors/groups.list.html
@@ -58,7 +58,13 @@
                   </div>
 
                   <div class="col-md-6">
-                    <a ui-sref="patientRegistry({ filters : [{ key : 'debtor_group_uuid', value : debtorGroup.uuid, displayValue: debtorGroup.name }]})"><span class="fa fa-bars" aria-hidden="true"></span> <b>{{debtorGroup.total_debtors}}</b> <span translate> DEBTOR_GROUP.DEBTOR.SUBSCRIBED </span></a>
+                    <a ui-sref="patientRegistry({
+                      filters : [
+                        { key : 'debtor_group_uuid', value : debtorGroup.uuid, displayValue: debtorGroup.name },
+                        { key : 'period', value : 'allTime' }
+                      ]})">
+                      <span class="fa fa-bars" aria-hidden="true"></span> <b>{{debtorGroup.total_debtors}}</b> <span translate> DEBTOR_GROUP.DEBTOR.SUBSCRIBED </span>
+                    </a>
                   </div>
                 </div>
               </div>

--- a/client/src/modules/patients/groups/groups.html
+++ b/client/src/modules/patients/groups/groups.html
@@ -42,7 +42,11 @@
                   <a class="btn btn-xs btn-default" ng-click="PatientGroupCtrl.update(group.uuid)" id="group-{{group.uuid}}">
                     <span class="glyphicon glyphicon-pencil"></span>
                   </a>
-                  <a class="btn btn-xs btn-default" ui-sref="patientRegistry({ filters : [{ key : 'patient_group_uuid', value : group.uuid, displayValue: group.name }]})">
+                  <a class="btn btn-xs btn-default" ui-sref="patientRegistry({
+                    filters : [
+                      { key : 'patient_group_uuid', value : group.uuid, displayValue: group.name },
+                      { key : 'period', value : 'allTime' }
+                    ]})">
                     <span class="fa fa-list"></span> <span translate> FORM.LABELS.PATIENT_LIST </span>
                   </a>
                 </td>

--- a/client/src/modules/stock/movements/modals/search.modal.js
+++ b/client/src/modules/stock/movements/modals/search.modal.js
@@ -114,7 +114,7 @@ function SearchMovementsModalController(data, Notify, Instance, Flux, $translate
       if (angular.isDefined(_value)) {
         // default to the original value if no display value is defined
         _displayValue = displayValues[key] || lastDisplayValues[key] || _value;
-        changes.post({ key, value : _value, displayValue : _displayValue });
+        changes.post({ key : key, value : _value, displayValue : _displayValue });
       }
     });
 


### PR DESCRIPTION
This commit fixes the links to the Patient Registry from both the Debtor Groups and Patients Groups.  Both links now allow the registry to show the period from 'all time'.

Closes #2391.
Closes #2403.