### PR TITLE
fix(General Ledger): ignore empty rows correctly

### DIFF
--- a/client/src/modules/general-ledger/general-ledger.ctrl.js
+++ b/client/src/modules/general-ledger/general-ledger.ctrl.js
@@ -337,6 +337,7 @@ function GeneralLedgerController(
   }
 
   vm.download = GeneralLedger.download;
+
   vm.openAccountReport = function openAccountReport(accountId) {
     const opts = {
       account_id : accountId,
@@ -371,7 +372,6 @@ function GeneralLedgerController(
 
     vm.filters = {
       fiscal_year_id : vm.year.id,
-      fiscal_year_label : vm.year.label,
     };
 
     load(vm.filters);

--- a/client/src/modules/general-ledger/general-ledger.html
+++ b/client/src/modules/general-ledger/general-ledger.html
@@ -35,19 +35,19 @@
 
             <li role="separator" class="divider"></li>
             <li role="menuitem">
-              <a ng-href="/reports/finance/general_ledger/?{{ GeneralLedgerCtrl.download('pdf', GeneralLedgerCtrl.filters) }}" download="{{GeneralLedgerCtrl.fiscalYearLabel | translate }}">
+              <a ng-href="/reports/finance/general_ledger/?{{ GeneralLedgerCtrl.download('pdf', GeneralLedgerCtrl.filters, GeneralLedgerCtrl.fiscalYearLabel) }}" download="{{GeneralLedgerCtrl.fiscalYearLabel | translate }}">
                 <span class="fa fa-file-pdf-o"></span> <span translate>DOWNLOADS.PDF</span>
               </a>
             </li>
 
             <li role="menuitem">
-              <a ng-href="/reports/finance/general_ledger/?{{ GeneralLedgerCtrl.download('csv', GeneralLedgerCtrl.filters) }}" download="{{ GeneralLedgerCtrl.fiscalYearLabel | translate }}">
+              <a ng-href="/reports/finance/general_ledger/?{{ GeneralLedgerCtrl.download('csv', GeneralLedgerCtrl.filters, GeneralLedgerCtrl.fiscalYearLabel) }}" download="{{ GeneralLedgerCtrl.fiscalYearLabel | translate }}">
                 <span class="fa fa-file-excel-o"></span> <span translate>DOWNLOADS.CSV</span>
               </a>
             </li>
 
             <li role="menuitem">
-              <a ng-href="/reports/finance/general_ledger/?{{ GeneralLedgerCtrl.download('xlsx', GeneralLedgerCtrl.filters) }}" download="{{GeneralLedgerCtrl.fiscalYearLabel | translate }}">
+              <a ng-href="/reports/finance/general_ledger/?{{ GeneralLedgerCtrl.download('xlsx', GeneralLedgerCtrl.filters, GeneralLedgerCtrl.fiscalYearLabel) }}" download="{{GeneralLedgerCtrl.fiscalYearLabel | translate }}">
                 <span class="fa fa-file-excel-o"></span> <span translate>DOWNLOADS.EXCEL</span>
               </a>
             </li>

--- a/client/src/modules/general-ledger/general-ledger.service.js
+++ b/client/src/modules/general-ledger/general-ledger.service.js
@@ -16,8 +16,9 @@ function GeneralLedgerService(Api, $httpParamSerializer, Languages, Session) {
   service.download = download;
   service.openAccountReport = openAccountReport;
 
-  function download(type, filters) {
+  function download(type, filters, label) {
     const filterOpts = filters;
+    filters.fiscal_year_label = label;
     const defaultOpts = { renderer : type, lang : Languages.key };
 
     // combine options
@@ -41,8 +42,7 @@ function GeneralLedgerService(Api, $httpParamSerializer, Languages, Session) {
   }
 
   // GET /general_ledger/aggregates
-  service.aggregates = (params) =>
-    service.read.call({ url : service.url.concat('aggregates') }, null, params);
+  service.aggregates = (params) => service.read.call({ url : service.url.concat('aggregates') }, null, params);
 
   return service;
 }

--- a/server/controllers/finance/generalLedger/index.js
+++ b/server/controllers/finance/generalLedger/index.js
@@ -23,12 +23,13 @@ const PERIODS = [
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
 ];
 
-// expose to the api
+// expose to the API
 exports.list = list;
 exports.getAggregates = getAggregates;
 
 // expose to server controllers
 exports.getAccountTotalsMatrix = getAccountTotalsMatrix;
+exports.getAccountTotalsMatrixAggregates = getAccountTotalsMatrixAggregates;
 
 /**
  * @function list
@@ -84,14 +85,14 @@ function getAccountTotalsMatrix(fiscalYearId) {
     ''
   );
 
-  const outerColumns =
-    PERIODS.map(number => `IFNULL(s.balance${number}, 0) AS balance${number}`)
-      .join(', ');
+  const outerColumns = PERIODS
+    .map(number => `IFNULL(s.balance${number}, 0) AS balance${number}`)
+    .join(', ');
 
   // we want to show every single account, so we do a left join of the account
   // table
   const sql = `
-    SELECT a.id, a.number, a.label, a.type_id, a.label, a.parent,
+    SELECT a.id, a.number, a.label, a.type_id, a.parent,
       IFNULL(s.balance, 0) AS balance, ${outerColumns}
     FROM account AS a LEFT JOIN (
       SELECT SUM(pt.debit - pt.credit) AS balance, pt.account_id ${columns}
@@ -104,7 +105,22 @@ function getAccountTotalsMatrix(fiscalYearId) {
   `;
 
   //  returns true if all the balances are 0
-  const isEmptyRow = (row) => row.balance === 0;
+  const isEmptyRow = (row) => (
+    row.balance === 0
+    && row.balance0 === 0
+    && row.balance1 === 0
+    && row.balance2 === 0
+    && row.balance3 === 0
+    && row.balance4 === 0
+    && row.balance5 === 0
+    && row.balance6 === 0
+    && row.balance7 === 0
+    && row.balance8 === 0
+    && row.balance9 === 0
+    && row.balance10 === 0
+    && row.balance11 === 0
+    && row.balance12 === 0
+  );
 
   return db.exec(sql, [fiscalYearId])
     .then(accounts => {
@@ -135,9 +151,9 @@ function getAccountTotalsMatrixAggregates(fiscalYearId) {
     ''
   );
 
-  const outerColumns =
-    PERIODS.map(number => `IFNULL(s.balance${number}, 0) AS balance${number}`)
-      .join(', ');
+  const outerColumns = PERIODS
+    .map(number => `IFNULL(s.balance${number}, 0) AS balance${number}`)
+    .join(', ');
 
   const sql = `
     SELECT IFNULL(s.balance, 0) AS balance, ${outerColumns}

--- a/server/controllers/finance/reports/generalLedger/report.handlebars
+++ b/server/controllers/finance/reports/generalLedger/report.handlebars
@@ -10,7 +10,6 @@
 
       <!-- page title  -->
       <h3 class="text-center text-uppercase"><strong>{{translate 'TREE.GENERAL_LEDGER'}}</strong></h3>
-
       <h4 class="text-center"><strong>{{ fiscal_year_label}}</strong></h4>
 
       <!-- invoices listed  -->


### PR DESCRIPTION
This commit fixes the General Ledger presentation so that it ignores empty rows correctly.  Previously we filtered out accounts whose balance was 0, even if they had movements during the exercise.  Now we only
remove accounts which are zero in every period.

You will find attached an upgrade script that will remove the REPORT transactions from the IMCK dataset and make them into period 0 transactions.

[period-zero-imck.sql.txt](https://github.com/IMA-WorldHealth/bhima-2.X/files/2141720/period-zero-imck.sql.txt)
