### PR TITLE
feat(role management) assign actions to roles

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -233,6 +233,7 @@
             "ON": "On",
             "BY_ID": "By Id",
             "BY_NAME": "By Name",
+            "CAN_EDIT_ROLES" : "Editing roles possibility",
             "CANCEL": "Cancel",
             "CANCELED": "Canceled",
             "CHARACTERISTICS": "Characteristics",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -273,6 +273,7 @@
             "CURRENCIES": "Monnaies",
             "CURRENCY": "Monnaie",
             "CURRENT_LOCATION": "Localisation actuelle",
+            "CAN_EDIT_ROLES" : "Possibilité d'éditer le rôle",
             "DAILY_SALARY": "Salaire Journalier",
             "DATE": "Date",
             "DATE_CREATED": "Date de création",

--- a/client/src/js/components/bhLoadingButton.js
+++ b/client/src/js/components/bhLoadingButton.js
@@ -4,7 +4,7 @@ angular.module('bhima.components')
   template   :
     '<button type="submit" class="btn" ng-class="$ctrl.buttonClass" ng-disabled="$ctrl.loadingState || $ctrl.disabled" data-method="submit">' +
       '<span ng-show="$ctrl.loadingState"><span class="fa fa-circle-o-notch fa-spin"></span> <span translate>FORM.INFO.LOADING</span></span>' +
-      '<span ng-hide="$ctrl.loadingState" ng-transclude translate>FORM.BUTTONS.SUBMIT</span>' +
+      '<span ng-hide="$ctrl.loadingState" ng-transclude><span translate>FORM.BUTTONS.SUBMIT</span></span>' +
     '</button>',
   controller : LoadingButtonController,
   bindings   : {

--- a/client/src/js/constants/bhConstants.js
+++ b/client/src/js/constants/bhConstants.js
@@ -10,6 +10,9 @@ function constantConfig() {
   var JOURNAL_UTIL_HEIGHT = '150px';
 
   return {
+    actions : {
+      CAN_EDIT_ROLES : 1,
+    },
     accounts : {
       ROOT  : 0,
       ASSET : 1,
@@ -119,8 +122,8 @@ function constantConfig() {
     },
     defaultFilters : [
       { key : 'period', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
-      { key : 'custom_period_start', label : 'PERIODS.START', comparitor: '>', valueFilter : 'date' },
-      { key : 'custom_period_end', label : 'PERIODS.END', comparitor: '<', valueFilter : 'date' },
+      { key : 'custom_period_start', label : 'PERIODS.START', comparitor : '>', valueFilter : 'date' },
+      { key : 'custom_period_end', label : 'PERIODS.END', comparitor : '<', valueFilter : 'date' },
       { key : 'limit', label : 'FORM.LABELS.LIMIT' }],
     weekDays : [
       { id : 0, label : 'FORM.LABELS.WEEK_DAYS.SUNDAY' },

--- a/client/src/modules/roles/modal/roleActions.html
+++ b/client/src/modules/roles/modal/roleActions.html
@@ -1,0 +1,31 @@
+<div class="modal-header">
+    <ol class="headercrumb">
+      <li class="static" translate>FORM.BUTTONS.ACTIONS</li>
+      <li class="title">
+        <span translate>{{RoleActionsCtrl.role.label}}</span>
+      </li>
+    </ol>
+</div>
+<div class="modal-body">
+
+  <div class="row">
+    <div class="col-lg-12">
+      <ul class="list-group">
+        <li  class="list-group-item" ng-repeat="action in RoleActionsCtrl.actions">
+          <label class="radio-inline">
+            <input type='checkbox' ng-model='action.affected' ng-true-value="1" ng-false-value="0" />
+            <span id="{{action.id}}" translate>{{action.description}}</span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div class="modal-footer text-right">
+  <button type="button" class='btn btn-default' ng-click='RoleActionsCtrl.close()' translate>FORM.BUTTONS.CLOSE</button>
+ 
+  <button data-method="submit" type="button" class="btn btn-primary" ng-click="RoleActionsCtrl.assignActionToRole()">
+      <span translate>FORM.BUTTONS.SAVE</span>
+  </button>
+</div>

--- a/client/src/modules/roles/modal/roleActions.html
+++ b/client/src/modules/roles/modal/roleActions.html
@@ -1,4 +1,6 @@
-<div class="modal-header">
+<form name="RoleActionForm" bh-submit="RoleActionsCtrl.assignActionToRole()">
+  <div class="modal-header">
+
     <ol class="headercrumb">
       <li class="static" translate>FORM.BUTTONS.ACTIONS</li>
       <li class="title">
@@ -24,8 +26,6 @@
 
 <div class="modal-footer text-right">
   <button type="button" class='btn btn-default' ng-click='RoleActionsCtrl.close()' translate>FORM.BUTTONS.CLOSE</button>
- 
-  <button data-method="submit" type="button" class="btn btn-primary" ng-click="RoleActionsCtrl.assignActionToRole()">
-      <span translate>FORM.BUTTONS.SAVE</span>
-  </button>
+  <bh-loading-button loading-state="RoleActionForm.$loading"></bh-loading-button>
 </div>
+</form>

--- a/client/src/modules/roles/modal/roles.actions.js
+++ b/client/src/modules/roles/modal/roles.actions.js
@@ -1,0 +1,46 @@
+angular.module('bhima.controllers').controller('RoleActionsController', RoleActionsController);
+RoleActionsController.$inject = [
+  'data', '$uibModal', '$uibModalInstance',
+  'RolesService', 'SessionService', 'NotifyService',
+];
+
+function RoleActionsController(data, $uibModal, $uibModalInstance, RolesService, session, Notify) {
+  const vm = this;
+  vm.close = close;
+  vm.role = angular.copy(data);
+  vm.loadRoles = loadRoles;
+  vm.assignActionToRole = assignActionToRole;
+  vm.actions = [];
+
+  // loa all roles
+  function loadRoles() {
+    RolesService.actions(vm.role.uuid)
+      .then(response => {
+        vm.actions = response.data;
+      })
+      .catch(Notify.handleError);
+  }
+
+  // assigned actions to a role
+  function assignActionToRole() {
+    const ids = vm.actions
+      .filter(action => action.affected === 1)
+      .map(action => action.id);
+
+    const param = {
+      role_uuid : vm.role.uuid,
+      action_ids : [...ids],
+    };
+    RolesService.assignActions(param)
+      .then(() => {
+        Notify.success('FORM.INFO.OPERATION_SUCCESS');
+        vm.close();
+      }).catch(Notify.handleError);
+  }
+
+  function close() {
+    $uibModalInstance.close();
+  }
+
+  vm.loadRoles();
+}

--- a/client/src/modules/roles/modal/userRole.html
+++ b/client/src/modules/roles/modal/userRole.html
@@ -1,3 +1,4 @@
+<form name="RolesForm" bh-submit=" UsersRolesCtrl.assignRolesToUser()">
 <div class="modal-header">
     <ol class="headercrumb">
       <li class="static" translate>FORM.LABELS.ROLES_FOR</li>
@@ -25,9 +26,7 @@
 <div class="modal-footer">
   <div class=" pull-right">
   <button type="button" class='btn inverse' ng-click='UsersRolesCtrl.close()' translate>FORM.BUTTONS.CLOSE</button>
- 
-  <button data-method="submit" type="button" class="btn btn-primary" ng-click="UsersRolesCtrl.assignRolesToUser()">
-      <span translate>FORM.BUTTONS.SAVE</span>
-    </button>
+  <bh-loading-button loading-state="RolesForm.$loading"></bh-loading-button>
   </div>
 </div>
+</form>

--- a/client/src/modules/roles/roles.ctrl.js
+++ b/client/src/modules/roles/roles.ctrl.js
@@ -2,13 +2,15 @@ angular.module('bhima.controllers')
   .controller('RolesController', RolesController);
 
 RolesController.$inject = [
-  '$uibModal', 'RolesService', 'SessionService', 'ModalService', 'NotifyService',
+  '$uibModal', 'RolesService', 'SessionService',
+  'ModalService', 'NotifyService', 'bhConstants',
 ];
 
-function RolesController($uibModal, RolesService, session, Modal, Notify) {
+function RolesController($uibModal, RolesService, session, Modal, Notify, bhConstants) {
   const vm = this;
   vm.loadRoles = loadRoles;
   vm.loading = false;
+  vm.canEditRoles = false;
 
   vm.add = function add(role) {
     const _role = role || {
@@ -24,6 +26,18 @@ function RolesController($uibModal, RolesService, session, Modal, Notify) {
         data : function dataProvider() {
           return _role;
         },
+      },
+    });
+  };
+
+  vm.editActions = function editActions(role) {
+    $uibModal.open({
+      keyboard : false,
+      backdrop : 'static',
+      templateUrl : 'modules/roles/modal/roleActions.html',
+      controller : 'RoleActionsController as RoleActionsCtrl',
+      resolve : {
+        data : () => role,
       },
     });
   };
@@ -58,8 +72,17 @@ function RolesController($uibModal, RolesService, session, Modal, Notify) {
       });
   };
 
+  function checkRoleEditonAllowability() {
+    RolesService.userHasAction(bhConstants.actions.CAN_EDIT_ROLES)
+      .then(response => {
+        vm.canEditRoles = response.data;
+      })
+      .catch(Notify.handleError);
+  }
+
   function loadRoles() {
     vm.loading = true;
+    checkRoleEditonAllowability();
     RolesService.list(session.project.id)
       .then(response => {
         vm.gridOptions.data = response.data;

--- a/client/src/modules/roles/roles.html
+++ b/client/src/modules/roles/roles.html
@@ -5,7 +5,7 @@
       <li class="title" translate>TREE.ROLE_MANAGEMENT</li>
     </ol>
     
-    <div class="toolbar">
+    <div class="toolbar" ng-show="RolesCtrl.canEditRoles">
       <div class="toolbar-item">
         <button data-method="add" class="btn btn-default text-capitalize" ng-click="RolesCtrl.add()" data-method="create">
           <span class="fa fa-plus"></span>

--- a/client/src/modules/roles/roles.service.js
+++ b/client/src/modules/roles/roles.service.js
@@ -35,6 +35,21 @@ function RolesService(Api) {
     return service.$http.get(url);
   };
 
+  service.actions = function actions(roleUuid) {
+    const url = '/roles/actions/'.concat(roleUuid);
+    return service.$http.get(url);
+  };
+
+  service.assignActions = function actions(data) {
+    const url = `/roles/actions`;
+    return service.$http.post(url, data);
+  };
+
+  service.userHasAction = function userHasAction(actionId) {
+    const url = '/roles/actions/user/'.concat(actionId);
+    return service.$http.get(url);
+  };
+
   function affectPages(data) {
     return service.$http.post('/roles/affectUnits', data);
   }

--- a/client/src/modules/roles/templates/action.tmpl.html
+++ b/client/src/modules/roles/templates/action.tmpl.html
@@ -1,4 +1,4 @@
-<div class="ui-grid-cell-contents text-right"
+<div class="ui-grid-cell-contents text-right" ng-show="grid.appScope.canEditRoles"
   uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
 
   <a href>
@@ -16,6 +16,11 @@
     <li>
       <a data-method="edit_permissions" ng-click="grid.appScope.pages(row.entity)" href>
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT_PERMISSIONS</span>
+      </a>
+    </li>
+    <li>
+      <a data-method="edit" ng-click="grid.appScope.editActions(row.entity)" href>
+        <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.ACTIONS</span>
       </a>
     </li>
     <li class="divider"></li>

--- a/client/src/modules/roles/templates/action.tmpl.html
+++ b/client/src/modules/roles/templates/action.tmpl.html
@@ -19,7 +19,7 @@
       </a>
     </li>
     <li>
-      <a data-method="edit" ng-click="grid.appScope.editActions(row.entity)" href>
+      <a data-method="edit_actions" ng-click="grid.appScope.editActions(row.entity)" href>
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.ACTIONS</span>
       </a>
     </li>

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jeremielodi"
   ],
   "dependencies": {
-    "@ima-worldhealth/topic": "^1.0.0",
+    "@ima-worldhealth/topic": "^1.0.1",
     "@types/angular": "^1.6.41",
     "accounting-js": "^1.1.1",
     "body-parser": "^1.15.0",

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -707,13 +707,16 @@ exports.configure = function configure(app) {
   // roles
   app.get('/roles', rolesCtrl.list);
   app.get('/roles/:uuid', rolesCtrl.detail);
+  app.get('/roles/actions/:roleUuid', rolesCtrl.rolesAction);
+  app.get('/roles/actions/user/:action_id', rolesCtrl.hasAction);
+  app.get('/roles/user/:user_id/:project_id', rolesCtrl.listForUser);
   app.post('/roles', rolesCtrl.create);
   app.put('/roles/:uuid', rolesCtrl.update);
   app.delete('/roles/:uuid', rolesCtrl.remove);
 
   app.post('/roles/affectUnits', rolesCtrl.affectPages);
   app.post('/roles/assignTouser', rolesCtrl.affectToUser);
-  app.get('/roles/user/:user_id/:project_id', rolesCtrl.listForUser);
+  app.post('/roles/actions', rolesCtrl.assignActionToRole);
   // unit
   app.get('/unit/:roleUuid', unitCtrl.list);
 

--- a/server/controllers/admin/roles.js
+++ b/server/controllers/admin/roles.js
@@ -115,7 +115,7 @@ function affectPages(req, res, next) {
 }
 
 
-// retireves affected and not affected role by a user id
+// retrieves affected and not affected role by a user id
 function listForUser(req, res, next) {
   const userId = req.params.user_id;
   const projectId = req.params.project_id;

--- a/server/models/bhima.sql
+++ b/server/models/bhima.sql
@@ -173,6 +173,12 @@ INSERT INTO `flux` VALUES
   (12, 'STOCK_FLUX.TO_ADJUSTMENT'),
   (13, 'STOCK_FLUX.FROM_INTEGRATION');
 
+-- Roles Actions
+
+INSERT INTO `actions`(`id`, `description`) VALUES
+  (1, 'FORM.LABELS.CAN_EDIT_ROLES');
+
+
 -- transaction type
 INSERT INTO `purchase_status` (`id`, `text`) VALUES
   (1,  'PURCHASES.STATUS.WAITING_CONFIRMATION'),

--- a/server/models/procedures/roles.sql
+++ b/server/models/procedures/roles.sql
@@ -15,5 +15,8 @@ BEGIN
 
     INSERT INTO user_role(uuid, user_id, role_uuid) 
     VALUES(HUID(uuid()), user_id, roleUUID);
+
+    INSERT INTO role_actions(uuid, role_uuid, actions_id)
+    SELECT HUID(uuid()) as uuid, roleUUID, id FROM actions;
 END$$
 DELIMITER ;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -230,6 +230,8 @@ CREATE TABLE `weekend_config` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
+
+
 DROP TABLE IF EXISTS `config_week_days`;
 CREATE TABLE `config_week_days` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -1677,6 +1679,22 @@ CREATE TABLE `role` (
   FOREIGN KEY (`project_id`) REFERENCES `project` (`id`) ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+
+DROP TABLE IF EXISTS `actions`;
+CREATE TABLE `actions` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `description` VARCHAR(100) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `role_actions` (
+  `uuid` binary(16) NOT NULL,
+  `role_uuid` binary(16) NOT NULL,
+  `actions_id`int(10) unsigned NOT NULL,
+  PRIMARY KEY (`uuid`),
+  FOREIGN KEY (`actions_id`) REFERENCES `actions` (`id`) ON UPDATE CASCADE,
+  FOREIGN KEY (`role_uuid`) REFERENCES `role` (`uuid`) ON UPDATE CASCADE  ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `user_role`;
 CREATE TABLE `user_role` (

--- a/test/data.sql
+++ b/test/data.sql
@@ -832,6 +832,10 @@ VALUES(@roleUUID, 'Admin', 1), (@regularRoleUUID, 'Regular', 1);
 -- superuser
 INSERT INTO role_unit
  SELECT HUID(uuid()) as uuid,@roleUUID, id FROM unit;
+-- actions
+INSERT INTO role_actions
+SELECT HUID(uuid()) as uuid, @roleUUID, id FROM actions;
+
 
 INSERT INTO `user_role`(uuid, user_id, role_uuid) 
 VALUES(HUID(uuid()), 1, @roleUUID);

--- a/test/end-to-end/user/roles.page.js
+++ b/test/end-to-end/user/roles.page.js
@@ -20,6 +20,8 @@ function RolesPage() {
   page.dismissNotification = dismissNotification;
   page.assignRole = assignRole;
   page.setRole = setRole;
+  page.assignActions = assignActions;
+  page.setAction = setAction;
 
   const actionLinkColumn = 1;
   //  label field in the create/edit modal
@@ -55,8 +57,17 @@ function RolesPage() {
   function assignRole(n) {
     GA.clickOnMethod(n, 2, 'assign_roles', 'users-grid');
   }
+
+  function assignActions(n) {
+    return GA.clickOnMethod(n, actionLinkColumn, 'edit_actions', gridId);
+  }
+
   function setRole(txt) {
     return element(by.css(`[title="${txt}"]`)).click();
+  }
+
+  function setAction(id) {
+    return element(by.css(`[id="${id}"]`)).click();
   }
 
   function openCreateModal() {

--- a/test/end-to-end/user/roles.spec.js
+++ b/test/end-to-end/user/roles.spec.js
@@ -4,9 +4,8 @@ const components = require('../shared/components');
 
 // the page object
 const page = new RolesPage();
-
+const canEditRoleAction = 1;
 function RolesManagementTests() {
-
   // navigate to the page
   before(() => helpers.navigate('#/roles'));
 
@@ -45,6 +44,13 @@ function RolesManagementTests() {
     page.deleteRole(3);
     page.submit();
   });
+
+  it(`Shoud assign an action to a role`, () => {
+    page.assignActions(2);
+    page.setAction(canEditRoleAction);
+    page.submit();
+    components.notification.hasSuccess();
+  });
 }
 
 function assigningRole() {
@@ -59,5 +65,8 @@ function assigningRole() {
   });
 }
 
-describe('Role management Test', RolesManagementTests);
-describe('Role management assigning role', assigningRole);
+
+describe('Role management Test', () => {
+  describe('Role management', RolesManagementTests);
+  describe('Role assignment', assigningRole);
+});

--- a/test/integration/role.js
+++ b/test/integration/role.js
@@ -14,6 +14,7 @@ describe('(/roles) The roles API endpoint', () => {
     project_id : 1,
   };
   const adminUuid = '5b7dd0d6-9273-4955-a703-126fbd504b61';
+  const canEditRoleAction = 1;
   const roleAdmin = {
     label : 'Administrator',
   };
@@ -22,6 +23,10 @@ describe('(/roles) The roles API endpoint', () => {
     role_uuids : adminUuid,
   };
 
+  const actions = {
+    role_uuid : adminUuid,
+    action_ids : [1],
+  };
   it('GET /roles returns a list of roles', () => {
     return agent.get('/roles')
       .query(roles)
@@ -57,6 +62,42 @@ describe('(/roles) The roles API endpoint', () => {
       .send(userRole)
       .then((res) => {
         expect(res).to.have.status(201);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /roles/actions/:roleUuid Should retrieve all assigned and unassigned actions to a role', () => {
+    return agent.get('/roles/actions/'.concat(adminUuid))
+      .then((res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.not.be.empty;
+      })
+      .catch(helpers.handler);
+  });
+
+
+  it('GET /roles/actions/user/:action_id Should test if a action is assigned to the connected user', () => {
+    return agent.get('/roles/actions/user/'.concat(canEditRoleAction))
+      .then((res) => {
+        expect(res.body).to.be.equal(true);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('POST /roles/actions assingning actions to a role', () => {
+    return agent.post('/roles/actions')
+      .send(actions)
+      .then((res) => {
+        expect(res).to.have.status(201);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /roles/user/:user_id/:project_id Should test if a action is assigned to the connected user', () => {
+    return agent.get('/roles/user/1/1')
+      .then((res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.not.be.empty;
       })
       .catch(helpers.handler);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6420,7 +6420,7 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
 
-path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
+path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 


### PR DESCRIPTION
The role management module allow us to assign just permissions to particular pages but not their actions.
Some actions can be sensitives so we should be able to manage them.
This PR tries to solve that problem