### PR TITLE
fix(reports): add title attribute

### DIFF
--- a/server/controllers/finance/reports/accounts/chart.handlebars
+++ b/server/controllers/finance/reports/accounts/chart.handlebars
@@ -26,7 +26,7 @@
         {{#equal this.type_id ../TITLE_ID}}
           <tr>
             <td class="text-right"><strong>{{ this.number }}</strong></td>
-            <td class="text-left">
+            <td class="text-left" title="{{this.label}}">
               <strong style="margin-left: {{indentAccount this.depth}};">
                 {{#if this.locked}}
                   <i class="fa fa-lock"></i>

--- a/server/controllers/finance/reports/cash/report.handlebars
+++ b/server/controllers/finance/reports/cash/report.handlebars
@@ -31,9 +31,9 @@
         <tbody>
           {{#each rows}}
             <tr>
-              <td>{{reference}}</td>
+              <td title="{{reference}}">{{reference}}</td>
               <td class="text-right">{{date date}}</td>
-              <td>{{debtor_name}}</td>
+              <td title="{{debtor_name}}">{{debtor_name}}</td>
               <td class="text-right">{{currency amount currency_id}}</td>
               <td>{{cashbox_label}}</td>
               <td>{{display_name}}</td>

--- a/server/controllers/finance/reports/financial.patient.handlebars
+++ b/server/controllers/finance/reports/financial.patient.handlebars
@@ -24,9 +24,9 @@
         {{#each transactions}}
           <tr>
             <td>{{date this.trans_date}}</td>
-            <td class="text-right">{{this.document}}</td>
-            <td class="text-right">{{this.trans_id}}</td>
-            <td style="max-width : 200px; white-space : nowrap; overflow : hidden; text-overflow : ellipsis;">{{this.description}}</td>
+            <td class="text-right" title="{{this.document}}">{{this.document}}</td>
+            <td class="text-right" title="{{this.trans_id}}">{{this.trans_id}}</td>
+            <td style="max-width : 200px; white-space : nowrap; overflow : hidden; text-overflow : ellipsis;" title="{{this.description}}">{{this.description}}</td>
             <td class="text-right {{#if this.credit}}text-danger{{/if}}">
               {{#if this.credit}}
                 ({{currency this.credit ../metadata.enterprise.currency_id}})

--- a/server/controllers/finance/reports/invoices/report.handlebars
+++ b/server/controllers/finance/reports/invoices/report.handlebars
@@ -29,9 +29,9 @@
         <tbody>
           {{#each rows}}
             <tr>
-              <td>{{reference}}</td>
+              <td title="{{reference}}">{{reference}}</td>
               <td class="text-right">{{date date}}</td>
-              <td>{{patientName}}</td>
+              <td title="{{patientName}}">{{patientName}}</td>
               <td class="text-right">{{currency cost currency_id}}</td>
               <td>{{serviceName}}</td>
               <td>{{display_name}}</td>

--- a/server/controllers/finance/reports/reportAccounts/report.handlebars
+++ b/server/controllers/finance/reports/reportAccounts/report.handlebars
@@ -52,9 +52,9 @@
         {{#each transactions}}
           <tr>
             <td>{{date this.trans_date}}</td>
-            <td>{{this.trans_id}}</td>
-            <td>{{this.document_reference}}</td>
-            <td style="max-width : 200px; white-space : nowrap; overflow : hidden; text-overflow : ellipsis;">{{this.description}}</td>
+            <td title="{{this.trans_id}}">{{this.trans_id}}</td>
+            <td title="{{this.document_reference}}">{{this.document_reference}}</td>
+            <td style="max-width : 200px; white-space : nowrap; overflow : hidden; text-overflow : ellipsis;" title="{{this.description}}">{{this.description}}</td>
             <td class="text-right">
               {{#if ../useOriginalTransactionCurrency}}
                 {{#if this.debit}}

--- a/server/controllers/finance/reports/vouchers/report.handlebars
+++ b/server/controllers/finance/reports/vouchers/report.handlebars
@@ -31,7 +31,7 @@
             <tr>
               <td>{{voucher.reference}}</td>
               <td>{{date voucher.date}}</td>
-              <td>{{voucher.description}}</td>
+              <td title="{{voucher.description}}">{{voucher.description}}</td>
               <td class="text-right">{{currency voucher.amount voucher.currency_id}}</td>
               <td>{{voucher.display_name}}</td>
             </tr>

--- a/server/controllers/inventory/reports/items.handlebars
+++ b/server/controllers/inventory/reports/items.handlebars
@@ -42,8 +42,8 @@
           <tbody>
             {{#each rows}}
               <tr>
-                <td>{{code}}</td>
-                <td>{{label}}</td>
+                <td title="{{code}}">{{code}}</td>
+                <td title="{{label}}">{{label}}</td>
                 <td class="text-right">{{currency price ../metadata.enterprise.currency_id }}</td>
                 <td>{{unit}}</td>
                 <td>{{type}}</td>

--- a/server/controllers/medical/reports/registrations.handlebars
+++ b/server/controllers/medical/reports/registrations.handlebars
@@ -25,9 +25,9 @@
       <tbody>
         {{#each patients}}
           <tr>
-            <td>{{this.reference}}</td>
+            <td title="{{this.reference}}">{{this.reference}}</td>
             <td>{{this.hospital_no}}</td>
-            <td>{{this.display_name}}</td>
+            <td title="{{this.display_name}}">{{this.display_name}}</td>
             <td>{{this.sex}}</td>
             <td>{{this.age}} ({{date this.dob}})</td>
             <td>{{this.originVillageName}}</td>

--- a/server/controllers/payroll/reports/registrations.handlebars
+++ b/server/controllers/payroll/reports/registrations.handlebars
@@ -24,7 +24,7 @@
         {{#each employees}}
           <tr>
             <td>{{this.code}}</td>
-            <td>{{this.display_name}}</td>
+            <td title="{{this.display_name}}">{{this.display_name}}</td>
             <td>{{this.sex}}</td>
             <td>{{this.age}} ({{date this.dob}})</td>
             <td>{{this.code_grade}}</td>            


### PR DESCRIPTION
This commit adds the HTML title attribute to select reports that run the risk of missing elements due to small screen sizes.  This title will only appear when the mouse hovers over the text, specifically on the report HTML preview.

Closes #2526.