### PR TITLE
fix(journal): cache filters typo

### DIFF
--- a/client/src/js/services/TransactionService.js
+++ b/client/src/js/services/TransactionService.js
@@ -4,8 +4,8 @@ angular.module('bhima.services')
 TransactionService.$inject = ['$http', 'util', '$uibModal'];
 
 function TransactionService($http, util, Modal) {
-  var service = this;
-  var baseUrl = '/transactions/';
+  const service = this;
+  const baseUrl = '/transactions/';
 
   service.remove = remove;
   service.comment = comment;
@@ -21,7 +21,7 @@ function TransactionService($http, util, Modal) {
    * payment as necessary.
    */
   function remove(uuid) {
-    var url = baseUrl.concat(uuid);
+    const url = baseUrl.concat(uuid);
     return $http.delete(url)
       .then(util.unwrapHttpResponse);
   }
@@ -29,14 +29,13 @@ function TransactionService($http, util, Modal) {
 
   /**
    * @method comment
-   *
    * @description
    * This function comments on individual lines of a transaction.  It is used by
    * the comment modal to modify, remove or add comments to transactions.
    */
   function comment(params) {
-    var url = baseUrl.concat('comments');
-    return $http.put(url, { params : params })
+    const url = baseUrl.concat('comments');
+    return $http.put(url, { params })
       .then(util.unwrapHttpResponse);
   }
 
@@ -48,12 +47,12 @@ function TransactionService($http, util, Modal) {
    * rows of transactions.
    */
   function openCommentModal(rows) {
-    var config = {
+    const config = {
       templateUrl  : 'modules/journal/modals/comment.modal.html',
       controller   : 'CommentModalController',
       controllerAs : '$ctrl',
       resolve : {
-        params :  function paramsProvider() { return rows; },
+        params :  () => rows,
       },
     };
 
@@ -67,7 +66,7 @@ function TransactionService($http, util, Modal) {
    * This function loads the history of a given transaction from the database.
    */
   function historyFn(uuid) {
-    var url = baseUrl.concat(uuid, '/history');
+    const url = baseUrl.concat(uuid, '/history');
     return $http.get(url)
       .then(util.unwrapHttpResponse);
   }

--- a/client/src/modules/journal/journal.js
+++ b/client/src/modules/journal/journal.js
@@ -530,11 +530,15 @@ function JournalController(
 
   // runs on startup
   function startup() {
-    const params = $state.params.filters;
-    Journal.filters.replaceFiltersFromState(params);
+    const { filters } = $state.params;
+    if (filters.length > 0) {
+      Journal.filters.replaceFiltersFromState(filters);
+    } else {
+      Journal.loadCachedFilters();
+    }
+
     load(Journal.filters.formatHTTP(true));
     vm.latestViewFilters = Journal.filters.formatView();
-    Journal.filters.removeUnCachableFilters(params);
   }
 
   startup();

--- a/client/src/modules/journal/journal.service.js
+++ b/client/src/modules/journal/journal.service.js
@@ -14,8 +14,8 @@ JournalService.$inject = [
  * also includes methods to open associated modals.
  */
 function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Transactions) {
-  var URL = '/journal/';
-  var service = new Api(URL);
+  const URL = '/journal/';
+  const service = new Api(URL);
 
   service.grid = grid;
   service.saveChanges = saveChanges;
@@ -29,7 +29,7 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
    * this method will always request aggregate information
    */
   function grid(id, parameters) {
-    var gridOptions = angular.extend({ aggregates : 1 }, parameters);
+    const gridOptions = angular.extend({ aggregates : 1 }, parameters);
     return this.read(id, gridOptions);
   }
 
@@ -61,10 +61,10 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
   //                - new rows (array)
   //                - removed rows (array)
   function saveChanges(entity, changes) {
-    var added = angular.copy(entity.newRows);
+    const added = angular.copy(entity.newRows);
 
     // format request for server
-    var saveRequest = {
+    const saveRequest = {
       changed : changes,
       added   : sanitiseNewRows(added),
       removed : entity.removedRows,
@@ -75,7 +75,7 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
   }
 
   function sanitiseNewRows(rows) {
-    rows.data.forEach(function (row) {
+    rows.data.forEach((row) => {
       // delete view data required by journal grid
       delete row.transaction;
       delete row.hrRecord;
@@ -84,12 +84,13 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
       delete row.display_name;
       delete row.posted;
     });
+
     return rows.data;
   }
 
   // set up base filters
-  var filterCache = new AppCache('journal-filters');
-  var journalFilters = new Filters();
+  const filterCache = new AppCache('journal-filters');
+  const journalFilters = new Filters();
 
   service.filters = journalFilters;
 
@@ -122,10 +123,10 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
 
   function assignDefaultFilters() {
     // get the keys of filters already assigned - on initial load this will be empty
-    var assignedKeys = Object.keys(journalFilters.formatHTTP());
+    const assignedKeys = Object.keys(journalFilters.formatHTTP());
 
     // assign default period filter
-    var periodDefined =
+    const periodDefined =
       service.util.arrayIncludes(assignedKeys, ['period', 'custom_period_start', 'custom_period_end']);
 
     if (!periodDefined) {
@@ -156,7 +157,8 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
   };
 
   /**
-   * openSearchModal
+   * @method openSearchModal
+   *
    * @param {object} filters
    * @param {object} options - { hasDefaultAccount: true } define other options
    */
@@ -166,14 +168,14 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
       controller :  'JournalSearchModalController as ModalCtrl',
       backdrop : 'static',
       resolve : {
-        filters : function () { return filters; },
-        options : function () { return options || {}; },
+        filters : () => filters,
+        options : () => options || {},
       },
     }).result;
   }
 
-
-  // @TODO(sfount) move this to a service that can easily be accessed by any module that will show a transactions details
+  // @TODO(sfount) move this to a service that can easily be accessed by any
+  // module that will show a transactions details.
   function openTransactionEditModal(transactionUuid, readOnly) {
     return Modal.open({
       templateUrl : 'modules/journal/modals/editTransaction.modal.html',
@@ -182,8 +184,8 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
       keyboard : false,
       size : 'lg',
       resolve : {
-        transactionUuid : function () { return transactionUuid; },
-        readOnly : function () { return readOnly; },
+        transactionUuid : () => transactionUuid,
+        readOnly : () => readOnly,
       },
     }).result;
   }

--- a/client/src/modules/journal/templates/details-link.cell.html
+++ b/client/src/modules/journal/templates/details-link.cell.html
@@ -2,7 +2,7 @@
   <a href
     data-method="detail"
     class="text-info"
-    ui-sref="journal({filters : [{ key : 'account_id', displayValue : row.entity.hrLabel, value: row.entity.account_id, cachable: 0 }]})"
+    ui-sref="journal({filters : [{ key : 'account_id', displayValue : row.entity.hrLabel, value: row.entity.account_id, cacheable: 0 }]})"
     ui-sref-opts="{ reload : false }">
     <span translate>FORM.BUTTONS.VIEW_IN_JOURNAL</span>
   </a>


### PR DESCRIPTION
This commit fixes a typo that caused filters to no longer be cached on the journal.  The code has also been improved by only checking for the cacheable flag when the filter is attempting to be cached.  This avoids
having to add any values to the modules that use FilterService.

Additionally, I've updated all files I've manipulated to pass ESLint.

Closes #2521.