### PR TITLE
deps(ci): bump minimal node to 8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
 
 language: node_js
 node_js:
-  - "6"
+  - "8"
   - node
 
 before_script:


### PR DESCRIPTION
This commit bumps to latest tested node version on Travis to node version 8.