### PR TITLE
fix stock loading button, transfer validation and depot selection

### DIFF
--- a/client/src/js/components/bhDepotSelect.js
+++ b/client/src/js/components/bhDepotSelect.js
@@ -17,25 +17,24 @@ DepotSelectController.$inject = ['DepotService', 'NotifyService'];
  * Depot selection component
  */
 function DepotSelectController(Depots, Notify) {
-  var $ctrl = this;
+  const $ctrl = this;
 
   $ctrl.$onInit = function onInit() {
     $ctrl.loading = true;
 
-    // download only the depots that the user has the management right
-
-    Depots.read(null, {only_user : true})
-      .then(function (depots) {
+    // load all depots
+    Depots.read(null)
+      .then((depots) => {
         $ctrl.depots = depots;
       })
       .catch(Notify.handleError)
-      .finally(function () {
+      .finally(() => {
         $ctrl.loading = false;
       });
   };
 
   // fires the onSelectCallback bound to the component boundary
-  $ctrl.onSelect = function ($item) {
+  $ctrl.onSelect = $item => {
     $ctrl.onSelectCallback({ depot : $item });
   };
 }

--- a/client/src/modules/stock/adjustment/adjustment.html
+++ b/client/src/modules/stock/adjustment/adjustment.html
@@ -140,7 +140,7 @@
               FORM.BUTTONS.SUSPEND
             </button>
 
-            <bh-loading-button loading-state="StockCtrl.$loading" disabled="!StockCtrl.validForSubmit">
+            <bh-loading-button loading-state="StockForm.$loading" disabled="!StockCtrl.validForSubmit">
               <span translate>FORM.BUTTONS.SUBMIT</span>
             </bh-loading-button>
           </div>

--- a/client/src/modules/stock/adjustment/adjustment.js
+++ b/client/src/modules/stock/adjustment/adjustment.js
@@ -227,9 +227,11 @@ function StockAdjustmentController(
 
     movement.lots = lots;
 
+    vm.$loading = true;
     return Stock.movements.create(movement)
       .then(document => {
         vm.Stock.store.clear();
+        vm.$loading = false;
         ReceiptModal.stockAdjustmentReceipt(document.uuid, fluxId);
       })
       .catch(Notify.handleError);

--- a/client/src/modules/stock/adjustment/adjustment.js
+++ b/client/src/modules/stock/adjustment/adjustment.js
@@ -227,11 +227,9 @@ function StockAdjustmentController(
 
     movement.lots = lots;
 
-    vm.$loading = true;
     return Stock.movements.create(movement)
       .then(document => {
         vm.Stock.store.clear();
-        vm.$loading = false;
         ReceiptModal.stockAdjustmentReceipt(document.uuid, fluxId);
       })
       .catch(Notify.handleError);

--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -326,6 +326,7 @@ function StockEntryController(
       .then((transfers) => {
         handleSelectedEntity(transfers, 'transfer_reception');
         setSelectedEntity(vm.movement.entity.instance);
+        vm.hasValidInput = hasValidInput();
       })
       .catch(Notify.handleError);
   }


### PR DESCRIPTION
This PR fixes : 
- loading button in the stock adjustment module
- load all depot with bhDepotSelect
- run validation after select a transfer from the transfer modal