### PR TITLE
Update invoicing-fees.ctrl.js for Issue 2747

### DIFF
--- a/client/src/modules/invoicing-fees/invoicing-fees.ctrl.js
+++ b/client/src/modules/invoicing-fees/invoicing-fees.ctrl.js
@@ -24,11 +24,6 @@ function InvoicingFeesController($state, InvoicingServices, Notify, bhConstants,
   vm.toggleFilter = toggleFilter;
 
   columns = [{
-    field : 'id',
-    displayName : 'TABLE.COLUMNS.ID',
-    headerCellFilter: 'translate',
-    width: 45,
-  }, {
     field : 'account',
     displayName : 'TABLE.COLUMNS.ACCOUNT',
     headerCellFilter: 'translate',

--- a/test/end-to-end/invoicingFees/invoicingFees.spec.js
+++ b/test/end-to-end/invoicingFees/invoicingFees.spec.js
@@ -1,8 +1,5 @@
 /* global by */
-const chai = require('chai');
 const helpers = require('../shared/helpers');
-
-helpers.configure(chai);
 
 const GU = require('../shared/GridUtils');
 const GA = require('../shared/GridAction');
@@ -35,7 +32,7 @@ describe('Invoicing Fees', () => {
 
   it('can update a invoicing fee', () => {
     // get the cell with the update button and click it
-    GA.clickOnMethod(0, 6, 'edit', 'InvoicingFeesGrid');
+    GA.clickOnMethod(0, 5, 'edit', 'InvoicingFeesGrid');
 
     // expect to find the update form has loaded
     FU.exists(by.css('[name="InvoicingFeesForm"]'), true);
@@ -50,7 +47,7 @@ describe('Invoicing Fees', () => {
 
   it('can delete a invoicing fee', () => {
     // get the cell with the delete button and click it
-    GA.clickOnMethod(0, 6, 'delete', 'InvoicingFeesGrid');
+    GA.clickOnMethod(0, 5, 'delete', 'InvoicingFeesGrid');
 
     // expect the modal to appear
     FU.exists(by.css('[data-confirm-modal]'), true);


### PR DESCRIPTION
This pull request is for issue #2747 to remove the ID column from the invoicing fees UI grid. I removed the following code from /bhima-2.X/client/src/modules/invoicing-fees/invoicing-fees.ctrl.js

{
field : 'id',
displayName : 'TABLE.COLUMNS.ID',
headerCellFilter: 'translate',
width: 45,
},