### PR TITLE
fix(invoice): use invoicing fees

### DIFF
--- a/client/src/modules/invoices/templates/grid/code.tmpl.html
+++ b/client/src/modules/invoices/templates/grid/code.tmpl.html
@@ -3,6 +3,7 @@
     <!-- TODO Design and implement custom typeahead template -->
     <input
       class="form-control"
+      autocomplete="off"
       ng-model="row.entity.inventory_uuid"
       typeahead-editable="false"
       typeahead-append-to-body="true"

--- a/client/src/modules/templates/bhFindPatient.tmpl.html
+++ b/client/src/modules/templates/bhFindPatient.tmpl.html
@@ -32,6 +32,7 @@
         ng-if="$ctrl.selected == $ctrl.options.findById"
         ng-keypress="$ctrl.onKeyPress($event)"
         translate-attr="{ 'placeholder': '{{$ctrl.selected.placeholder}}' }"
+        autocomplete="off"
         ng-required="$ctrl.required">
 
       <!-- search by Name  -->
@@ -48,6 +49,7 @@
         typeahead-template-url="/modules/templates/patientList.tmpl.html"
         typeahead-on-select="$ctrl.submit($item)"
         translate-attr="{ 'placeholder': '{{$ctrl.selected.placeholder}}' }"
+        autocomplete="off"
         ng-required="$ctrl.required">
 
       <!-- submit button for search by ID -->

--- a/test/integration/patientInvoice.js
+++ b/test/integration/patientInvoice.js
@@ -1,3 +1,4 @@
+/* eslint no-unused-expressions:"off" */
 /* global expect, agent */
 
 const helpers = require('./helpers');
@@ -284,8 +285,8 @@ function InvoicingFeeScenario() {
         // ensure the data in the database is correct
         const invoice = res.body;
 
-        // this is the invoice cost ($100) + 20% ($20) of billing service
-        expect(invoice.cost).to.equal(100);
+        // this is the invoice cost ($100) + 20% ($20) of invoicing fee
+        expect(invoice.cost).to.equal(120);
         expect(invoice.items).to.have.length(2);
       })
       .catch(helpers.handler);


### PR DESCRIPTION
During a name change, we accidentally started ignoring invoicing fees in our invoicing procedures.  This corrects the mistake and updates all names to be "invoicing fees" from "billing services".  It also updates
the tests to reflect these changes.