### PR TITLE
feat(enterprise): disable record deletion

### DIFF
--- a/client/src/i18n/en/enterprise.json
+++ b/client/src/i18n/en/enterprise.json
@@ -13,7 +13,9 @@
       "ENABLE_PRICE_LOCK_LABEL" : "Lock Price Changes for Patient Invoicing",
       "ENABLE_PRICE_LOCK_HELP_TEXT" : "Enabling this feature will disallow users from modifying the prices of inventory items in the Patient Invoice module.",
       "ENABLE_PREPAYMENTS_LABEL" : "Enable Cash Prepayments",
-      "ENABLE_PREPAYMENTS_HELP_TEXT" : "Enabling this feature allow patients to deposit funds with the institution at the cash window for future invoices.  If the patient has a creditor balance, their invoices will be automatically paid after invoicing."
+      "ENABLE_PREPAYMENTS_HELP_TEXT" : "Enabling this feature allow patients to deposit funds with the institution at the cash window for future invoices.  If the patient has a creditor balance, their invoices will be automatically paid after invoicing.",
+      "ENABLE_DELETE_RECORDS_LABEL" : "Enable Record Deletion from Registries",
+      "ENABLE_DELETE_RECORDS_HELP_TEXT" : "This feature allows users to delete transactions as an alternative to reversing transactions directly from the record registries."
     }
   }
 }

--- a/client/src/i18n/fr/enterprise.json
+++ b/client/src/i18n/fr/enterprise.json
@@ -13,7 +13,9 @@
       "ENABLE_PRICE_LOCK_LABEL" : "Verrouiller les changements de prix pour la facturation des patients",
       "ENABLE_PRICE_LOCK_HELP_TEXT" : "L'activation de cette fonctionnalité empêchera les utilisateurs de modifier les prix des articles en stock dans le module Facturation de Patients.",
       "ENABLE_PREPAYMENTS_LABEL" : "Activer les Cautions",
-      "ENABLE_PREPAYMENTS_HELP_TEXT" : "L'activation de cette fonctionnalité permet aux patients de déposer des fonds à la fenêtre de paiement avant d'être facturé. Si le patient a un solde créditeur, ses factures seront automatiquement payées après facturation."
+      "ENABLE_PREPAYMENTS_HELP_TEXT" : "L'activation de cette fonctionnalité permet aux patients de déposer des fonds à la fenêtre de paiement avant d'être facturé. Si le patient a un solde créditeur, ses factures seront automatiquement payées après facturation.",
+      "ENABLE_DELETE_RECORDS_LABEL" : "Activer la Suppression d'Enregistrements",
+      "ENABLE_DELETE_RECORDS_HELP_TEXT" : "Cette fonctionnalité permet aux utilisateurs de supprimer des transactions comme une alternative à l'inversion des transactions directement à partir des registres."
     }
   }
 }

--- a/client/src/modules/cash/payments/registry.js
+++ b/client/src/modules/cash/payments/registry.js
@@ -45,6 +45,8 @@ function CashPaymentRegistryController(
   vm.deleteCashPayment = deleteCashPaymentWithConfirmation;
   vm.download = Cash.download;
 
+  vm.allowsRecordDeletion = allowsRecordDeletion;
+
   columnDefs = [{
     field : 'reference',
     displayName : 'TABLE.COLUMNS.REFERENCE',
@@ -217,6 +219,10 @@ function CashPaymentRegistryController(
       .then((isOk) => {
         if (isOk) { remove(entity); }
       });
+  }
+
+  function allowsRecordDeletion() {
+    return Session.enterprise.settings.enable_delete_records;
   }
 
   startup();

--- a/client/src/modules/cash/payments/templates/action.cell.html
+++ b/client/src/modules/cash/payments/templates/action.cell.html
@@ -56,7 +56,7 @@
       </a>
     </li>
 
-    <li ng-hide="row.entity._hasCreditNote">
+    <li ng-hide="row.entity._hasCreditNote"  ng-if="grid.appScope.allowsRecordDeletion()">
       <a data-method="delete-record" href ng-click="grid.appScope.deleteCashPayment(row.entity)">
         <span class="text-danger"><i class="fa fa-trash"></i> <span translate>FORM.BUTTONS.DELETE_RECORD</span></span>
       </a>

--- a/client/src/modules/enterprises/enterprises.html
+++ b/client/src/modules/enterprises/enterprises.html
@@ -192,6 +192,13 @@
               help-text="ENTERPRISE.SETTINGS.ENABLE_PREPAYMENTS_HELP_TEXT"
               on-change-callback="EnterpriseCtrl.enablePrepaymentsSetting(value)">
             </bh-yes-no-radios>
+
+            <bh-yes-no-radios
+              label="ENTERPRISE.SETTINGS.ENABLE_DELETE_RECORDS_LABEL"
+              value="EnterpriseCtrl.enterprise.settings.enable_delete_records"
+              help-text="ENTERPRISE.SETTINGS.ENABLE_DELETE_RECORDS_HELP_TEXT"
+              on-change-callback="EnterpriseCtrl.enableDeleteRecordsSetting(value)">
+            </bh-yes-no-radios>
           </div>
         </div>
 

--- a/client/src/modules/enterprises/enterprises.js
+++ b/client/src/modules/enterprises/enterprises.js
@@ -28,6 +28,7 @@ function EnterpriseController(Enterprises, util, Notify, Projects, Modal, Scroll
   vm.onSelectLossAccount = onSelectLossAccount;
   vm.enablePriceLockSetting = enablePriceLockSetting;
   vm.enablePrepaymentsSetting = enablePrepaymentsSetting;
+  vm.enableDeleteRecordsSetting = enableDeleteRecordsSetting;
 
   // fired on startup
   function startup() {
@@ -174,6 +175,11 @@ function EnterpriseController(Enterprises, util, Notify, Projects, Modal, Scroll
 
   function enablePrepaymentsSetting(enabled) {
     vm.enterprise.settings.enable_prepayments = enabled;
+    $touched = true;
+  }
+
+  function enableDeleteRecordsSetting(enabled) {
+    vm.enterprise.settings.enable_delete_records = enabled;
     $touched = true;
   }
 

--- a/client/src/modules/invoices/registry/registry.js
+++ b/client/src/modules/invoices/registry/registry.js
@@ -37,6 +37,8 @@ function InvoiceRegistryController(
   // date format function
   vm.format = util.formatDate;
 
+  vm.allowsRecordDeletion = allowsRecordDeletion;
+
   // track if module is making a HTTP request for invoices
   vm.loading = false;
   vm.enterprise = Session.enterprise;
@@ -235,6 +237,10 @@ function InvoiceRegistryController(
       .then(isOk => {
         if (isOk) { remove(entity); }
       });
+  }
+
+  function allowsRecordDeletion() {
+    return Session.enterprise.settings.enable_delete_records;
   }
 
   // fire up the module

--- a/client/src/modules/invoices/registry/templates/action.cell.html
+++ b/client/src/modules/invoices/registry/templates/action.cell.html
@@ -59,7 +59,7 @@
       </a>
     </li>
 
-    <li ng-hide="row.entity.reversed">
+    <li ng-hide="row.entity.reversed" ng-if="grid.appScope.allowsRecordDeletion()">
       <a data-method="delete-record" href ng-click="grid.appScope.deleteInvoice(row.entity)">
         <span class="text-danger"><i class="fa fa-trash"></i> <span translate>FORM.BUTTONS.DELETE_RECORD</span></span>
       </a>

--- a/client/src/modules/vouchers/templates/action.cell.html
+++ b/client/src/modules/vouchers/templates/action.cell.html
@@ -27,10 +27,10 @@
       </a>
     </li>
 
-    <li class="divider"></li>
+    <li class="divider" ng-if="grid.appScope.allowRecordDeletion()"></li>
 
     <!-- delete voucher record -->
-    <li>
+    <li ng-if="grid.appScope.allowsRecordDeletion()">
       <a data-method="delete-record" href ng-click="grid.appScope.deleteVoucher(row.entity)">
         <span class="text-danger"><i class="fa fa-trash-o"></i> <span translate>FORM.BUTTONS.DELETE_RECORD</span></span>
       </a>

--- a/client/src/modules/vouchers/voucher-registry.ctrl.js
+++ b/client/src/modules/vouchers/voucher-registry.ctrl.js
@@ -5,6 +5,7 @@ VoucherController.$inject = [
   'VoucherService', 'NotifyService', 'uiGridConstants', 'ReceiptModal',
   'TransactionTypeService', 'bhConstants', 'GridSortingService',
   'GridColumnService', 'GridStateService', '$state', 'ModalService', 'util',
+  'SessionService',
 ];
 
 /**
@@ -17,7 +18,7 @@ VoucherController.$inject = [
  */
 function VoucherController(
   Vouchers, Notify, uiGridConstants, Receipts, TransactionTypes, bhConstants,
-  Sorting, Columns, GridState, $state, Modals, util
+  Sorting, Columns, GridState, $state, Modals, util, Session
 ) {
   const vm = this;
 
@@ -39,6 +40,8 @@ function VoucherController(
 
   // date format function
   vm.format = util.formatDate;
+
+  vm.allowsRecordDeletion = allowsRecordDeletion;
 
   vm.loading = false;
 
@@ -238,6 +241,10 @@ function VoucherController(
       .then(isOk => {
         if (isOk) { remove(entity); }
       });
+  }
+
+  function allowsRecordDeletion() {
+    return Session.enterprise.settings.enable_delete_records;
   }
 
   vm.showReceipt = Receipts.voucher;

--- a/server/controllers/admin/enterprises.js
+++ b/server/controllers/admin/enterprises.js
@@ -22,7 +22,8 @@ exports.list = function list(req, res, next) {
     sql = `
       SELECT id, name, abbr, email, po_box, phone,
         BUID(location_id) AS location_id, logo, currency_id,
-        gain_account_id, loss_account_id, enable_price_lock, enable_prepayments
+        gain_account_id, loss_account_id, enable_price_lock, enable_prepayments,
+        enable_delete_records
       FROM enterprise LEFT JOIN enterprise_setting
         ON enterprise.id = enterprise_setting.enterprise_id
       ;`;
@@ -40,6 +41,7 @@ exports.list = function list(req, res, next) {
           const settings = [
             'enable_price_lock',
             'enable_prepayments',
+            'enable_delete_records',
           ];
 
           row.settings = _.pick(row, settings);

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -232,7 +232,7 @@ function loadSessionInformation(user) {
       [session.enterprise] = rows;
 
       sql = `
-        SELECT enable_price_lock, enable_prepayments FROM enterprise_setting
+        SELECT enable_price_lock, enable_prepayments, enable_delete_records FROM enterprise_setting
         WHERE enterprise_id = ?;
       `;
 

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -617,6 +617,7 @@ DROP TABLE IF EXISTS `enterprise_setting`;
 CREATE TABLE `enterprise_setting` (
   `enterprise_id`   SMALLINT(5) UNSIGNED NOT NULL,
   `enable_price_lock` TINYINT(1) NOT NULL DEFAULT 1,
+  `enable_delete_records` TINYINT(1) NOT NULL DEFAULT 0,
   `enable_prepayments` TINYINT(1) NOT NULL DEFAULT 1,
   PRIMARY KEY (`enterprise_id`),
   FOREIGN KEY (`enterprise_id`) REFERENCES `enterprise` (`id`)

--- a/test/data.sql
+++ b/test/data.sql
@@ -7,8 +7,8 @@ SET NAMES 'utf8';
 INSERT INTO `enterprise` VALUES
   (1, 'Test Enterprise', 'TE', '243 81 504 0540', 'enterprise@test.org', HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, 2, 103, NULL, NULL);
 
-INSERT INTO `enterprise_setting` (enterprise_id, enable_price_lock) VALUES
-  (1, 0);
+INSERT INTO `enterprise_setting` (enterprise_id, enable_price_lock, enable_delete_records) VALUES
+  (1, 0, 1);
 
 -- Project
 INSERT INTO `project` VALUES


### PR DESCRIPTION
The enterprise now has the option to disable the deletion of records
from the registries.  Deletion transaction from the posting journal is
still supported.

Closes #2730.

![2018-05-10_11-48-28](https://user-images.githubusercontent.com/896472/39866825-1529a1ec-544a-11e8-87ee-4b18189f8f2a.gif)
_Fig 1: The setting in action_.