### PR TITLE
ci: bail protractor on errors

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -24,6 +24,7 @@ const config = {
       clearOldScreenshots  : true,
       jsonReport           : false,
     },
+    // bail : true,
     timeout : 30000,
   },
 
@@ -76,6 +77,7 @@ if (process.env.TRAVIS_BUILD_NUMBER) {
       takePassedScreenshot : false,
       clearOldScreenshots  : true,
     },
+    bail : true,
     timeout : 30000,
   };
 }


### PR DESCRIPTION
This commit makes protractor bail on errors to reduce time spent testing.