### PR TITLE
refactor: rewrite and test stock entry modal

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -26,11 +26,12 @@
     "ENTRY_INTEGRATION" : "Integration",
     "ENTRY_TRANSFER"  : "Transfer",
     "ERRORS" : {
-      "MISSING_LOT_NAME":"Missing Lot Identifier",
-      "INVALID_LOT_QUANTITY":"Invalid Lot Quantity",
-      "INVALID_LOT_EXPIRATION":"Invalid Lot Expiration Date",
-      "INVALID_GLOBAL_QUANTITY":"Invalid Global Lot's Quantity",
-      "LOT_ROW_WITH_ERRORS":"Some lot line contains invalid data",
+      "NO_ROWS" : "Must have at least one row in the grid.",
+      "MISSING_LOT_NAME" : "Missing Lot Identifier",
+      "INVALID_LOT_QUANTITY" : "Invalid Lot Quantity",
+      "INVALID_LOT_EXPIRATION" : "Invalid Lot Expiration Date",
+      "INVALID_GLOBAL_QUANTITY" : "Invalid Global Lot's Quantity",
+      "LOT_ROW_WITH_ERRORS" : "Some lot line contains invalid data",
       "EXCESSIVE_QUANTITY": "Excessive Quantity",
       "PLEASE_CHECK_EXPIRY_DATE": "Please check the expiration date"
     },

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -26,11 +26,12 @@
     "ENTRY_INTEGRATION" : "Integration",
     "ENTRY_TRANSFER"  : "Transfert",
     "ERRORS" : {
-      "MISSING_LOT_NAME":"Identifiant de lot manquant",
-      "INVALID_LOT_QUANTITY":"Quantité de lot invalide",
-      "INVALID_LOT_EXPIRATION":"Date d'expiration invalide",
-      "INVALID_GLOBAL_QUANTITY":"Quantité globale des lots invalide",
-      "LOT_ROW_WITH_ERRORS":"Données invalide dans certaines lignes de lot ",
+      "NO_ROWS" : "Vous devez avoir au moins une ligne dans le grid.",
+      "MISSING_LOT_NAME" : "Identifiant de lot manquant",
+      "INVALID_LOT_QUANTITY" : "Quantité de lot invalide",
+      "INVALID_LOT_EXPIRATION" : "Date d'expiration invalide",
+      "INVALID_GLOBAL_QUANTITY" : "Quantité globale des lots invalide",
+      "LOT_ROW_WITH_ERRORS" : "Données invalide dans certaines lignes de lot ",
       "EXCESSIVE_QUANTITY": "Quantité excessive",
       "PLEASE_CHECK_EXPIRY_DATE": "Veuillez vérifier la date d'expiration"
     },    

--- a/client/src/js/components/bhAddItem.js
+++ b/client/src/js/components/bhAddItem.js
@@ -3,30 +3,33 @@ angular.module('bhima.components')
     templateUrl : 'modules/templates/bhAddItem.tmpl.html',
     controller  : addItemController,
     bindings    : {
-      disable     : '<',
       callback    : '&',
+      disable     : '<?',
     },
   });
 
 /**
  * Add Item component
- *
  */
 function addItemController() {
-  var $ctrl = this;
+  const $ctrl = this;
 
-  $ctrl.$onInit = function onInit() {    
+  $ctrl.$onInit = function onInit() {
     // default for form name
     $ctrl.name = 'AddItemForm';
-    
+
     // default value for incrementation
     $ctrl.itemIncrement = 1;
+
+    if (!angular.isDefined($ctrl.disable)) {
+      $ctrl.disable = false;
+    }
   };
 
   // fires the Callback bound to the component boundary
-  $ctrl.addItems = function ($item) {
+  $ctrl.addItems = $item => {
     if ($item > 0) {
-      $ctrl.callback({ numItem : $item });  
+      $ctrl.callback({ numItem : $item });
     }
   };
 }

--- a/client/src/js/components/bhDatePicker.js
+++ b/client/src/js/components/bhDatePicker.js
@@ -1,15 +1,15 @@
 angular.module('bhima.components')
-.component('bhDatePicker', {
-  templateUrl : '/modules/templates/bhDatePickerAction.tmpl.html',
-  controller  : DatePickerController,
-  bindings    : {
-    date     : '<', // set the date once as the initial date and use callbacks to change it later
-    format   : '<',
-    mode     : '@', // will this ever change?  If so, we can use '<'
-    required : '<',
-    onChange : '&', // use a callback to notify for changes
-  },
-});
+  .component('bhDatePicker', {
+    templateUrl : '/modules/templates/bhDatePickerAction.tmpl.html',
+    controller  : DatePickerController,
+    bindings    : {
+      date     : '<', // set the date once as the initial date and use callbacks to change it later
+      onChange : '&', // use a callback to notify for changes
+      format   : '<?',
+      mode     : '@?', // will this ever change?  If so, we can use '<'
+      required : '<?',
+    },
+  });
 
 DatePickerController.$inject = ['$uibModal', 'bhConstants'];
 
@@ -21,9 +21,9 @@ DatePickerController.$inject = ['$uibModal', 'bhConstants'];
  * @module components/bhDatePicker
  */
 function DatePickerController(Modal, bhConstants) {
-  var vm = this;
+  const vm = this;
 
-  var modalParameters = {
+  const modalParameters = {
     size         : 'sm',
     backdrop     : 'static',
     animation    : true,
@@ -39,24 +39,24 @@ function DatePickerController(Modal, bhConstants) {
 
   // on date change
   function notifyDateChange() {
-    vm.onChange({ date: vm.date });
+    vm.onChange({ date : vm.date });
   }
 
   function open() {
-    openDatePicker({ mode: vm.mode })
-    .then(function (res) {
-      // notify the parent controller of a date change via a callback
-      vm.onChange({ date: res });
-    });
+    openDatePicker({ mode : vm.mode })
+      .then(date => {
+        // notify the parent controller of a date change via a callback
+        vm.onChange({ date });
+      });
   }
 
   function openDatePicker() {
-    var params = angular.extend(modalParameters, {
+    const params = angular.extend(modalParameters, {
       resolve : {
         data : function dataProvider() { return {}; },
       },
     });
-    var instance = Modal.open(params);
+    const instance = Modal.open(params);
     return instance.result;
   }
 }
@@ -67,7 +67,7 @@ function DatePickerController(Modal, bhConstants) {
 DatePickerModalController.$inject = ['$uibModalInstance', 'data'];
 
 function DatePickerModalController(Instance, Data) {
-  var vm = this;
+  const vm = this;
 
   vm.selected = new Date();
 

--- a/client/src/modules/stock/entry/entry.html
+++ b/client/src/modules/stock/entry/entry.html
@@ -88,7 +88,6 @@
           <!-- "Add number of grid rows" input-group -->
           <bh-add-item disable="StockCtrl.entryOption" callback="StockCtrl.addItems(numItem)">
           </bh-add-item>
-
         </div>
       </div>
 
@@ -97,7 +96,8 @@
         id="stock-entry-grid"
         ui-grid="StockCtrl.gridOptions"
         style="height: 300px; width: 100%;"
-        ui-grid-auto-resize ui-grid-resize-columns>
+        ui-grid-auto-resize
+        ui-grid-resize-columns>
       </div>
 
       <!-- footer -->

--- a/client/src/modules/stock/entry/modals/StockEntryModalForm.service.js
+++ b/client/src/modules/stock/entry/modals/StockEntryModalForm.service.js
@@ -21,6 +21,10 @@ function StockEntryModalForm() {
     this.lot = row.lot || null;
     this.isInvalid = true;
     this.isValid = false;
+
+    if (row.uuid) {
+      this.uuid = row.uuid;
+    }
   }
 
   function StockForm(opts = {}) {

--- a/client/src/modules/stock/entry/modals/StockEntryModalForm.service.js
+++ b/client/src/modules/stock/entry/modals/StockEntryModalForm.service.js
@@ -1,0 +1,115 @@
+angular.module('bhima.services')
+  .service('StockEntryModalForm', StockEntryModalForm);
+
+/**
+ * @function StockEntryModalForm
+ *
+ * @description
+ * This function creates new instances of the StockForm used for registering
+ * new lots during stock entry.  It also encapsulates the business logic for
+ * validation of lots, as well as removal or addition of new ones.
+ */
+function StockEntryModalForm() {
+  const ERR_NO_ROWS = 'STOCK.ERRORS.NO_ROWS';
+  const ERR_INVALID_QUANTITY = 'STOCK.ERRORS.INVALID_LOT_QUANTITY';
+  const ERR_INVALID_EXPIRATION = 'STOCK.ERRORS.INVALID_LOT_EXPIRATION';
+  const ERR_INVALID_IDENTIFIER = 'STOCK.ERRORS.MISSING_LOT_NAME';
+
+  function Lot(row = {}) {
+    this.expiration_date = row.expiration_date || new Date();
+    this.quantity = row.quantity || 1;
+    this.lot = row.lot || null;
+    this.isInvalid = true;
+    this.isValid = false;
+  }
+
+  function StockForm(opts = {}) {
+    this.rows = [];
+    this.opts = opts;
+
+    if (opts.rows) {
+      this.rows = opts.rows.map(row => new Lot(row));
+      this.validate();
+    }
+  }
+
+  StockForm.prototype.addItem = function addItem() {
+    this.rows.push(new Lot());
+  };
+
+  StockForm.prototype.removeItem = function removeItem(idx) {
+    this.rows.splice(idx, 1);
+  };
+
+  /**
+   * @function total
+   *
+   * @description
+   * This function computes the total quantity in the form.
+   */
+  StockForm.prototype.total = function total() {
+    return this.rows.reduce((sum, lot) => sum + lot.quantity, 0);
+  };
+
+  /**
+   * @function validateSingleRow
+   *
+   * @description
+   * This function takes in a single row and runs validation against it.
+   */
+  function validateSingleRow(row) {
+    let hasFutureExpirationDate = new Date(row.expiration_date) >= new Date();
+    row._error = null;
+
+    // if the stock does not expire/have an expiration date, generate a fake one
+    if (!this.opts.expires) {
+      hasFutureExpirationDate = true;
+      row.expiration_date = new Date((new Date().getFullYear() + 1000), new Date().getMonth());
+    }
+    // check invalid lot expiration date
+    const hasInvalidExpiration = (!row.expiration_date || !hasFutureExpirationDate);
+    if (hasInvalidExpiration) {
+      row._error = ERR_INVALID_EXPIRATION;
+    }
+
+    // check invalid lot quantity
+    if (row.quantity <= 0) {
+      row._error = ERR_INVALID_QUANTITY;
+    }
+
+    // check missing lot identifier
+    if (!row.lot) {
+      row._error = ERR_INVALID_IDENTIFIER;
+    }
+
+    row.isInvalid = row._error != null;
+    row.isValid = !row.isInvalid;
+  }
+
+  function validateAllRows() {
+    const errors = [];
+
+    if (this.rows.length === 0) {
+      errors.push(ERR_NO_ROWS);
+    }
+
+    this.rows.forEach(lot => {
+      validateSingleRow.call(this, lot);
+
+      if (lot.isInvalid) {
+        errors.push(lot._error);
+      }
+    });
+
+    // return unique errors
+    return errors
+      .filter((err, idx, arr) => arr.indexOf(err) === idx);
+  }
+
+  StockForm.prototype.validate = function validate(row) {
+    const validationFn = angular.isDefined(row) ? validateSingleRow : validateAllRows;
+    return validationFn.call(this, row);
+  };
+
+  return StockForm;
+}

--- a/client/src/modules/stock/entry/modals/lots.modal.html
+++ b/client/src/modules/stock/entry/modals/lots.modal.html
@@ -1,6 +1,7 @@
-<form 
+<form
   name="FindForm"
   bh-submit="$ctrl.submit(FindForm)"
+  ng-model-options="{ 'debounce' : { 'default' : 200, 'blur' : 0 }}"
   novalidate>
 
   <div class="modal-header">
@@ -11,20 +12,20 @@
     </ol>
   </div>
 
-  <div class="modal-body clearfix">
+  <div class="modal-body">
     <div class="form-group">
       <label class="control-label" translate>FORM.LABELS.GLOBAL_QUANTITY</label>
-      
+
       <div ng-if="$ctrl.entryType === 'purchase' || $ctrl.entryType === 'transfer_reception'">
         <span class="form-control-static">{{ $ctrl.stockLine.quantity }}</span>
       </div>
 
-      <input 
-        ng-if="$ctrl.entryType !== 'purchase' && $ctrl.entryType !== 'transfer_reception'" 
-        class="form-control" 
-        type="number" 
-        ng-model="$ctrl.stockLine.quantity" 
-        ng-model-options="{ 'debounce' : { 'default' : 150, 'blur' : 0 }}"
+      <input
+        ng-if="$ctrl.isCostEditable"
+        class="form-control"
+        type="number"
+        ng-model="$ctrl.stockLine.quantity"
+        ng-model-options="{ '*' : '$inherit' }"
         min="0">
     </div>
 
@@ -36,25 +37,18 @@
       </div>
 
       <div ng-if="$ctrl.isCostEditable" class="input-group">
-        <input  
-          class="form-control" 
-          type="number" 
+        <input
+          class="form-control"
+          type="number"
           ng-model="$ctrl.stockLine.unit_cost"
-          ng-model-options="{ 'debounce' : { 'default' : 150, 'blur' : 0 }}">
+          ng-model-options="{ '*' : '$inherit' }">
         <span class="input-group-addon">{{ $ctrl.enterprise.currencySymbol }}</span>
       </div>
     </div>
 
-    <!-- No need of defining lot label if it is a transfer reception -->
-    <div class="text-right" style="margin-bottom: 5px;"> 
-      <button type="button"
-        data-add-lot
-        ng-click="$ctrl.addLot()"
-        class="btn btn-default"
-        ng-disabled="$ctrl.entryType === 'transfer_reception'">
-        <span class="fa fa-plus-circle"></span> 
-        <span translate>FORM.LABELS.ADD</span>
-      </button>
+    <div style="margin-bottom: 5px;">
+      <bh-add-item callback="$ctrl.form.addItem()" disable="true">
+      </bh-add-item>
     </div>
 
     <div class="row">
@@ -73,16 +67,11 @@
       </div>
     </div>
 
-    <div ng-if="$ctrl.hasInvalidEntries" class="alert alert-danger clearfix" style="margin-top: 10px;">
-      <ul>
-        <li ng-if="$ctrl.hasMissingLotIdentifier" translate>STOCK.ERRORS.MISSING_LOT_NAME</li>
-        <li ng-if="$ctrl.hasInvalidLotQuantity" translate>STOCK.ERRORS.INVALID_LOT_QUANTITY</li>
-        <li ng-if="$ctrl.hasInvalidLotExpiration" translate>STOCK.ERRORS.INVALID_LOT_EXPIRATION</li>
-        <li ng-if="$ctrl.isQuantityIncorrect" translate>STOCK.ERRORS.INVALID_GLOBAL_QUANTITY</li>
-        <li ng-if="$ctrl.isSomeLineIncorrect" translate>STOCK.ERRORS.LOT_ROW_WITH_ERRORS</li>
-      </ul>
+    <div ng-if="$ctrl.errors.length > 0" class="alert alert-danger" style="margin-top: 10px;">
+      <p ng-repeat="error in $ctrl.errors">
+        <b><i class="fa fa-warning"></i></b> <span translate>{{error}}</span>
+      </p>
     </div>
-
   </div>
 
   <div class="modal-footer">
@@ -94,5 +83,4 @@
       <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>
   </div>
-
 </form>

--- a/client/src/modules/stock/entry/modals/templates/lot.actions.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/lot.actions.tmpl.html
@@ -1,3 +1,5 @@
 <div class="ui-grid-cell-contents text-center">
-  <a class="text-action" ng-click="grid.appScope.removeLot(rowRenderIndex)" tabindex="-1"><i class="fa fa-trash-o text-danger"></i></a>
+  <a class="text-action" ng-click="grid.appScope.form.removeItem(rowRenderIndex)" tabindex="-1">
+    <i class="fa fa-trash-o text-danger"></i>
+  </a>
 </div>

--- a/client/src/modules/stock/entry/modals/templates/lot.expiration.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/lot.expiration.tmpl.html
@@ -1,9 +1,7 @@
-<div 
-  class="ui-grid-cell-contents"
-  >
+<div class="ui-grid-cell-contents">
   <bh-date-picker
     date="row.entity.expiration_date"
-    on-change="grid.appScope.checkLine(row.entity, date)"
+    on-change="grid.appScope.onDateChange(date, row.entity)"
     required="true">
   </bh-date-picker>
 </div>

--- a/client/src/modules/stock/entry/modals/templates/lot.input.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/lot.input.tmpl.html
@@ -1,10 +1,14 @@
 <div class="ui-grid-cell-contents">
-  <input 
+  <span ng-if="grid.appScope.isTransfer">
+    {{row.entity.lot}}
+  </span>
+
+  <input
     type="text"
-    ng-disabled="grid.appScope.entryType === 'transfer_reception'"
+    ng-if="!grid.appScope.isTransfer"
     class="form-control"
     ng-model="row.entity.lot"
-    ng-model-options="{ 'debounce' : { 'default' : 150, 'blur' : 0 }}"
-    ng-change="grid.appScope.checkLine(row.entity)"
+    ng-model-options="{ 'debounce' : '$inherit' }"
+    ng-change="grid.appScope.onChanges()"
     required>
 </div>

--- a/client/src/modules/stock/entry/modals/templates/lot.quantity.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/lot.quantity.tmpl.html
@@ -3,9 +3,9 @@
     min="0"
     type="number"
     class="form-control"
-    style="padding-left : 5px !important;text-align: right;"
+    style="padding-left : 5px !important; text-align: right;"
     ng-model="row.entity.quantity"
-    ng-model-options="{ 'debounce' : { 'default' : 150, 'blur' : 0 }}"
-    ng-change="grid.appScope.checkLine(row.entity)"
+    ng-model-options="{ 'debounce' : '$inherit' }"
+    ng-change="grid.appScope.onChanges()"
     required>
 </div>

--- a/client/src/modules/stock/entry/modals/templates/lot.status.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/lot.status.tmpl.html
@@ -1,13 +1,13 @@
-<div 
-  ng-hide="row.entity.isValid" 
+<div
+  ng-hide="row.entity.isValid"
   class="ui-grid-cell-contents text-center"
   ng-class="{
-    'bg-danger text-danger' : !row.entity.quantity,
-    'bg-warning text-warning' : row.entity.quantity
+    'bg-danger text-danger' : row.entity.lot,
+    'bg-warning text-warning' : !row.entity.lot,
   }"
   style="padding: 5px;">
-  <span ng-show="row.entity.quantity" class="fa fa-circle-o"></span>
-  <span ng-hide="row.entity.quantity" class="fa fa-times-circle"></span>
+  <span ng-show="!row.entity.lot" class="fa fa-circle-o"></span>
+  <span ng-hide="!row.entity.lot" class="fa fa-times-circle"></span>
 </div>
 
 <div ng-show="row.entity.isValid" class="ui-grid-cell-contents bg-success text-center">

--- a/client/src/modules/stock/stock.service.js
+++ b/client/src/modules/stock/stock.service.js
@@ -1,7 +1,6 @@
 angular.module('bhima.services')
   .service('StockModalService', StockModalService);
 
-// dependencies injection
 StockModalService.$inject = ['$uibModal'];
 
 // service definition
@@ -30,12 +29,7 @@ function StockModalService(Modal) {
       templateUrl  : 'modules/stock/lots/modals/search.modal.html',
       controller   : 'SearchLotsModalController',
       controllerAs : '$ctrl',
-      size         : 'md',
-      backdrop     : 'static',
-      animation    : false,
-      resolve      : {
-        data : function dataProvider() { return request; },
-      },
+      resolve      : { data : () => request },
     });
 
     const instance = Modal.open(params);
@@ -48,12 +42,7 @@ function StockModalService(Modal) {
       templateUrl  : 'modules/stock/movements/modals/search.modal.html',
       controller   : 'SearchMovementsModalController',
       controllerAs : '$ctrl',
-      size         : 'md',
-      backdrop     : 'static',
-      animation    : false,
-      resolve      : {
-        data : function dataProvider() { return request; },
-      },
+      resolve      : { data : () => request },
     });
 
     const instance = Modal.open(params);
@@ -66,12 +55,7 @@ function StockModalService(Modal) {
       templateUrl  : 'modules/stock/inventories/modals/search.modal.html',
       controller   : 'SearchInventoriesModalController',
       controllerAs : '$ctrl',
-      size         : 'md',
-      backdrop     : 'static',
-      animation    : false,
-      resolve      : {
-        data : function dataProvider() { return request; },
-      },
+      resolve      : { data : () => request },
     });
 
     const instance = Modal.open(params);
@@ -84,12 +68,7 @@ function StockModalService(Modal) {
       templateUrl  : 'modules/stock/exit/modals/findPatient.modal.html',
       controller   : 'StockFindPatientModalController',
       controllerAs : '$ctrl',
-      size         : 'md',
-      backdrop     : 'static',
-      animation    : false,
-      resolve      : {
-        data : function dataProvider() { return request; },
-      },
+      resolve      : { data : () => request },
     });
 
     const instance = Modal.open(params);
@@ -102,12 +81,7 @@ function StockModalService(Modal) {
       templateUrl  : 'modules/stock/exit/modals/findService.modal.html',
       controller   : 'StockFindServiceModalController',
       controllerAs : '$ctrl',
-      size         : 'md',
-      backdrop     : 'static',
-      animation    : false,
-      resolve      : {
-        data : function dataProvider() { return request; },
-      },
+      resolve      : { data : () => request },
     });
 
     const instance = Modal.open(params);
@@ -120,12 +94,7 @@ function StockModalService(Modal) {
       templateUrl  : 'modules/stock/exit/modals/findDepot.modal.html',
       controller   : 'StockFindDepotModalController',
       controllerAs : '$ctrl',
-      size         : 'md',
-      backdrop     : 'static',
-      animation    : false,
-      resolve      : {
-        data : function dataProvider() { return request; },
-      },
+      resolve      : { data : () => request },
     });
 
     const instance = Modal.open(params);
@@ -138,12 +107,7 @@ function StockModalService(Modal) {
       templateUrl  : 'modules/stock/entry/modals/findPurchase.modal.html',
       controller   : 'StockFindPurchaseModalController',
       controllerAs : '$ctrl',
-      size         : 'md',
-      backdrop     : 'static',
-      animation    : false,
-      resolve      : {
-        data : function dataProvider() { return request; },
-      },
+      resolve      : { data : () => request },
     });
 
     const instance = Modal.open(params);
@@ -156,11 +120,8 @@ function StockModalService(Modal) {
       templateUrl  : 'modules/stock/entry/modals/findTransfer.modal.html',
       controller   : 'StockFindTransferModalController',
       controllerAs : '$ctrl',
-      size         : 'md',
-      backdrop     : 'static',
-      animation    : false,
       resolve      : {
-        data : function dataProvider() { return request; },
+        data : () => request,
       },
     });
 
@@ -168,18 +129,13 @@ function StockModalService(Modal) {
     return instance.result;
   }
 
-  /** lots definition */
   function openDefineLots(request) {
     const params = angular.extend(modalParameters, {
       templateUrl  : 'modules/stock/entry/modals/lots.modal.html',
       controller   : 'StockDefineLotsModalController',
       controllerAs : '$ctrl',
-      size         : 'md',
-      backdrop     : 'static',
-      animation    : false,
-      resolve      : {
-        data : function dataProvider() { return request; },
-      },
+      size         : 'lg',
+      resolve      : { data : () => request },
     });
 
     const instance = Modal.open(params);

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -216,25 +216,25 @@ function getLotsMovements(depotUuid, params) {
   }
 
   const sql = `
-        SELECT
-          BUID(l.uuid) AS uuid, l.label, l.initial_quantity, m.quantity, m.reference, m.description,
-          d.text AS depot_text, IF(is_exit = 1, "OUT", "IN") AS io, l.unit_cost,
-          l.expiration_date, BUID(l.inventory_uuid) AS inventory_uuid,
-          BUID(l.origin_uuid) AS origin_uuid, l.entry_date, i.code, i.text,
-          BUID(m.depot_uuid) AS depot_uuid, m.is_exit, m.date, BUID(m.document_uuid) AS document_uuid,
-          m.flux_id, BUID(m.entity_uuid) AS entity_uuid, m.unit_cost,
-          f.label AS flux_label, i.delay,
-          iu.text AS unit_type,
-          dm.text AS documentReference
-        FROM stock_movement m
-        JOIN lot l ON l.uuid = m.lot_uuid
-        JOIN inventory i ON i.uuid = l.inventory_uuid
-        JOIN inventory_unit iu ON iu.id = i.unit_id
-        JOIN depot d ON d.uuid = m.depot_uuid
-        JOIN depot_permission dp ON m.depot_uuid = dp.depot_uuid
-        JOIN flux f ON f.id = m.flux_id
-        LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
-    `;
+    SELECT
+      BUID(l.uuid) AS uuid, l.label, l.initial_quantity, m.quantity, m.reference, m.description,
+      d.text AS depot_text, IF(is_exit = 1, "OUT", "IN") AS io, l.unit_cost,
+      l.expiration_date, BUID(l.inventory_uuid) AS inventory_uuid,
+      BUID(l.origin_uuid) AS origin_uuid, l.entry_date, i.code, i.text,
+      BUID(m.depot_uuid) AS depot_uuid, m.is_exit, m.date, BUID(m.document_uuid) AS document_uuid,
+      m.flux_id, BUID(m.entity_uuid) AS entity_uuid, m.unit_cost,
+      f.label AS flux_label, i.delay,
+      iu.text AS unit_type,
+      dm.text AS documentReference
+    FROM stock_movement m
+    JOIN lot l ON l.uuid = m.lot_uuid
+    JOIN inventory i ON i.uuid = l.inventory_uuid
+    JOIN inventory_unit iu ON iu.id = i.unit_id
+    JOIN depot d ON d.uuid = m.depot_uuid
+    JOIN depot_permission dp ON m.depot_uuid = dp.depot_uuid
+    JOIN flux f ON f.id = m.flux_id
+    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+  `;
 
   return getLots(sql, params, finalClause);
 }
@@ -254,38 +254,38 @@ function getLotsOrigins(depotUuid, params) {
   }
 
   const sql = `
-        SELECT BUID(l.uuid) AS uuid, l.label, l.unit_cost, l.expiration_date,
-            BUID(l.inventory_uuid) AS inventory_uuid, BUID(l.origin_uuid) AS origin_uuid,
-            l.entry_date, i.code, i.text, origin.display_name, origin.reference,
-            BUID(m.document_uuid) AS document_uuid, m.flux_id,
-            iu.text AS unit_type,
-            dm.text AS documentReference
-        FROM lot l
-        JOIN inventory i ON i.uuid = l.inventory_uuid
-        JOIN inventory_unit iu ON iu.id = i.unit_id
-        JOIN (
-          SELECT
-            p.uuid, CONCAT_WS('.', '${identifiers.PURCHASE_ORDER.key}', proj.abbr, p.reference) AS reference,
-            'STOCK.PURCHASE_ORDER' AS display_name
-          FROM
-            purchase p JOIN project proj ON proj.id = p.project_id
-          UNION
-          SELECT
-            d.uuid, CONCAT_WS('.', '${identifiers.DONATION.key}', proj.abbr, d.reference) AS reference,
-            'STOCK.DONATION' AS display_name
-            FROM
-              donation d JOIN project proj ON proj.id = d.project_id
-          UNION
-          SELECT
-            i.uuid, CONCAT_WS('.', '${identifiers.INTEGRATION.key}', proj.abbr, i.reference) AS reference,
-            'STOCK.INTEGRATION' AS display_name
-            FROM
-              integration i JOIN project proj ON proj.id = i.project_id
-        ) AS origin ON origin.uuid = l.origin_uuid
-        JOIN stock_movement m ON m.lot_uuid = l.uuid AND m.is_exit = 0
-          AND m.flux_id IN (${flux.FROM_PURCHASE}, ${flux.FROM_DONATION}, ${flux.FROM_INTEGRATION})
-        LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
-    `;
+    SELECT BUID(l.uuid) AS uuid, l.label, l.unit_cost, l.expiration_date,
+        BUID(l.inventory_uuid) AS inventory_uuid, BUID(l.origin_uuid) AS origin_uuid,
+        l.entry_date, i.code, i.text, origin.display_name, origin.reference,
+        BUID(m.document_uuid) AS document_uuid, m.flux_id,
+        iu.text AS unit_type,
+        dm.text AS documentReference
+    FROM lot l
+    JOIN inventory i ON i.uuid = l.inventory_uuid
+    JOIN inventory_unit iu ON iu.id = i.unit_id
+    JOIN (
+      SELECT
+        p.uuid, CONCAT_WS('.', '${identifiers.PURCHASE_ORDER.key}', proj.abbr, p.reference) AS reference,
+        'STOCK.PURCHASE_ORDER' AS display_name
+      FROM
+        purchase p JOIN project proj ON proj.id = p.project_id
+      UNION
+      SELECT
+        d.uuid, CONCAT_WS('.', '${identifiers.DONATION.key}', proj.abbr, d.reference) AS reference,
+        'STOCK.DONATION' AS display_name
+        FROM
+          donation d JOIN project proj ON proj.id = d.project_id
+      UNION
+      SELECT
+        i.uuid, CONCAT_WS('.', '${identifiers.INTEGRATION.key}', proj.abbr, i.reference) AS reference,
+        'STOCK.INTEGRATION' AS display_name
+        FROM
+          integration i JOIN project proj ON proj.id = i.project_id
+    ) AS origin ON origin.uuid = l.origin_uuid
+    JOIN stock_movement m ON m.lot_uuid = l.uuid AND m.is_exit = 0
+      AND m.flux_id IN (${flux.FROM_PURCHASE}, ${flux.FROM_DONATION}, ${flux.FROM_INTEGRATION})
+    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+  `;
 
   return getLots(sql, params);
 }
@@ -531,7 +531,7 @@ function getInventoryMovements(params) {
       let stockValue = 0;
 
       // stock method CUMP : cout unitaire moyen pondere
-      const movements = bundle.movements.map((line) => {
+      const movements = bundle.movements.map(line => {
         const movement = {
           date : line.date,
           entry : { quantity : 0, unit_cost : 0, value : 0 },

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1760,9 +1760,6 @@ CREATE TABLE IF NOT EXISTS `voucher_item` (
   FOREIGN KEY (`voucher_uuid`) REFERENCES `voucher` (`uuid`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SET foreign_key_checks = 1;
-
-
 -- stock tables
 
 DROP TABLE IF EXISTS `flux`;
@@ -1779,6 +1776,7 @@ CREATE TABLE `lot` (
   `initial_quantity`  INT(11) NOT NULL DEFAULT 0,
   `quantity`          INT(11) NOT NULL DEFAULT 0,
   `unit_cost`         DECIMAL(19, 4) UNSIGNED NOT NULL,
+  `description`       TEXT,
   `expiration_date`   DATE NOT NULL,
   `inventory_uuid`    BINARY(16) NOT NULL,
   `origin_uuid`       BINARY(16) NOT NULL,
@@ -1928,3 +1926,5 @@ CREATE TABLE `config_rubric_item` (
   CONSTRAINT `config_rubric_item_ibfk_1` FOREIGN KEY (`config_rubric_id`) REFERENCES `config_rubric` (`id`),
   CONSTRAINT `config_rubric_item_ibfk_2` FOREIGN KEY (`rubric_payroll_id`) REFERENCES `rubric_payroll` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+SET foreign_key_checks = 1;

--- a/test/client-unit/services/StockEntryModalForm.spec.js
+++ b/test/client-unit/services/StockEntryModalForm.spec.js
@@ -1,0 +1,184 @@
+/* global inject, expect, chai */
+/* eslint no-unused-expressions:off, no-restricted-properties:off */
+describe('StockEntryModalForm', () => {
+  beforeEach(module('bhima.services'));
+
+  let StockForm;
+
+  beforeEach(inject(_StockEntryModalForm_ => {
+    StockForm = _StockEntryModalForm_;
+  }));
+
+  const clone = obj => JSON.parse(JSON.stringify(obj));
+
+  it('#constructor() sets up rows as an empty array', () => {
+    const form = new StockForm();
+    expect(form.rows).to.be.a('array');
+    expect(form.rows).to.have.length(0);
+  });
+
+  it('#constructor() calls validate() if rows are passed in as options', () => {
+    const spy = chai.spy(StockForm.prototype.validate);
+    StockForm.prototype.validate = spy;
+
+    const form = new StockForm({
+      rows : [{}, {}],
+    });
+
+    expect(spy).to.have.been.called.exactly(1);
+    expect(form.rows).to.have.length(2);
+  });
+
+  it('#addItem() should add an item to the rows array', () => {
+    const form = new StockForm();
+    form.addItem();
+    expect(form.rows).to.have.length(1);
+    form.addItem();
+    expect(form.rows).to.have.length(2);
+  });
+
+  it('#removeItem() should remove an item from the rows array at an index', () => {
+    const form = new StockForm();
+    form.addItem();
+    form.addItem();
+    form.addItem();
+
+    expect(form.rows).to.have.length(3);
+
+    // mock some identities
+    form.rows.forEach((row, index) => {
+      row.id = index;
+    });
+
+    // remove the last item
+    form.removeItem(2);
+
+    let lastItem = form.rows[form.rows.length - 1];
+    expect(lastItem.id).to.equal(1);
+
+    form.removeItem(0);
+    lastItem = form.rows[form.rows.length - 1];
+    expect(lastItem.id).to.equal(1);
+  });
+
+  it('#total() calculates the totals of all quantities', () => {
+    const form = new StockForm({
+      rows : [{ quantity : 15 }, { quantity : 25 }],
+    });
+
+    const total = 40;
+    const calculated = form.total();
+    expect(total).to.equal(calculated);
+  });
+
+  const sampleRow = {
+    expiration_date : new Date(),
+    lot : 1234,
+    quantity : 10,
+  };
+
+  it('#validate() will set isValid to true for a valid row', () => {
+    const form = new StockForm({
+      rows : [sampleRow],
+    });
+
+    form.validate();
+    const [row] = form.rows;
+    expect(row.isValid).to.equal(true);
+    expect(row._error).to.equal(null);
+  });
+
+  it('#validate() will detect an invalid lot number', () => {
+    const data = clone(sampleRow);
+    data.lot = null;
+
+    const form = new StockForm({ rows : [data] });
+    form.validate();
+    const [row] = form.rows;
+
+    expect(row.isValid).to.equal(false);
+    expect(row.isInvalid).to.equal(true);
+    expect(row._error).to.equal('STOCK.ERRORS.MISSING_LOT_NAME');
+  });
+
+  it('#validate() will detect an invalid quantity', () => {
+    const data = clone(sampleRow);
+    data.quantity = -100;
+
+    const form = new StockForm({ rows : [data] });
+    form.validate();
+    const [row] = form.rows;
+
+    expect(row.isValid).to.equal(false);
+    expect(row.isInvalid).to.equal(true);
+    expect(row._error).to.equal('STOCK.ERRORS.INVALID_LOT_QUANTITY');
+  });
+
+  it('#validate() will detect an invalid expiration date', () => {
+    const data = clone(sampleRow);
+
+    // set date in the past by a couple years
+    data.expiration_date = new Date(Date.now() - Math.pow(10, 11));
+
+    const form = new StockForm({ rows : [data], expires : true });
+    form.validate();
+    const [row] = form.rows;
+
+    expect(row.isValid).to.equal(false);
+    expect(row.isInvalid).to.equal(true);
+    expect(row._error).to.equal('STOCK.ERRORS.INVALID_LOT_EXPIRATION');
+  });
+
+  it('#validate() will detect an invalid expiration date', () => {
+    const data = clone(sampleRow);
+
+    // set date in the past by a couple years
+    data.expiration_date = new Date(Date.now() - Math.pow(10, 11));
+
+    const form = new StockForm({ rows : [data], expires : true });
+    form.validate();
+    const [row] = form.rows;
+
+    expect(row.isValid).to.equal(false);
+    expect(row.isInvalid).to.equal(true);
+    expect(row._error).to.equal('STOCK.ERRORS.INVALID_LOT_EXPIRATION');
+  });
+
+  it('#validate() will throw an error if there are no rows', () => {
+    const form = new StockForm();
+    const errors = form.validate();
+
+    expect(errors).to.deep.equal(['STOCK.ERRORS.NO_ROWS']);
+  });
+
+  it('#validate() returns an array of one or more errors', () => {
+    const first = clone(sampleRow);
+    const second = clone(sampleRow);
+    const third = clone(sampleRow);
+
+    // set date in the past by a couple years
+    first.expiration_date = new Date(Date.now() - Math.pow(10, 11));
+    third.quantity = -100;
+
+    const form = new StockForm({ rows : [first, second, third], expires : true });
+    const errors = form.validate();
+
+    const expectedErrors = [
+      'STOCK.ERRORS.INVALID_LOT_EXPIRATION',
+      'STOCK.ERRORS.INVALID_LOT_QUANTITY',
+    ];
+
+    expect(errors).to.deep.equal(expectedErrors);
+  });
+
+  it('#validate() will ignore expiration date if `expires` is false', () => {
+    const data = clone(sampleRow);
+    // set date in the past by a couple years
+    data.expiration_date = new Date(Date.now() - Math.pow(10, 11));
+
+    const form = new StockForm({ rows : [data], expires : false });
+    const errors = form.validate();
+    expect(errors).to.deep.equal([]);
+  });
+});
+

--- a/test/client-unit/services/StockEntryModalForm.spec.js
+++ b/test/client-unit/services/StockEntryModalForm.spec.js
@@ -82,7 +82,6 @@ describe('StockEntryModalForm', () => {
       rows : [sampleRow],
     });
 
-    form.validate();
     const [row] = form.rows;
     expect(row.isValid).to.equal(true);
     expect(row._error).to.equal(null);
@@ -93,7 +92,6 @@ describe('StockEntryModalForm', () => {
     data.lot = null;
 
     const form = new StockForm({ rows : [data] });
-    form.validate();
     const [row] = form.rows;
 
     expect(row.isValid).to.equal(false);
@@ -106,7 +104,6 @@ describe('StockEntryModalForm', () => {
     data.quantity = -100;
 
     const form = new StockForm({ rows : [data] });
-    form.validate();
     const [row] = form.rows;
 
     expect(row.isValid).to.equal(false);
@@ -121,7 +118,6 @@ describe('StockEntryModalForm', () => {
     data.expiration_date = new Date(Date.now() - Math.pow(10, 11));
 
     const form = new StockForm({ rows : [data], expires : true });
-    form.validate();
     const [row] = form.rows;
 
     expect(row.isValid).to.equal(false);
@@ -136,7 +132,6 @@ describe('StockEntryModalForm', () => {
     data.expiration_date = new Date(Date.now() - Math.pow(10, 11));
 
     const form = new StockForm({ rows : [data], expires : true });
-    form.validate();
     const [row] = form.rows;
 
     expect(row.isValid).to.equal(false);

--- a/test/end-to-end/patient/invoice/invoice.page.js
+++ b/test/end-to-end/patient/invoice/invoice.page.js
@@ -1,12 +1,11 @@
 /* global element, by */
-'use strict';
 
 const FU = require('../../shared/FormUtils');
 const GU = require('../../shared/GridUtils');
 
 const findPatient = require('../../shared/components/bhFindPatient');
 const dateEditor = require('../../shared/components/bhDateEditor');
-const addItem = require('../../shared/components/bhAddItem'); 
+const addItem = require('../../shared/components/bhAddItem');
 
 function PatientInvoicePage() {
   const page = this;

--- a/test/end-to-end/shared/components/bhAddItem.js
+++ b/test/end-to-end/shared/components/bhAddItem.js
@@ -4,14 +4,15 @@ const FU = require('../FormUtils');
 
 module.exports = {
   selector : '[bh-add-item]',
-  set      : function set(increment) {
+  set      : function set(increment, anchor) {
     // get the input and enter the increment provided
-    FU.input('$ctrl.itemIncrement', increment);
+    FU.input('$ctrl.itemIncrement', increment, anchor);
+
+    const btn = anchor ?
+      anchor.element(by.id('btn-add-rows')) :
+      element(by.id('btn-add-rows'));
 
     // submit the value
-    // var submit = element(by.id('btn-add-rows'));
-    // submit.click();
-    element(by.id('btn-add-rows')).click();
-
+    btn.click();
   },
 };

--- a/test/end-to-end/stock/stock.entry.page.js
+++ b/test/end-to-end/stock/stock.entry.page.js
@@ -130,7 +130,7 @@ function StockEntryPage() {
 
       if (index < lotsArray.length - 1) {
         // Add another lot line
-        $('[data-add-lot]').click();
+        components.addItem.set(1, $('[uib-modal-transclude]'));
       }
     });
 


### PR DESCRIPTION
This PR rewrites the Stock Entry modal so that it can be unit tested.  To that end, it moves a lot of code out of the controller and into a new service - `StockEntryModalForm`.  This service has a series of unit tests to make sure that lots are properly set and initialized.

Some other relevant changes:
 1. A description field has been added to the database, though the logic for entering descriptions is not implemented yet.  Partially responds to #2680.
 2. The button has been swapped out with the [bhAddItem](https://github.com/IMA-WorldHealth/bhima-2.X/blob/master/client/src/js/components/bhAddItem.js) component.
 3. A line can only have a single error at a time, though multiple lines with different errors will list them at the bottom of the modal.
