### PR TITLE
fix(operating report): update presentation

### DIFF
--- a/client/src/modules/reports/generate/operating/operating.html
+++ b/client/src/modules/reports/generate/operating/operating.html
@@ -8,7 +8,7 @@
 <div ng-show="!ReportConfigCtrl.previewGenerated">
   <div class="row">
     <div class="col-md-12">
-      <h3 class="text-capitalize" translate>TREE.OPERATING_ACCOUNT</h3> 
+      <h3 class="text-capitalize" translate>TREE.OPERATING_ACCOUNT</h3>
     </div>
   </div>
 

--- a/server/controllers/finance/reports/operating/index.js
+++ b/server/controllers/finance/reports/operating/index.js
@@ -11,7 +11,10 @@ const TEMPLATE = './server/controllers/finance/reports/operating/report.handleba
 
 exports.document = document;
 exports.formatData = formatData;
-exports.prepareTree = prepareTree;
+
+const EXPENSE_ACCOUNT_TYPE = 5;
+const INCOME_ACCOUNT_TYPE = 4;
+const DECIMAL_PRECISION = 2; // ex: 12.4567 => 12.46
 
 function document(req, res, next) {
   const params = req.query;
@@ -30,12 +33,8 @@ function document(req, res, next) {
     return;
   }
 
-
-  const queries = [];
+  let queries;
   let range;
-  const EXPENSE_ACCOUNT_TYPE = 5;
-  const INCOME_ACCOUNT_TYPE = 4;
-  const DECIMAL_PRECISION = 2; // ex: 12.4567 => 12.46
 
   const getQuery = fiscal.accountBanlanceByTypeId;
 
@@ -63,10 +62,12 @@ function document(req, res, next) {
       INCOME_ACCOUNT_TYPE,
     ];
 
-    queries.push(db.exec(getQuery(), expenseParams));
-    queries.push(db.exec(getQuery(), incomeParams));
-    queries.push(db.one(totalExpense, expenseParams));
-    queries.push(db.one(totalIncome, incomeParams));
+    queries = [
+      db.exec(getQuery(), expenseParams),
+      db.exec(getQuery(), incomeParams),
+      db.one(totalExpense, expenseParams),
+      db.one(totalIncome, incomeParams),
+    ];
 
     return q.all(queries);
   })
@@ -118,7 +119,6 @@ function prepareTree(data, prop, value, summableProp) {
 // set the percentage of each amoun's row,
 // round amounts
 function formatData(result, total, decimalPrecision) {
-
   const _total = (total === 0) ? 1 : total;
   return result.forEach(row => {
     row.title = (row.depth < 3);

--- a/server/controllers/finance/reports/operating/report.handlebars
+++ b/server/controllers/finance/reports/operating/report.handlebars
@@ -1,6 +1,5 @@
 {{> head title="{{translate 'TREE.OPERATING_ACCOUNT' }}" }}
 
-
 <div class="container">
   {{> header}}
 
@@ -11,7 +10,7 @@
       <h3 class="text-center text-uppercase">
         <strong>{{translate 'TREE.OPERATING_ACCOUNT'}}</strong>
       </h3>
-      
+
       <h5 style="margin:15px; font-weight:bold" class="text-center text-uppercase">
         {{date this.dateFrom}} - {{date this.dateTo}}
       </h5>
@@ -19,29 +18,31 @@
         <tbody>
           <tr>
             <th class="text-center">
-              {{ translate 'ACCOUNT.TYPES.EXPENSE'}}
+              {{translate 'ACCOUNT.TYPES.EXPENSE'}}
             </th>
             <th class="text-center">
-              {{ translate 'ACCOUNT.TYPES.INCOME'}}
+              {{translate 'ACCOUNT.TYPES.INCOME'}}
             </th>
           </tr>
           <tr>
             <td>
               <table class="table table-condensed table-report table-bordered">
                 <thead>
-                  <th>{{ translate 'FORM.LABELS.ACCOUNT_NUMBER'}}</th>
-                  <th>{{ translate 'FORM.LABELS.LABEL'}}</th>
-                  <th> {{ translate 'FORM.LABELS.AMOUNT'}}</th>
+                  <th>{{translate 'FORM.LABELS.ACCOUNT_NUMBER'}}</th>
+                  <th>{{translate 'FORM.LABELS.LABEL'}}</th>
+                  <th>{{translate 'FORM.LABELS.AMOUNT'}}</th>
                   <th>%</th>
                 </thead>
                 <tbody>
                   {{#each this.expense}}
                   <tr>
                     <td class="text-right">{{number}}</td>
-                    <td {{#if title}}style="font-weight:bold; text-align:center;"{{/if}}>
+                    <td
+                      {{#if title}}class="text-bold text-center"{{/if}}
+                        style="padding-left:calc(({{depth}} - 1) * 5px);">
                       {{label}}
                     </td>
-                    <td class="text-right">{{amount}}</td>
+                    <td class="text-right">{{debcred amount}}</td>
                     <td class="text-right">{{percent}}</td>
                   </tr>
                   {{/each}}
@@ -51,21 +52,22 @@
             <td>
               <table class="table table-condensed table-report table-bordered">
                 <thead>
-                  <th>{{ translate 'FORM.LABELS.ACCOUNT_NUMBER'}}</th>
-                  <th>{{ translate 'FORM.LABELS.LABEL'}}</th>
-                  <th> {{ translate 'FORM.LABELS.AMOUNT'}}</th>
+                  <th>{{translate 'FORM.LABELS.ACCOUNT_NUMBER'}}</th>
+                  <th>{{translate 'FORM.LABELS.LABEL'}}</th>
+                  <th>{{translate 'FORM.LABELS.AMOUNT'}}</th>
                   <th>%</th>
                 </thead>
                 <tbody>
                   {{#each this.revenue}}
                   <tr>
                     <td class="text-right">{{number}}</td>
-                    <td {{#if title}}style="font-weight:bold; text-align:center;"{{/if}}>
+                    <td
+                      {{#if title}}class="text-bold text-center"{{/if}}
+                        style="padding-left:calc(({{depth}} - 1) * 5px);">
                       {{label}}
                     </td>
-                    <td class="text-right">{{amount}}</td>
+                    <td class="text-right">{{debcred amount}}</td>
                     <td class="text-right">{{percent}}</td>
-  
                   </tr>
                   {{/each}}
                 </tbody>
@@ -73,56 +75,54 @@
             </td>
           </tr>
           <tr>
-            <td colspan="2">
+            <td>
             <table class="table table-condensed table-report table-bordered">
               <tr>
                 <th>
                 </th>
                 <th class="text-center">
-                  {{ translate 'ACCOUNT.TYPES.EXPENSE'}}
+                  {{translate 'ACCOUNT.TYPES.EXPENSE'}}
                 </th>
                  <th class="text-center">
-                   {{ translate 'ACCOUNT.TYPES.INCOME'}}
+                   {{translate 'ACCOUNT.TYPES.INCOME'}}
                 </th>
               </tr>
                <tr>
                 <th class="text-center">
-                  {{ translate 'FORM.LABELS.TOTAL'}}
+                  {{translate 'FORM.LABELS.TOTAL'}}
                 </th>
                 <td class="text-right">
-                  {{this.totalExpense}}
+                  {{debcred this.totalExpense}}
                 </td>
                  <td class="text-right">
-                    {{this.totalIncome}}
+                  {{debcred this.totalIncome}}
                 </td>
               </tr>
               <tr>
                 <th class="text-center">
-                  {{ translate 'FORM.LABELS.RESULT'}}
+                  {{translate 'FORM.LABELS.RESULT'}}
                 </th>
                 <td class="text-right">
-                  {{this.leftResult}}
+                  {{debcred this.leftResult}}
                 </td>
                 <td class="text-right">
-                  {{this.rightResult}}
+                  {{debcred this.rightResult}}
                 </td>
               </tr>
               <tr>
                 <th class="text-center">
-                  {{ translate 'FORM.LABELS.BALANCE'}}
+                  {{translate 'FORM.LABELS.BALANCE'}}
                 </th>
                 <td class="text-right">
-                  {{this.totalIncome}}
+                  {{debcred this.totalIncome}}
                 </td>
                  <td class="text-right">
-                    {{this.totalIncome}}
+                  {{debcred this.totalIncome}}
                 </td>
               </tr>
-            
             </table>
             </td>
-            </tr>
-
+          </tr>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
This commit updates the operating account report presentation with the fixes desired by IMCK.

Closes #2907.

This is what the new format looks like:
![newoperatingpresentation](https://user-images.githubusercontent.com/896472/41720371-c3b142f2-755a-11e8-8111-3c73d2032ff8.PNG)
_Fig 1: New Presentation of Operating Account_