### PR TITLE
Cleanup util.js library

### DIFF
--- a/server/lib/backup.js
+++ b/server/lib/backup.js
@@ -11,7 +11,7 @@ const tmp = require('tempy');
 const util = require('./util');
 const lzma = require('lzma-native');
 const streamToPromise = require('stream-to-promise');
-const fs = require('fs');
+const fs = require('mz/fs');
 const moment = require('moment');
 
 /**
@@ -116,7 +116,7 @@ function xz(file) {
   let beforeSizeInMegabytes;
   let afterSizeInMegabytes;
 
-  return util.statp(file)
+  return fs.stat(file)
     .then(stats => {
       beforeSizeInMegabytes = stats.size / 1000000.0;
       debug(`#xz() ${file} is ${beforeSizeInMegabytes}MB`);

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -26,7 +26,6 @@ exports.loadModuleIfExists = requireModuleIfExists;
 exports.dateFormatter = dateFormatter;
 exports.execp = execp;
 exports.unlinkp = unlinkp;
-exports.statp = statp;
 exports.format = require('util').format;
 
 exports.roundDecimal = roundDecimal;
@@ -120,24 +119,6 @@ function execp(cmd) {
   const child = exec(cmd);
   child.addListener('error', deferred.reject);
   child.addListener('exit', deferred.resolve);
-  return deferred.promise;
-}
-
-/**
- * @method statp
- *
- * @description
- * This method promisifies the stats method.
- */
-function statp(file) {
-  debug(`#statp(): ${file}`);
-  const deferred = q.defer();
-
-  fs.stat(file, (err, stats) => {
-    if (err) { return deferred.reject(err); }
-    return deferred.resolve(stats);
-  });
-
   return deferred.promise;
 }
 

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -19,13 +19,11 @@ const q = require('q');
 const moment = require('moment');
 const debug = require('debug')('util');
 const { exec } = require('child_process');
-const fs = require('fs');
 
 exports.take = take;
 exports.loadModuleIfExists = requireModuleIfExists;
 exports.dateFormatter = dateFormatter;
 exports.execp = execp;
-exports.unlinkp = unlinkp;
 exports.format = require('util').format;
 
 exports.roundDecimal = roundDecimal;
@@ -124,27 +122,13 @@ function execp(cmd) {
 
 
 /**
- * @method statp
+ * @function roundDecimal
  *
  * @description
- * This method promisifies the unlink method.
- */
-function unlinkp(file) {
-  debug(`#unlinkp(): ${file}`);
-  const deferred = q.defer();
-
-  fs.unlink(file, (err) => {
-    if (err) { return deferred.reject(err); }
-    return deferred.resolve();
-  });
-
-  return deferred.promise;
-}
-
-/**
- * Round a decimal to a certain precision
- * @param {*} number
- * @param {*} precision
+ * Round a decimal to a certain precision.
+ *
+ * @param {Number} number
+ * @param {Number} precision
  */
 function roundDecimal(number, precision = 4) {
   const base = Math.pow(10, precision);

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -1,4 +1,4 @@
-/* eslint global-require:off, import/no-dynamic-require:off */
+/* eslint global-require:off, import/no-dynamic-require:off, no-restricted-properties:off */
 
 /**
  * @overview util
@@ -24,7 +24,6 @@ const fs = require('fs');
 exports.take = take;
 exports.loadModuleIfExists = requireModuleIfExists;
 exports.dateFormatter = dateFormatter;
-exports.resolveObject = resolveObject;
 exports.execp = execp;
 exports.unlinkp = unlinkp;
 exports.statp = statp;
@@ -85,28 +84,6 @@ function requireModuleIfExists(moduleName) {
     return false;
   }
   return true;
-}
-
-/**
- * @function resolveObject
- *
- * @description
- * This utility takes in an object of promise queries and returns the object
- * with all values resolved when all promises have settled.  If any one is
- * rejected, the promise is rejected.
- *
- * @param {Object} object - this is the object of keys mapped to promise
- *   values.
- * @returns {Promise} - one all promises resolve, the same object mapped to
- */
-function resolveObject(object) {
-  const settled = {};
-
-  return q.all(_.values(object))
-    .then((results) => {
-      _.keys(object).forEach((key, index) => { settled[key] = results[index]; });
-      return settled;
-    });
 }
 
 /**

--- a/test/server-unit/util.spec.js
+++ b/test/server-unit/util.spec.js
@@ -1,18 +1,19 @@
 const util = require('../../server/lib/util');
-const { expect } = require('chai');
-var _ = require('lodash');
 
-const newLocal = function () {
+const { expect } = require('chai');
+const _ = require('lodash');
+
+describe('util.js', () => {
   it('#take() should take values from one key of each object in an array of objects', () => {
     const objects = [{ id : 1 }, { id : 2 }, { id : 3 }];
     const expected = [1, 2, 3];
-    var filter = util.take('id');
-    var ids = _.flatMap(objects, filter);
+    const filter = util.take('id');
+    const ids = _.flatMap(objects, filter);
     expect(ids).to.deep.equal(expected);
   });
 
   it('#requireModuleIfExists() should require module if it exists', () => {
-    var exists = util.loadModuleIfExists('chai');
+    const exists = util.loadModuleIfExists('chai');
     expect(exists).to.equal(true);
   });
 
@@ -31,8 +32,20 @@ const newLocal = function () {
     expect(formated).to.deep.equal(expected);
   });
 
-// resolveObject
+  it('#roundDecimal() should round a number to the specified number of decimal places', () => {
+    let value = 12.125;
+    expect(util.roundDecimal(value, 2)).to.equal(12.13);
+    expect(util.roundDecimal(value, 3)).to.equal(value);
+    expect(util.roundDecimal(value, 0)).to.equal(12);
 
-};
+    value = 12.00;
+    expect(util.roundDecimal(value, 2)).to.equal(value);
+    expect(util.roundDecimal(value, 3)).to.equal(value);
+    expect(util.roundDecimal(value, 0)).to.equal(value);
+  });
 
-describe('util.js', newLocal);
+  it('#roundDecimal() defaults to 4 decimal places precision', () => {
+    const value = 12.11111;
+    expect(util.roundDecimal(value)).to.equal(12.1111);
+  });
+});


### PR DESCRIPTION
This PR strips the util.js library of all its NodeJS `fs` functions and writes a couple new tests.  The file system promise functions can be handled by `mz/fs`.  Less code means fewer bugs!