### PR TITLE
fix: add typings for es6 + DOM

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -184,6 +184,7 @@ gulp.task('client-compile-typescript', (cb) => {
     typescript({
       allowJs : true,
       target : 'es5',
+      lib : ['es6', 'dom'],
       module : 'none',
       outFile : 'js/bhima.min.js',
     }),


### PR DESCRIPTION
Recent version of typescript seem to refuse to build if the types for ES6 and the DOM are not provided.

Closes #3020.