### PR TITLE
fix(balance): update balance calculations

### DIFF
--- a/client/src/i18n/en/balance.json
+++ b/client/src/i18n/en/balance.json
@@ -5,6 +5,7 @@
     "DATE_RANGE":"Date range",
     "DATE_UNTIL":"Until a date",
     "MONTH_SOLD":"Month Movement",
+    "MOVEMENTS":"Movements",
     "NEW_SOLD":"New Balance",
     "OLD_SOLD":"Old Balance",
     "PERIOD_CHOICE":"Period choice",

--- a/client/src/i18n/fr/balance.json
+++ b/client/src/i18n/fr/balance.json
@@ -3,6 +3,7 @@
 "DATE_RANGE":"Intervalle de date",
 "DATE_UNTIL":"Jusqu'a la date",
 "MONTH_SOLD":"Mouvement du mois",
+"MOVEMENTS":"Mouvements",
 "NEW_SOLD":"Nouveau solde",
 "OLD_SOLD":"Ancien solde",
 "PERIOD_CHOICE":"Choix de la période",

--- a/server/controllers/finance/reports/balance/report.handlebars
+++ b/server/controllers/finance/reports/balance/report.handlebars
@@ -17,10 +17,9 @@
       </h2>
 
       <h4 class="text-center">
-        {{#if period.start_date}}
-          <span class="text-capitalize">{{translate "FORM.LABELS.UNTIL_PERIOD"}}</span>
-          <strong class="text-capitalize">{{date period.start_date "MMMM YYYY"}}</strong>
-        {{/if}}
+        <strong class="text-capitalize">{{date period.fiscalYearStart "MMMM YYYY"}}</strong>
+         -
+        <strong class="text-capitalize">{{date period.end_date "MMMM YYYY"}}</strong>
       </h4>
 
       <!-- data  -->
@@ -34,15 +33,12 @@
               </th>
               <th colspan="2" class="text-center">
                 {{translate "BALANCE.OLD_SOLD"}} <br>
-                <small class="text-capitalize">&lt; {{date period.start_date "MMMM YYYY"}}</small>
               </th>
               <th colspan="2" class="text-center">
                 {{translate "BALANCE.MONTH_SOLD"}} <br>
-                <small class="text-capitalize">{{date period.start_date "MMMM YYYY"}}</small>
               </th>
               <th colspan="2" class="text-center">
                 {{translate "BALANCE.NEW_SOLD"}} <br>
-                <small class="text-capitalize">&gt; {{date period.start_date "MMMM YYYY"}}</small>
               </th>
             </tr>
           {{else}}
@@ -85,59 +81,40 @@
               </td>
 
               {{#if ../useSeparateDebitsAndCredits}}
-                {{!-- debtor sold --}}
-                {{#gt account.before.amount 0}}
-                  <td>{{currency account.before.debit account.currencyId }}</td>
-                  <td></td>
-                {{/gt}}
-
-                {{!-- creditor sold --}}
-                {{#lt account.before.amount 0}}
-                  <td></td>
-                  <td>{{currency account.before.credit account.currencyId }}</td>
-                {{/lt}}
-
-                {{!-- void cells in other case --}}
-                {{#unless account.before}}
-                  <td></td>
-                  <td></td>
-                {{/unless}}
+                <td>
+                  {{#if account.before_debit}}
+                    {{currency account.before_debit account.currencyId }}
+                  {{/if}}
+                </td>
+                <td>
+                  {{#if account.before_credit}}
+                    {{currency account.before_credit account.currencyId }}
+                  {{/if}}
+                </td>
               {{else}}
-                <td>{{#if account.before}}{{debcred account.before.amount account.currencyId }}{{/if}}</td>
+                <td>{{#if account.before}}{{debcred account.before account.currencyId }}{{/if}}</td>
               {{/if}}
 
               {{#if ../useSeparateDebitsAndCredits}}
-                {{#if account.during}}
-                  <td>{{currency account.during_debit.amount account.currencyId }}</td>
-                  <td>{{currency account.during_credit.amount account.currencyId }}</td>
-                {{else}}
-                  <td></td>
-                  <td></td>
-                {{/if}}
+                <td>{{currency account.during_debit account.currencyId }}</td>
+                <td>{{currency account.during_credit account.currencyId }}</td>
               {{else}}
-                <td>{{#if account.during}}{{debcred account.during.amount account.currencyId }}{{/if}}</td>
+                <td>{{#if account.during}}{{debcred account.during account.currencyId }}{{/if}}</td>
               {{/if}}
 
               {{#if ../useSeparateDebitsAndCredits}}
-                {{!-- debtor sold --}}
-                {{#gt account.after.amount 0}}
-                  <td>{{currency account.after.debit account.currencyId }}</td>
-                  <td></td>
-                {{/gt}}
-
-                {{!-- creditor sold --}}
-                {{#lt account.after.amount 0}}
-                  <td></td>
-                  <td>{{currency account.after.credit account.currencyId }}</td>
-                {{/lt}}
-
-                {{!-- void cells in other case --}}
-                {{#unless account.after}}
-                  <td></td>
-                  <td></td>
-                {{/unless}}
+                <td>
+                  {{#if account.after_debit}}
+                    {{currency account.after_debit account.currencyId }}
+                  {{/if}}
+                </td>
+                <td>
+                  {{#if account.after_credit}}
+                    {{currency account.after_credit account.currencyId }}
+                  {{/if}}
+                </td>
               {{else}}
-                <td>{{#if account.after}}{{debcred account.after.amount account.currencyId }}{{/if}}</td>
+                <td>{{#if account.after}}{{debcred account.after account.currencyId }}{{/if}}</td>
               {{/if}}
             </tr>
           {{/each}}

--- a/server/controllers/finance/reports/balance/report.handlebars
+++ b/server/controllers/finance/reports/balance/report.handlebars
@@ -35,7 +35,7 @@
                 {{translate "BALANCE.OLD_SOLD"}} <br>
               </th>
               <th colspan="2" class="text-center">
-                {{translate "BALANCE.MONTH_SOLD"}} <br>
+                {{translate "BALANCE.MOVEMENTS"}} <br>
               </th>
               <th colspan="2" class="text-center">
                 {{translate "BALANCE.NEW_SOLD"}} <br>
@@ -51,7 +51,7 @@
                 <small class="text-capitalize">&lt; {{date period.start_date "MMMM YYYY"}}</small>
               </th>
               <th class="text-center">
-                {{translate "BALANCE.MONTH_SOLD"}} <br>
+                {{translate "BALANCE.MOVEMENTS"}} <br>
                 <small class="text-capitalize">{{date period.start_date "MMMM YYYY"}}</small>
               </th>
               <th class="text-center">

--- a/server/models/admin.sql
+++ b/server/models/admin.sql
@@ -23,7 +23,7 @@ BEGIN
   -- employee
   INSERT INTO entity_map
     SELECT employee.creditor_uuid, CONCAT_WS('.', 'EM', enterprise.abbr, employee.reference)
-    FROM employee 
+    FROM employee
     JOIN patient ON patient.uuid = employee.patient_uuid
     JOIN project ON project.id = patient.project_id
     JOIN enterprise ON enterprise.id = project.enterprise_id;
@@ -128,7 +128,7 @@ BEGIN
     FROM general_ledger
       JOIN period ON general_ledger.period_id = period.id
       JOIN project ON general_ledger.project_id = project.id
-    GROUP BY account_id, period_id, enterprise_id;
+    GROUP BY account_id, period_id, fiscal_year_id, enterprise_id;
 
 END $$
 


### PR DESCRIPTION
The PR rewrites the balance report.  Here's what it look like now:
![balancereportnoew](https://user-images.githubusercontent.com/896472/42079683-38cc474e-7b78-11e8-8f58-b53e5dd5ffda.PNG)
_Fig 1: New Balance Presentation_

The following changes have been made:
 1. The `before` section is now replaced with the period 0 balance.
 2. The `movements` section is replaced with all movements up through the selected period.
 3. The `after` section is replace by `before` + `after`.
 4. The Income/Expense accounts are removed from the report.
 5. The title reflects the fact that the report only goes from January through the period selected.

