### PR TITLE
fix(reports): increase preview height to 80vh

### DIFF
--- a/client/src/modules/templates/bhReportPreview.tmpl.html
+++ b/client/src/modules/templates/bhReportPreview.tmpl.html
@@ -15,7 +15,7 @@
         <div class="panel-body" style="padding : 5px;">
           <!-- HTML rendered report presented in `iframe`, this ensures that -->
           <!-- the classes within the document do not clash with the page -->
-          <iframe id="report" name="report" style="border : none; width : 100%; height : 60vh;" srcdoc="{{$ctrl.sourceDocument}}"></iframe>
+          <iframe id="report" name="report" style="border : none; width : 100%; height : 80vh;" srcdoc="{{$ctrl.sourceDocument}}"></iframe>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This commit increases the preview height to allow better viewing on larger screens.

See the comparison below:
![reportheightbefore](https://user-images.githubusercontent.com/896472/40778104-e7c1ea1e-64c7-11e8-978d-e3166e6e747b.PNG)
_Fig 1: Report Height Before_

![reportheightafter](https://user-images.githubusercontent.com/896472/40778101-e3d1f570-64c7-11e8-8e32-c28d6736841d.PNG)
_Fig 2: Report Height After_


