### PR TITLE
feat(invoice registry modal) reload last views filters

### DIFF
--- a/client/src/modules/invoices/registry/registry.js
+++ b/client/src/modules/invoices/registry/registry.js
@@ -145,11 +145,13 @@ function InvoiceRegistryController(
 
     Invoices.openSearchModal(filtersSnapshot)
       .then(changes => {
+        if (!changes) {
+          return 0;
+        }
         Invoices.filters.replaceFilters(changes);
 
         Invoices.cacheFilters();
         vm.latestViewFilters = Invoices.filters.formatView();
-
         return load(Invoices.filters.formatHTTP(true));
       });
   }


### PR DESCRIPTION
The invoice registry modal reset filters. When the user click on cancel, the next time he will open the modal there will have no filter
