### PR TITLE
fix(account statement): remove posted toggle

### DIFF
--- a/client/src/modules/account_statement/account_statement.ctrl.js
+++ b/client/src/modules/account_statement/account_statement.ctrl.js
@@ -221,7 +221,7 @@ function AccountStatementController(
   vm.openSearchModal = function openSearchModal() {
     var filtersSnapshot = AccountStatement.filters.formatHTTP();
 
-    Journal.openSearchModal(filtersSnapshot, { hasDefaultAccount : true, title : 'ACCOUNT_STATEMENT.TITLE' })
+    Journal.openSearchModal(filtersSnapshot, { hasDefaultAccount : true, title : 'ACCOUNT_STATEMENT.TITLE', hidePostedOption : true })
       .then(function (changes) {
         AccountStatement.filters.replaceFilters(changes);
 

--- a/client/src/modules/journal/modals/search.modal.html
+++ b/client/src/modules/journal/modals/search.modal.html
@@ -18,7 +18,7 @@
         <!-- acting body class="tab-body" -->
         <div class="tab-body">
 
-        <div class="form-group">
+        <div class="form-group" ng-if="!ModalCtrl.hidePostedOption">
           <label class="control-label" translate>TRANSACTIONS.VERIFIED_TRANSACTIONS</label>
           <bh-clear on-clear="ModalCtrl.clear('includeNonPosted')"></bh-clear>
           <div class="checkbox">
@@ -150,24 +150,6 @@
             <div class="help-block" ng-messages="ModalForm.limit.$error">
               <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
             </div>
-          </div>
-          <!-- posted/ non-posted records -->
-          <!-- <div class="form-group"> -->
-          <!--   <label class="form-label">Transactions Limit</label> -->
-
-          <!--   <div class="checkbox"> -->
-          <!--     <label> -->
-          <!--       <input type="checkbox" value=""> -->
-          <!--       Posted transactions -->
-          <!--     </label> -->
-          <!--   </div> -->
-          <!--   <div class="checkbox"> -->
-          <!--     <label> -->
-          <!--       <input type="checkbox" value=""> -->
-          <!--       Non-posted transactions -->
-          <!--     </label> -->
-          <!--   </div> -->
-
           </div>
         </div>
       </uib-tab>

--- a/client/src/modules/journal/modals/search.modal.js
+++ b/client/src/modules/journal/modals/search.modal.js
@@ -2,15 +2,26 @@ angular.module('bhima.controllers')
   .controller('JournalSearchModalController', JournalSearchModalController);
 
 JournalSearchModalController.$inject = [
-  '$uibModalInstance', 'NotifyService',
-  'Store', 'filters', 'options', 'PeriodService', '$translate',
-  'util', 'TransactionTypeService', 'JournalService',
+  '$uibModalInstance', 'NotifyService', 'Store', 'filters', 'options',
+  'PeriodService', '$translate', 'util', 'TransactionTypeService',
+  'JournalService',
 ];
 
 function JournalSearchModalController(Instance, Notify,
   Store, filters, options, Periods, $translate,
   util, TransactionTypes, Journal) {
   var vm = this;
+
+  // displayValues will be an id:displayValue pair
+  var displayValues = {};
+  var lastDisplayValues = Journal.filters.getDisplayValueMap();
+
+  // @TODO ideally these should be passed in when the modal is initialised
+  //       these are known when the filter service is defined
+  var searchQueryOptions = [
+    'description', 'user_id', 'account_id', 'project_id', 'amount', 'trans_id',
+    'origin_id', 'includeNonPosted',
+  ];
 
   var changes = new Store({ identifier : 'key' });
   vm.filters = filters;
@@ -19,22 +30,6 @@ function JournalSearchModalController(Instance, Notify,
   // an object to keep track of all custom filters, assigned in the view
   vm.searchQueries = {};
   vm.defaultQueries = {};
-
-  // displayValues will be an id:displayValue pair
-  var displayValues = {};
-
-  // @TODO ideally these should be passed in when the modal is initialised
-  //       these are known when the filter service is defined
-  var searchQueryOptions = ['description', 'user_id', 'account_id', 'project_id', 'amount', 'trans_id', 'origin_id', 'includeNonPosted'];
-
-  var lastViewFilters = Journal.filters.formatView().customFilters;
-
-  // map key to last display value for lookup in loggedChange
-  var lastDisplayValues = lastViewFilters.reduce(function (object, filter) {
-    object[filter._key] = filter.displayValue;
-    return object;
-  }, {});
-
   // assign already defined custom filters to searchQueries object
   vm.searchQueries = util.maskObjectFromKeys(filters, searchQueryOptions);
 
@@ -49,6 +44,11 @@ function JournalSearchModalController(Instance, Notify,
    */
   if (options.hasDefaultAccount) {
     vm.hasDefaultAccount = true;
+  }
+
+  // hide the posted toggle when not needed
+  if (options.hidePostedOption) {
+    vm.hidePostedOption = true;
   }
 
   // assign default filters

--- a/client/src/modules/patients/registry/search.modal.js
+++ b/client/src/modules/patients/registry/search.modal.js
@@ -41,8 +41,6 @@ function PatientRegistryModalController(ModalInstance, filters, bhConstants, mom
   // assign already defined custom filters to searchQueries object
   vm.searchQueries = util.maskObjectFromKeys(filters, searchQueryOptions);
 
-
-
   // bind methods
   vm.submit = submit;
   vm.cancel = cancel;


### PR DESCRIPTION
The posted toggle should not be shown on the account statement since all records are posted.  Having this option on the page can cause unexpected behavior in production, so it is removed.

Closes #2429.