### PR TITLE
deps: remove compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "bower-npm-resolver": "^0.9.0",
     "chai-spies": "^1.0.0",
     "chai-spies-next": "^0.9.3",
-    "compression": "^1.7.0",
     "connect-redis": "^3.0.2",
     "cross-env": "^5.1.1",
     "csvtojson": "^1.1.9",

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -6,7 +6,6 @@
  */
 
 const express = require('express');
-const compress = require('compression');
 const bodyParser = require('body-parser');
 const session = require('express-session');
 const RedisStore = require('connect-redis')(session);
@@ -43,7 +42,6 @@ exports.configure = function configure(app) {
 
   // helmet guards
   app.use(helmet());
-  app.use(compress());
 
   app.use(bodyParser.json({ limit : '8mb' }));
   app.use(bodyParser.urlencoded({ extended : false }));


### PR DESCRIPTION
This commit removes compression from NodeJS server.  Similar to SSL, this will be handled by our nginx server in production.

Closes #2736.