### PR TITLE
fix exchange rate bug

### DIFF
--- a/server/models/procedures/invoicing.sql
+++ b/server/models/procedures/invoicing.sql
@@ -238,7 +238,7 @@ BEGIN
   -- variables to store core set-up results
   DECLARE current_fiscal_year_id MEDIUMINT(8) UNSIGNED;
   DECLARE current_period_id MEDIUMINT(8) UNSIGNED;
-  DECLARE current_exchange_rate DECIMAL(19, 4) UNSIGNED;
+  DECLARE current_exchange_rate DECIMAL(19, 8) UNSIGNED;
   DECLARE enterprise_currency_id TINYINT(3) UNSIGNED;
   DECLARE transaction_id VARCHAR(100);
   DECLARE gain_account_id INT UNSIGNED;

--- a/server/models/procedures/voucher.sql
+++ b/server/models/procedures/voucher.sql
@@ -48,7 +48,7 @@ BEGIN
   -- variables to store core set-up results
   DECLARE fiscal_year_id MEDIUMINT(8) UNSIGNED;
   DECLARE period_id MEDIUMINT(8) UNSIGNED;
-  DECLARE current_exchange_rate DECIMAL(19, 4) UNSIGNED;
+  DECLARE current_exchange_rate DECIMAL(19, 8) UNSIGNED;
   DECLARE enterprise_currency_id TINYINT(3) UNSIGNED;
   DECLARE transaction_id VARCHAR(100);
   DECLARE gain_account_id INT UNSIGNED;


### PR DESCRIPTION
This PR fix a bug with variables of the exchange rate in procedures which had the type `DECIMAL(19, 4)` instead of `DECIMAL(19, 8)`.