### PR TITLE
Refactor: Account Statement Report

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -85,7 +85,8 @@
     "REPORT_ACCOUNTS": {
       "TITLE": "Account Report",
       "DESCRIPTION": "This report shows all transactions for an individual account given a set time period.",
-      "WARN_MULTIPLE": "N.B. This report concerns an income/ expense account and spans multiple fiscal years. Income/ expense accounts are cleared to 0 at the begining of every fiscal year, the cumulative balance displayed is for the transactions within this period of time. It is recommended to use this statement within a single fiscal year."
+      "WARN_MULTIPLE": "N.B. This report concerns an income/ expense account and spans multiple fiscal years. Income/ expense accounts are cleared to 0 at the beginning of every fiscal year, the cumulative balance displayed is for the transactions within this period of time. It is recommended to use this statement within a single fiscal year.",
+      "WARN_CURRENCY": "Attention! You are using a currency other than the enterprise currency.  Values on this report are subject to change with changes to the exchange rate and should not be considered final.  Please save a report in the enterprise currency for long term reference."
     },
     "INCOME_EXPENSE_REPORT": {
       "TITLE": "Income Expense Report",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -80,7 +80,8 @@
     "REPORT_ACCOUNTS": {
       "TITLE": "Rapport de comptes",
       "DESCRIPTION": "Ce rapport affiche toutes les transactions sur un compte individuel pour une période donnée",
-      "WARN_MULTIPLE": "N.B. Ce rapport concerne des comptes de produits / charges et s'étend sur plusieurs années fiscales. Les comptes de produits / charges sont remis à 0 au début de chaque exercice financier, le solde cumulatif affiché est destiné aux transactions dans ce délai. Il est recommandé d'utiliser cette déclaration au cours d'un exercice financier unique."
+      "WARN_MULTIPLE": "N.B. Ce rapport concerne des comptes de produits / charges et s'étend sur plusieurs années fiscales. Les comptes de produits / charges sont remis à 0 au début de chaque exercice financier, le solde cumulatif affiché est destiné aux transactions dans ce délai. Il est recommandé d'utiliser cette déclaration au cours d'un exercice financier unique.",
+      "WARN_CURRENCY" : "Attention! Vous utilisez une devise autre que la devise de l'entreprise. Les valeurs de ce rapport sont susceptibles d'être modifiées en fonction du taux de change et ne doivent pas être considérées comme définitives. Veuillez enregistrer un rapport dans la devise de l'entreprise pour référence à long terme."
     },
     "INCOME_EXPENSE_REPORT": {
       "TITLE": "Rapport des Comptes d'exploitation",

--- a/client/src/modules/reports/generate/account_report/account_report.config.js
+++ b/client/src/modules/reports/generate/account_report/account_report.config.js
@@ -49,24 +49,24 @@ function AccountReportConfigController(
     };
 
     return SavedReports.saveAsModal(options)
-      .then(function () {
+      .then(() => {
         $state.go('reportsBase.reportsArchive', { key : options.report.report_key });
       })
       .catch(Notify.handleError);
   };
 
   vm.preview = function preview(form) {
-    if (form.$invalid) { return; }
+    if (form.$invalid) { return 0; }
 
     parseDateInterval(vm.reportDetails);
 
     // update cached configuration
     cache.reportDetails = angular.copy(vm.reportDetails);
 
-    var sendDetails = sanitiseDateStrings(vm.reportDetails);
+    const sendDetails = sanitiseDateStrings(vm.reportDetails);
 
     return SavedReports.requestPreview(reportUrl, reportData.id, sendDetails)
-      .then(function (result) {
+      .then(result => {
         vm.previewGenerated = true;
         vm.previewResult = $sce.trustAsHtml(result);
       })

--- a/client/src/modules/reports/generate/account_report/account_report.html
+++ b/client/src/modules/reports/generate/account_report/account_report.html
@@ -43,55 +43,12 @@
               validation-trigger="ConfigForm.$submitted">
             </bh-date-interval>
 
-            <bh-hidden-field
-              show-text="REPORT.OPTIONS.MORE_OPTIONS"
-              hide-text="REPORT.OPTIONS.MORE_OPTIONS">
-
-              <div class="radio" ng-class="{ 'has-error': ConfigForm.$submitted && ConfigForm.useOriginalTransactionCurrency.$invalid }">
-                <p class="control-label" style="margin-bottom:5px;">
-                  <strong translate>REPORT.OPTIONS.USE_ORIGINAL_TRANSACTION_CURRENCY</strong>
-                </p>
-
-                <label
-                  class="radio-inline"
-                  translate-attr="{ title : 'FORM.LABELS.YES' }">
-                  <input
-                    name="useOriginalTransactionCurrency"
-                    type="radio"
-                    ng-model="ReportConfigCtrl.reportDetails.useOriginalTransactionCurrency"
-                    ng-value="true"
-                    required>
-                  <span translate>FORM.LABELS.YES</span>
-                </label>
-
-                <label
-                  class="radio-inline"
-                  translate-attr="{ title : 'FORM.LABELS.NO' }">
-                  <input
-                    name="useOriginalTransactionCurrency"
-                    type="radio"
-                    ng-model="ReportConfigCtrl.reportDetails.useOriginalTransactionCurrency"
-                    ng-value="false"
-                    required>
-                  <span translate>FORM.LABELS.NO</span>
-                </label>
-
-                <div class="help-block" ng-messages="ConfigForm.$error" ng-show="ConfigForm.$submitted">
-                  <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-                </div>
-
-                <p class="help-block" translate>REPORT.OPTIONS.USE_ORIGINAL_TRANSACTION_CURRENCY_HELP</p>
-              </div>
-
-              <!-- the currency to be used in the footer -->
-              <bh-currency-select
-                label="REPORT.OPTIONS.TOTALS_CURRENCY"
-                currency-id="ReportConfigCtrl.reportDetails.currency_id"
-                on-change="ReportConfigCtrl.setCurrency(currency)"
-                validation-trigger="ConfigForm.$submitted">
-              </bh-currency-select>
-              <p class="help-block" translate>REPORT.OPTIONS.TOTALS_CURRENCY_HELP</p>
-            </bh-hidden-field>
+            <!-- the currency to be used in the footer -->
+            <bh-currency-select
+              currency-id="ReportConfigCtrl.reportDetails.currency_id"
+              on-change="ReportConfigCtrl.setCurrency(currency)"
+              validation-trigger="ConfigForm.$submitted">
+            </bh-currency-select>
 
             <bh-loading-button loading-state="ConfigForm.$loading">
               <span translate>REPORT.UTIL.PREVIEW</span>

--- a/server/controllers/finance/accounts/extra.js
+++ b/server/controllers/finance/accounts/extra.js
@@ -144,8 +144,7 @@ function getOpeningBalanceForDate(accountId, date, includeMaxDate = true) {
 
     // 3. Calculate the sum of all general ledger transaction against this account
     //    for the current period up to the current date
-    .then(periodId =>
-      getComputedAccountBalanceUntilDate(accountId, date, periodId, includeMaxDate))
+    .then(periodId => getComputedAccountBalanceUntilDate(accountId, date, periodId, includeMaxDate))
     .then(runningPeriod => {
       return {
         balance : (balance + runningPeriod.balance).toFixed(4),

--- a/server/controllers/finance/currencies.js
+++ b/server/controllers/finance/currencies.js
@@ -9,6 +9,18 @@
 
 const db = require('../../lib/db');
 
+exports.lookupCurrencyById = lookupCurrencyById;
+function lookupCurrencyById(id) {
+  const sql = `
+    SELECT c.id, c.name, c.note, c.format_key,
+      c.symbol, c.min_monentary_unit
+    FROM currency AS c
+    WHERE c.id = ?;
+  `;
+
+  return db.one(sql, id);
+}
+
 /** list currencies in the database */
 exports.list = function list(req, res, next) {
   const sql =
@@ -27,13 +39,7 @@ exports.list = function list(req, res, next) {
 
 /** get the details of a single currency */
 exports.detail = function detail(req, res, next) {
-  const sql =
-    `SELECT c.id, c.name, c.note, c.format_key,
-      c.symbol, c.min_monentary_unit
-    FROM currency AS c
-    WHERE c.id = ?;`;
-
-  db.one(sql, [req.params.id])
+  lookupCurrencyById(req.params.id)
     .then((row) => {
       res.status(200).json(row);
     })

--- a/server/controllers/finance/reports/financial.patient.handlebars
+++ b/server/controllers/finance/reports/financial.patient.handlebars
@@ -27,14 +27,12 @@
             <td class="text-right" title="{{this.document}}">{{this.document}}</td>
             <td class="text-right" title="{{this.trans_id}}">{{this.trans_id}}</td>
             <td style="max-width : 200px; white-space : nowrap; overflow : hidden; text-overflow : ellipsis;" title="{{this.description}}">{{this.description}}</td>
-            <td class="text-right {{#if this.credit}}text-danger{{/if}}">
-              {{#if this.credit}}
-                ({{currency this.exchangedCredit ../params.currency_id}})
-              {{else}}
-                {{currency this.exchangedDebit ../params.enterprise.currency_id}}
-              {{/if}}
+            <td class="text-right">
+              {{debcred this.balance ../metadata.enterprise.currency_id}}
             </td>
-            <td class="text-right">{{currency this.cumsum ../metadata.enterprise.currency_id}} </td>
+            <td class="text-right">
+              {{debcred this.cumsum ../metadata.enterprise.currency_id}}
+            </td>
           </tr>
         {{else}}
           {{>emptyTable columns=5}}
@@ -58,13 +56,7 @@
             {{translate "FORM.LABELS.TOTAL_BALANCE_REMAINING" }}
           </th>
           <th class="text-right">
-            {{#unless aggregates.hasDebitBalance }}
-              <span class="text-danger">
-                ({{currency aggregates.balance metadata.enterprise.currency_id}})
-              </span>
-            {{else}}
-              {{currency aggregates.balance metadata.enterprise.currency_id}}
-            {{/unless}}
+            {{debcred aggregates.balance metadata.enterprise.currency_id}}
           </th>
         </tr>
       </tfoot>

--- a/server/controllers/finance/reports/financial.patient.handlebars
+++ b/server/controllers/finance/reports/financial.patient.handlebars
@@ -29,9 +29,9 @@
             <td style="max-width : 200px; white-space : nowrap; overflow : hidden; text-overflow : ellipsis;" title="{{this.description}}">{{this.description}}</td>
             <td class="text-right {{#if this.credit}}text-danger{{/if}}">
               {{#if this.credit}}
-                ({{currency this.credit ../metadata.enterprise.currency_id}})
+                ({{currency this.exchangedCredit ../params.currency_id}})
               {{else}}
-                {{currency this.debit ../metadata.enterprise.currency_id}}
+                {{currency this.exchangedDebit ../params.enterprise.currency_id}}
               {{/if}}
             </td>
             <td class="text-right">{{currency this.cumsum ../metadata.enterprise.currency_id}} </td>

--- a/server/controllers/finance/reports/reportAccounts/index.js
+++ b/server/controllers/finance/reports/reportAccounts/index.js
@@ -237,6 +237,9 @@ function getAccountTransactions(options, openingBalance = 0) {
       const lastDate = (lastTransaction && lastTransaction.trans_date) || options.dateTo;
       const lastCumSum = (lastTransaction && lastTransaction.cumsum) || (totals.balance * totals.rate);
 
+      const lastCurrencyId = (lastTransaction && lastTransaction.currency_id) || totals.currency_id;
+      const shouldDisplayDebitCredit = bundle.transactions.every(txn => txn.currency_id === lastCurrencyId);
+
       // contains the grid totals for the footer
       const footer = {
         date : lastDate,
@@ -246,6 +249,8 @@ function getAccountTransactions(options, openingBalance = 0) {
         exchangedCumSum : lastCumSum,
         exchangedDate : new Date(),
         invertedRate : util.roundDecimal(1 / totals.rate, 2),
+        shouldDisplayDebitCredit,
+        transactionCurrencyId : lastCurrencyId,
       };
 
       // combine shared properties

--- a/server/controllers/finance/reports/reportAccounts/report.handlebars
+++ b/server/controllers/finance/reports/reportAccounts/report.handlebars
@@ -104,8 +104,16 @@
           <th>{{date footer.date}}</th>
           <th colspan="3">{{translate "FORM.LABELS.TOTAL"}}</th>
           <th class="text-right">{{footer.invertedRate}}</th>
-          <th></th>
-          <th></th>
+          <th class="text-right">
+            {{#if footer.shouldDisplayDebitCredit}}
+              {{currency footer.debit footer.transactionCurrencyId}}
+            {{/if}}
+          </th>
+          <th class="text-right">
+            {{#if footer.shouldDisplayDebitCredit}}
+              {{currency footer.credit footer.transactionCurrencyId}}
+            {{/if}}
+          </th>
           <th class="text-right">
             {{debcred footer.exchangedBalance footer.currency_id }}
           </th>

--- a/server/controllers/finance/reports/reportAccounts/report.handlebars
+++ b/server/controllers/finance/reports/reportAccounts/report.handlebars
@@ -5,7 +5,7 @@
 
   <h3 class="text-center text-uppercase"><strong>{{translate "REPORT.ACCOUNT"}}</strong></h3>
 
-  <h4 class="text-center"><strong>{{ accountDetails.number }} | {{ accountDetails.label}}</strong></h4>
+  <h4 class="text-center"><strong>{{ account.number }} | {{ account.label}}</strong></h4>
 
   {{#if params.dateFrom }}
     <h5 style="margin:15px; font-weight:bold" class="text-center text-uppercase">
@@ -19,6 +19,12 @@
   </section>
   {{/if}}
 
+  {{#unless params.isEnterpriseCurrency}}
+    <div class="alert alert-warning">
+      <p>{{translate "REPORT.REPORT_ACCOUNTS.WARN_CURRENCY"}}</p>
+    </div>
+  {{/unless}}
+
   <section>
     <table class="table table-condensed table-report table-bordered">
       <thead>
@@ -27,105 +33,87 @@
           <th>{{translate "TABLE.COLUMNS.TRANSACTION" }}</th>
           <th>{{translate "TABLE.COLUMNS.DOCUMENT" }}</th>
           <th>{{translate "TABLE.COLUMNS.DESCRIPTION" }}</th>
-          <th style="min-width:12%">{{translate "TABLE.COLUMNS.DEBIT" }}</th>
-          <th style="min-width:12%">{{translate "TABLE.COLUMNS.CREDIT" }}</th>
-          <th style="min-width:12%">{{translate "TABLE.COLUMNS.BALANCE" }}</th>
+          <th class="text-center">{{translate "FORM.LABELS.RATE" }}</th>
+          <th class="text-center" style="min-width:12%">{{translate "TABLE.COLUMNS.DEBIT" }}</th>
+          <th class="text-center" style="min-width:12%">{{translate "TABLE.COLUMNS.CREDIT" }}</th>
+          <th class="text-center">{{translate "FORM.LABELS.VALUE" }} ({{currency.symbol}})</th>
+          <th class="text-center" style="min-width:12%">{{translate "TABLE.COLUMNS.BALANCE" }} ({{currency.symbol}})</th>
         </tr>
       </thead>
       <tbody>
 
         {{! Opening Balance Line }}
         <tr>
-          <th>{{ date openingBalance.date }}</th>
+          <th>{{ date header.date }}</th>
           <th colspan="3">{{translate "REPORT.OPENING_BALANCE"}}</th>
 
           <th class="text-right">
-            {{currency openingBalance.debit metadata.enterprise.currency_id}}
-          </th>
-          <th class="text-right">
-            {{currency openingBalance.credit metadata.enterprise.currency_id}}
+            {{ header.invertedRate }}
           </th>
 
-          <th class="text-right">{{currency openingBalance.balance metadata.enterprise.currency_id}}</th>
+          <th class="text-right">
+            {{currency header.debit metadata.enterprise.currency_id}}
+          </th>
+
+          <th class="text-right">
+            {{currency header.credit metadata.enterprise.currency_id }}
+          </th>
+
+          <th></th>
+
+          <th class="text-right">
+            {{debcred header.exchangedBalance params.currency_id }}
+          </th>
         </tr>
 
+        {{! All transactions within the query range }}
         {{#each transactions}}
           <tr>
             <td>{{date this.trans_date}}</td>
             <td title="{{this.trans_id}}">{{this.trans_id}}</td>
             <td title="{{this.document_reference}}">{{this.document_reference}}</td>
-            <td style="max-width : 200px; white-space : nowrap; overflow : hidden; text-overflow : ellipsis;" title="{{this.description}}">{{this.description}}</td>
+            <td title="{{this.description}}" style="max-width : 200px; white-space : nowrap; overflow : hidden; text-overflow : ellipsis;">{{this.description}}</td>
+            <td class="text-right">{{this.invertedRate}}</td>
             <td class="text-right">
-              {{#if ../useOriginalTransactionCurrency}}
-                {{#if this.debit}}
-                  {{currency this.debit this.currency_id}}
-                  {{#if this.rate}} (&#64; {{this.rate}}){{/if}}
-                {{/if}}
-              {{else}}
-                {{#if this.debit_equiv}}
-                  {{currency this.debit_equiv ../metadata.enterprise.currency_id}}
-                {{/if}}
-              {{/if}}
-            </td>
-            <td class="text-right">
-              {{#if ../useOriginalTransactionCurrency}}
-                {{#if this.credit}}
-                  {{currency this.credit this.currency_id}}
-                  {{#if this.rate}} (&#64; {{this.rate}}){{/if}}
-                {{/if}}
-              {{else}}
-                {{#if this.credit_equiv}}
-                  {{currency this.credit_equiv ../metadata.enterprise.currency_id}}
-                {{/if}}
+              {{#if this.debit}}
+                {{currency this.debit this.currency_id}}
               {{/if}}
             </td>
 
             <td class="text-right">
-              {{currency this.cumsum ../metadata.enterprise.currency_id}}
+              {{#if this.credit}}
+                {{currency this.credit this.currency_id}}
+              {{/if}}
+            </td>
+
+            <td class="text-right">
+              {{debcred this.exchangedBalance ../params.currency_id }}
+            </td>
+            <td class="text-right">
+              {{debcred this.cumsum ../params.currency_id }}
             </td>
           </tr>
         {{else}}
-          {{> emptyTable columns=7}}
+          {{> emptyTable columns=9}}
         {{/each}}
-
-        {{!  This contains the grid totals }}
-        <tr>
-          <td><strong>{{date sum.footer.date}}</strong></th>
-          <td colspan="3"><strong>{{translate "FORM.LABELS.TOTAL"}}</strong></td>
-          <td class="text-right"><strong>{{currency sum.footer.exchangedDebit sum.footer.currency_id}}</strong></td>
-          <td class="text-right"><strong>{{currency sum.footer.exchangedCredit sum.footer.currency_id}}</strong></td>
-          <td></td>
-        </tr>
       </tbody>
+
+      {{!  This contains the grid totals }}
       <tfoot>
-        {{! This contains the period totals (opening balance + grid totals }}
-        <tr style="background-color: #ddd;">
-          <td colspan="4"><strong>{{translate "FORM.LABELS.PERIOD_TOTAL" }}</strong></td>
+        <tr>
+          <th>{{date footer.date}}</th>
+          <th colspan="3">{{translate "FORM.LABELS.TOTAL"}}</th>
+          <th class="text-right">{{footer.invertedRate}}</th>
+          <th></th>
+          <th></th>
           <th class="text-right">
-            {{currency sum.period.exchangedDebit sum.period.currency_id}}
+            {{debcred footer.exchangedBalance footer.currency_id }}
           </th>
           <th class="text-right">
-            {{currency sum.period.exchangedCredit sum.period.currency_id}}
-          </th>
-          <th class="text-right">
-            {{currency sum.period.exchangedBalance sum.period.currency_id}}
+            {{debcred footer.exchangedCumSum footer.currency_id }}
           </th>
         </tr>
       </tfoot>
-    </table>
-    <table class="table table-condensed">
-      {{#if sum.period.showExchangeRate }}
-        <tr>
-          <th colspan="5" class="text-right" style="padding-bottom:0;">
-            {{translate "FORM.LABELS.EXCHANGE_RATE"}} ({{date sum.period.exchangedDate}}) {{currency sum.period.inverted_rate metadata.enterprise.currency_id}} 
-          </th>
-        </tr>
-      {{/if}}
-      <tr style="border-top: none;">
-        <th colspan="5" class="text-right" style="border-top: none;">
-          <strong>{{translate "FORM.LABELS.BALANCE" }} ({{date params.dateTo }}) {{currency sum.period.exchangedBalance sum.period.currency_id}}</strong>
-        </th>
-      </tr>
     </table>
   </section>
 </body>

--- a/server/lib/template/helpers/finance.js
+++ b/server/lib/template/helpers/finance.js
@@ -1,5 +1,6 @@
 const accountingjs = require('accounting-js');
 const NumberToText = require('../../../lib/NumberToText');
+const Handlebars = require('handlebars');
 
 const USD_FMT = { precision : 2 };
 
@@ -45,6 +46,22 @@ function indentAccount(depth) {
   return number ? number * INDENTATION_STEP : 0;
 }
 
+function debcred(value = 0, currencyId) {
+  let cellClass = '';
+  let _value;
+  if (value < 0) {
+    cellClass = 'text-danger';
+    _value = `(${currency(Math.abs(value), currencyId)})`;
+  } else {
+    _value = `${currency(value, currencyId)}`;
+  }
+
+  return new Handlebars.SafeString(`
+    <span class="text-right ${cellClass}">${_value}</span>
+  `);
+}
+
+exports.debcred = debcred;
 exports.currency = currency;
 exports.indentAccount = indentAccount;
 exports.numberToText = numberToText;

--- a/server/lib/template/index.js
+++ b/server/lib/template/index.js
@@ -37,6 +37,7 @@ const hbs = exphbs.create({
     currency      : finance.currency,
     numberToText  : finance.numberToText,
     indentAccount : finance.indentAccount,
+    debcred       : finance.debcred,
     look          : objects.look,
     equal         : logic.equal,
     gt            : logic.gt,

--- a/server/lib/template/partials/emptyTable.handlebars
+++ b/server/lib/template/partials/emptyTable.handlebars
@@ -3,3 +3,4 @@
     <i class="fa fa-warning"></i> {{translate "TABLE.COLUMNS.EMPTY"}}
   </td>
 </tr>
+


### PR DESCRIPTION
This commit implements multi-currency support on the Account Statement
Report. It is derived from a template by @WayneNiles.

The logic is somewhat complex.  If a user produces a report in the
enterprise currency, then the values should convert from a foreign
currency into the enterprise currency.  This is done through _division_
with the formula `amount / rate`.  However, if the user produces a
report in a different currency, all values must be converted from the
enterprise currency to that foreign currency.  This happens by
_multiplication_ with the formula `amount * rate`.

The report has been clarified by:
 1. Combining the two footers into one and naming it `footer`.
 2. Renaming the `openingBalance` property to `header`, since that is
 what is it.
 3. Removing the multiple options on the report page to simply give
 "currency" instead of having different total currencies.
 4. Renaming `accountDetails` to just `account`.

Finally, a new HBS helper has been made for rendering debits/credits
nicely.  It will automatically convert negative values into red currency
values.

Closes #1919.  Closes #2557.

See the attached example report: 
[ExampleReport.pdf](https://github.com/IMA-WorldHealth/bhima-2.X/files/1752025/ExampleReport.pdf)
