### PR TITLE
fix(navigation): do not error if no nextURL

### DIFF
--- a/client/src/js/components/bhNavigation.js
+++ b/client/src/js/components/bhNavigation.js
@@ -90,7 +90,7 @@ function NavigationController($location, $rootScope, Tree, AppCache, Notify, $tr
 
     paths.forEach(key => {
       const node = unitsIndex.path[key];
-      if (nextUrl.includes(node.path)) {
+      if (nextUrl && nextUrl.includes(node.path)) {
         selectUnit(node);
       }
     });


### PR DESCRIPTION
During page refreshes, there is no nextURL.  We don't want to throw an error in this case.