### PR TITLE
refactor(fiscal year): close FYs by period totals

### DIFF
--- a/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.html
+++ b/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.html
@@ -62,7 +62,7 @@
             account-id="$ctrl.resultAccount.id"
             on-select-callback="$ctrl.onSelectAccount(account)"
             label="FORM.SELECT.RESULT_ACCOUNT_SCT"
-            excludeTitleAccounts="true">
+            exclude-title-accounts="true">
           </bh-account-select>
         </div>
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:server-unit": "./node_modules/.bin/mocha --recursive --exit test/server-unit",
     "build": "./node_modules/.bin/gulp build",
     "build:db": "./sh/build-database.sh",
+    "build:clean" : "./sh/build-init-database.sh",
     "watch": "./node_modules/.bin/gulp watch-client",
     "release": "./node_modules/.bin/standard-version",
     "snyk-protect": "snyk protect",

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -17,6 +17,7 @@ const _ = require('lodash');
 const helmet = require('helmet');
 
 const debug = require('debug')('app');
+const debugHTTP = require('debug')('http');
 
 const interceptors = require('./interceptors');
 const { Unauthorized } = require('../lib/errors');
@@ -38,7 +39,7 @@ exports.configure = function configure(app) {
   // const isProduction = (process.env.NODE_ENV === 'production');
   const isProduction = false;
 
-  debug('Configuring middleware.');
+  debug('configuring middleware.');
 
   // helmet guards
   app.use(helmet());
@@ -76,13 +77,13 @@ exports.configure = function configure(app) {
   app.use(session(sess));
 
   // provide a stream for morgan to write to
-  winston.stream = {
-    write : message => winston.silly(message.trim()),
+  const stream = {
+    write : message => debugHTTP(message.trim()),
   };
 
   // http logger setup
   // options: combined | common | dev | short | tiny
-  app.use(morgan('combined', { stream : winston.stream }));
+  app.use(morgan('short', { stream }));
 
   // public static directories include the entire client and the uploads
   // directory.

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -8,11 +8,10 @@
  * @todo Pass authenticate and authorize middleware down through controllers,
  * allowing for modules to subscribe to different levels of authority
  *
- * @requires winston
  * @requires uploader
  */
 
-const winston = require('winston');
+const debug = require('debug')('app');
 const upload = require('../lib/uploader');
 
 // unclassified routes
@@ -92,7 +91,7 @@ const referenceLookup = require('../lib/referenceLookup');
 
 // expose routes to the server.
 exports.configure = function configure(app) {
-  winston.debug('Configuring routes');
+  debug('configuring routes.');
 
   // exposed to the outside without authentication
   app.get('/languages', languages.list);

--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -47,9 +47,4 @@ SOURCE server/models/procedures/trial_balance.sql
 */
 SOURCE server/models/procedures/stock.sql
 
-/*
-  Posting procedures include: PostPurchase and PostIntegration
-*/
-SOURCE server/models/procedures/posting.sql
-
 DELIMITER ;

--- a/server/models/procedures/time_period.sql
+++ b/server/models/procedures/time_period.sql
@@ -96,3 +96,97 @@ BEGIN
     SET periodNumber = periodNumber + 1;
   END WHILE;
 END $$
+
+/*
+CALL CloseFiscalYear();
+
+DESCRIPTION
+This procedure closes a fiscal year in the follow way:
+ 1. Look up the next fiscal year.  You can only close a fiscal year if you
+have a subsequent fiscal year created.
+ 2. Retrieve the balances for every account by summing the period_totals.
+ 3. Find the balance of income and expense accounts by summing both groups and
+subtracting the total income from the total expense.
+ 4. Write the balances of every account that isn't an income or expense account
+to the period 0 of the subsequent year.
+ 5. Write the balance of income and expense accounts (step 3) to the period 0
+value of the account provided. If this account had a previous value, add the two
+to get the final opening balance.
+
+TODO - check that there are no unposted records from previous years.
+*/
+CREATE PROCEDURE CloseFiscalYear(
+  IN fiscalYearId MEDIUMINT UNSIGNED,
+  IN closingAccountId INT UNSIGNED
+)
+BEGIN
+  DECLARE NoSubsequentFiscalYear CONDITION FOR SQLSTATE '45010';
+  DECLARE nextFiscalYearId MEDIUMINT UNSIGNED;
+  DECLARE nextPeriodZeroId MEDIUMINT UNSIGNED;
+
+  DECLARE incomeAccountType SMALLINT;
+  DECLARE expenseAccountType SMALLINT;
+
+  DECLARE carryForwardBalance DECIMAL(16,4);
+  DECLARE hasPreviousBalance BOOLEAN;
+
+  -- constants
+  SET incomeAccountType = 4;
+  SET expenseAccountType = 5;
+
+  -- find the subsequent fiscal year
+  SET nextFiscalYearId = (
+    SELECT id FROM fiscal_year
+    WHERE previous_fiscal_year_id = fiscalYearId
+    LIMIT 1
+  );
+
+  IF nextFiscalYearId IS NULL THEN
+    SIGNAL NoSubsequentFiscalYear
+    SET MESSAGE_TEXT =
+      'A fiscal year can only be closed into a subsequent fiscal year.  There is no following year for this fiscal year.';
+  END IF;
+
+  -- find the period id of the period 0 for the subsequent fiscal year
+  SET nextPeriodZeroId = (
+    SELECT period.id FROM period
+    WHERE period.fiscal_year_id = nextFiscalYearId AND period.number = 0
+  );
+
+  -- create the fiscal year balances
+  CREATE TEMPORARY TABLE FiscalYearBalances AS
+    SELECT a.id, MAX(fy.id) AS fiscal_year_id, MAX(fy.enterprise_id) AS enterprise_id,
+      SUM(pt.credit) AS credit, SUM(pt.debit) AS debit,
+      SUM(pt.debit - pt.credit) AS balance, MAX(a.type_id) AS type_id
+    FROM period_total AS pt
+      JOIN account AS a ON pt.account_id = a.id
+      JOIN account_type AS at ON a.type_id = at.id
+      JOIN fiscal_year AS fy ON pt.fiscal_year_id = fy.id
+    WHERE pt.fiscal_year_id = fiscalYearId
+    GROUP BY a.id
+    ORDER BY a.number;
+
+  -- copy all balances of non-income and non-expense accounts as the opening
+  -- balance of the next fiscal year
+  INSERT INTO period_total
+    (enterprise_id, fiscal_year_id, period_id, account_id, credit, debit)
+  SELECT fyb.enterprise_id, nextFiscalYearId, nextPeriodZeroId, fyb.id,
+    fyb.credit, fyb.debit
+  FROM FiscalYearBalances AS fyb
+  WHERE fyb.type_id NOT IN (incomeAccountType, expenseAccountType);
+
+  -- sum all income/expense accounts from the fiscal year into the closing
+  -- account
+  INSERT INTO period_total
+    (enterprise_id, fiscal_year_id, period_id, account_id, credit, debit)
+  SELECT fyb.enterprise_id, nextFiscalYearId, nextPeriodZeroId,
+    closingAccountId, SUM(fyb.credit) credit, SUM(fyb.debit) debit
+  FROM FiscalYearBalances AS fyb
+  WHERE fyb.type_id IN (incomeAccountType, expenseAccountType)
+  GROUP BY fyb.enterprise_id
+  ON DUPLICATE KEY UPDATE credit = credit + VALUES(credit), debit = debit + VALUES(debit);
+
+  -- lock the fiscal year and associated periods
+  UPDATE fiscal_year SET locked = 1 WHERE id = fiscalYearId;
+  UPDATE period SET locked = 1 WHERE fiscal_year_id = fiscalYearId;
+END $$

--- a/test/integration/fiscalYear.js
+++ b/test/integration/fiscalYear.js
@@ -9,13 +9,15 @@ describe('(/fiscal) Fiscal Year', () => {
     end_date : new Date('2019-12-31 01:00'),
     number_of_months : 12,
     note : 'Fiscal Year for Integration Test',
-    closing_account: 3627, // what is this account?
+    closing_account : 111, // 1311 - Résusltat net : Bénéfice *
   };
 
   const responseKeys = [
     'id', 'enterprise_id', 'number_of_months', 'label', 'start_date',
     'end_date', 'previous_fiscal_year_id', 'locked', 'note',
   ];
+
+  const YEAR_TO_CLOSE = 2;
 
   it('POST /fiscal adds a fiscal year', () => {
     return agent.post('/fiscal')
@@ -78,13 +80,12 @@ describe('(/fiscal) Fiscal Year', () => {
   it('PUT /fiscal/:id/closing closing a fiscal year', () => {
     const closingAccount = { account_id : newFiscalYear.closing_account };
 
-    return agent.put(`/fiscal/${newFiscalYear.id}/closing`)
+    return agent.put(`/fiscal/${YEAR_TO_CLOSE}/closing`)
       .send({ params: closingAccount })
       .then(res => {
         expect(res).to.have.status(200);
         expect(res).to.be.json;
-        const value = parseInt(res.body.id, 10);
-        expect(value).to.be.equal(newFiscalYear.id);
+        expect(res.body.id).to.equal(YEAR_TO_CLOSE);
       })
       .catch(helpers.handler);
   });

--- a/test/integration/vouchers.js
+++ b/test/integration/vouchers.js
@@ -12,7 +12,7 @@ describe('(/vouchers) The vouchers HTTP endpoint', () => {
   const date = new Date();
 
   const vUuid = 'b140c144-6ca8-47b0-99ba-94732cf6efde';
-  const numVouchers = 9;
+  const numVouchers = 8;
 
   const TO_DELETE_UUID = '3688e9ce-85ea-4b5c-9144-688177edcb63';
 


### PR DESCRIPTION
This commit implements the closing fiscal year code as a stored
procedure `CloseFiscalYear(fiscalYearId, closingAccountId)`.  This
replaces the previous several hundred lines of JavaScript code with a
single database call, and optimises the process significantly. It also
removes the need for a period number 13 and importing the previous
year's balances.

The following things still need to be done:
 1. Remove the import code for the previous fiscal year balances.
 2. Remove the generation of period number 13.
 3. Document the FY creation procedures with comments.

Closes #1651.  Closes #2464.