### PR TITLE
refactor(vouchers): require transaction type

### DIFF
--- a/client/src/i18n/en/vouchers.json
+++ b/client/src/i18n/en/vouchers.json
@@ -44,7 +44,6 @@
       "CASH_TRANSFER":"Cash Transfer",
       "REPORT":"Voucher Registry",
       "TITLE":"Voucher",
-      "TRANSACTION_TYPE_INFO":"Transaction type must be set if there is income or expenses.",
       "USE_FINANCIAL_ACCOUNT": "This transactions uses a cash or bank account.  Be sure to set a transaction type.",
       "RECEIPT":{
         "SUCCESS":"Voucher Payment recorded successfully."

--- a/client/src/i18n/fr/vouchers.json
+++ b/client/src/i18n/fr/vouchers.json
@@ -49,7 +49,6 @@
             "REPORT": "Rapport des Quittances",
             "SUPPORT_PAYMENT_DESCRIPTION":"Transfert de la dette du {{patientName}} ({{patientReference}}) pour {{numInvoices}} facture(s) {{invoiceReferences}}.",
             "TITLE": "Quittance",
-            "TRANSACTION_TYPE_INFO": "Type de transaction selon qu'on a soit une recette ou une depense",
             "USE_FINANCIAL_ACCOUNT": "Utilisation de compte de caisses ou banques dans cette transaction"
         },
         "SIMPLE": {

--- a/client/src/modules/vouchers/complex-voucher.html
+++ b/client/src/modules/vouchers/complex-voucher.html
@@ -99,20 +99,15 @@
               <div class="col-md-6">
 
                 <div class="form-group" ng-class="{ 'has-error' : ComplexVoucherForm.$submitted && ComplexVoucherForm.type_id.$invalid }">
-                  <label class="control-label">
-                    <span translate>FORM.LABELS.TRANSACTION_TYPE</span>
-                    <span uib-popover="{{ 'VOUCHERS.GLOBAL.TRANSACTION_TYPE_INFO' | translate }}"
-                      popover-trigger="'mouseenter'"
-                      popover-placement="bottom"
-                      class="text-info fa fa-info-circle">
-                    </span>
+                  <label class="control-label" translate>
+                    FORM.LABELS.TRANSACTION_TYPE
                   </label>
 
                   <!-- Select a Transaction Type -->
                   <ui-select
                     name="type_id"
                     ng-model="ComplexVoucherCtrl.Voucher.details.type_id"
-                    ng-required="ComplexVoucherCtrl.Voucher.hasCashboxAccount"
+                    required="true"
                     on-select="ComplexVoucherCtrl.Voucher.validate()">
 
                     <ui-select-match placeholder="{{ 'FORM.SELECT.TRANSACTION_TYPE' | translate }}">
@@ -126,12 +121,6 @@
                       <div ng-bind-html="item.hrText | highlight: $select.search"></div>
                     </ui-select-choices>
                   </ui-select>
-
-                  <div class="help-block" ng-show="ComplexVoucherCtrl.Voucher.hasCashboxAccount">
-                    <p class="text-info">
-                      <i class="fa fa-info-circle"></i> <span translate>VOUCHERS.GLOBAL.USE_FINANCIAL_ACCOUNT</span>
-                    </p>
-                  </div>
 
                   <div class="help-block" ng-messages="ComplexVoucherForm.type_id.$error" ng-show="ComplexVoucherForm.$submitted">
                     <div ng-messages-include="modules/templates/messages.tmpl.html"></div>

--- a/client/src/modules/vouchers/simple-voucher.html
+++ b/client/src/modules/vouchers/simple-voucher.html
@@ -46,19 +46,14 @@
 
               <div class="form-group" ng-class="{ 'has-error' : SimpleVoucherForm.$submitted && SimpleVoucherForm.type_id.$invalid }">
 
-                <label class="control-label">
-                  <span translate>FORM.LABELS.TRANSACTION_TYPE</span>
-                  <span uib-popover="{{ ::'VOUCHERS.GLOBAL.TRANSACTION_TYPE_INFO' | translate }}"
-                    popover-trigger="'mouseenter'"
-                    popover-placement="top"
-                    class="text-info fa fa-info-circle">
-                  </span>
+                <label class="control-label" translate>
+                  FORM.LABELS.TRANSACTION_TYPE
                 </label>
 
                 <ui-select
                   name="type_id"
                   ng-model="SimpleVoucherCtrl.Voucher.details.type_id"
-                  ng-required="SimpleVoucherCtrl.Voucher.hasCashboxAccount"
+                  required="true"
                   append-to-body="true">
 
                   <ui-select-match placeholder="{{ 'FORM.SELECT.TRANSACTION_TYPE' | translate }}">
@@ -72,12 +67,6 @@
                     <div ng-bind-html="item.hrText | highlight: $select.search"></div>
                   </ui-select-choices>
                 </ui-select>
-
-                <div class="help-block" ng-show="SimpleVoucherCtrl.Voucher.hasCashboxAccount">
-                  <p class="text-info">
-                    <i class="fa fa-info-circle"></i> <span translate>VOUCHERS.GLOBAL.USE_FINANCIAL_ACCOUNT</span>
-                  </p>
-                </div>
 
                 <div class="help-block" ng-messages="SimpleVoucherForm.type_id.$error" ng-show="SimpleVoucherForm.$submitted">
                   <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
@@ -94,7 +83,7 @@
                   class="form-control"
                   name="description"
                   ng-model="SimpleVoucherCtrl.Voucher.details.description"
-                  placeholder="{{ ::'FORM.PLACEHOLDERS.DESCRIPTION' | translate }}"
+                  translate-attrs="{ placeholder : 'FORM.PLACEHOLDERS.DESCRIPTION' }"
                   ng-maxlength="SimpleVoucherCtrl.maxLength"
                   required>
                 </textarea>

--- a/client/src/modules/vouchers/voucher-form.service.js
+++ b/client/src/modules/vouchers/voucher-form.service.js
@@ -3,7 +3,7 @@ angular.module('bhima.services')
 
 VoucherFormService.$inject = [
   'VoucherService', 'bhConstants', 'SessionService', 'VoucherItemService',
-  'CashboxService', 'AppCache', 'Store', 'AccountService', '$timeout', '$translate',
+  'AppCache', 'Store', 'AccountService', '$timeout', '$translate',
 ];
 
 /**
@@ -17,7 +17,7 @@ VoucherFormService.$inject = [
  * @todo - finish the caching implementation
  */
 function VoucherFormService(
-  Vouchers, Constants, Session, VoucherItem, Cashboxes, AppCache, Store, Accounts,
+  Vouchers, Constants, Session, VoucherItem, AppCache, Store, Accounts,
   $timeout, $translate
 ) {
   // Error Flags
@@ -62,32 +62,9 @@ function VoucherFormService(
     // this is the overarching details of the voucher to be filled in
     this.details = {};
 
-    // cash accounts require a certain voucher type
-    this.cashAccounts = [];
-    const self = this;
-
-    // load cashboxes for their accounts.
-    Cashboxes.read(null, { detailed : 1 })
-      .then((cashboxes) => {
-        self.cashAccounts = cashboxes
-
-          // collect a lost of all cashbox accounts
-          .reduce((accounts, cashbox) => {
-            return accounts.concat([cashbox.account_id, cashbox.transfer_account_id]);
-          }, [])
-
-          // make sure the list is unique
-          .filter((account, index, accounts) => {
-            return accounts.indexOf(account) === index;
-          });
-
-        // self.cashAccounts is now a proper list of unique cash account ids
-        // that can be used to determine if a voucher type is required.
-      });
-
     Accounts.read()
       .then((accounts) => {
-        self.accounts = Accounts.order(accounts);
+        this.accounts = Accounts.order(accounts);
       });
 
     // this will contain the grid rows
@@ -104,10 +81,6 @@ function VoucherFormService(
    * This function is called on the journal voucher items to run validation
    * checks against each item, returning the global validation state.  If there
    * is an error in any single line item, that error is set on the form.
-   *
-   * It also performs validation to check if a type_id is required for the
-   * voucher.  Voucher types are required if any of the concerned accounts are
-   * cashbox accounts.
    */
   VoucherForm.prototype.validate = function validate() {
     const items = this.store.data;
@@ -124,12 +97,6 @@ function VoucherFormService(
     // seems like Chrome greedily exits if a false condition is it.
     let valid = true;
 
-    // do validation checks to see if we have a transaction type for a cashbox
-    // account
-    const { cashAccounts } = this;
-
-    let hasCashboxAccount = false;
-
     // loop through each row, checking the amounts and accounts of each item.
     items.forEach(item => {
       valid = valid && item.validate();
@@ -142,22 +109,15 @@ function VoucherFormService(
       // only test for unique accounts if there are valid accounts selected
       if (item.account_id) {
         // if there unique accounts array does not have this account, add it.
-        if (uniqueAccountsArray.indexOf(item.account_id) === -1) {
+        if (!uniqueAccountsArray.includes(item.account_id)) {
           uniqueAccountsArray.push(item.account_id);
         }
       }
-
-      if (cashAccounts.indexOf(item.account_id) !== -1) {
-        hasCashboxAccount = true;
-      }
     });
 
-    // if there is a cashbox account used, the voucher type_id is required
-    this.hasCashboxAccount = hasCashboxAccount;
-
-    // validate that the cashbox accounts and type_id are set
+    // validate that the type_id are set
     const hasTypeId = angular.isDefined(this.details.type_id);
-    if (!hasTypeId && this.hasCashboxAccount) {
+    if (!hasTypeId) {
       err = ERROR_MISSING_TRANSACTION_TYPE;
     }
 
@@ -284,7 +244,6 @@ function VoucherFormService(
       // of individual items which will not have been configured, manually
       // reset error state
       delete this._error;
-      this.hasCashboxAccount = false;
     });
   };
 

--- a/test/client-unit/services/VoucherForm.spec.js
+++ b/test/client-unit/services/VoucherForm.spec.js
@@ -28,9 +28,6 @@ describe('VoucherForm', () => {
 
     httpBackend = $httpBackend;
 
-    httpBackend.when('GET', '/cashboxes/?detailed=1')
-      .respond(200, Mocks.cashboxes());
-
     httpBackend.when('GET', '/accounts/')
       .respond(200, Mocks.accounts());
 


### PR DESCRIPTION
The behavior of both the transaction type inputs on the voucher modules have changed - we now require them explicitly.  This simplifies the code greatly and forces users to provide a designation for their transactions.

Closes #2323.