### PR TITLE
chore(*): add timestamps to main tables

### DIFF
--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -689,7 +689,7 @@ CREATE TABLE `general_ledger` (
   `period_id`         MEDIUMINT(8) UNSIGNED DEFAULT NULL,
   `trans_id`          VARCHAR(100) NOT NULL,
   `trans_date`        DATETIME NOT NULL,
-  `record_uuid`       BINARY(16) NOT NULL, -- previously doc_num
+  `record_uuid`       BINARY(16) NOT NULL,
   `description`       TEXT NOT NULL,
   `account_id`        INT(10) UNSIGNED NOT NULL,
   `debit`             DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.00,
@@ -697,13 +697,15 @@ CREATE TABLE `general_ledger` (
   `debit_equiv`       DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.00,
   `credit_equiv`      DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.00,
   `currency_id`       TINYINT(3) UNSIGNED NOT NULL,
-  `entity_uuid`       BINARY(16),    -- previously deb_cred_uuid
-  `reference_uuid`    BINARY(16),  -- previously inv_po_id
+  `entity_uuid`       BINARY(16),
+  `reference_uuid`    BINARY(16),
   `comment`           TEXT,
   `origin_id`         TINYINT(3) UNSIGNED NULL,
   `user_id`           SMALLINT(5) UNSIGNED NOT NULL,
   `cc_id`             SMALLINT(6),
   `pc_id`             SMALLINT(6),
+  `created_at`        TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`        TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`uuid`),
   KEY `project_id` (`project_id`),
   KEY `fiscal_year_id` (`fiscal_year_id`),
@@ -1212,7 +1214,7 @@ CREATE TABLE `posting_journal` (
   `period_id`         MEDIUMINT(8) UNSIGNED DEFAULT NULL,
   `trans_id`          VARCHAR(100) NOT NULL,
   `trans_date`        DATETIME NOT NULL,
-  `record_uuid`       BINARY(16) NOT NULL, -- previously doc_num
+  `record_uuid`       BINARY(16) NOT NULL,
   `description`       TEXT,
   `account_id`        INT(10) UNSIGNED NOT NULL,
   `debit`             DECIMAL(19,4) NOT NULL DEFAULT 0.00,
@@ -1220,13 +1222,15 @@ CREATE TABLE `posting_journal` (
   `debit_equiv`       DECIMAL(19,4) NOT NULL DEFAULT 0.00,
   `credit_equiv`      DECIMAL(19,4) NOT NULL DEFAULT 0.00,
   `currency_id`       TINYINT(3) UNSIGNED NOT NULL,
-  `entity_uuid`       BINARY(16),    -- previously deb_cred_uuid
-  `reference_uuid`    BINARY(16),  -- previously inv_po_id
+  `entity_uuid`       BINARY(16),
+  `reference_uuid`    BINARY(16),
   `comment`           TEXT,
   `origin_id`         TINYINT(3) UNSIGNED NULL,
   `user_id`           SMALLINT(5) UNSIGNED NOT NULL,
   `cc_id`             SMALLINT(6),
   `pc_id`             SMALLINT(6),
+  `created_at`        TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`        TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`uuid`),
   KEY `project_id` (`project_id`),
   KEY `fiscal_year_id` (`fiscal_year_id`),


### PR DESCRIPTION
This commit adds timestamps to the posting_journal and general_ledger tables to enable us to sort them correctly in the future.

Closes #2573.