### PR TITLE
feat(stock): allow moving lots registry columns

### DIFF
--- a/client/src/modules/stock/lots/registry.html
+++ b/client/src/modules/stock/lots/registry.html
@@ -10,7 +10,7 @@
         <div uib-dropdown dropdown-append-to-body data-action="open-menu">
           <a class="btn btn-default" uib-dropdown-toggle>
             <span class="fa fa-bars"></span>
-            <span class="hidden-xs" translate>FORM.LABELS.MENU</span> 
+            <span class="hidden-xs" translate>FORM.LABELS.MENU</span>
             <span class="caret"></span>
           </a>
 
@@ -59,15 +59,15 @@
 
       <div class="toolbar-item">
         <div class="btn-group" uib-dropdown>
-          <a class="btn btn-default" 
-            ng-class="{ 'btn-info' : StockLotsCtrl.grouped }" 
+          <a class="btn btn-default"
+            ng-class="{ 'btn-info' : StockLotsCtrl.grouped }"
             ng-click="StockLotsCtrl.toggleGroup(StockLotsCtrl.selectedGroup.value)"
             ng-disabled="!StockLotsCtrl.selectedGroup.label">
             <span>
               <i class="fa fa-object-group"></i>
               <span ng-hide="StockLotsCtrl.selectedGroup.label" translate>STOCK.GROUPING</span>
-              <span 
-                ng-show="StockLotsCtrl.selectedGroup.label" 
+              <span
+                ng-show="StockLotsCtrl.selectedGroup.label"
                 translate>
                 {{ StockLotsCtrl.selectedGroup.label }}
               </span>
@@ -104,6 +104,7 @@
       ui-grid="StockLotsCtrl.gridOptions"
       class="grid-util-full-height"
       ui-grid-resize-columns
+      ui-grid-move-columns
       ui-grid-auto-resize
       ui-grid-save-state
       ui-grid-grouping>


### PR DESCRIPTION
This commit implements the ui-grid plugin to move columns on the stock lots registry.

Closes #2502.