### PR TITLE
Add barcode scanning to all registries

### DIFF
--- a/client/src/js/services/BarcodeService.js
+++ b/client/src/js/services/BarcodeService.js
@@ -1,9 +1,9 @@
 angular.module('bhima.services')
   .service('BarcodeService', BarcodeService);
 
-BarcodeService.$inject = ['$http', 'util'];
+BarcodeService.$inject = ['$http', 'util', '$uibModal'];
 
-function BarcodeService($http, util) {
+function BarcodeService($http, util, Modal) {
   const service = this;
 
   // TODO - barcode redirection
@@ -13,6 +13,14 @@ function BarcodeService($http, util) {
     return $http.get('/barcode/'.concat(code))
       .then(util.unwrapHttpResponse);
   };
+
+  service.modal = () => Modal.open({
+    controller  : 'BarcodeModalController as BarcodeModalCtrl',
+    templateUrl : 'modules/templates/barcode-scanner-modal.html',
+    size        : 'lg',
+    backdrop    : 'static',
+    keyboard    : true,
+  }).result;
 
   return service;
 }

--- a/client/src/modules/cash/cash.service.js
+++ b/client/src/modules/cash/cash.service.js
@@ -132,6 +132,7 @@ function CashService(
   cashFilters.registerDefaultFilters(bhConstants.defaultFilters);
 
   cashFilters.registerCustomFilters([
+    { key : 'uuid', label : 'FORM.LABELS.REFERENCE' },
     { key : 'is_caution', label : 'FORM.LABELS.CAUTION' },
     { key : 'cashbox_id', label : 'FORM.LABELS.CASHBOX' },
     { key : 'project_id', label : 'FORM.LABELS.PROJECT' },

--- a/client/src/modules/cash/payments/registry.html
+++ b/client/src/modules/cash/payments/registry.html
@@ -48,6 +48,12 @@
                 <span class="fa fa-file-excel-o"></span> <span translate>DOWNLOADS.EXCEL</span>
               </a>
             </li>
+            <li role="separator" class="divider"></li>
+            <li role="menuitem">
+              <a href ng-click="CPRCtrl.openBarcodeScanner()" data-action="scan-barcode">
+                <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN</span>
+              </a>
+            </li>
           </ul>
         </div>
       </div>

--- a/client/src/modules/cash/payments/registry.js
+++ b/client/src/modules/cash/payments/registry.js
@@ -4,7 +4,7 @@ angular.module('bhima.controllers')
 CashPaymentRegistryController.$inject = [
   'CashService', 'bhConstants', 'NotifyService', 'SessionService', 'uiGridConstants',
   'ModalService', 'GridSortingService', '$state', 'FilterService',
-  'GridColumnService', 'GridStateService', 'util', 'ReceiptModal',
+  'GridColumnService', 'GridStateService', 'util', 'ReceiptModal', 'BarcodeService',
 ];
 
 /**
@@ -15,7 +15,7 @@ CashPaymentRegistryController.$inject = [
  */
 function CashPaymentRegistryController(
   Cash, bhConstants, Notify, Session, uiGridConstants, Modal, Sorting, $state,
-  Filters, Columns, GridState, util, Receipts
+  Filters, Columns, GridState, util, Receipts, Barcode
 ) {
   const vm = this;
 
@@ -43,6 +43,7 @@ function CashPaymentRegistryController(
   vm.download = Cash.download;
 
   vm.allowsRecordDeletion = allowsRecordDeletion;
+  vm.openBarcodeScanner = openBarcodeScanner;
 
   const columnDefs = [{
     field : 'reference',
@@ -223,6 +224,25 @@ function CashPaymentRegistryController(
 
   function allowsRecordDeletion() {
     return Session.enterprise.settings.enable_delete_records;
+  }
+
+  /**
+   * @function openBarcodeScanner
+   *
+   * @description
+   * Opens the barcode scanner component and receives the record from the
+   * modal.
+   */
+  function openBarcodeScanner() {
+    Barcode.modal()
+      .then(record => {
+        Cash.filters.replaceFilters([
+          { key : 'uuid', value : record.uuid, displayValue : record.reference },
+        ]);
+
+        load(Cash.filters.formatHTTP(true));
+        vm.latestViewFilters = Cash.filters.formatView();
+      });
   }
 
   startup();

--- a/client/src/modules/invoices/patientInvoice.service.js
+++ b/client/src/modules/invoices/patientInvoice.service.js
@@ -99,7 +99,7 @@ function PatientInvoiceService(
       backdrop : 'static',
       controller : 'InvoiceRegistrySearchModalController as $ctrl',
       resolve : {
-        filters : function filtersProvider() { return filters; },
+        filters : () => filters,
       },
     }).result;
   }
@@ -120,6 +120,7 @@ function PatientInvoiceService(
   invoiceFilters.registerDefaultFilters(bhConstants.defaultFilters);
 
   invoiceFilters.registerCustomFilters([
+    { key : 'uuid', label : 'FORM.LABELS.REFERENCE' },
     { key : 'service_id', label : 'FORM.LABELS.SERVICE' },
     { key : 'user_id', label : 'FORM.LABELS.USER' },
     { key : 'reference', label : 'FORM.LABELS.REFERENCE' },

--- a/client/src/modules/invoices/registry/registry.html
+++ b/client/src/modules/invoices/registry/registry.html
@@ -6,7 +6,7 @@
     </ol>
 
     <div class="toolbar">
-     
+
       <div class="toolbar-item">
         <div uib-dropdown dropdown-append-to-body data-action="open-menu">
           <a class="btn btn-default" uib-dropdown-toggle>
@@ -49,6 +49,12 @@
                 <span class="fa fa-file-excel-o"></span> <span translate>DOWNLOADS.EXCEL</span>
               </a>
             </li>
+            <li role="separator" class="divider"></li>
+            <li role="menuitem">
+              <a href ng-click="InvoiceRegistryCtrl.openBarcodeScanner()" data-action="scan-barcode">
+                <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN</span>
+              </a>
+            </li>
           </ul>
         </div>
       </div>
@@ -61,7 +67,7 @@
           <span class="fa fa-search"></span> <span class="hidden-xs" translate>FORM.BUTTONS.SEARCH</span>
         </button>
       </div>
-      
+
       <bh-filter-toggle on-toggle="InvoiceRegistryCtrl.toggleInlineFilter()">
       </bh-filter-toggle>
 

--- a/client/src/modules/invoices/registry/registry.js
+++ b/client/src/modules/invoices/registry/registry.js
@@ -5,7 +5,7 @@ InvoiceRegistryController.$inject = [
   'PatientInvoiceService', 'bhConstants', 'NotifyService', 'SessionService',
   'ReceiptModal', 'uiGridConstants', 'ModalService', 'GridSortingService',
   'GridColumnService', 'GridStateService', '$state', 'ModalService',
-  'ReceiptModal', 'util',
+  'ReceiptModal', 'util', 'BarcodeService',
 ];
 
 /**
@@ -16,7 +16,8 @@ InvoiceRegistryController.$inject = [
  */
 function InvoiceRegistryController(
   Invoices, bhConstants, Notify, Session, Receipt, uiGridConstants,
-  ModalService, Sorting, Columns, GridState, $state, Modals, Receipts, util
+  ModalService, Sorting, Columns, GridState, $state, Modals, Receipts, util,
+  Barcode
 ) {
   const vm = this;
 
@@ -37,6 +38,7 @@ function InvoiceRegistryController(
   vm.format = util.formatDate;
 
   vm.allowsRecordDeletion = allowsRecordDeletion;
+  vm.openBarcodeScanner = openBarcodeScanner;
 
   // track if module is making a HTTP request for invoices
   vm.loading = false;
@@ -232,6 +234,25 @@ function InvoiceRegistryController(
   function toggleInlineFilter() {
     vm.uiGridOptions.enableFiltering = !vm.uiGridOptions.enableFiltering;
     vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
+  }
+
+  /**
+   * @function openBarcodeScanner
+   *
+   * @description
+   * Opens the barcode scanner component and receives the record from the
+   * modal.
+   */
+  function openBarcodeScanner() {
+    Barcode.modal()
+      .then(record => {
+        Invoices.filters.replaceFilters([
+          { key : 'uuid', value : record.uuid, displayValue : record.reference },
+        ]);
+
+        load(Invoices.filters.formatHTTP(true));
+        vm.latestViewFilters = Invoices.filters.formatView();
+      });
   }
 
   // fire up the module

--- a/client/src/modules/patients/patients.service.js
+++ b/client/src/modules/patients/patients.service.js
@@ -191,6 +191,7 @@ function PatientService(
   patientFilters.registerDefaultFilters(bhConstants.defaultFilters);
 
   patientFilters.registerCustomFilters([
+    { key : 'uuid', label : 'FORM.LABELS.NAME' },
     { key : 'display_name', label : 'FORM.LABELS.NAME' },
     { key : 'sex', label : 'FORM.LABELS.GENDER' },
     { key : 'hospital_no', label : 'FORM.LABELS.HOSPITAL_NO' },

--- a/client/src/modules/patients/registry/registry.html
+++ b/client/src/modules/patients/registry/registry.html
@@ -48,6 +48,12 @@
                 <span class="fa fa-file-excel-o"></span> <span translate>DOWNLOADS.EXCEL</span>
               </a>
             </li>
+            <li role="separator" class="divider"></li>
+            <li role="menuitem">
+              <a href ng-click="PatientRegistryCtrl.openBarcodeScanner()" data-action="scan-barcode">
+                <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN</span>
+              </a>
+            </li>
           </ul>
 
         </div>

--- a/client/src/modules/patients/registry/registry.js
+++ b/client/src/modules/patients/registry/registry.js
@@ -5,7 +5,7 @@ PatientRegistryController.$inject = [
   '$state', 'PatientService', 'NotifyService', 'AppCache', 'util',
   'ReceiptModal', 'uiGridConstants', '$translate', 'GridColumnService',
   'GridSortingService', 'bhConstants', 'GridStateService', '$httpParamSerializer', 'LanguageService',
-  'GridSortingService', 'bhConstants', 'GridStateService', 'LanguageService',
+  'BarcodeService',
 ];
 
 /**
@@ -16,7 +16,8 @@ PatientRegistryController.$inject = [
  */
 function PatientRegistryController(
   $state, Patients, Notify, AppCache, util, Receipts, uiGridConstants,
-  $translate, Columns, Sorting, bhConstants, GridState, $httpParamSerializer, Languages
+  $translate, Columns, Sorting, bhConstants, GridState, $httpParamSerializer, Languages,
+  Barcode
 ) {
   const vm = this;
   const cacheKey = 'PatientRegistry';
@@ -29,6 +30,7 @@ function PatientRegistryController(
   vm.downloadExcel = downloadExcel;
   vm.languageKey = Languages.key;
   vm.toggleInlineFilter = toggleInlineFilter;
+  vm.openBarcodeScanner = openBarcodeScanner;
 
   // track if module is making a HTTP request for patients
   vm.loading = false;
@@ -241,6 +243,25 @@ function PatientRegistryController(
     // return  serialized options
     return $httpParamSerializer(options);
   }
+
+  /**
+   * @function searchByBarcode()
+   *
+   * @description
+   * Gets the barcode from the barcode modal and then
+   */
+  function openBarcodeScanner() {
+    Barcode.modal()
+      .then(record => {
+        Patients.filters.replaceFilters([
+          { key : 'uuid', value : record.uuid, displayValue : record.display_name },
+        ]);
+
+        load(Patients.filters.formatHTTP(true));
+        vm.latestViewFilters = Patients.filters.formatView();
+      });
+  }
+
   // fire up the module
   startup();
 }

--- a/client/src/modules/templates/barcode-scanner-modal.ctrl.js
+++ b/client/src/modules/templates/barcode-scanner-modal.ctrl.js
@@ -1,0 +1,10 @@
+angular.module('bhima.controllers')
+  .controller('BarcodeModalController', BarcodeModalController);
+
+BarcodeModalController.$inject = ['$uibModalInstance'];
+
+function BarcodeModalController(ModalInstance) {
+  const vm = this;
+  vm.dismiss = ModalInstance.dismiss;
+  vm.onScanCallback = (result) => ModalInstance.close(result);
+}

--- a/client/src/modules/templates/barcode-scanner-modal.html
+++ b/client/src/modules/templates/barcode-scanner-modal.html
@@ -1,0 +1,19 @@
+<form name="BarcodeForm" novalidate>
+  <div class="modal-header">
+    <ol class="headercrumb">
+      <li class="title" translate>BARCODE.SCAN</li>
+    </ol>
+  </div>
+
+  <div class="modal-body text-center" style="min-height:300px;">
+    <h2 translate>BARCODE.SCAN</h2>
+
+    <bh-barcode-scanner on-scan-callback="BarcodeModalCtrl.onScanCallback(record)"></bh-barcode-scanner>
+  </div>
+
+  <div class="modal-footer text-right">
+    <button type="button" class="btn btn-default" ng-click="BarcodeModalCtrl.dismiss()" translate>
+      FORM.BUTTONS.CANCEL
+    </button>
+  </div>
+</form>

--- a/client/src/modules/templates/bhSnapShot.html
+++ b/client/src/modules/templates/bhSnapShot.html
@@ -1,33 +1,28 @@
-<div>
-  <div class="modal-header">
-    <h4><i class="fa fa-camera fa-1x"></i> <b>Snapshot</b></h4>
-  </div>
-  <div class="modal-body">
-    <div class='row'>
-      <div class="col-lg-6">
-        <center>
-          <webcam class="well"
-            on-stream="snapshotCtrl.onStream(stream)"
-            on-error="snapshotCtrl.onError(err)"
-            on-streaming="snapshotCtrl.onSuccess()"
-            channel="snapshotCtrl.channel">
-            <div class="alert alert-error" ng-show="snapshotCtrl.webcamError">
-              <span translate>FORM.LABELS.WEBCAM_NOT_STARTED</span>
-            </div>
-          </webcam>
-        </center>
-      </div> 
-      <div class ='col-lg-6'>
-        <center>
-            <canvas id="snapshot" class="well" ng-show='snapshotCtrl.hasDataUrl'></canvas>
-        </center>
-        
-      </div>
+<div class="modal-header">
+  <h4><i class="fa fa-camera fa-1x"></i> <b>Snapshot</b></h4>
+</div>
+
+<div class="modal-body">
+  <div class="row">
+    <div class="col-lg-6">
+      <webcam class="well"
+        on-stream="snapshotCtrl.onStream(stream)"
+        on-error="snapshotCtrl.onError(err)"
+        on-streaming="snapshotCtrl.onSuccess()"
+        channel="snapshotCtrl.channel">
+        <div class="alert alert-error" ng-show="snapshotCtrl.webcamError">
+          <span translate>FORM.LABELS.WEBCAM_NOT_STARTED</span>
+        </div>
+      </webcam>
     </div>
-  <div>
-  <div class="modal-footer">
-    <button class="btn btn-small" ng-click="snapshotCtrl.closeModal()" translate>FORM.LABELS.CANCEL</button>
-    <button class="btn btn-large btn-primary" ng-click="snapshotCtrl.makeSnapshot()" translate> FORM.LABELS.TAKE_SNAPSHOT</button>
-    <button class="btn btn-small" ng-show="snapshotCtrl.hasDataUrl" ng-click="snapshotCtrl.getDataUrl()" translate>FORM.BUTTONS.SAVE</button>
+    <div class="col-lg-6 text-center">
+      <canvas id="snapshot" class="well" ng-show="snapshotCtrl.hasDataUrl"></canvas>
+    </div>
   </div>
-  </div>
+<div>
+
+<div class="modal-footer">
+  <button class="btn btn-small" ng-click="snapshotCtrl.closeModal()" translate>FORM.LABELS.CANCEL</button>
+  <button class="btn btn-large btn-primary" ng-click="snapshotCtrl.makeSnapshot()" translate> FORM.LABELS.TAKE_SNAPSHOT</button>
+  <button class="btn btn-small" ng-show="snapshotCtrl.hasDataUrl" ng-click="snapshotCtrl.getDataUrl()" translate>FORM.BUTTONS.SAVE</button>
+</div>

--- a/client/src/modules/vouchers/voucher-registry.ctrl.js
+++ b/client/src/modules/vouchers/voucher-registry.ctrl.js
@@ -5,7 +5,7 @@ VoucherController.$inject = [
   'VoucherService', 'NotifyService', 'uiGridConstants', 'ReceiptModal',
   'TransactionTypeService', 'bhConstants', 'GridSortingService',
   'GridColumnService', 'GridStateService', '$state', 'ModalService', 'util',
-  'SessionService',
+  'SessionService', 'BarcodeService',
 ];
 
 /**
@@ -18,7 +18,7 @@ VoucherController.$inject = [
  */
 function VoucherController(
   Vouchers, Notify, uiGridConstants, Receipts, TransactionTypes, bhConstants,
-  Sorting, Columns, GridState, $state, Modals, util, Session
+  Sorting, Columns, GridState, $state, Modals, util, Session, Barcode
 ) {
   const vm = this;
 
@@ -39,11 +39,13 @@ function VoucherController(
   vm.reverseVoucher = reverseVoucher;
   vm.showReceipt = showReceipt;
   vm.toggleInlineFilter = toggleInlineFilter;
+  vm.openBarcodeScanner = openBarcodeScanner;
 
   // date format function
   vm.format = util.formatDate;
 
   vm.allowsRecordDeletion = allowsRecordDeletion;
+  vm.showReceipt = Receipts.voucher;
 
   vm.loading = false;
 
@@ -282,7 +284,24 @@ function VoucherController(
     return Session.enterprise.settings.enable_delete_records;
   }
 
-  vm.showReceipt = Receipts.voucher;
+  /**
+   * @function openBarcodeScanner
+   *
+   * @description
+   * Opens the barcode scanner component and receives the record from the
+   * modal.
+   */
+  function openBarcodeScanner() {
+    Barcode.modal()
+      .then(record => {
+        Vouchers.filters.replaceFilters([
+          { key : 'uuid', value : record.uuid, displayValue : record.reference },
+        ]);
+
+        load(Vouchers.filters.formatHTTP(true));
+        vm.latestViewFilters = Vouchers.filters.formatView();
+      });
+  }
 
   startup();
 }

--- a/client/src/modules/vouchers/voucher-registry.html
+++ b/client/src/modules/vouchers/voucher-registry.html
@@ -48,6 +48,12 @@
                 <span class="fa fa-file-excel-o"></span> <span translate>DOWNLOADS.EXCEL</span>
               </a>
             </li>
+            <li role="separator" class="divider"></li>
+            <li role="menuitem">
+              <a href ng-click="VoucherCtrl.openBarcodeScanner()" data-action="scan-barcode">
+                <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN</span>
+              </a>
+            </li>
           </ul>
         </div>
       </div>

--- a/client/src/modules/vouchers/vouchers.service.js
+++ b/client/src/modules/vouchers/vouchers.service.js
@@ -42,6 +42,7 @@ function VoucherService(
   voucherFilters.registerDefaultFilters(bhConstants.defaultFilters);
 
   voucherFilters.registerCustomFilters([
+    { key : 'uuid', label : 'FORM.LABELS.REFERENCE' },
     { key : 'user_id', label : 'FORM.LABELS.USER' },
     { key : 'reference', label : 'FORM.LABELS.REFERENCE' },
     { key : 'reversed', label : 'FORM.INFO.ANNULLED' },

--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -124,7 +124,7 @@ function read(req, res, next) {
  */
 function find(options) {
   // ensure expected options are parsed appropriately as binary
-  db.convert(options, ['debtor_uuid', 'debtor_group_uuid', 'invoice_uuid']);
+  db.convert(options, ['debtor_uuid', 'debtor_group_uuid', 'invoice_uuid', 'uuid']);
   const filters = new FilterParser(options, { tableAlias : 'cash' });
 
   const sql = `
@@ -142,6 +142,7 @@ function find(options) {
       JOIN user u ON u.id = cash.user_id
   `;
 
+  filters.equals('uuid');
   filters.dateFrom('custom_period_start', 'date');
   filters.dateTo('custom_period_end', 'date');
   filters.equals('cashbox_id');

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -97,8 +97,8 @@ function lookupInvoice(invoiceUuid) {
   let record = {};
   const buid = db.bid(invoiceUuid);
 
-  const invoiceDetailQuery =
-    `SELECT
+  const invoiceDetailQuery = `
+    SELECT
       BUID(invoice.uuid) as uuid, CONCAT_WS('.', '${identifiers.INVOICE.key}',
       project.abbr, invoice.reference) AS reference, invoice.cost,
       invoice.description, BUID(invoice.debtor_uuid) AS debtor_uuid,
@@ -111,27 +111,30 @@ function lookupInvoice(invoiceUuid) {
     JOIN project ON project.id = invoice.project_id
     JOIN enterprise ON enterprise.id = project.enterprise_id
     JOIN user ON user.id = invoice.user_id
-    WHERE invoice.uuid = ?;`;
+    WHERE invoice.uuid = ?;
+  `;
 
-  const invoiceItemsQuery =
-    `SELECT
+  const invoiceItemsQuery = `
+    SELECT
       BUID(invoice_item.uuid) as uuid, invoice_item.quantity, invoice_item.inventory_price,
       invoice_item.transaction_price, inventory.code, inventory.text,
       inventory.consumable
     FROM invoice_item
     LEFT JOIN inventory ON invoice_item.inventory_uuid = inventory.uuid
     WHERE invoice_uuid = ?
-    ORDER BY inventory.code;`;
+    ORDER BY inventory.code;
+  `;
 
-  const invoiceBillingQuery =
-    `SELECT
+  const invoiceBillingQuery = `
+    SELECT
       invoice_invoicing_fee.value, invoicing_fee.label, invoicing_fee.value AS billing_value,
       SUM(invoice_item.quantity * invoice_item.transaction_price) AS invoice_cost
     FROM invoice_invoicing_fee
     JOIN invoicing_fee ON invoicing_fee.id = invoice_invoicing_fee.invoicing_fee_id
     JOIN invoice_item ON invoice_item.invoice_uuid = invoice_invoicing_fee.invoice_uuid
     WHERE invoice_invoicing_fee.invoice_uuid = ?
-    GROUP BY invoicing_fee.id`;
+    GROUP BY invoicing_fee.id
+  `;
 
   const invoiceSubsidyQuery = `
     SELECT invoice_subsidy.value, subsidy.label, subsidy.value AS subsidy_value
@@ -219,7 +222,7 @@ function create(req, res, next) {
 function find(options) {
   // ensure expected options are parsed as binary
   db.convert(options, [
-    'patientUuid', 'debtor_group_uuid', 'cash_uuid', 'debtor_uuid', 'inventory_uuid',
+    'patientUuid', 'debtor_group_uuid', 'cash_uuid', 'debtor_uuid', 'inventory_uuid', 'uuid',
   ]);
 
   const filters = new FilterParser(options, { tableAlias : 'invoice' });
@@ -252,6 +255,7 @@ function find(options) {
   filters.equals('reversed');
   filters.equals('service_id');
   filters.equals('user_id');
+  filters.equals('uuid');
 
   filters.equals('reference', 'text', 'dm');
   filters.equals('patientReference', 'text', 'em');

--- a/server/controllers/finance/vouchers.js
+++ b/server/controllers/finance/vouchers.js
@@ -144,6 +144,7 @@ function find(options) {
 
   delete options.detailed;
 
+  filters.equals('uuid');
   filters.period('period', 'date');
   filters.dateFrom('custom_period_start', 'date');
   filters.dateTo('custom_period_end', 'date');

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -194,8 +194,7 @@ function update(req, res, next) {
   delete data.uuid;
   delete data.reference;
 
-  const updatePatientQuery =
-    'UPDATE patient SET ? WHERE uuid = ?';
+  const updatePatientQuery = 'UPDATE patient SET ? WHERE uuid = ?';
 
   db.exec(updatePatientQuery, [data, buid])
     .then(() => updatePatientDebCred(patientUuid))
@@ -401,8 +400,7 @@ function lookupByDebtorUuid(debtorUuid) {
 function hospitalNumberExists(req, res, next) {
   const hospitalNumber = req.params.id;
 
-  const verifyQuery =
-    'SELECT uuid, hospital_no FROM patient WHERE hospital_no = ?';
+  const verifyQuery = 'SELECT uuid, hospital_no FROM patient WHERE hospital_no = ?';
 
   db.exec(verifyQuery, [hospitalNumber])
     .then((result) => {
@@ -463,11 +461,12 @@ function searchByName(req, res, next) {
  */
 function find(options) {
   // ensure epected options are parsed appropriately as binary
-  db.convert(options, ['patient_group_uuid', 'debtor_group_uuid', 'debtor_uuid']);
+  db.convert(options, ['patient_group_uuid', 'debtor_group_uuid', 'debtor_uuid', 'uuid']);
 
   const filters = new FilterParser(options, {
     tableAlias : 'p',
   });
+
   const sql = patientEntityQuery(options.detailed);
 
   filters.equals('debtor_uuid');
@@ -477,6 +476,7 @@ function find(options) {
   filters.equals('health_zone');
   filters.equals('health_area');
   filters.equals('project_id');
+  filters.equals('uuid');
 
   // filters for location
   const orignSql = `(originVillage.name LIKE ?) OR (originSector.name LIKE ?) OR (originProvince.name LIKE ?)`;

--- a/server/lib/barcode.js
+++ b/server/lib/barcode.js
@@ -10,6 +10,7 @@ exports.reverseLookup = reverseLookup;
 
 const { lookupPatient } = require('../controllers/medical/patients');
 const { lookupInvoice } = require('../controllers/finance/patientInvoice');
+const lookupCashPayment = require('../controllers/finance/cash').lookup;
 
 const identifiersIndex = {};
 indexIdentifiers();
@@ -79,4 +80,5 @@ function indexIdentifiers() {
   // @TODO this method of mapping should be reviewed
   identifiers.PATIENT.lookup = lookupPatient;
   identifiers.INVOICE.lookup = lookupInvoice;
+  identifiers.CASH_PAYMENT.lookup = lookupCashPayment;
 }

--- a/server/lib/barcode.js
+++ b/server/lib/barcode.js
@@ -11,6 +11,7 @@ exports.reverseLookup = reverseLookup;
 const { lookupPatient } = require('../controllers/medical/patients');
 const { lookupInvoice } = require('../controllers/finance/patientInvoice');
 const lookupCashPayment = require('../controllers/finance/cash').lookup;
+const { lookupVoucher } = require('../controllers/finance/vouchers');
 
 const identifiersIndex = {};
 indexIdentifiers();
@@ -81,4 +82,5 @@ function indexIdentifiers() {
   identifiers.PATIENT.lookup = lookupPatient;
   identifiers.INVOICE.lookup = lookupInvoice;
   identifiers.CASH_PAYMENT.lookup = lookupCashPayment;
+  identifiers.VOUCHER.lookup = lookupVoucher;
 }

--- a/test/client-unit/components/bhBarcoderScanner.spec.js
+++ b/test/client-unit/components/bhBarcoderScanner.spec.js
@@ -10,7 +10,7 @@ function bhBarcodeScannerTests() {
   `;
 
   // make sure the modules are correctly loaded.
-  beforeEach(module('pascalprecht.translate', 'bhima.services', 'templates', 'bhima.components', 'angularMoment'));
+  beforeEach(module('pascalprecht.translate', 'bhima.services', 'templates', 'bhima.components', 'angularMoment', 'ui.bootstrap'));
 
   let $scope;
   let $compile;


### PR DESCRIPTION
This PR adds the barcode scanning to the principal registries.  This includes:
 1. Invoice Registry
 2. Cash Payments Registry
 3. Voucher Registry

It depends on the work done in #3009.

Once these have been approved, the stock, purchase orders, etc can relatively easily be added in if desired.