### PR TITLE
chore(fiscal): polish user interface

### DIFF
--- a/client/src/modules/accounts/templates/grid.labelCell.tmpl.html
+++ b/client/src/modules/accounts/templates/grid.labelCell.tmpl.html
@@ -1,5 +1,6 @@
-<div class="ui-grid-cell-contents">
-  <!-- Indent accounts -->
+<div class="ui-grid-cell-contents" ng-class="{ 'text-bold' : row.entity.isTitleAccount }">
+
+  <!-- indent accounts -->
   <span style="padding-left : {{row.entity.$$treeLevel * grid.appScope.indentTitleSpace}}px;"></span>
   <i ng-if="row.entity.locked" class="fa fa-lock"></i> {{grid.getCellValue(row, col)}}
 </div>

--- a/client/src/modules/fiscal/fiscal.closingBalance.js
+++ b/client/src/modules/fiscal/fiscal.closingBalance.js
@@ -2,17 +2,16 @@ angular.module('bhima.controllers')
   .controller('FiscalClosingBalanceController', FiscalClosingBalanceController);
 
 FiscalClosingBalanceController.$inject = [
-  '$state', 'AccountService', 'AccountStoreService', 'FiscalService',
-  'NotifyService', 'util', 'moment', 'uiGridConstants',
+  '$state', 'AccountService', 'FiscalService', 'NotifyService',
+  'uiGridConstants', 'bhConstants',
 ];
 
 /**
  * This controller is responsible for handling the closing balance of a fiscal year.
  */
-function FiscalClosingBalanceController($state, Accounts, AccountStore, Fiscal, Notify, util, moment, uiGridConstants) {
-  var vm = this;
-  var columns;
-  var fiscalYearId = $state.params.id;
+function FiscalClosingBalanceController($state, Accounts, Fiscal, Notify, uiGridConstants, bhConstants) {
+  const vm = this;
+  const fiscalYearId = $state.params.id;
 
   // expose to the view
   vm.showAccountFilter = false;
@@ -22,42 +21,44 @@ function FiscalClosingBalanceController($state, Accounts, AccountStore, Fiscal, 
   vm.indentTitleSpace = 20;
   vm.gridApi = {};
 
-  columns = [
-    { field : 'number', displayName : '', cellClass : 'text-right', width : 100 },
-    { field : 'label',
-      displayName : 'FORM.LABELS.ACCOUNT',
-      cellTemplate : '/modules/accounts/templates/grid.labelCell.tmpl.html',
-      headerCellFilter : 'translate',
-      enableFiltering : true,
-    },
-    { field : 'debit',
-      displayName : 'FORM.LABELS.DEBIT',
-      headerCellClass : 'text-center',
-      headerCellFilter : 'translate',
-      cellTemplate : '/modules/fiscal/templates/balance.debit.tmpl.html',
-      width : 200,
-      enableFiltering : false,
-    },
-    { field : 'credit',
-      displayName : 'FORM.LABELS.CREDIT',
-      headerCellClass : 'text-center',
-      headerCellFilter : 'translate',
-      cellTemplate : '/modules/fiscal/templates/balance.credit.tmpl.html',
-      width : 200,
-      enableFiltering : false,
-    },
-  ];
+  const columns = [{
+    field : 'number',
+    displayName : '',
+    cellClass : 'text-right',
+    width : 100,
+  }, {
+    field : 'label',
+    displayName : 'FORM.LABELS.ACCOUNT',
+    cellTemplate : '/modules/accounts/templates/grid.labelCell.tmpl.html',
+    headerCellFilter : 'translate',
+    enableFiltering : true,
+  }, {
+    field : 'debit',
+    displayName : 'FORM.LABELS.DEBIT',
+    headerCellClass : 'text-center',
+    headerCellFilter : 'translate',
+    cellTemplate : '/modules/fiscal/templates/balance.debit.tmpl.html',
+    width : 200,
+    enableFiltering : false,
+  }, {
+    field : 'credit',
+    displayName : 'FORM.LABELS.CREDIT',
+    headerCellClass : 'text-center',
+    headerCellFilter : 'translate',
+    cellTemplate : '/modules/fiscal/templates/balance.credit.tmpl.html',
+    width : 200,
+    enableFiltering : false,
+  }];
 
   vm.gridOptions = {
     appScopeProvider : vm,
     fastWatch : true,
     flatEntityAccess : true,
     enableSorting : false,
-    enableFiltering : vm.showAccountFilter,
     enableColumnMenus : false,
-    rowTemplate : '/modules/accounts/templates/grid.titleRow.tmpl.html',
+    enableFiltering : vm.showAccountFilter,
     columnDefs : columns,
-    onRegisterApi : onRegisterApi,
+    onRegisterApi,
   };
 
   // API register function
@@ -67,13 +68,13 @@ function FiscalClosingBalanceController($state, Accounts, AccountStore, Fiscal, 
 
   // get fiscal year
   Fiscal.read(fiscalYearId)
-  .then(function (fy) {
-    vm.fiscal = fy;
-    $state.params.label = vm.fiscal.label;
-    return fy.previous_fiscal_year_id;
-  })
-  .then(loadPeriodicBalance)
-  .catch(Notify.handleError);
+    .then((fy) => {
+      vm.fiscal = fy;
+      $state.params.label = vm.fiscal.label;
+      return fy.previous_fiscal_year_id;
+    })
+    .then(loadPeriodicBalance)
+    .catch(Notify.handleError);
 
   /**
    * loadPeriodicBalance
@@ -84,11 +85,15 @@ function FiscalClosingBalanceController($state, Accounts, AccountStore, Fiscal, 
       id : fiscalYearId,
       period_number : vm.fiscal.number_of_months + 1,
     })
-    .then(function (list) {
-      vm.accounts = list;
-      vm.gridOptions.data = Accounts.order(vm.accounts);
-    })
-    .catch(Notify.handleError);
+      .then((list) => {
+        list.forEach(account => {
+          account.isTitleAccount = account.type_id === bhConstants.accounts.TITLE;
+        });
+
+        vm.accounts = list;
+        vm.gridOptions.data = Accounts.order(vm.accounts);
+      })
+      .catch(Notify.handleError);
   }
 
   /**

--- a/client/src/modules/fiscal/fiscal.manage.html
+++ b/client/src/modules/fiscal/fiscal.manage.html
@@ -1,7 +1,7 @@
 <form name="FiscalForm" bh-submit="FiscalManageCtrl.submit(FiscalForm)" novalidate>
 
   <div class="row">
-    <div class="col-md-12">
+    <div class=" col-lg-6 col-md-10 col-sm-12 col-xs-12">
       <div class="panel panel-primary">
         <div ng-if="FiscalManageCtrl.isCreateState" class="panel-heading" translate>FISCAL.NEW_FISCAL_YEAR</div>
         <div ng-if="FiscalManageCtrl.isUpdateState" class="panel-heading">
@@ -41,7 +41,7 @@
             <select class="form-control"
               ng-model="FiscalManageCtrl.fiscal.previous_fiscal_year_id"
               ng-options="fy.id as fy.hrLabel for fy in FiscalManageCtrl.previous_fiscal_year">
-              <option value="" disabled>--{{ 'FORM.SELECT.FISCAL_YEAR' | translate }}--</option>
+              <option value="" disabled translate>FORM.SELECT.FISCAL_YEAR</option>
             </select>
           </div>
 
@@ -66,7 +66,7 @@
       <p><strong translate>FORM.INFO.OTHER_ACTIONS</strong></p>
       <p>
         <!-- close the fiscal year  -->
-        <a class="btn btn-danger" data-action="closing-fiscal-year" href ng-click="FiscalManageCtrl.closingFiscalYear()">
+        <a class="btn btn-danger" data-action="closing-fiscal-year" href ng-click="FiscalManageCtrl.closingFiscalYear()" ng-hide="FiscalManageCtrl.fiscal.locked">
           <i class="fa fa-lock"></i>
           <span translate>FORM.INFO.CLOSE_FISCAL_YEAR</span>
         </a>

--- a/client/src/modules/fiscal/fiscal.openingBalance.html
+++ b/client/src/modules/fiscal/fiscal.openingBalance.html
@@ -1,8 +1,6 @@
 <div class="row">
   <div class="col-md-12">
-
     <form name="OpeningAccountForm" bh-submit="FiscalOBCtrl.submit(OpeningAccountForm)" novalidate>
-
       <div class="panel panel-primary">
 
         <!-- heading  -->
@@ -20,7 +18,6 @@
               <span translate>FORM.BUTTONS.EDIT</span> <i class="fa fa-edit"></i>
             </span>
           </div>
-
         </div>
 
         <!-- body  -->
@@ -47,7 +44,7 @@
           </div>
 
           <button type="submit" data-method="submit" ng-disabled="!FiscalOBCtrl.editBalanceEnabled && !FiscalOBCtrl.previousFiscalYearExist" class="btn btn-primary">
-            <span ng-show="!FiscalOBCtrl.previousFiscalYearExist" translate>FORM.BUTTONS.SUBMIT</span>
+            <span ng-hide="FiscalOBCtrl.previousFiscalYearExist" translate>FORM.BUTTONS.SUBMIT</span>
             <span ng-show="FiscalOBCtrl.previousFiscalYearExist" translate>FORM.BUTTONS.IMPORT_PREVIOUS_CLOSING_BALANCE</span>
           </button>
         </div>

--- a/client/src/modules/fiscal/templates/exploitation_type.tmpl.html
+++ b/client/src/modules/fiscal/templates/exploitation_type.tmpl.html
@@ -1,8 +1,3 @@
-<div class="text-center ui-grid-cell-contents">
-  <span class="text-success" ng-show="row.entity.type === 'revenue'">
-    <i class="fa fa-circle"></i>
-  </span>
-  <span class="text-danger" ng-show="row.entity.type === 'expense'">
-    <i class="fa fa-circle"></i>
-  </span>
+<div class="text-center ui-grid-cell-contents" ng-class="{ 'text-success' : row.entity.type === 'revenue', 'text-danger' : row.entity.type === 'expense' }">
+  <i class="fa fa-circle"></i>
 </div>

--- a/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.js
+++ b/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.js
@@ -9,12 +9,10 @@ ClosingFiscalYearModalController.$inject = [
 ];
 
 // The closing fiscal year controller
-function ClosingFiscalYearModalController(Notify, Fiscal, Modal,
-  Session, Instance, Data, uiGridGroupingConstants) {
-  var vm = this;
-  var columns;
+function ClosingFiscalYearModalController(Notify, Fiscal, Modal, Session, Instance, Data, uiGridGroupingConstants) {
+  const vm = this;
 
-  // global variables
+  // global
   vm.currency_id = Session.enterprise.currency_id;
 
   // expose to the view
@@ -23,32 +21,33 @@ function ClosingFiscalYearModalController(Notify, Fiscal, Modal,
   vm.onSelectAccount = onSelectAccount;
 
   // exploitation grid
-  columns = [
-    { field            : 'type',
-      displayName      : '',
-      cellTemplate     : 'modules/fiscal/templates/exploitation_type.tmpl.html',
-      width            : 25,
-    },
-    { field            : 'number',
-      displayName      : 'ACCOUNT.NUMBER',
-      headerCellFilter : 'translate',
-      treeAggregationType : uiGridGroupingConstants.aggregation.COUNT,
-    },
-    { field            : 'label',
-      displayName      : 'TABLE.COLUMNS.ACCOUNT',
-      headerCellFilter : 'translate',
-    },
-    { field            : 'debit',
-      displayName      : 'TABLE.COLUMNS.DEBIT',
-      headerCellFilter : 'translate',
-      treeAggregationType : uiGridGroupingConstants.aggregation.SUM,
-    },
-    { field            : 'credit',
-      displayName      : 'TABLE.COLUMNS.CREDIT',
-      headerCellFilter : 'translate',
-      treeAggregationType : uiGridGroupingConstants.aggregation.SUM,
-    },
-  ];
+  const columns = [{
+    field            : 'type',
+    displayName      : '',
+    cellTemplate     : 'modules/fiscal/templates/exploitation_type.tmpl.html',
+    width            : 25,
+  }, {
+    field            : 'number',
+    displayName      : 'ACCOUNT.NUMBER',
+    headerCellFilter : 'translate',
+  }, {
+    field            : 'label',
+    displayName      : 'TABLE.COLUMNS.ACCOUNT',
+    headerCellFilter : 'translate',
+  }, {
+    field            : 'debit',
+    displayName      : 'TABLE.COLUMNS.DEBIT',
+    headerCellFilter : 'translate',
+    treeAggregationType : uiGridGroupingConstants.aggregation.SUM,
+    aggregationHideLabel : true,
+  }, {
+    field            : 'credit',
+    displayName      : 'TABLE.COLUMNS.CREDIT',
+    headerCellFilter : 'translate',
+    treeAggregationType : uiGridGroupingConstants.aggregation.SUM,
+    aggregationHideLabel : true,
+  }];
+
   vm.gridOptions = {
     columnDefs        : columns,
     enableColumnMenus : false,
@@ -63,35 +62,35 @@ function ClosingFiscalYearModalController(Notify, Fiscal, Modal,
   }
 
   Fiscal.read(Data.id)
-  .then(function (fiscal) {
-    vm.fiscal = fiscal;
+    .then(fiscal => {
+      vm.fiscal = fiscal;
 
-    // get balance until period N of the year to close
-    return Fiscal.periodicBalance({
-      id            : vm.fiscal.id,
-      period_number : vm.fiscal.number_of_months, // last month
-    });
-  })
-  .then(function (balance) {
-    var profit = balance.filter(getProfitAccount);
-    var charge = balance.filter(getExpenseAccount);
+      // get balance until period N of the year to close
+      return Fiscal.periodicBalance({
+        id            : vm.fiscal.id,
+        period_number : vm.fiscal.number_of_months, // last month
+      });
+    })
+    .then(balance => {
+      const profit = balance.filter(getProfitAccount);
+      const charge = balance.filter(getExpenseAccount);
 
-    vm.gridOptions.data = profit.concat(charge);
-    vm.profit = creditorSold(profit);
-    vm.charge = debitorSold(charge);
-    vm.globalResult = vm.profit - vm.charge;
-  })
-  .catch(Notify.handleError);
+      vm.gridOptions.data = profit.concat(charge);
+      vm.profit = creditorSold(profit);
+      vm.charge = debitorSold(charge);
+      vm.globalResult = vm.profit - vm.charge;
+    })
+    .catch(Notify.handleError);
 
   // get profit account
   function getProfitAccount(account) {
-    var nullBalance = account.debit === account.credit && account.credit === 0;
+    const nullBalance = account.debit === account.credit && account.credit === 0;
     return account.type === 'revenue' && !nullBalance;
   }
 
   // get expense account
   function getExpenseAccount(account) {
-    var nullBalance = account.debit === account.credit && account.credit === 0;
+    const nullBalance = account.debit === account.credit && account.credit === 0;
     return account.type === 'expense' && !nullBalance;
   }
 
@@ -108,42 +107,38 @@ function ClosingFiscalYearModalController(Notify, Fiscal, Modal,
 
   // confirm closing
   function confirmClosing() {
-    var request = {
+    const request = {
       pattern     : vm.fiscal.label,
       patternName : 'FORM.PATTERNS.FISCAL_YEAR_NAME',
     };
 
     return Modal.openConfirmDialog(request)
-    .then(function (ans) {
-      if (!ans) { return; }
+      .then(ans => {
+        if (!ans) { return 0; }
 
-      return Fiscal.closing({
-        id         : vm.fiscal.id,
-        account_id : vm.resultAccount.id,
+        return Fiscal.closing({
+          id         : vm.fiscal.id,
+          account_id : vm.resultAccount.id,
+        });
+      })
+      .then(res => {
+        if (!res) { return; }
+
+        Instance.close(true);
+        Notify.success('FISCAL.CLOSING_SUCCESS');
+      })
+      .catch(err => {
+        Instance.close(false);
+        Notify.handleError(err);
       });
-    })
-    .then(function (res) {
-      if (!res) { return; }
-
-      Instance.close(true);
-      Notify.success('FISCAL.CLOSING_SUCCESS');
-    })
-    .catch(function (err) {
-      Instance.close(false);
-      Notify.handleError(err);
-    });
   }
 
-  // utilities
+  // utility fns
   function debitorSold(array) {
-    return array.reduce(function (a, b) {
-      return (a + b.debit) - b.credit;
-    }, 0);
+    return array.reduce((a, b) => (a + b.debit) - b.credit, 0);
   }
 
   function creditorSold(array) {
-    return array.reduce(function (a, b) {
-      return (a + b.credit) - b.debit;
-    }, 0);
+    return array.reduce((a, b) => (a + b.credit) - b.debit, 0);
   }
 }


### PR DESCRIPTION
This commit polishes the user interface and updates the code to the
latest ESLint checks in the client.  The most significant changes are:
 1. Title accounts are highlighted on the opening/closing balance grids.
 2. Performance increases on the UI-grids via template optimisations and
 fastWatch.
 3. The "Close Fiscal Year" button is hidden if a Fiscal Year is closed.
 4. Removes aggregation labels from footers.

Partially addresses #2490.  References #715.