### PR TITLE
chore: remove ban icon from cancel buttons

### DIFF
--- a/client/src/modules/services/modals/service.modal.html
+++ b/client/src/modules/services/modals/service.modal.html
@@ -26,11 +26,11 @@
 
   <div class="modal-footer">
     <button data-method="cancel" type="button" class="btn btn-default" ng-click="ServiceModalCtrl.closeModal()">
-      <i class="fa fa-ban"></i> <span translate>FORM.BUTTONS.CANCEL</span>
+      <span translate>FORM.BUTTONS.CANCEL</span>
     </button>
 
     <bh-loading-button loading-state="ServiceForm.$loading">
-      <i class="fa fa-ok"></i> <span translate>FORM.BUTTONS.SUBMIT</span>
+      <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>
   </div>
 </form>

--- a/client/src/modules/users/UserCashBoxManagementModal.html
+++ b/client/src/modules/users/UserCashBoxManagementModal.html
@@ -14,7 +14,7 @@
     <div class="form-group" ng-class="{ 'has-error' : UserForm.$submitted && UserForm.display_name.$invalid }">
       <label class="control-label" translate>FORM.LABELS.USERNAME</label>
       <div>
-        <h4><i> {{ UsersCashBoxModalCtrl.user.display_name }} </i></h4>
+        <h4><i>{{ UsersCashBoxModalCtrl.user.display_name }}</i></h4>
       </div>
     </div>
 
@@ -29,11 +29,11 @@
 
   <div class="modal-footer">
     <button id="user-cancel" type="button" class="btn btn-default" ng-click="UsersCashBoxModalCtrl.closeModal()">
-      <i class="fa fa-ban"></i> <span translate>FORM.BUTTONS.CANCEL</span>
+      <span translate>FORM.BUTTONS.CANCEL</span>
     </button>
 
     <bh-loading-button loading-state="UserForm.$loading">
-      <i class="fa fa-ok"></i> <span translate>FORM.BUTTONS.SUBMIT</span>
+      <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>
   </div>
 </form>

--- a/client/src/modules/users/UserDepotManagementModal.html
+++ b/client/src/modules/users/UserDepotManagementModal.html
@@ -22,18 +22,18 @@
     <bh-multiple-depot-select
       label="STOCK.DEPOT"
       depots-uuids = "UsersDepotModalCtrl.depots"
-      on-change="UsersDepotModalCtrl.onDepotChange(depots)">            
+      on-change="UsersDepotModalCtrl.onDepotChange(depots)">
     </bh-multiple-depot-select>
 
   </div>
 
   <div class="modal-footer">
     <button id="user-cancel" type="button" class="btn btn-default" ng-click="UsersDepotModalCtrl.closeModal()">
-      <i class="fa fa-ban"></i> <span translate>FORM.BUTTONS.CANCEL</span>
+      <span translate>FORM.BUTTONS.CANCEL</span>
     </button>
 
     <bh-loading-button loading-state="UserForm.$loading">
-      <i class="fa fa-ok"></i> <span translate>FORM.BUTTONS.SUBMIT</span>
+      <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>
   </div>
 </form>


### PR DESCRIPTION
This commit improves visual consistency by removing icons from the cancel and ban buttons.