### PR TITLE
fix(ci): sleep before running protrator tests

### DIFF
--- a/sh/integration-tests.sh
+++ b/sh/integration-tests.sh
@@ -27,7 +27,7 @@ echo "[test] Spawned node process $NODE_PID."
 
 # make sure we have enough time for the server to start
 echo "[test] Sleeping for $TIMEOUT seconds."
-sleep $TIMEOUT
+sleep "$TIMEOUT"
 
 echo "[test] running tests using mocha"
 

--- a/sh/test-ends.sh
+++ b/sh/test-ends.sh
@@ -27,6 +27,9 @@ NODE_PID=$!
 
 echo "[test] Spawned node process $NODE_PID."
 
+echo "[test] Sleeping for $TIMEOUT seconds."
+sleep "$TIMEOUT"
+
 echo "[test] Running tests using protractor."
 ../node_modules/.bin/protractor ../protractor.conf.js
 


### PR DESCRIPTION
It looks like our protractor tests often fail to start on Travis.  This commit should give them enough time to complete a build before starting the test suite.

See [this timeout](https://travis-ci.org/IMA-WorldHealth/bhima-2.X/builds/345277851) as an example.