### PR TITLE
chore(receipts): use large modal

### DIFF
--- a/client/src/js/services/receipts/ReceiptModal.js
+++ b/client/src/js/services/receipts/ReceiptModal.js
@@ -18,9 +18,9 @@ function ReceiptModal(Modal, Receipts) {
   var modalConfiguration = {
     templateUrl : '/js/services/receipts/modal/receiptModal.tmpl.html',
     controller  : 'ReceiptModalController as ReceiptCtrl',
-    size        : 'md',
+    size        : 'lg',
     backdrop    : 'static',
-    animation   : false
+    animation   : false,
   };
 
   // expose available receipts


### PR DESCRIPTION
This commit changes the receipt modal to use a large modal.  It should be easier for our users to see.  See below for comparison:

![mediumreceiptmodal](https://user-images.githubusercontent.com/896472/38686838-3374569e-3e6d-11e8-8cdd-96281258399d.PNG)
_Fig 1: Medium Receipt Modal_

![largereceiptmodal](https://user-images.githubusercontent.com/896472/38686837-3312048a-3e6d-11e8-9967-90aee85720b6.PNG)
_Fig 2: Large Receipt Modal_
