### PR TITLE
fix(stock): better error message in lot modal

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -25,6 +25,11 @@
     "ENTRY_INTEGRATION" : "Integration",
     "ENTRY_TRANSFER"  : "Transfer",
     "ERRORS" : {
+      "MISSING_LOT_NAME":"Missing Lot Identifier",
+      "INVALID_LOT_QUANTITY":"Invalid Lot Quantity",
+      "INVALID_LOT_EXPIRATION":"Invalid Lot Expiration Date",
+      "INVALID_GLOBAL_QUANTITY":"Invalid Global Lot's Quantity",
+      "LOT_ROW_WITH_ERRORS":"Some lot line contains invalid data",
       "EXCESSIVE_QUANTITY": "Excessive Quantity",
       "PLEASE_CHECK_EXPIRY_DATE": "Please check the expiration date"
     },

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -25,6 +25,11 @@
     "ENTRY_INTEGRATION" : "Integration",
     "ENTRY_TRANSFER"  : "Transfert",
     "ERRORS" : {
+      "MISSING_LOT_NAME":"Identifiant de lot manquant",
+      "INVALID_LOT_QUANTITY":"Quantité de lot invalide",
+      "INVALID_LOT_EXPIRATION":"Date d'expiration invalide",
+      "INVALID_GLOBAL_QUANTITY":"Quantité globale des lots invalide",
+      "LOT_ROW_WITH_ERRORS":"Données invalide dans certaines lignes de lot ",
       "EXCESSIVE_QUANTITY": "Quantité excessive",
       "PLEASE_CHECK_EXPIRY_DATE": "Veuillez vérifier la date d'expiration"
     },    

--- a/client/src/modules/stock/entry/modals/lots.modal.html
+++ b/client/src/modules/stock/entry/modals/lots.modal.html
@@ -25,7 +25,6 @@
         type="number" 
         ng-model="$ctrl.stockLine.quantity" 
         ng-model-options="{ 'debounce' : { 'default' : 150, 'blur' : 0 }}"
-        ng-change="$ctrl.checkAll()"
         min="0">
     </div>
 
@@ -74,21 +73,14 @@
       </div>
     </div>
 
-    <div ng-if="$ctrl.hasInvalidEntries">
-      <div ng-if="$ctrl.hasNoLot" class="alert alert-warning">
-        <i class="fa fa-warning"></i> 
-        <span translate>FORM.WARNINGS.NO_LOT</span>
-      </div>
-
-      <div ng-if="$ctrl.isSomeLineIncorrect" class="alert alert-danger">
-        <i class="fa fa-warning"></i> 
-        <span translate>FORM.ERRORS.STOCK_LINE</span>
-      </div>
-
-      <div ng-if="$ctrl.isQuantityIncorrect" class="alert alert-danger">
-        <i class="fa fa-warning"></i> 
-        <span translate>FORM.ERRORS.LOT_QUANTITY</span>
-      </div>
+    <div ng-if="$ctrl.hasInvalidEntries" class="alert alert-danger clearfix" style="margin-top: 10px;">
+      <ul>
+        <li ng-if="$ctrl.hasMissingLotIdentifier" translate>STOCK.ERRORS.MISSING_LOT_NAME</li>
+        <li ng-if="$ctrl.hasInvalidLotQuantity" translate>STOCK.ERRORS.INVALID_LOT_QUANTITY</li>
+        <li ng-if="$ctrl.hasInvalidLotExpiration" translate>STOCK.ERRORS.INVALID_LOT_EXPIRATION</li>
+        <li ng-if="$ctrl.isQuantityIncorrect" translate>STOCK.ERRORS.INVALID_GLOBAL_QUANTITY</li>
+        <li ng-if="$ctrl.isSomeLineIncorrect" translate>STOCK.ERRORS.LOT_ROW_WITH_ERRORS</li>
+      </ul>
     </div>
 
   </div>


### PR DESCRIPTION
This PR : 
- Set the default quantity to 1 for stock lots in the modal
- Define a better message for errors on lots entry
- Show error message only when click on submit
- Remove data binding with quantity in the modal and in the grid

Close #2494 
Close #2495 
Close #2496 