### PR TITLE
feact(xlsx report)Remove the need for res.xls() to send an XLS file

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -10,7 +10,7 @@ DB_NAME='bhima_test'
 # session variables
 SESS_SECRET='XopEn BlowFISH'
 
-DEBUG=app
+DEBUG=errors
 
 UPLOAD_DIR='client/upload'
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "helmet": "^3.8.0",
     "ioredis": "^3.1.2",
     "json-2-csv": "^2.1.0",
-    "json2xls": "^0.1.2",
     "lodash": "^4.16.2",
     "lzma-native": "^3.0.4",
     "mailgun-js": "^0.18.0",

--- a/server/app.js
+++ b/server/app.js
@@ -21,10 +21,6 @@
  * @copyright IMA World Health 2016
  */
 
-// json2xls has a strict-mode octal error in underlying modules.
-// Workaround - required before 'use-strict'
-const json2xls = require('json2xls');
-
 require('use-strict');
 const dotEnv = require('dotenv');
 
@@ -35,11 +31,6 @@ const express = require('express');
 const debug = require('debug')('app');
 
 const app = express();
-/*
-  * json2xls middelware used to send xlsx file as http response
-  *example : res.xls('data.xlsx', jsonArray);
-*/
-app.use(json2xls.middleware);
 
 /**
  * @function configureEnvironmentVariables

--- a/server/controllers/finance/reports/account_statement/index.js
+++ b/server/controllers/finance/reports/account_statement/index.js
@@ -9,7 +9,6 @@
 const _ = require('lodash');
 const db = require('../../../../lib/db');
 const ReportManager = require('../../../../lib/ReportManager');
-const util = require('../../../../lib/util');
 const generalLedger = require('../../generalLedger');
 
 const REPORT_TEMPLATE = './server/controllers/finance/reports/account_statement/report.handlebars';
@@ -66,11 +65,7 @@ function report(req, res, next) {
       });
     })
     .then((result) => {
-      if (result.headers.type === 'xlsx') {
-        res.xls(result.headers.filename, util.dateFormatter(result.report.rows));
-      } else {
-        res.set(result.headers).send(result.report);
-      }
+      res.set(result.headers).send(result.report);
     })
     .catch(next)
     .done();

--- a/server/controllers/finance/reports/accounts/index.js
+++ b/server/controllers/finance/reports/accounts/index.js
@@ -39,11 +39,7 @@ function chart(req, res, next) {
     .then(Accounts.processAccountDepth)
     .then(accounts => report.render({ accounts }))
     .then(result => {
-      if (result.headers.type === 'xlsx') {
-        res.xls(result.headers.filename, result.report.accounts);
-      } else {
-        res.set(result.headers).send(result.report);
-      }
+      res.set(result.headers).send(result.report);
     })
     .catch(next)
     .done();

--- a/server/controllers/finance/reports/generalLedger/index.js
+++ b/server/controllers/finance/reports/generalLedger/index.js
@@ -69,11 +69,7 @@ function renderReport(req, res, next) {
       return report.render(data);
     })
     .then((result) => {
-      if (result.headers.type === 'xlsx') {
-        res.xls(result.headers.filename, result.report.rows);
-      } else {
-        res.set(result.headers).send(result.report);
-      }
+      res.set(result.headers).send(result.report);
     })
     .catch(next)
     .done();

--- a/server/controllers/finance/reports/journal/index.js
+++ b/server/controllers/finance/reports/journal/index.js
@@ -10,7 +10,6 @@ const _ = require('lodash');
 const ReportManager = require('../../../../lib/ReportManager');
 const db = require('../../../../lib/db');
 const Journal = require('../../journal');
-const util = require('../../../../lib/util');
 
 const REPORT_TEMPLATE = './server/controllers/finance/reports/journal/report.handlebars';
 
@@ -22,6 +21,13 @@ exports.postingReport = postingJournalExport;
  * @method postingJournalExport
  */
 function postingJournalExport(req, res, next) {
+
+  /*
+   theses below properties are used for rename the result keys
+    some time export report with the database columns' labels
+    whitch is not understandable for the end user
+  */
+
   const options = _.extend(req.query, {
     filename                 : 'POSTING_JOURNAL.TITLE',
     orientation              : 'landscape',
@@ -58,11 +64,7 @@ function postingJournalExport(req, res, next) {
       return report.render({ rows, totals });
     })
     .then((result) => {
-      if (result.headers.type === 'xlsx') {
-        res.xls(result.headers.filename, util.dateFormatter(result.report.rows));
-      } else {
-        res.set(result.headers).send(result.report);
-      }
+      res.set(result.headers).send(result.report);
     })
     .catch(next)
     .done();

--- a/server/controllers/finance/reports/journal/index.js
+++ b/server/controllers/finance/reports/journal/index.js
@@ -22,12 +22,6 @@ exports.postingReport = postingJournalExport;
  */
 function postingJournalExport(req, res, next) {
 
-  /*
-   theses below properties are used for rename the result keys
-    some time export report with the database columns' labels
-    whitch is not understandable for the end user
-  */
-
   const options = _.extend(req.query, {
     filename                 : 'POSTING_JOURNAL.TITLE',
     orientation              : 'landscape',

--- a/server/lib/ReportManager.js
+++ b/server/lib/ReportManager.js
@@ -149,7 +149,6 @@ class ReportManager {
 
       const renderHeaders = renderer.headers;
       const report = reportStream;
-
       if (this.options.filename) {
         const translate = translateHelper(this.options.lang);
         const translatedName = translate(this.options.filename);

--- a/server/lib/renderers/xlsx.js
+++ b/server/lib/renderers/xlsx.js
@@ -47,7 +47,7 @@ function render(data) {
 
   const normaFontSize = {
     font : {
-      size : 12,
+      size : 10,
     },
   };
   const borderInfo = {
@@ -65,14 +65,16 @@ function render(data) {
   };
   // Add Worksheets to the workbook
   const ws = wb.addWorksheet('Sheet 1');
-  const { rows } = data;
+  let { rows } = data;
+  rows = rows || [];
   const firstObject = rows[0] || {};
 
   // writing columns
   const firstLineCols = Object.keys(firstObject);
   let line = 1;
   firstLineCols.forEach((key, index) => {
-    ws.cell(line, index + 1).string(key)
+    ws.cell(line, index + 1)
+      .string(key)
       .style(headerStryle)
       .style(styleAllBorders);
   });
@@ -101,5 +103,5 @@ function setValue(ws, x, y, value) {
       numberFormat : 'yyyy-mm-dd hh:mm:ss',
     });
   }
-  return ws.cell(x, y).string(''.concat(value || ''));
+  return ws.cell(x, y).string(value || '');
 }

--- a/server/lib/renderers/xlsx.js
+++ b/server/lib/renderers/xlsx.js
@@ -3,34 +3,103 @@
  *
  * @description
  * This library is just a shim to ensure API uniformity with other renderers.
- * The core functionality is identical to the JSON renderer.
- *
+ * it renders an Excel report(from data.rows that we pass as render function param).
+ * Having the same data structure will help to have less xlsx rendereres
  * @module lib/renderers/xlsx
  *
  * @requires q
  */
-
-const q = require('q');
+const xl = require('excel4node');
+const _ = require('lodash');
 
 const headers = {
-  'Content-Type' : 'application/xlsx',
-  type : 'xlsx',
+  'Content-Type' : 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 };
 
-exports.render = renderXLSX;
+exports.render = render;
 exports.extension = '.xlsx';
 exports.headers = headers;
 
 /**
- * JSON Render Method
- * @param {Object} data      Contains data in any format that will be used to
- *                            drive the final report - this will be exposed to
- *                            the view by the renderer.
- * @param {Object} options   (Optional) parameters that can be passed to switch
- *                            render features on/off.
- * @returns {Object}          JSON Object representing a report that can be sent
- *                            to the client.
+ * XLSX Render Method
+ * @param {Object} data   { rows : []}
  */
-function renderXLSX(data) {
-  return q.resolve(data);
+
+function render(data) {
+
+
+  // Create a new instance of a Workbook class
+  const wb = new xl.Workbook();
+
+  // style applied to cells
+  const headerStryle = wb.createStyle({
+    font : {
+      color : '#ffffff',
+      size : 12,
+      bold : true,
+    },
+    fill : {
+      type : 'pattern',
+      patternType : 'solid',
+      fgColor : '2384F5',
+    },
+  });
+
+  const normaFontSize = {
+    font : {
+      size : 12,
+    },
+  };
+  const borderInfo = {
+    style : 'thin',
+    color : '#000000',
+  };
+
+  const styleAllBorders = {
+    border : {
+      bottom : borderInfo,
+      left : borderInfo,
+      top : borderInfo,
+      right : borderInfo,
+    },
+  };
+  // Add Worksheets to the workbook
+  const ws = wb.addWorksheet('Sheet 1');
+  const { rows } = data;
+  const firstObject = rows[0] || {};
+
+  // writing columns
+  const firstLineCols = Object.keys(firstObject);
+  let line = 1;
+  firstLineCols.forEach((key, index) => {
+    ws.cell(line, index + 1).string(key)
+      .style(headerStryle)
+      .style(styleAllBorders);
+  });
+  line++;
+
+  // writing rows
+  rows.forEach((row) => {
+    firstLineCols.forEach((key, index) => {
+      setValue(ws, line, index + 1, row[key])
+        .style(styleAllBorders)
+        .style(normaFontSize);
+    });
+    line++;
+  });
+  return wb.writeToBuffer();
+}
+
+// set value to a paticular cell
+function setValue(ws, x, y, value) {
+  if (_.isNumber(value)) {
+    return ws.cell(x, y).number(value);
+  }
+
+  if (_.isDate(value)) {
+    return ws.cell(x, y).date(value).style({
+      numberFormat : 'yyyy-mm-dd hh:mm:ss',
+    });
+  }
+  return ws.cell(x, y).string(''.concat(value || ''));
 }

--- a/test/server-unit/xlsx.js
+++ b/test/server-unit/xlsx.js
@@ -1,0 +1,33 @@
+const xlsx = require('../../server/lib/renderers/xlsx');
+
+const { expect } = require('chai');
+const _ = require('lodash');
+
+describe('util.js', () => {
+
+  it('Shoul return a xlsx buffer', (done) => {
+    const data = {
+      rows : [{ Firstname : 'Alice', Lastname : 'Bob' }],
+    };
+    xlsx.render(data)
+      .then(reportStream => {
+        expect(_.isBuffer(reportStream)).to.be.equal(true);
+        done();
+      })
+      .catch((error) => {
+        done(error);
+      });
+  });
+
+  it('Shoul works for an empty object', (done) => {
+    const data = {};
+    xlsx.render(data)
+      .then(reportStream => {
+        expect(_.isBuffer(reportStream)).to.be.equal(true);
+        done();
+      })
+      .catch((error) => {
+        done(error);
+      });
+  });
+});


### PR DESCRIPTION
This PR rewrire xlsx.js renderer, we were using json2excel that is why we were obliged to have res.xls() method in our code. Now we switch xlsx.js to excel4node witch is much better than json2excel.
closes #2723