### PR TITLE
fix(ci): remove gecko from webdriver

### DIFF
--- a/sh/dependencies.sh
+++ b/sh/dependencies.sh
@@ -6,7 +6,7 @@ yarn install
 
 ./node_modules/.bin/bower install --quiet
 ./node_modules/.bin/gulp build
-./node_modules/.bin/webdriver-manager update
+./node_modules/.bin/webdriver-manager update --gecko false
 
 # cd into the built directory
 cd bin


### PR DESCRIPTION
Apparently we are hitting all sorts of rate limits while downloading gecko from Github that fails our tests.  We don't even use gecko.  This removes gecko to try and overcome the problem.

See #2599 for example.