### PR TITLE
fix(General Ledger): identify title accounts

### DIFF
--- a/client/src/js/constants/bhConstants.js
+++ b/client/src/js/constants/bhConstants.js
@@ -12,6 +12,11 @@ function constantConfig() {
   return {
     accounts : {
       ROOT  : 0,
+      ASSET : 1,
+      LIABILITY : 2,
+      EQUITY : 3,
+      INCOME : 4,
+      EXPENSE : 5,
       TITLE : 6,
     },
     purchase : {

--- a/client/src/less/bhima-bootstrap.less
+++ b/client/src/less/bhima-bootstrap.less
@@ -428,3 +428,7 @@ div.ui-grid-cell .form-group input.form-control.ng-invalid {
 div.ui-grid-cell .form-group.has-error input.ng-invalid {
   border : 1px solid #fc8f8f;
 }
+
+.text-bold {
+  font-weight: bold;
+}

--- a/client/src/modules/accounts/accounts.service.js
+++ b/client/src/modules/accounts/accounts.service.js
@@ -21,6 +21,7 @@ function AccountService(Api, bhConstants) {
   service.getOpeningBalanceForPeriod = getOpeningBalanceForPeriod;
   service.getChildren = getChildren;
   service.filterTitleAccounts = filterTitleAccounts;
+  service.filterAccountByType = filterAccountsByType;
 
   service.flatten = flatten;
   service.order = order;
@@ -79,11 +80,13 @@ function AccountService(Api, bhConstants) {
   }
 
   function filterTitleAccounts(accounts) {
-    return accounts.filter(handleFilterTitleAccount);
+    return filterAccountsByType(accounts, bhConstants.accounts.TITLE);
   }
 
-  function handleFilterTitleAccount(account) {
-    return account.type_id !== bhConstants.accounts.TITLE;
+  function filterAccountsByType(accounts, type) {
+    return accounts.filter(function filterFn(account) {
+      return account.type_id !== type;
+    });
   }
 
   /**

--- a/client/src/modules/general-ledger/general-ledger-accounts.ctrl.js
+++ b/client/src/modules/general-ledger/general-ledger-accounts.ctrl.js
@@ -2,9 +2,9 @@ angular.module('bhima.controllers')
   .controller('GeneralLedgerAccountsController', GeneralLedgerAccountsController);
 
 GeneralLedgerAccountsController.$inject = [
-  'GeneralLedgerService', 'SessionService', 'NotifyService',
-  'uiGridConstants', 'ReceiptModal', 'ExportService', 'GridColumnService', 'AppCache', 'GridStateService',
-  '$state', 'LanguageService', 'ModalService', 'FiscalService',
+  'GeneralLedgerService', 'SessionService', 'NotifyService', 'uiGridConstants',
+  'ReceiptModal', 'ExportService', 'GridColumnService', 'GridStateService',
+  '$state', 'LanguageService', 'ModalService', 'FiscalService', 'bhConstants',
 ];
 
 /**
@@ -13,30 +13,34 @@ GeneralLedgerAccountsController.$inject = [
  * @description
  * This controller is responsible for displaying accounts and their balances
  */
-function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
-  uiGridConstants, Receipts, Export, Columns, AppCache, GridState, $state, Languages, Modal, Fiscal) {
+function GeneralLedgerAccountsController(
+  GeneralLedger, Session, Notify, uiGridConstants, Receipts, Export, Columns,
+  GridState, $state, Languages, Modal, Fiscal, bhConstants
+) {
   var vm = this;
   var columns;
   var state;
   var cacheKey = 'GeneralLedgerAccounts';
-  var cache = AppCache(cacheKey);
 
-  vm.enterprise = Session.enterprise;
   vm.today = new Date();
   vm.filterEnabled = false;
   vm.openColumnConfiguration = openColumnConfiguration;
+
+  function computeAccountCellStyle(grid, row) {
+    return row.entity.isTitleAccount ? 'text-bold' : '';
+  }
 
   columns = [
     { field            : 'number',
       displayName      : 'TABLE.COLUMNS.ACCOUNT',
       enableFiltering  : true,
-      cellTemplate     : '/modules/general-ledger/templates/account_number.cell.html',
+      cellClass        : computeAccountCellStyle,
       headerCellFilter : 'translate' },
 
     { field            : 'label',
       displayName      : 'TABLE.COLUMNS.LABEL',
-      cellTemplate     : '/modules/general-ledger/templates/account_label.cell.html',
       enableFiltering  : true,
+      cellClass        : computeAccountCellStyle,
       headerCellFilter : 'translate' },
 
     { field            : 'balance',
@@ -44,27 +48,31 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
-      cellTemplate     : '/modules/general-ledger/templates/balance.cell.html' },
+      cellClass        : computeAccountCellStyle,
+      cellFilter       : 'currency:'.concat(Session.enterprise.currency_id) },
 
     { field            : 'balance0',
       displayName      : 'FORM.LABELS.OPENING_BALANCE',
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
-      cellTemplate     : getCellTemplate('balance0')},
+      cellClass        : computeAccountCellStyle,
+      cellTemplate     : getCellTemplate('balance0') },
 
     { field            : 'balance1',
       displayName      : 'TABLE.COLUMNS.DATE_MONTH.JANUARY',
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
-       cellTemplate    : getCellTemplate('balance1')},
+      cellClass        : computeAccountCellStyle,
+       cellTemplate    : getCellTemplate('balance1') },
 
     { field            : 'balance2',
       displayName      : 'TABLE.COLUMNS.DATE_MONTH.FEBRUARY',
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
+      cellClass        : computeAccountCellStyle,
       cellTemplate     : getCellTemplate('balance2') },
 
     { field            : 'balance3',
@@ -72,6 +80,7 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
+      cellClass        : computeAccountCellStyle,
       cellTemplate     : getCellTemplate('balance3') },
 
     { field            : 'balance4',
@@ -79,6 +88,7 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
+      cellClass        : computeAccountCellStyle,
       cellTemplate     : getCellTemplate('balance4') },
 
     { field            : 'balance5',
@@ -86,6 +96,7 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
+      cellClass        : computeAccountCellStyle,
       cellTemplate     : getCellTemplate('balance5') },
 
     { field            : 'balance6',
@@ -93,6 +104,7 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
+      cellClass        : computeAccountCellStyle,
       cellTemplate     : getCellTemplate('balance6') },
 
     { field            : 'balance7',
@@ -100,6 +112,7 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
+      cellClass        : computeAccountCellStyle,
       cellTemplate     : getCellTemplate('balance7') },
 
     { field            : 'balance8',
@@ -107,6 +120,7 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
+      cellClass        : computeAccountCellStyle,
       cellTemplate     : getCellTemplate('balance8') },
 
     { field            : 'balance9',
@@ -114,6 +128,7 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
+      cellClass        : computeAccountCellStyle,
       cellTemplate     : getCellTemplate('balance9') },
 
     { field            : 'balance10',
@@ -121,6 +136,7 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
+      cellClass        : computeAccountCellStyle,
       cellTemplate     : getCellTemplate('balance10') },
 
     { field            : 'balance11',
@@ -128,6 +144,7 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
+      cellClass        : computeAccountCellStyle,
       cellTemplate     : getCellTemplate('balance11') },
 
 
@@ -136,6 +153,7 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
       enableFiltering  : false,
       headerCellFilter : 'translate',
       headerCellClass  : 'text-center',
+      cellClass        : computeAccountCellStyle,
       cellTemplate     : getCellTemplate('balance12') },
 
     {
@@ -167,9 +185,10 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
   vm.clearGridState = function clearGridState() {
     state.clearGridState();
     $state.reload();
-  }
+  };
 
   function handleError(err) {
+    console.log('err:', err);
     vm.hasError = true;
     Notify.handleError(err);
   }
@@ -193,21 +212,23 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
     vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
   }
 
-  function loadData(data) {
-    vm.gridOptions.data = data;
+  function labelTitleAccounts(account) {
+    account.isTitleAccount = account.type_id === bhConstants.accounts.TITLE;
+  }
+
+  function loadData(accounts) {
+    // make sure the title accounts are identified
+    accounts.forEach(labelTitleAccounts);
+
+    vm.gridOptions.data = accounts;
   }
 
   function getCellTemplate(key) {
     return '<div class="ui-grid-cell-contents text-right">' +
-      '<div ng-show="row.entity.' + key +'" >' +
-        '{{ row.entity.' + key +' | currency: grid.appScope.enterprise.currency_id }}' +
+      '<div ng-show="row.entity.' + key + '" >' +
+        '{{ row.entity.' + key + ' | currency:' + Session.enterprise.currency_id + ' }}' +
       '</div>' +
     '</div>';
-  }
-
-  // format Export Parameters
-  function formatExportParameters(type) {
-    return { renderer: type || 'pdf', lang: Languages.key };
   }
 
   vm.download = GeneralLedger.download;
@@ -223,12 +244,13 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
 
         vm.filters = {
           fiscal_year_id : filters.fiscal_year.id,
-          fiscal_year_label : filters.fiscal_year.label
+          fiscal_year_label : filters.fiscal_year.label,
         };
 
         vm.filtersSlip = {
           dateFrom : filters.fiscal_year.start_date,
-          dateTo : filters.fiscal_year.end_date
+          dateTo : filters.fiscal_year.end_date,
+          limit : 1000,
         };
 
         load(vm.filters);
@@ -249,18 +271,25 @@ function GeneralLedgerAccountsController(GeneralLedger, Session, Notify,
   // runs on startup
   function startup() {
     Fiscal.fiscalYearDate({ date : vm.today })
-    .then(function (year) {
-      vm.year = year[0];
-      vm.fiscalYearLabel = vm.year.label;
-      vm.year.fiscal_year_id;
-      vm.filters = {fiscal_year_id : vm.year.fiscal_year_id, fiscal_year_label : vm.year.label};
-      vm.filtersSlip = {dateFrom : vm.year.start_date, dateTo : vm.year.end_date};
+      .then(function (year) {
+        vm.year = year[0];
+        vm.fiscalYearLabel = vm.year.label;
 
-      load(vm.filters);
-    })
-    .catch(Notify.handleError);
+        vm.filters = {
+          fiscal_year_id : vm.year.fiscal_year_id,
+          fiscal_year_label : vm.year.label,
+        };
+
+        vm.filtersSlip = {
+          dateFrom : vm.year.start_date,
+          dateTo : vm.year.end_date,
+          limit : 1000,
+        };
+
+        load(vm.filters);
+      })
+      .catch(Notify.handleError);
   }
 
   startup();
-
 }

--- a/client/src/modules/general-ledger/general-ledger.service.js
+++ b/client/src/modules/general-ledger/general-ledger.service.js
@@ -13,6 +13,7 @@ function GeneralLedgerService(Api, $httpParamSerializer, Languages) {
   var service = new Api('/general_ledger/');
 
   service.accounts = new Api('/general_ledger/accounts');
+
   service.download = download;
   service.slip = slip;
 

--- a/client/src/modules/general-ledger/templates/account_label.cell.html
+++ b/client/src/modules/general-ledger/templates/account_label.cell.html
@@ -1,3 +1,0 @@
-<div class="ui-grid-cell-contents">
-  <span ng-dblClick="grid.appScope.slip(row.entity.id)">{{ row.entity.label }}</span>
-</div>

--- a/client/src/modules/general-ledger/templates/account_number.cell.html
+++ b/client/src/modules/general-ledger/templates/account_number.cell.html
@@ -1,3 +1,0 @@
-<div class="ui-grid-cell-contents">
-  <span ng-dblClick="grid.appScope.slip(row.entity.id)">{{ row.entity.number }}</span>
-</div>

--- a/client/src/modules/general-ledger/templates/action.cell.html
+++ b/client/src/modules/general-ledger/templates/action.cell.html
@@ -1,24 +1,16 @@
 <div class="ui-grid-cell-contents text-right">
-  <span uib-dropdown dropdown-append-to-body>
+  <span uib-dropdown dropdown-append-to-body ng-if="!row.entity.isTitleAccount">
     <a href uib-dropdown-toggle>
       <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
       <span class="caret"></span>
     </a>
 
-    <ul class="dropdown-menu-right" uib-dropdown-menu>
+    <ul class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
       <li>
-        <a ng-href="/reports/finance/account_report/?{{ grid.appScope.slip('pdf', grid.appScope.filtersSlip, row.entity.id) }}" download="{{GENERAL_LEDGER.ACCOUNT_SLIP | translate }}">
+        <a ng-href="/reports/finance/account_report/?{{ grid.appScope.slip('pdf', grid.appScope.filtersSlip, row.entity.id) }}" download="{{ GENERAL_LEDGER.ACCOUNT_SLIP | translate }}">
           <span class="fa fa-file-pdf-o"></span> <span translate>GENERAL_LEDGER.ACCOUNT_SLIP</span>
         </a>
       </li>
-<!-- 
-      FIX ME FOR THE CSV DOWNLOAD
-      <li>
-        <a ng-href="/reports/finance/account_report/?{{ grid.appScope.slip('csv', grid.appScope.filtersSlip, row.entity.id) }}" download="{{FORM.BUTTONS.CSV_EXPORT | translate }}">
-          <span class="fa fa-file-pdf-o"></span> <span translate>FORM.BUTTONS.CSV_EXPORT</span>
-        </a>
-      </li>
- -->    
     </ul>
   </span>
 </div>

--- a/client/src/modules/general-ledger/templates/balance.cell.html
+++ b/client/src/modules/general-ledger/templates/balance.cell.html
@@ -1,3 +1,0 @@
-<div class="ui-grid-cell-contents text-right">
-  {{ row.entity.balance | currency: grid.appScope.enterprise.currency_id }}
-</div>

--- a/client/src/modules/general-ledger/templates/creditor.cell.html
+++ b/client/src/modules/general-ledger/templates/creditor.cell.html
@@ -1,8 +1,0 @@
-<div class="ui-grid-cell-contents text-right">
-  <div ng-show="row.entity.creditor_balance" >
-      {{ row.entity.creditor_balance | currency: grid.appScope.enterprise.currency_id }}
-  </div>
-  <div ng-hide="row.entity.creditor_balance">
-      {{ row.entity.creditor_balance | currency: grid.appScope.enterprise.currency_id }}
-  </div>
-</div>

--- a/client/src/modules/general-ledger/templates/debtor.cell.html
+++ b/client/src/modules/general-ledger/templates/debtor.cell.html
@@ -1,8 +1,0 @@
-<div class="ui-grid-cell-contents text-right">
-  <div ng-show="row.entity.debtor_balance" >
-      {{ row.entity.debtor_balance | currency: grid.appScope.enterprise.currency_id }}
-  </div>
-  <div ng-hide="row.entity.debtor_balance">
-      {{ row.entity.debtor_balance | currency: grid.appScope.enterprise.currency_id }}
-  </div>
-</div>

--- a/server/controllers/finance/reports/generalLedger/index.js
+++ b/server/controllers/finance/reports/generalLedger/index.js
@@ -49,7 +49,7 @@ function renderReport(req, res, next) {
 
   return Fiscal.getPeriodByFiscal(fiscalYearId)
     .then(rows => {
-      return GeneralLedger.getlistAccounts(rows);
+      return GeneralLedger.getAccountTotalsMatrix(rows);
     })
     .then((rows) => {
       data = { rows };


### PR DESCRIPTION
This commit fixes the general ledger by rendering the title accounts in bold and removing the option to download their account slips.  I've also optimized the GL by removing dead code and using ui-grid's native tools instead of multiple cell templates.

![titleaccountbold](https://user-images.githubusercontent.com/896472/34944090-80d30cae-f9fe-11e7-9b4a-07a5ca9da92c.PNG)
_Fig 1: Example of Bold Titles_

Closes #2348.