### PR TITLE
fix(caution): rename variable

### DIFF
--- a/server/models/procedures/invoicing.sql
+++ b/server/models/procedures/invoicing.sql
@@ -477,7 +477,7 @@ BEGIN
 
     -- check: if the caution is more than the cost, assign the total cost of the
     -- invoice to the caution and exit the loop.
-    IF cbalance >= scost THEN
+    IF cbalance >= icost THEN
 
       -- write the cost value from into the posting journal
       INSERT INTO posting_journal


### PR DESCRIPTION
There was an old/unknown variable named "scost" that blocks payments if you have a caution.  It has been renamed.