### PR TITLE
bug(Paiement Convention)

### DIFF
--- a/server/controllers/finance/debtors/groups/index.js
+++ b/server/controllers/finance/debtors/groups/index.js
@@ -321,7 +321,8 @@ function loadInvoices(params) {
   `;
 
   // balanced or not
-  sqlInvoices += params.balanced ? ' HAVING balance = 0 ' : ' HAVING balance <> 0 ';
+  // Payment must only be made for invoices whose balances are strictly greater than Zero
+  sqlInvoices += params.balanced ? ' HAVING balance = 0 ' : ' HAVING balance > 0 ';
 
   const bid = db.bid(params.debtor_uuid);
 


### PR DESCRIPTION
- For the payment of the agreements it is necessary to pay only for the
invoices whose balance is greater than zero, this issue allows to solve
the problem by displaying only the invoices whose balances is strictly
superior to zero

Closes #2943 