### PR TITLE
chore: remove Modal.confirm() from Credit Note

### DIFF
--- a/client/src/modules/invoices/registry/modalCreditNote.html
+++ b/client/src/modules/invoices/registry/modalCreditNote.html
@@ -7,6 +7,11 @@
   </div>
 
   <div class="modal-body">
+    <div class="alert alert-danger" ng-if="ModalCtrl.hasPaymentsAgainstInvoice">
+      <i class="fa fa-exclamation-triangle"></i>
+      <span translate>FORM.DIALOGS.CONFIRM_CREDIT_NOTE</span>
+    </div>
+
     <div class="alert alert-warning">
       <i class="fa fa-exclamation-triangle"></i>
       <span translate translate-values="ModalCtrl.alertI18nValues" translate-sanitize-strategy="'sce'">PATIENT_INVOICE.ALERT_CREDIT_NOTE</span>

--- a/client/src/modules/invoices/registry/modalCreditNote.js
+++ b/client/src/modules/invoices/registry/modalCreditNote.js
@@ -4,12 +4,12 @@ angular.module('bhima.controllers')
 ModalCreditNoteController.$inject = [
   '$uibModalInstance', 'PatientInvoiceService', 'data', 'VoucherService',
   'NotifyService', '$translate', 'CurrencyService', 'bhConstants', '$state',
-  '$filter',
+  '$filter', 'CashService',
 ];
 
 function ModalCreditNoteController(
   Instance, Invoices, data, Vouchers, Notify, $translate, CurrencyService,
-  bhConstants, $state, $filter
+  bhConstants, $state, $filter, Cash
 ) {
   const vm = this;
   vm.Constants = bhConstants;
@@ -25,6 +25,13 @@ function ModalCreditNoteController(
   vm.invoice = data.invoice;
   vm.billingAmount = 0;
   vm.subsidyAmount = 0;
+
+  // checks if there has been payments made against the invoice about to
+  // be reversed
+  Cash.checkCashPayment(data.invoice.uuid)
+    .then(paymentsAgainstInvoice => {
+      vm.hasPaymentsAgainstInvoice = paymentsAgainstInvoice.length > 0;
+    });
 
   Invoices.read(data.invoice.uuid)
     .then(response => {

--- a/client/src/modules/invoices/registry/registry.js
+++ b/client/src/modules/invoices/registry/registry.js
@@ -3,9 +3,9 @@ angular.module('bhima.controllers')
 
 InvoiceRegistryController.$inject = [
   'PatientInvoiceService', 'bhConstants', 'NotifyService', 'SessionService',
-  'ReceiptModal', 'uiGridConstants', 'ModalService', 'CashService',
-  'GridSortingService', 'GridColumnService', 'GridStateService', '$state',
-  'ModalService', 'ReceiptModal', 'util',
+  'ReceiptModal', 'uiGridConstants', 'ModalService', 'GridSortingService',
+  'GridColumnService', 'GridStateService', '$state', 'ModalService',
+  'ReceiptModal', 'util',
 ];
 
 /**
@@ -16,7 +16,7 @@ InvoiceRegistryController.$inject = [
  */
 function InvoiceRegistryController(
   Invoices, bhConstants, Notify, Session, Receipt, uiGridConstants,
-  ModalService, Cash, Sorting, Columns, GridState, $state, Modals, Receipts, util
+  ModalService, Sorting, Columns, GridState, $state, Modals, Receipts, util
 ) {
   const vm = this;
 
@@ -199,32 +199,13 @@ function InvoiceRegistryController(
     $state.reload();
   };
 
-  // Call the opening of Modal
-  function openModal(invoice) {
+  // Function for Credit Note cancel all Invoice
+  function creditNote(invoice) {
     Invoices.openCreditNoteModal(invoice)
       .then(success => {
         if (success) {
           Notify.success('FORM.INFO.TRANSACTION_REVER_SUCCESS');
           load(vm.filters);
-        }
-      })
-      .catch(Notify.handleError);
-  }
-
-  // Function for Credit Note cancel all Invoice
-  function creditNote(invoice) {
-    Cash.checkCashPayment(invoice.uuid)
-      .then(res => {
-        const numberPayment = res.length;
-        if (numberPayment > 0) {
-          ModalService.confirm('FORM.DIALOGS.CONFIRM_CREDIT_NOTE')
-            .then(bool => {
-              if (bool) {
-                openModal(invoice);
-              }
-            });
-        } else {
-          openModal(invoice);
         }
       })
       .catch(Notify.handleError);

--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -254,7 +254,8 @@ function checkInvoicePayment(req, res, next) {
   const bid = db.bid(req.params.invoiceUuid);
 
   const sql = `
-    SELECT cash.reversed, cash_item.cash_uuid, cash_item.invoice_uuid FROM cash JOIN cash_item
+    SELECT cash_item.cash_uuid, cash_item.invoice_uuid
+    FROM cash JOIN cash_item
     WHERE cash_item.invoice_uuid = ? AND cash.reversed <> 1
     GROUP BY cash_item.invoice_uuid;
   `;


### PR DESCRIPTION
This commit removes the Modal.confirm() call, instead putting a danger text on the credit note page.

![newpresentationofcreditnote](https://user-images.githubusercontent.com/896472/41465221-8161d25c-709d-11e8-92c8-752b929d58f3.PNG)

Closes #2836