### PR TITLE
refactor(reports): update balance report

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -457,6 +457,7 @@
             "PERCENTAGE": "Percentage",
             "PERCENT": "Percent",
             "PERIODES": "Periods",
+            "PERIOD": "Period",
             "PERIOD_FROM": "Period From",
             "PERIOD_TO": "Period To",
             "PHONE": "Phone",

--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -143,7 +143,11 @@
       "USE_ORIGINAL_TRANSACTION_CURRENCY" : "Display original transaction currency?",
       "USE_ORIGINAL_TRANSACTION_CURRENCY_HELP" : "If yes, the report will show the recorded currency of the transaction instead of the value in the enterprise's currency.",
       "TOTALS_CURRENCY" : "Select Totals Currency",
-      "TOTALS_CURRENCY_HELP" : "This options lets you view the totals in the selected currency by exchanging the totals into the selected currency using today's exchange rate."
+      "TOTALS_CURRENCY_HELP" : "This options lets you view the totals in the selected currency by exchanging the totals into the selected currency using today's exchange rate.",
+      "SEPARATE_DEBITS_AND_CREDITS" : "Separate Debits and Credits?",
+      "SEPARATE_DEBITS_AND_CREDITS_HELP" : "This option breaks out columns from a single positive or negative balance into two columns representing debits and credits.",
+      "REMOVE_ZERO_ROWS" : "Hide zero rows?",
+      "REMOVE_ZERO_ROWS_HELP" : "This option will remove rows that do not have any data in them.  Produces a more compact output."
     }
   }
 }

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -457,6 +457,7 @@
             "PERCENTAGE": "Pourcentage",
             "PERCENT": "Pourcent",
             "PERIODES": "Périodes",
+            "PERIOD": "Périod",
             "PERIOD_FROM": "Période Du",
             "PERIOD_TO": "Période Au",
             "PERIOD_TOTAL": "Total de la période",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -146,7 +146,11 @@
       "USE_ORIGINAL_TRANSACTION_CURRENCY" : "Afficher la devise de transaction originale?",
       "USE_ORIGINAL_TRANSACTION_CURRENCY_HELP" : "Si oui, le rapport affichera la devise de la transaction au lieu de la valeur dans la devise de l'entreprise.",
       "TOTALS_CURRENCY" : "Sélectionnez la Devise des Totaux",
-      "TOTALS_CURRENCY_HELP" : "Cette option vous permet d'afficher les totaux dans la devise sélectionnée en échangeant les totaux dans la devise sélectionnée en utilisant le taux de change du jour."
+      "TOTALS_CURRENCY_HELP" : "Cette option vous permet d'afficher les totaux dans la devise sélectionnée en échangeant les totaux dans la devise sélectionnée en utilisant le taux de change du jour.",
+      "SEPARATE_DEBITS_AND_CREDITS" : "Séparer les débits et les crédits?",
+      "SEPARATE_DEBITS_AND_CREDITS_HELP" : "Cette option répartit les colonnes d'un seul solde positif ou négatif en deux colonnes représentant les débits et les crédits.",
+      "REMOVE_ZERO_ROWS" : "Cacher les colonnes vide?",
+      "REMOVE_ZERO_ROWS_HELP" : "Cette option supprime les lignes qui ne contiennent aucune donnée. Produit un rapport plus compacte."
     }
   }
 }

--- a/client/src/js/components/bhReportPeriodSelect.js
+++ b/client/src/js/components/bhReportPeriodSelect.js
@@ -15,7 +15,7 @@ angular.module('bhima.components')
   });
 
 ReportPeriodSelectController.$inject = [
-  'FiscalPeriodService', '$filter'
+  'FiscalPeriodService', '$filter',
 ];
 
 /**
@@ -23,7 +23,7 @@ ReportPeriodSelectController.$inject = [
  *
  */
 function ReportPeriodSelectController(FiscalPeriod, $filter) {
-  var $ctrl = this;
+  const $ctrl = this;
 
   $ctrl.$onInit = function onInit() {
     // fired when a Period has been selected
@@ -37,8 +37,8 @@ function ReportPeriodSelectController(FiscalPeriod, $filter) {
 
     // load all Fiscal Yeal Period
     FiscalPeriod.read(null, { excludeExtremityPeriod : true })
-      .then(function (periodes) {
-        periodes.forEach(function (period) {
+      .then(periodes => {
+        periodes.forEach(period => {
           period.monthYear = $filter('date')(period.end_date, 'MMMM yyyy');
         });
 
@@ -49,7 +49,5 @@ function ReportPeriodSelectController(FiscalPeriod, $filter) {
   };
 
   // fires the onSelectCallback bound to the component boundary
-  $ctrl.onSelect = function ($item) {
-    $ctrl.onSelectCallback({ period : $item });
-  };
+  $ctrl.onSelect = period => $ctrl.onSelectCallback({ period });
 }

--- a/client/src/js/components/bhReportPeriodSelect.js
+++ b/client/src/js/components/bhReportPeriodSelect.js
@@ -33,7 +33,7 @@ function ReportPeriodSelectController(FiscalPeriod, $filter) {
     $ctrl.name = $ctrl.name || 'PeriodForm';
 
     // translated label for the form input
-    $ctrl.label = $ctrl.label || 'FORM.LABELS.PERIODES';
+    $ctrl.label = $ctrl.label || 'FORM.LABELS.PERIOD';
 
     // load all Fiscal Yeal Period
     FiscalPeriod.read(null, { excludeExtremityPeriod : true })

--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -24,19 +24,15 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
   };
 
   vm.onChangeLayout = (bool) => {
-    console.log('layout bool:', bool);
     vm.reportDetails.useSeparateDebitsAndCredits = bool;
   };
 
   vm.onChangeEmptyRows = (bool) => {
-    console.log('empty bool:', bool);
     vm.reportDetails.shouldPruneEmptyRows = bool;
   };
 
   vm.preview = function preview(form) {
     if (form.$invalid) { return 0; }
-
-    console.log('reportDetails', vm.reportDetails);
 
     // update cached configuration
     cache.reportDetails = angular.copy(vm.reportDetails);

--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -3,49 +3,46 @@ angular.module('bhima.controllers')
 
 BalanceReportConfigController.$inject = [
   '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
-  'LanguageService', 'moment',
 ];
 
-function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state,
-  Languages, moment) {
-  var vm = this;
-  var cache = new AppCache('configure_balance_report');
-  var reportUrl = 'reports/finance/balance';
+function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+  const vm = this;
+  const cache = new AppCache('BalanceReport');
+  const reportUrl = 'reports/finance/balance';
 
   vm.previewGenerated = false;
   vm.reportDetails = {};
   vm.timestamp = new Date();
-  vm.date = angular.copy(vm.timestamp);
+
+  vm.onSelectPeriod = (period) => {
+    vm.reportDetails.period_id = period.id;
+  };
 
   vm.clearPreview = function clearPreview() {
     vm.previewGenerated = false;
     vm.previewResult = null;
   };
 
-  vm.preview = function preview(form) {
-    var options;
+  vm.onChangeLayout = (bool) => {
+    console.log('layout bool:', bool);
+    vm.reportDetails.useSeparateDebitsAndCredits = bool;
+  };
 
+  vm.onChangeEmptyRows = (bool) => {
+    console.log('empty bool:', bool);
+    vm.reportDetails.shouldPruneEmptyRows = bool;
+  };
+
+  vm.preview = function preview(form) {
     if (form.$invalid) { return 0; }
 
-    options = {
-      accountOption : vm.accountOption,
-      lang : Languages.key,
-    };
-
-    if (vm.dateOption === 'date-range') {
-      options.dateFrom = moment(vm.dateFrom).format('YYYY-MM-DD');
-      options.dateTo = moment(vm.dateTo).format('YYYY-MM-DD');
-    } else {
-      options.date = moment(vm.date).format('YYYY-MM-DD');
-    }
-
-    vm.reportDetails = options;
+    console.log('reportDetails', vm.reportDetails);
 
     // update cached configuration
     cache.reportDetails = angular.copy(vm.reportDetails);
 
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
-      .then(function (result) {
+      .then(result => {
         vm.previewGenerated = true;
         vm.previewResult = $sce.trustAsHtml(result);
       })
@@ -53,14 +50,14 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
   };
 
   vm.requestSaveAs = function requestSaveAs() {
-    var options = {
+    const options = {
       url : reportUrl,
       report : reportData,
       reportOptions : angular.copy(vm.reportDetails),
     };
 
     return SavedReports.saveAsModal(options)
-      .then(function () {
+      .then(() => {
         $state.go('reportsBase.reportsArchive', { key : options.report.report_key });
       })
       .catch(Notify.handleError);

--- a/client/src/modules/reports/generate/balance_report/balance_report.html
+++ b/client/src/modules/reports/generate/balance_report/balance_report.html
@@ -21,22 +21,29 @@
         </div>
 
         <div class="panel-body">
+          <form name="ConfigForm" bh-submit="ReportConfigCtrl.preview(ConfigForm)" novalidate>
 
-        <form name="ConfigForm" bh-submit="ReportConfigCtrl.preview(ConfigForm)" novalidate autocomplete="off">
+            <bh-report-period-select
+              period-id="ReportConfigCtrl.reportDetails.period_id"
+              on-select-callback="ReportConfigCtrl.onSelectPeriod(period)">
+            </bh-report-period-select>
 
-          <!--select the period by a date-->
-          <bh-date-editor
-            date-value="ReportConfigCtrl.date"
-            max-date="ReportConfigCtrl.timestamp">
-          </bh-date-editor>
+            <bh-yes-no-radios
+              label="Use Two Column Layout?"
+              value="ReportConfigCtrl.reportDetails.useSeparateDebitsAndCredits"
+              on-change-callback="ReportConfigCtrl.onChangeLayout(bool)">
+            </bh-yes-no-radios>
 
-          <!--preview-->
-          <bh-loading-button loading-state="ConfigForm.$loading">
-            <span translate>REPORT.UTIL.PREVIEW</span>
-          </bh-loading-button>
+            <bh-yes-no-radios
+              label="Remove Empty Rows?"
+              value="ReportConfigCtrl.reportDetails.shouldPruneEmptyRows"
+              on-change-callback="ReportConfigCtrl.onChangeEmptyRows(bool)">
+            </bh-yes-no-radios>
 
-        </form>
-
+            <bh-loading-button loading-state="ConfigForm.$loading">
+              <span translate>REPORT.UTIL.PREVIEW</span>
+            </bh-loading-button>
+          </form>
         </div>
       </div>
     </div>

--- a/client/src/modules/reports/generate/balance_report/balance_report.html
+++ b/client/src/modules/reports/generate/balance_report/balance_report.html
@@ -30,6 +30,7 @@
 
             <bh-yes-no-radios
               label="REPORT.OPTIONS.SEPARATE_DEBITS_AND_CREDITS"
+              id="useSeparateDebitsAndCredits"
               help-text="REPORT.OPTIONS.SEPARATE_DEBITS_AND_CREDITS_HELP"
               name="useSeparateDebitsAndCredits"
               value="ReportConfigCtrl.reportDetails.useSeparateDebitsAndCredits"
@@ -40,6 +41,7 @@
               label="REPORT.OPTIONS.REMOVE_ZERO_ROWS"
               help-text="REPORT.OPTIONS.REMOVE_ZERO_ROWS_HELP"
               name="shouldPruneEmptyRows"
+              id="shouldPruneEmptyRows"
               value="ReportConfigCtrl.reportDetails.shouldPruneEmptyRows"
               on-change-callback="ReportConfigCtrl.onChangeEmptyRows(value)">
             </bh-yes-no-radios>

--- a/client/src/modules/reports/generate/balance_report/balance_report.html
+++ b/client/src/modules/reports/generate/balance_report/balance_report.html
@@ -29,15 +29,19 @@
             </bh-report-period-select>
 
             <bh-yes-no-radios
-              label="Use Two Column Layout?"
+              label="REPORT.OPTIONS.SEPARATE_DEBITS_AND_CREDITS"
+              help-text="REPORT.OPTIONS.SEPARATE_DEBITS_AND_CREDITS_HELP"
+              name="useSeparateDebitsAndCredits"
               value="ReportConfigCtrl.reportDetails.useSeparateDebitsAndCredits"
-              on-change-callback="ReportConfigCtrl.onChangeLayout(bool)">
+              on-change-callback="ReportConfigCtrl.onChangeLayout(value)">
             </bh-yes-no-radios>
 
             <bh-yes-no-radios
-              label="Remove Empty Rows?"
+              label="REPORT.OPTIONS.REMOVE_ZERO_ROWS"
+              help-text="REPORT.OPTIONS.REMOVE_ZERO_ROWS_HELP"
+              name="shouldPruneEmptyRows"
               value="ReportConfigCtrl.reportDetails.shouldPruneEmptyRows"
-              on-change-callback="ReportConfigCtrl.onChangeEmptyRows(bool)">
+              on-change-callback="ReportConfigCtrl.onChangeEmptyRows(value)">
             </bh-yes-no-radios>
 
             <bh-loading-button loading-state="ConfigForm.$loading">

--- a/client/src/modules/templates/bhReportPeriodSelect.tmpl.html
+++ b/client/src/modules/templates/bhReportPeriodSelect.tmpl.html
@@ -7,8 +7,8 @@
     </label>
     <ui-select name="period_id"
       ng-model="$ctrl.periodId"
-      on-select="$ctrl.onSelect($item, $model)" required>
-      <ui-select-match placeholder="{{ 'FORM.SELECT.PERIOD' | translate }}"><span>{{$select.selected.monthYear}}</span></ui-select-match>
+      on-select="$ctrl.onSelect($item)" required>
+      <ui-select-match placeholder="{{ 'FORM.SELECT.PERIOD' | translate }}"><span class="text-capitalize">{{$select.selected.monthYear}}</span></ui-select-match>
       <ui-select-choices ui-select-focus-patch repeat="period.id as period in ($ctrl.periodes | filter:$select.search) track by period.id">
         <span ng-bind-html="period.monthYear | highlight:$select.search"></span>
       </ui-select-choices>

--- a/client/src/modules/templates/bhYesNoRadios.tmpl.html
+++ b/client/src/modules/templates/bhYesNoRadios.tmpl.html
@@ -1,13 +1,13 @@
-<div ng-form="RadioForm"
-  class="form-group"
-  ng-class="{'has-error' : RadioForm.$error && RadioForm.$submitted }">
-  <label class="control-label" translate>{{$ctrl.label}}</label>
+<div class="form-group">
+  <label class="control-label" translate>
+    {{$ctrl.label}}
+  </label>
 
-  <div class="col-sm-12">
+  <div>
     <label class="radio-inline">
       <input
         type="radio"
-        name="$ctrl.name"
+        name="{{$ctrl.name}}"
         data-choice="yes"
         ng-value="1"
         ng-model="$ctrl.value"
@@ -19,7 +19,7 @@
     <label class="radio-inline">
       <input
         type="radio"
-        name="$ctrl.name"
+        name="{{$ctrl.name}}"
         data-choice="no"
         ng-value="0"
         ng-model="$ctrl.value"
@@ -28,9 +28,8 @@
       <span translate>FORM.LABELS.NO</span>
     </label>
 
-    <span class="help-block" ng-show="$ctrl.helpText" translate>{{$ctrl.helpText}}</span>
-    <div class="help-block" ng-messages="yesNoRadiosForm.yesNoOptions.$error" ng-show="yesNoRadiosForm.$submitted">
-      <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-    </div>
+    <span class="help-block" ng-show="$ctrl.helpText" translate>
+      {{$ctrl.helpText}}
+    </span>
   </div>
 </div>

--- a/client/src/modules/templates/bhYesNoRadios.tmpl.html
+++ b/client/src/modules/templates/bhYesNoRadios.tmpl.html
@@ -1,4 +1,4 @@
-<div class="form-group">
+<div class="form-group" data-bh-yes-no-radios>
   <label class="control-label" translate>
     {{$ctrl.label}}
   </label>

--- a/server/controllers/finance/fiscalPeriod.js
+++ b/server/controllers/finance/fiscalPeriod.js
@@ -50,7 +50,7 @@ function list(req, res, next) {
 function find(options) {
   const sql =
     `
-    SELECT 
+    SELECT
       p.id, p.fiscal_year_id, p.number, p.start_date, p.end_date,
       CONCAT(IFNULL(p.start_date, p.number), '/',  IFNULL(p.end_date, p.number)) AS label,
       MONTH(p.start_date) AS month_number, YEAR(p.start_date) AS year_number
@@ -79,12 +79,12 @@ function isInSameFiscalYear(opt) {
     return false;
   }
   const sql = `
-  SELECT 
-    p.fiscal_year_id 
-  FROM 
+  SELECT
+    p.fiscal_year_id
+  FROM
     period AS p
   WHERE p.id IN (${opt.periods.join(',')})
-  GROUP BY 
+  GROUP BY
     p.fiscal_year_id`;
 
   return db.exec(sql)
@@ -96,7 +96,7 @@ function isInSameFiscalYear(opt) {
 function getPeriodDiff(periodIdA, periodIdB) {
   const sql =
   `
-  SELECT 
+  SELECT
   DATEDIFF(
    (SELECT start_date FROM period where id = ?), (SELECT start_date FROM period WHERE id = ?)
   ) as nb`;

--- a/server/controllers/finance/reports/balance/index.js
+++ b/server/controllers/finance/reports/balance/index.js
@@ -12,45 +12,42 @@
  */
 
 const _ = require('lodash');
-const moment = require('moment');
 const db = require('../../../../lib/db');
+const Tree = require('../../../../lib/Tree');
 const ReportManager = require('../../../../lib/ReportManager');
 
 // report template
 const TEMPLATE = './server/controllers/finance/reports/balance/report.handlebars';
 
-// TODO(@jniles)
-// Not sure why this is structured this way
-const ASSET_ID = 1;
-const EXPENSE_ID = 5;
-const shouldShowCredit = (typeId) =>
-  [ASSET_ID, EXPENSE_ID].includes(typeId);
-
 // expose to the API
 exports.document = document;
 
+// default report parameters
+const DEFAULT_PARAMS = {
+  csvKey : 'accounts',
+  filename : 'TREE.BALANCE',
+  orientation : 'landscape',
+  footerRight : '[page] / [toPage]',
+};
+
+const TITLE_ID = 6;
+
 /**
  * @function document
- * @description process and render the balance report document
+ *
+ * @description
+ * This function renders the Balance report.  The balance report provides a view
+ * of the balances of any account used during the period.
  */
 function document(req, res, next) {
   const params = req.query;
-  const session = {};
+  const context = {};
   let report;
 
-  // date option
-  if (params.dateFrom && params.dateTo) {
-    session.dateFrom = moment(params.dateFrom).format('YYYY-MM-DD');
-    session.dateTo = moment(params.dateTo).format('YYYY-MM-DD');
-  } else {
-    session.date = moment(params.date).format('YYYY-MM-DD');
-  }
+  context.useSeparateDebitsAndCredits = params.useSeparateDebitsAndCredits || false;
+  context.shouldPruneEmptyRows = params.shouldPruneEmptyRows || false;
 
-  session.classe = params.classe;
-  session.classe_name = params.classe_name;
-  session.enterprise = req.session.enterprise;
-
-  _.defaults(params, { orientation : 'landscape', user : req.session.user });
+  _.defaults(params, DEFAULT_PARAMS);
 
   try {
     report = new ReportManager(TEMPLATE, req.session, params);
@@ -59,12 +56,13 @@ function document(req, res, next) {
     return;
   }
 
-  params.enterpriseId = session.enterprise.id;
+  getBalanceSummary(params.period_id, req.session.enterprise.currency_id, context.shouldPruneEmptyRows)
+    .then(data => {
+      _.merge(context, data);
 
-  balanceReporting(params)
-    .then(balances => processAccounts(balances))
-    .then((result) => report.render({ accounts : result.accounts, totals : result.totals, session }))
-    .then((result) => {
+      return report.render(context);
+    })
+    .then(result => {
       res.set(result.headers).send(result.report);
     })
     .catch(next)
@@ -72,151 +70,75 @@ function document(req, res, next) {
 }
 
 /**
- * @method processAccounts
- * @description process and format accounts balance
- * @param {object} balances The result of balanceReporting function
+ * @function getBalanceSummary(periodId, currencyId)
+ *
+ * @description
+ * Returns the balance of the accounts for a given period.
+ *
+ * TODO(@jniles) - use the currencyId to get an exchange rate.
+ *
  */
-function processAccounts(balances) {
-  // format and process opening balance for accounts
-
-  const accounts = balances.beginning.reduce((account, row) => {
-    const id = row.number;
-    const obj = {};
-    const sold = getSold(row);
-    obj.label = row.label;
-    obj.number = row.number;
-    obj.beginDebit = sold.debit;
-    obj.beginCredit = sold.credit;
-    obj.middleDebit = 0;
-    obj.middleCredit = 0;
-    account[id] = obj;
-    return account;
-  }, {});
-
-  // format and process the monthly balance for accounts
-  balances.middle.forEach((row) => {
-    const account = accounts[row.number] || {};
-    account.middleDebit = row.debit;
-    account.middleCredit = row.credit;
-    account.label = row.label;
-    account.number = row.number;
-    accounts[row.number] = account;
-  });
-
-  Object.keys(accounts).forEach((item) => {
-    accounts[item].endDebit = 0;
-    accounts[item].endCredit = 0;
-    const sold = (accounts[item].beginDebit || 0 - accounts[item].beginCredit || 0)
-      + (accounts[item].middleDebit - accounts[item].middleCredit);
-    if (sold < 0) {
-      accounts[item].endCredit = sold * -1;
-    } else {
-      accounts[item].endDebit = sold;
-    }
-  });
-
-  // process for getting totals
-  const vtotals = Object.keys(accounts)
-    .reduce((t, key) => {
-      const account = accounts[key];
-      t.beginDebit += (account.beginDebit || 0);
-      t.beginCredit += (account.beginCredit || 0);
-      t.middleDebit += (account.middleDebit || 0);
-      t.middleCredit += (account.middleCredit || 0);
-      t.endDebit += (account.endDebit || 0);
-      t.endCredit += (account.endCredit || 0);
-      return t;
-    }, {
-      beginDebit   : 0,
-      beginCredit  : 0,
-      middleDebit  : 0,
-      middleCredit : 0,
-      endDebit     : 0,
-      endCredit    : 0,
-    });
-
-  return { accounts, totals : vtotals };
-}
-
-/**
- * @function getSold
- * @description return the balance of an account
- * @param {object} object An object from the array returned by balanceReporting function
- */
-function getSold(item) {
-  let debit = 0;
-  let credit = 0;
-  let sold = 0;
-
-  if (shouldShowCredit(item.type_id)) {
-    sold = item.debit - item.credit;
-    if (sold < 0) {
-      credit = sold * -1;
-    } else {
-      debit = sold;
-    }
-  } else {
-    sold = item.credit - item.debit;
-    if (sold < 0) {
-      debit = sold * -1;
-    } else {
-      credit = sold;
-    }
-  }
-  return { debit, credit };
-}
-
-/**
- * @function balanceReporting
- * @description return the balance needed according the given params
- * @param {object} params An object which contains dates range and the account class
- */
-function balanceReporting(params) {
-  const query = params;
-  const data = {};
-
-  const sqlFiscalYear = `
-    SELECT id, number_of_months FROM fiscal_year WHERE DATE(?) BETWEEN DATE(start_date) AND DATE(end_date) LIMIT 1;
+function getBalanceSummary(periodId, currencyId, shouldPrune) {
+  const getFiscalYearSQL = `
+    SELECT id, start_date, end_date, fiscal_year_id FROM period WHERE id = ?
   `;
 
-  let sql;
-  let fiscal;
+  const sql = `
+    SELECT a.id, a.number, a.label, a.type_id, a.label, a.parent,
+      a.type_id = ${TITLE_ID} AS isTitleAccount,
+      IFNULL(s.before, 0) AS "before",
+      IFNULL(s.during, 0) AS "during",
+      IFNULL(s.after, 0) AS "after",
+      ? AS currencyId
+    FROM account AS a LEFT JOIN (
+      SELECT pt.account_id,
+        IF(p.id < ?, SUM(pt.debit - pt.credit), 0) AS "before",
+        IF(p.id = ?, SUM(pt.debit - pt.credit), 0) AS "during",
+        IF(p.id <= ?, SUM(pt.debit - pt.credit), 0) AS "after"
+      FROM period_total AS pt
+      JOIN period AS p ON p.id = pt.period_id
+      WHERE pt.fiscal_year_id = ?
+      GROUP BY pt.account_id
+    )s ON a.id = s.account_id
+    ORDER BY a.number;
+  `;
 
-  return db.one(sqlFiscalYear, [query.date])
-    .then((fiscalYear) => {
-      fiscal = fiscalYear;
+  const context = {};
 
-      sql = `
-        SELECT a.number, a.id, a.label, a.type_id,
-          SUM(pt.credit) AS credit, SUM(pt.debit) AS debit, SUM(pt.debit - pt.credit) AS balance
-        FROM period_total AS pt JOIN account AS a ON pt.account_id = a.id
-        JOIN period AS p ON pt.period_id = p.id
-        WHERE (p.end_date < DATE(?) OR p.number = 0) AND pt.enterprise_id = ? AND p.fiscal_year_id = ?
-        GROUP BY a.id HAVING balance <> 0;`;
+  // if the after result is 0, that means no movements occurred
+  const isEmptyRow = (row) => row.after === 0;
 
-      const queryParameters = [query.date, query.enterpriseId, fiscal.id];
-      return db.exec(sql, queryParameters);
+  return db.one(getFiscalYearSQL, [periodId])
+    .then(period => {
+      const params = _.fill(Array(3), period.id);
+      _.merge(context, { period });
+      return db.exec(sql, [currencyId, ...params, period.fiscal_year_id]);
     })
-    .then((rows) => {
-      data.beginning = rows;
+    .then(accounts => {
+      const tree = new Tree(accounts);
 
-      sql = `
-        SELECT a.number, a.label, a.id, a.type_id,
-        SUM(pt.credit) AS credit, SUM(pt.debit) AS debit, SUM(pt.debit - pt.credit) AS balance
-        FROM period_total AS pt JOIN account AS a ON pt.account_id = a.id
-        JOIN period AS p ON pt.period_id = p.id
-        WHERE (DATE(?) BETWEEN p.start_date AND p.end_date AND pt.enterprise_id = ?)
-          OR (MONTH(?) = ? AND pt.enterprise_id = ? AND p.number = ? AND p.fiscal_year_id = ?)
-        GROUP BY a.id HAVING balance <> 0;`;
+      // compute the values of the title accounts as the values of their children
+      // takes O(n * m) time, where n is the number of nodes and m is the number
+      // of periods
+      const balanceKeys = ['before', 'during', 'after'];
+      const bulkSumFn = (currentNode, parentNode) => {
+        balanceKeys.forEach(key => {
+          parentNode[key] = (parentNode[key] || 0) + currentNode[key];
+        });
+      };
 
-      const period13 = fiscal.number_of_months + 1;
-      return db.exec(sql, [
-        query.date, query.enterpriseId,
-        query.date, fiscal.number_of_months, query.enterpriseId, period13, fiscal.id,
-      ]);
-    })
-    .then((rows) => {
-      data.middle = rows;
-      return data;
+      // sum the debits and credits
+      tree.walk(bulkSumFn, false);
+
+      // label depths
+      tree.walk(Tree.common.computeNodeDepth);
+
+      // prune empty rows
+      if (shouldPrune) {
+        const trimmed = tree.prune(isEmptyRow);
+        _.merge(context, { accounts : trimmed });
+      }
+
+      return context;
     });
 }

--- a/server/controllers/finance/reports/balance/report.handlebars
+++ b/server/controllers/finance/reports/balance/report.handlebars
@@ -143,39 +143,39 @@
             <th>{{translate "FORM.LABELS.TOTAL"}}</th>
             {{#if useSeparateDebitsAndCredits}}
               {{#gt totals.before 0}}
-                <th>{{currency totals.before totals.currencyId }}</th>
-                <th></th>
+                <th class="text-right">{{currency totals.before totals.currencyId }}</th>
+                <th class="text-right">{{currency 0 totals.currencyId }}</th>
               {{else}}
-                <th></th>
-                <th>{{currency totals.before totals.currencyId }}</th>
+                <th class="text-right">{{currency 0 totals.currencyId }}</th>
+                <th class="text-right">{{currency totals.before totals.currencyId }}</th>
               {{/gt}}
             {{else}}
-              <th>{{debcred totals.before totals.currencyId }}</th>
+              <th class="text-right">{{debcred totals.before totals.currencyId }}</th>
             {{/if}}
 
             {{#if useSeparateDebitsAndCredits}}
               {{#gt totals.during 0}}
-                <th>{{currency totals.during totals.currencyId }}</th>
-                <th></th>
+                <th class="text-right">{{currency totals.during totals.currencyId }}</th>
+                <th class="text-right">{{currency 0 totals.currencyId }}</th>
               {{else}}
-                <th></th>
-                <th>{{currency totals.during totals.currencyId }}</th>
+                <th class="text-right">{{currency 0 totals.currencyId }}</th>
+                <th class="text-right">{{currency totals.during totals.currencyId }}</th>
               {{/gt}}
             {{else}}
-              <th>{{debcred totals.during totals.currencyId }}</th>
+              <th class="text-right">{{debcred totals.during totals.currencyId }}</th>
             {{/if}}
 
 
             {{#if useSeparateDebitsAndCredits}}
               {{#gt totals.after 0}}
-                <th>{{currency totals.after totals.currencyId }}</th>
-                <th></th>
+                <th class="text-right">{{currency totals.after totals.currencyId }}</th>
+                <th class="text-right">{{currency 0 totals.currencyId }}</th>
               {{else}}
-                <th></th>
-                <th>{{currency totals.after totals.currencyId }}</th>
+                <th class="text-right">{{currency 0 totals.currencyId }}</th>
+                <th class="text-right">{{currency totals.after totals.currencyId }}</th>
               {{/gt}}
             {{else}}
-              <th>{{debcred totals.after totals.currencyId }}</th>
+              <th class="text-right">{{debcred totals.after totals.currencyId }}</th>
             {{/if}}
           </tr>
         </tfoot>

--- a/server/controllers/finance/reports/balance/report.handlebars
+++ b/server/controllers/finance/reports/balance/report.handlebars
@@ -34,15 +34,15 @@
               </th>
               <th colspan="2" class="text-center">
                 {{translate "BALANCE.OLD_SOLD"}} <br>
-                <small class="text-capitalize">&lt; {{date ../period.start_date "MMMM YYYY"}}</small>
+                <small class="text-capitalize">&lt; {{date period.start_date "MMMM YYYY"}}</small>
               </th>
               <th colspan="2" class="text-center">
                 {{translate "BALANCE.MONTH_SOLD"}} <br>
-                <small class="text-capitalize">{{date ../period.start_date "MMMM YYYY"}}</small>
+                <small class="text-capitalize">{{date period.start_date "MMMM YYYY"}}</small>
               </th>
               <th colspan="2" class="text-center">
                 {{translate "BALANCE.NEW_SOLD"}} <br>
-                <small class="text-capitalize">&gt; {{date ../period.start_date "MMMM YYYY"}}</small>
+                <small class="text-capitalize">&gt; {{date period.start_date "MMMM YYYY"}}</small>
               </th>
             </tr>
           {{else}}
@@ -52,15 +52,15 @@
               </th>
               <th class="text-center">
                 {{translate "BALANCE.OLD_SOLD"}} <br>
-                <small class="text-capitalize">&lt; {{date ../period.start_date "MMMM YYYY"}}</small>
+                <small class="text-capitalize">&lt; {{date period.start_date "MMMM YYYY"}}</small>
               </th>
               <th class="text-center">
                 {{translate "BALANCE.MONTH_SOLD"}} <br>
-                <small class="text-capitalize">{{date ../period.start_date "MMMM YYYY"}}</small>
+                <small class="text-capitalize">{{date period.start_date "MMMM YYYY"}}</small>
               </th>
               <th class="text-center">
                 {{translate "BALANCE.NEW_SOLD"}} <br>
-                <small class="text-capitalize">&gt; {{date ../period.start_date "MMMM YYYY"}}</small>
+                <small class="text-capitalize">&gt; {{date period.start_date "MMMM YYYY"}}</small>
               </th>
             </tr>
           {{/if}}
@@ -140,21 +140,48 @@
 
         <tfoot>
           <tr class="text-right" style="background-color: #efefef;">
-            <!--
             <th>{{translate "FORM.LABELS.TOTAL"}}</th>
-            <td>{{currency totals.beginDebit metadata.enterprise.currency_id }}</td>
-            <td>{{currency totals.beginCredit metadata.enterprise.currency_id }}</td>
-            <td>{{currency totals.middleDebit metadata.enterprise.currency_id }}</td>
-            <td>{{currency totals.middleCredit metadata.enterprise.currency_id }}</td>
-            <td>{{currency totals.endDebit metadata.enterprise.currency_id }}</td>
-            <td>{{currency totals.endCredit metadata.enterprise.currency_id }}</td>
-            -->
+            {{#if useSeparateDebitsAndCredits}}
+              {{#gt totals.before 0}}
+                <th>{{currency totals.before totals.currencyId }}</th>
+                <th></th>
+              {{else}}
+                <th></th>
+                <th>{{currency totals.before totals.currencyId }}</th>
+              {{/gt}}
+            {{else}}
+              <th>{{debcred totals.before totals.currencyId }}</th>
+            {{/if}}
+
+            {{#if useSeparateDebitsAndCredits}}
+              {{#gt totals.during 0}}
+                <th>{{currency totals.during totals.currencyId }}</th>
+                <th></th>
+              {{else}}
+                <th></th>
+                <th>{{currency totals.during totals.currencyId }}</th>
+              {{/gt}}
+            {{else}}
+              <th>{{debcred totals.during totals.currencyId }}</th>
+            {{/if}}
+
+
+            {{#if useSeparateDebitsAndCredits}}
+              {{#gt totals.after 0}}
+                <th>{{currency totals.after totals.currencyId }}</th>
+                <th></th>
+              {{else}}
+                <th></th>
+                <th>{{currency totals.after totals.currencyId }}</th>
+              {{/gt}}
+            {{else}}
+              <th>{{debcred totals.after totals.currencyId }}</th>
+            {{/if}}
           </tr>
         </tfoot>
       </table>
     </div>
   </div>
-
 </main>
 </body>
 </html>

--- a/server/controllers/finance/reports/balance/report.handlebars
+++ b/server/controllers/finance/reports/balance/report.handlebars
@@ -1,8 +1,10 @@
+<!doctype html>
+<html>
 {{> head title="TREE.BALANCE"}}
 
 <body>
 
-<div class="container">
+<main class="container">
   {{> header}}
 
   <!-- body  -->
@@ -14,59 +16,131 @@
         {{translate 'REPORT.BALANCE'}}
       </h2>
 
-      <h4 class="text-center text-capitalize">
-        <strong>{{translate session.classe_name}}</strong>
-      </h4>
-
       <h4 class="text-center">
-        {{#if session.date}}
-          <span class="text-capitalize">{{translate "FORM.LABELS.UNTIL_PERIOD"}}</span> 
-          <strong class="text-capitalize">{{date session.date "MMMM YYYY"}}</strong>
+        {{#if period.start_date}}
+          <span class="text-capitalize">{{translate "FORM.LABELS.UNTIL_PERIOD"}}</span>
+          <strong class="text-capitalize">{{date period.start_date "MMMM YYYY"}}</strong>
         {{/if}}
       </h4>
 
       <!-- data  -->
       <table class="table table-condensed table-report">
         <thead>
-          <tr style="background-color:#ddd;">
-            <th rowspan="2" class="text-center">{{translate "FORM.LABELS.ACCOUNT"}}</th>
-            <th colspan="2" class="text-center">
-              {{translate "BALANCE.OLD_SOLD"}} <br>
-              <small>{{#if session.date}} &lt; {{date session.date "MMMM"}}{{/if}}</small>
-            </th>
-            <th colspan="2" class="text-center">
-              {{translate "BALANCE.MONTH_SOLD"}} <br>
-              <small>{{#if session.date}}{{date session.date "MMMM YYYY"}}{{/if}}</small>
-            </th>
-            <th colspan="2" class="text-center">
-              {{translate "BALANCE.NEW_SOLD"}} <br>
-              <small>{{#if session.date}}{{date session.date "MMMM YYYY"}}{{/if}}</small>
-            </th>
-          </tr>
-          <tr style="background-color:#ddd;">
-            <th class="text-center">{{translate "FORM.LABELS.DEBIT"}}</th>
-            <th class="text-center">{{translate "FORM.LABELS.CREDIT"}}</th>
-            <th class="text-center">{{translate "FORM.LABELS.DEBIT"}}</th>
-            <th class="text-center">{{translate "FORM.LABELS.CREDIT"}}</th>
-            <th class="text-center">{{translate "FORM.LABELS.DEBIT"}}</th>
-            <th class="text-center">{{translate "FORM.LABELS.CREDIT"}}</th>
-          </tr>
+          {{! only shown if we are separating the debit and credit columns }}
+          {{#if useSeparateDebitsAndCredits}}
+            <tr style="background-color:#ddd;">
+              <th class="text-center" rowspan="2" style="vertical-align:middle">
+                {{translate "FORM.LABELS.ACCOUNT"}}
+              </th>
+              <th colspan="2" class="text-center">
+                {{translate "BALANCE.OLD_SOLD"}} <br>
+                <small class="text-capitalize">&lt; {{date ../period.start_date "MMMM YYYY"}}</small>
+              </th>
+              <th colspan="2" class="text-center">
+                {{translate "BALANCE.MONTH_SOLD"}} <br>
+                <small class="text-capitalize">{{date ../period.start_date "MMMM YYYY"}}</small>
+              </th>
+              <th colspan="2" class="text-center">
+                {{translate "BALANCE.NEW_SOLD"}} <br>
+                <small class="text-capitalize">&gt; {{date ../period.start_date "MMMM YYYY"}}</small>
+              </th>
+            </tr>
+          {{else}}
+            <tr style="background-color:#ddd;">
+              <th class="text-center">
+                {{translate "FORM.LABELS.ACCOUNT"}}
+              </th>
+              <th class="text-center">
+                {{translate "BALANCE.OLD_SOLD"}} <br>
+                <small class="text-capitalize">&lt; {{date ../period.start_date "MMMM YYYY"}}</small>
+              </th>
+              <th class="text-center">
+                {{translate "BALANCE.MONTH_SOLD"}} <br>
+                <small class="text-capitalize">{{date ../period.start_date "MMMM YYYY"}}</small>
+              </th>
+              <th class="text-center">
+                {{translate "BALANCE.NEW_SOLD"}} <br>
+                <small class="text-capitalize">&gt; {{date ../period.start_date "MMMM YYYY"}}</small>
+              </th>
+            </tr>
+          {{/if}}
+
+          {{! separating debits and credits requires an additional header to name each column }}
+          {{#if useSeparateDebitsAndCredits}}
+            <tr style="background-color:#ddd;">
+              <th class="text-center">{{translate "FORM.LABELS.DEBIT"}}</th>
+              <th class="text-center">{{translate "FORM.LABELS.CREDIT"}}</th>
+              <th class="text-center">{{translate "FORM.LABELS.DEBIT"}}</th>
+              <th class="text-center">{{translate "FORM.LABELS.CREDIT"}}</th>
+              <th class="text-center">{{translate "FORM.LABELS.DEBIT"}}</th>
+              <th class="text-center">{{translate "FORM.LABELS.CREDIT"}}</th>
+            </tr>
+          {{/if}}
         </thead>
         <tbody>
           {{#each accounts as |account|}}
-          <tr class="text-right">
-            <td class="text-left"><b>{{ account.number }}</b> - {{ account.label }}</td>
-            <td>{{#if account.beginDebit}}{{currency account.beginDebit ../metadata.enterprise.currency_id }}{{/if}}</td>
-            <td>{{#if account.beginCredit}}{{currency account.beginCredit ../metadata.enterprise.currency_id }}{{/if}}</td>
-            <td>{{#if account.middleDebit}}{{currency account.middleDebit ../metadata.enterprise.currency_id }}{{/if}}</td>
-            <td>{{#if account.middleCredit}}{{currency account.middleCredit ../metadata.enterprise.currency_id }}{{/if}}</td>
-            <td>{{#if account.endDebit}}{{currency account.endDebit ../metadata.enterprise.currency_id }}{{/if}}</td>
-            <td>{{#if account.endCredit}}{{currency account.endCredit ../metadata.enterprise.currency_id }}{{/if}}</td>
-          </tr>
+            <tr class="text-right" {{#if account.isTitleAccount}}style="font-weight:bold;"{{/if}}>
+              <td class="text-left">
+                <span style="padding-left: calc(10px * {{account.depth}})">{{ account.number }} - {{ account.label }}</span>
+              </td>
+
+              {{#if ../useSeparateDebitsAndCredits}}
+                {{#if account.before}}
+                  {{#gt account.before 0}}
+                    <td>{{currency account.before account.currencyId }}</td>
+                    <td></td>
+                  {{else}}
+                    <td></td>
+                    <td>{{currency account.before account.currencyId }}</td>
+                  {{/gt}}
+                {{else}}
+                  <td></td>
+                  <td></td>
+                {{/if}}
+              {{else}}
+                <td>{{#if account.before}}{{debcred account.before account.currencyId }}{{/if}}</td>
+              {{/if}}
+
+              {{#if ../useSeparateDebitsAndCredits}}
+                {{#if account.during}}
+                  {{#gt account.during 0}}
+                    <td>{{currency account.during account.currencyId }}</td>
+                    <td></td>
+                  {{else}}
+                    <td></td>
+                    <td>{{currency account.during account.currencyId }}</td>
+                  {{/gt}}
+                {{else}}
+                  <td></td>
+                  <td></td>
+                {{/if}}
+              {{else}}
+                <td>{{#if account.during}}{{debcred account.during account.currencyId }}{{/if}}</td>
+              {{/if}}
+
+              {{#if ../useSeparateDebitsAndCredits}}
+                {{#if account.after}}
+                  {{#gt account.after 0}}
+                    <td>{{currency account.after account.currencyId }}</td>
+                    <td></td>
+                  {{else}}
+                    <td></td>
+                    <td>{{currency account.after account.currencyId }}</td>
+                  {{/gt}}
+                {{else}}
+                  <td></td>
+                  <td></td>
+                {{/if}}
+              {{else}}
+                <td>{{#if account.after}}{{debcred account.after account.currencyId }}{{/if}}</td>
+              {{/if}}
+            </tr>
           {{/each}}
         </tbody>
+
         <tfoot>
-          <tr class="text-right" style="font-weight: bold; background-color: #efefef;">
+          <tr class="text-right" style="background-color: #efefef;">
+            <!--
             <th>{{translate "FORM.LABELS.TOTAL"}}</th>
             <td>{{currency totals.beginDebit metadata.enterprise.currency_id }}</td>
             <td>{{currency totals.beginCredit metadata.enterprise.currency_id }}</td>
@@ -74,11 +148,13 @@
             <td>{{currency totals.middleCredit metadata.enterprise.currency_id }}</td>
             <td>{{currency totals.endDebit metadata.enterprise.currency_id }}</td>
             <td>{{currency totals.endCredit metadata.enterprise.currency_id }}</td>
+            -->
           </tr>
         </tfoot>
       </table>
     </div>
   </div>
 
-</div>
+</main>
 </body>
+</html>

--- a/server/controllers/finance/reports/balance_sheet/index.js
+++ b/server/controllers/finance/reports/balance_sheet/index.js
@@ -28,7 +28,6 @@ const EXPENSE = 5;
 const DATE_FORMAT = 'YYYY-MM-DD';
 const FC_CURRENCY = 1;
 
-
 // expose to the API
 exports.document = document;
 

--- a/test/end-to-end/reports/balance_report/balance_report.page.js
+++ b/test/end-to-end/reports/balance_report/balance_report.page.js
@@ -1,10 +1,3 @@
-/* global browser, element, by */
-
-const chai = require('chai');
-const helpers = require('../../shared/helpers');
-
-helpers.configure(chai);
-
 const FU = require('../../shared/FormUtils');
 const ReportPage = require('../page');
 const components = require('../../shared/components');
@@ -15,14 +8,16 @@ class BalanceReportPage {
   }
 
   // preview an account report
-  showBalanceReportPreview(date) {
-    components.dateEditor.set(date);
+  showBalanceReportPreview(period) {
+    components.reportPeriodSelect.set(period);
+    components.yesNoRadios.set('yes', 'useSeparateDebitsAndCredits');
+    components.yesNoRadios.set('yes', 'shouldPruneEmptyRows');
     this.page.preview();
   }
 
   // save an account report
-  saveBalanceReport(date, reportName, reportFormat) {
-    this.showBalanceReportPreview(date);
+  saveBalanceReport(period, reportName, reportFormat) {
+    this.showBalanceReportPreview(period);
 
     // save report as PDF
     this.page.saveAs();

--- a/test/end-to-end/reports/balance_report/balance_report.spec.js
+++ b/test/end-to-end/reports/balance_report/balance_report.spec.js
@@ -1,23 +1,14 @@
-/* global browser, element, by */
-
-const chai = require('chai');
 const helpers = require('../../shared/helpers');
-
-helpers.configure(chai);
 
 const BalanceReportPage = require('./balance_report.page');
 
-describe('Balance report ::', () => {
+describe('Balance Report', () => {
   let Page;
   const key = 'balance_report';
 
   const dataset = {
-    dateFrom   : '01/01/2016',
-    dateTo     : '31/12/2016',
-    date       : new Date('2016-12-31 12:00'),
-    dateOption : 0,
-    classe     : '*',
-    report_name : 'Balance Report Saved by E2E',
+    period : '2018',
+    reportName : 'Balance Report Saved by E2E',
     renderer : 'PDF',
   };
 
@@ -27,7 +18,7 @@ describe('Balance report ::', () => {
   });
 
   it('preview a new balance report', () => {
-    Page.showBalanceReportPreview(dataset.date);
+    Page.showBalanceReportPreview(dataset.period);
   });
 
   it('close the previewed report', () => {
@@ -35,14 +26,14 @@ describe('Balance report ::', () => {
   });
 
   it('save a previewed report', () => {
-    Page.saveBalanceReport(dataset.date, dataset.report_name, dataset.renderer);
+    Page.saveBalanceReport(dataset.period, dataset.reportName, dataset.renderer);
   });
 
   it('report has been saved into archive', () => {
-    Page.checkSavedBalanceReport(dataset.report_name);
+    Page.checkSavedBalanceReport(dataset.reportName);
   });
 
   it('print the previewed report', () => {
-    Page.printBalanceReport(dataset.date);
+    Page.printBalanceReport(dataset.period);
   });
 });

--- a/test/end-to-end/shared/components/bhFiscalPeriodSelect.js
+++ b/test/end-to-end/shared/components/bhFiscalPeriodSelect.js
@@ -1,25 +1,19 @@
-/* global browser, element, by */
-
-const FU = require('../FormUtils');
+/* global element, by */
 
 module.exports = {
   mainSelector : '[bh-fiscal-period-select]',
-  set : function set(fiscal_year_id, periodFrom_id, periodTo_id, id) {
-      var opts;
-    /** return selector for an option element */
-    function getValue(id) {
-      return by.css('option[value="number:?"]'.replace('?', id));
-    }
+  set : function set(fiscalYearId, periodFromId, periodToId, id) {
+    const getValue = ident => by.css(`option[value="number:${ident}"]`);
 
     const bhFiscalPeriod = (id) ? element(by.id(id)) : element(by.css(this.mainSelector));
 
-    opts = bhFiscalPeriod.element(by.model('$ctrl.selectedFiscal'));
-    opts.element(getValue(fiscal_year_id)).click();
+    let opts = bhFiscalPeriod.element(by.model('$ctrl.selectedFiscal'));
+    opts.element(getValue(fiscalYearId)).click();
 
     opts = bhFiscalPeriod.element(by.model('$ctrl.selectedPeriodFrom'));
-    opts.element(getValue(periodFrom_id)).click();
+    opts.element(getValue(periodFromId)).click();
 
     opts = bhFiscalPeriod.element(by.model('$ctrl.selectedPeriodTo'));
-    opts.element(getValue(periodTo_id)).click();
+    opts.element(getValue(periodToId)).click();
   },
 };

--- a/test/end-to-end/shared/components/bhReportPeriodSelect.js
+++ b/test/end-to-end/shared/components/bhReportPeriodSelect.js
@@ -1,4 +1,4 @@
-/* global browser, element, by */
+/* global element, by */
 
 const FU = require('../FormUtils');
 

--- a/test/end-to-end/shared/components/bhYesNoRadios.js
+++ b/test/end-to-end/shared/components/bhYesNoRadios.js
@@ -1,0 +1,21 @@
+/* global element, by */
+
+module.exports = {
+  selector : '[data-bh-yes-no-radios]',
+
+  set : (value, id) => {
+
+    // get the root value of the
+    const root = element(id ? by.id(id) : by.css(this.selector));
+
+    // construct a locator for the value
+    const locator = `[data-choice="${value}"]`;
+
+    // get the appropriate option by the locator
+    const option = root.element(by.css(locator));
+
+    // click it!
+    option.click();
+  },
+};
+

--- a/test/end-to-end/shared/components/index.js
+++ b/test/end-to-end/shared/components/index.js
@@ -49,5 +49,6 @@ module.exports = {
   iprConfigSelect             : require('./bhIprConfigSelect'),
   rubricConfigSelect          : require('./bhRubricConfigSelect'),
   accountConfigSelect         : require('./bhAccountConfigSelect'),
-  weekConfigSelect            : require('./bhWeekConfigSelect'), 
+  weekConfigSelect            : require('./bhWeekConfigSelect'),
+  yesNoRadios : require('./bhYesNoRadios'),
 };


### PR DESCRIPTION
This commit updates the balance report with a tree structure, an optional expanded or collapsed presentation and using a fiscal period select component instead of a naked date.

Closes #2617.

This report is now ready for review.

The interface looks like this:

**Configuration Panel**
![balancereportconfiguration](https://user-images.githubusercontent.com/896472/37964686-46dd4ad4-31ba-11e8-8e4b-abd400aaf3a7.PNG)

**View of Combined Debits and Credits**
![combineddebitsandcredits](https://user-images.githubusercontent.com/896472/37964709-503c2320-31ba-11e8-88c6-11066c27d746.PNG)

**View of Separated Debits and Credits**
![separateddebitsandcredits](https://user-images.githubusercontent.com/896472/37964712-50901c1e-31ba-11e8-961a-569a43a786c3.PNG)

