### PR TITLE
fix(bhPDFPrint): anticipate memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ nbproject/
 # ignore istanbul generated folders
 .nyc_output/
 
+yarn-error.log


### PR DESCRIPTION
This PR cleans up the bhPDFPrint by removing unused bits and migrating to modern JS.

This commit uses the $onDestroy() hook of angularjs components to clean up the event handlers for printing.  It also defers the load() event to prevent FireFox from automatically attempting to print the window before any PDFs are loaded.

Note that the print() function is still broken in FF, but this allows you to preview modules without print() calls suddenly hijacking the session.

Partially addresses #2350.
