### PR TITLE
fix: misc presentation ui-glitches

### DIFF
--- a/client/src/modules/depots/modals/depot.modal.html
+++ b/client/src/modules/depots/modals/depot.modal.html
@@ -124,11 +124,11 @@
 
   <div class="modal-footer">
     <button data-method="cancel" type="button" class="btn btn-default" ui-sref="depots">
-      <i class="fa fa-ban"></i> <span translate>FORM.BUTTONS.CANCEL</span>
+      <span translate>FORM.BUTTONS.CANCEL</span>
     </button>
 
     <bh-loading-button loading-state="DepotForm.$loading">
-      <i class="fa fa-ok"></i> <span translate>FORM.BUTTONS.SUBMIT</span>
+      <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>
   </div>
 </form>

--- a/client/src/modules/locations/village/village.html
+++ b/client/src/modules/locations/village/village.html
@@ -150,19 +150,25 @@
                 </div>
               </div>
 
-              <div class="form-group">
+              <div class="row">
+
                 <div class="col-xs-6">
-                  <label class="control-label" translate> FORM.LABELS.LONGITUDE </label>
-                  <input type="number" step="1.0" placeholder="{{ 'FORM.PLACEHOLDERS.LONGITUDE' | translate }}" autocomplete="off" class="form-control" name="longitude" ng-model="VillageCtrl.village.longitude">
+                  <div class="form-group">
+                    <label class="control-label" translate> FORM.LABELS.LONGITUDE </label>
+                    <input type="number" step="1.0" placeholder="{{ 'FORM.PLACEHOLDERS.LONGITUDE' | translate }}" autocomplete="off" class="form-control" name="longitude" ng-model="VillageCtrl.village.longitude">
+                  </div>
                 </div>
+
                 <div class="col-xs-6">
-                  <label class="control-label" translate> FORM.LABELS.LATITUDE </label>
-                  <input type="number" step="1.0" placeholder="{{ 'FORM.PLACEHOLDERS.LATITUDE' | translate }}" autocomplete="off" class="form-control" name="latitude" ng-model="VillageCtrl.village.latitude">
+                  <div class="form-group">
+                    <label class="control-label" translate> FORM.LABELS.LATITUDE </label>
+                    <input type="number" step="1.0" placeholder="{{ 'FORM.PLACEHOLDERS.LATITUDE' | translate }}" autocomplete="off" class="form-control" name="latitude" ng-model="VillageCtrl.village.latitude">
+                  </div>
                 </div>
               </div>
 
               <div class="form-group">
-                <button class="btn btn-default" id="submit-village" type="submit" data-method="submit" translate>
+                <button class="btn btn-primary" id="submit-village" type="submit" data-method="submit" translate>
                   FORM.BUTTONS.SAVE
                 </button>
                 <button class="btn btn-default" type="button" ng-click="VillageCtrl.cancel()" data-method="cancel" translate>
@@ -246,25 +252,25 @@
               <div class="form-group">
                 <div class="col-xs-12 col-md-6">
                   <label class="control-label" translate> FORM.LABELS.LONGITUDE </label>
-                  <input type="number" placeholder="{{ 'FORM.PLACEHOLDERS.LONGITUDE' | translate }}" 
-                    autocomplete="off" 
-                    class="form-control" 
-                    name="longitude" 
+                  <input type="number" placeholder="{{ 'FORM.PLACEHOLDERS.LONGITUDE' | translate }}"
+                    autocomplete="off"
+                    class="form-control"
+                    name="longitude"
                     ng-model="VillageCtrl.village.longitude">
                 </div>
                 <div class="col-xs-12 col-md-6">
                   <label class="control-label" translate> FORM.LABELS.LATITUDE </label>
-                  <input type="number" placeholder="{{ 'FORM.PLACEHOLDERS.LATITUDE' | translate }}" 
-                    autocomplete="off" 
-                    class="form-control" 
-                    name="latitude" 
+                  <input type="number" placeholder="{{ 'FORM.PLACEHOLDERS.LATITUDE' | translate }}"
+                    autocomplete="off"
+                    class="form-control"
+                    name="latitude"
                     ng-model="VillageCtrl.village.latitude">
                 </div>
                 <div class="clearfix"></div>
               </div>
 
               <div class="form-group">
-                <button class="btn btn-default" id="change_village" type="submit" data-method="submit" translate>
+                <button class="btn btn-primary" id="change_village" type="submit" data-method="submit" translate>
                   FORM.BUTTONS.SAVE
                 </button>
                 <button class="btn btn-default" type="button" ng-click="VillageCtrl.cancel()" data-method="cancel" translate>

--- a/client/src/modules/purchases/modals/search.tmpl.html
+++ b/client/src/modules/purchases/modals/search.tmpl.html
@@ -4,9 +4,9 @@
   data-modal="purchase-search"
   novalidate>
 
-  <div class="search-modal-header">
+  <div class="modal-header">
     <ol class="headercrumb">
-      <li class="static" translate>FORM.INFO.PATIENTS</li>
+      <li class="static" translate>TREE.PURCHASE</li>
       <li class="title" translate>FORM.INFO.SEARCH</li>
     </ol>
   </div>
@@ -33,7 +33,7 @@
             required="false">
             <bh-clear on-clear="$ctrl.clear('supplier_uuid')"></bh-clear>
           </bh-supplier-select>
-    
+
           <!-- user -->
           <bh-user-select
             user-id="$ctrl.searchQueries.user_id"
@@ -67,8 +67,8 @@
             </div>
           </div>
         </div>
-      </uib-tab>      
-    </uib-tabset>  
+      </uib-tab>
+    </uib-tabset>
   </div>
 
   <div class="modal-footer">

--- a/client/src/modules/roles/modal/userRole.html
+++ b/client/src/modules/roles/modal/userRole.html
@@ -2,9 +2,7 @@
 <div class="modal-header">
     <ol class="headercrumb">
       <li class="static" translate>FORM.LABELS.ROLES_FOR</li>
-      <li class="title">
-        <span translate>{{UsersRolesCtrl.user.display_name}}</span>
-      </li>
+      <li class="title">{{UsersRolesCtrl.user.display_name}}</li>
     </ol>
 </div>
 <div class="modal-body">
@@ -14,7 +12,7 @@
       <ul class="list-group">
         <li  class="list-group-item" ng-repeat="role in UsersRolesCtrl.roles">
           <label class="radio-inline">
-            <input type='checkbox' ng-model='role.affected' ng-true-value="1" ng-false-value="0" />
+            <input type="checkbox" ng-model="role.affected" ng-true-value="1" ng-false-value="0" />
             <span title="{{role.label}}">{{role.label}}</span>
           </label>
         </li>
@@ -23,10 +21,8 @@
   </div>
 </div>
 
-<div class="modal-footer">
-  <div class=" pull-right">
-  <button type="button" class='btn inverse' ng-click='UsersRolesCtrl.close()' translate>FORM.BUTTONS.CLOSE</button>
+<div class="modal-footer text-right">
+  <button type="button" class='btn btn-default' ng-click="UsersRolesCtrl.close()" translate>FORM.BUTTONS.CLOSE</button>
   <bh-loading-button loading-state="RolesForm.$loading"></bh-loading-button>
-  </div>
 </div>
 </form>


### PR DESCRIPTION
This commit fixes the following UI errors noticed during out
presentation:
 1. Purchase orders search modal says "purchase" not "patient"
 2. Depots save/cancel buttons' icons are removed.
 3. Locations have primary save buttons and long/lat are properly
 formatted.
 4. User roles have btn-cancel instead of inverse.