### PR TITLE
feat(exchange): add the current exchange rate

### DIFF
--- a/client/src/i18n/en/exchange.json
+++ b/client/src/i18n/en/exchange.json
@@ -1,13 +1,18 @@
-{"EXCHANGE":{"ADDING_RATE":"Adding an exchange Rate",
-"ADD_EXCHANGE":"Ajouter taux",
-"DESCRIPTION":"This section help you to define an exchange rate",
-"ENTERPRISE_CURRENCY":"Enterprise Currency",
-"EXCHANGE_RATES":"Exchange Rate(s)",
-"NEW_RATE":"New Exchange Rate",
-"RATE_SET":"Rate last set",
-"REVIEW_RATE":"Review the exchange rate",
-"TITLE":"Exchange Rate Management",
-"REVIEW":"Review Rates ",
-"INVOICE_DISCLAIMER":"Exchange rate based on the latest enterprise exchange:",
-"SET_AS":"Set as",
-"ON":"on"}}
+{
+  "EXCHANGE":{
+    "ADDING_RATE" : "Adding an exchange Rate",
+    "CURRENT_RATE" : "Current Exchange Rate",
+    "ADD_EXCHANGE" : "Ajouter taux",
+    "DESCRIPTION" : "This section help you to define an exchange rate",
+    "ENTERPRISE_CURRENCY" : "Enterprise Currency",
+    "EXCHANGE_RATES" : "Exchange Rate(s)",
+    "NEW_RATE" : "New Exchange Rate",
+    "RATE_SET" : "Rate last set",
+    "REVIEW_RATE" : "Review the exchange rate",
+    "TITLE" : "Exchange Rate Management",
+    "REVIEW" : "Review Rates ",
+    "INVOICE_DISCLAIMER" : "Exchange rate based on the latest enterprise exchange:",
+    "SET_AS" : "Set as",
+    "ON" : "on"
+  }
+}

--- a/client/src/i18n/fr/exchange.json
+++ b/client/src/i18n/fr/exchange.json
@@ -1,13 +1,18 @@
-{"EXCHANGE":{"ADDING_RATE":"Ajout d'un taux",
-"ADD_EXCHANGE":"Ajouter taux",
-"DESCRIPTION":"Cette interface vous permet d'ajouter un taux d'echange",
-"ENTERPRISE_CURRENCY":"Monnaie de l'entreprise",
-"EXCHANGE_RATES":"Taux de change",
-"NEW_RATE":"Nouveau taux",
-"RATE_SET":"Taux configuré",
-"REVIEW_RATE":"Revoir le taux",
-"TITLE":"Gestion taux d'echange",
-"REVIEW":"Revoir le taux",
-"INVOICE_DISCLAIMER":"Taux de Change basé sur le dernier taux de l'entreprise",
-"SET_AS":"Defini comme",
-"ON":"sur"}}
+{
+  "EXCHANGE":{
+    "ADDING_RATE" : "Ajout d'un taux",
+    "CURRENT_RATE" : "Taux de Change Actuel",
+    "ADD_EXCHANGE" : "Ajouter taux",
+    "DESCRIPTION" : "Cette interface vous permet d'ajouter un taux d'echange",
+    "ENTERPRISE_CURRENCY" : "Monnaie de l'entreprise",
+    "EXCHANGE_RATES" : "Taux de change",
+    "NEW_RATE" : "Nouveau taux",
+    "RATE_SET" : "Taux configuré",
+    "REVIEW_RATE" : "Revoir le taux",
+    "TITLE" : "Gestion taux d'echange",
+    "REVIEW" : "Revoir le taux",
+    "INVOICE_DISCLAIMER" : "Taux de Change basé sur le dernier taux de l'entreprise",
+    "SET_AS" : "Defini comme",
+    "ON" : "sur"
+  }
+}

--- a/client/src/modules/enterprises/exchange/exchange.modal.html
+++ b/client/src/modules/enterprises/exchange/exchange.modal.html
@@ -41,9 +41,12 @@
       max-date="ModalCtrl.timestamp">
     </bh-date-editor>
 
+    <p>
+      <span translate>EXCHANGE.CURRENT_RATE</span>: <i>{{ ModalCtrl.currentExchangeRate | currency:ModalCtrl.rate.currency.id }}</i>
+    </p>
+
     <div class="form-group"
-      ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.rate.$invalid }"
-      >
+      ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.rate.$invalid }">
       <label class="control-label">{{ "FORM.LABELS.EXCHANGE_RATE" | translate }}</label>
       <div class="row">
         <div class="col-xs-2">

--- a/client/src/modules/enterprises/exchange/exchange.modal.js
+++ b/client/src/modules/enterprises/exchange/exchange.modal.js
@@ -2,7 +2,8 @@ angular.module('bhima.controllers')
   .controller('ExchangeRateModalController', ExchangeRateModalController);
 
 ExchangeRateModalController.$inject = [
-  '$uibModalInstance', 'ExchangeRateService', 'CurrencyService', 'SessionService', 'NotifyService'
+  '$uibModalInstance', 'ExchangeRateService', 'CurrencyService',
+  'SessionService', 'NotifyService',
 ];
 
 /**
@@ -25,7 +26,7 @@ function ExchangeRateModalController(ModalInstance, Exchange, Currencies, Sessio
   vm.submit = submit;
   vm.format = Currencies.format;
   vm.symbol = Currencies.symbol;
-  vm.cancel = function () { ModalInstance.dismiss(); };
+  vm.cancel = function cancel() { ModalInstance.dismiss(); };
 
   // this turns on and off the currency select input
   vm.hasMultipleCurrencies = false;
@@ -45,6 +46,8 @@ function ExchangeRateModalController(ModalInstance, Exchange, Currencies, Sessio
       if (vm.currencies.length > 1) {
         vm.hasMultipleCurrencies = true;
       }
+
+      vm.currentExchangeRate = Exchange.getCurrentRate(vm.rate.currency.id);
     })
     .catch(Notify.handleError);
 


### PR DESCRIPTION
This commit adds the current exchange rate to the exchange rate modal
for reference.  This feature was requested by our clients at HEV.

![exchangerateupdates](https://user-images.githubusercontent.com/896472/34944109-92731706-f9fe-11e7-9ec6-a208c434bf81.PNG)
_Fig 1: Show Exchange Rate on Modal_

Closes #2387.