### PR TITLE
Allow users to disable barcodes for enterprise

### DIFF
--- a/client/src/i18n/en/enterprise.json
+++ b/client/src/i18n/en/enterprise.json
@@ -19,7 +19,9 @@
       "ENABLE_PASSWORD_VALIDATION_LABEL" : "Enforce Strict Password Validation",
       "ENABLE_PASSWORD_VALIDATION_HELP_TEXT" : "Enabling this feature forces users to use hard-to-guess passwords.  This action is not retroactive.  Old passwords will continue to work until manually changed.",
       "ENABLE_PREPAYMENT_INVOICE_LABEL" : "Enable to see the balance on invoice",
-      "ENABLE_PREPAYMENT_INVOICE_HELP_TEXT" : "Enabling this feature allows to see the balance and the paid amount on an invoice"
+      "ENABLE_PREPAYMENT_INVOICE_HELP_TEXT" : "Enabling this feature allows to see the balance and the paid amount on an invoice",
+      "ENABLE_BARCODES_LABEL" : "Enables barcodes throughout the application",
+      "ENABLE_BARCODES_HELP_TEXT" : "Enabling this feature will place barcodes on most printed records and enable options to scan barcodes for document inputs."
     }
   }
 }

--- a/client/src/i18n/fr/enterprise.json
+++ b/client/src/i18n/fr/enterprise.json
@@ -19,7 +19,9 @@
       "ENABLE_PASSWORD_VALIDATION_LABEL" : "Strictement valider les mots de passe",
       "ENABLE_PASSWORD_VALIDATION_HELP_TEXT" : "L'activation de cette fonctionnalité oblige les utilisateurs à utiliser des mots de passe difficiles à deviner. Cette action n'est pas rétroactive. Les anciens mots de passe continueront à fonctionner jusqu'à modification manuelle.",
       "ENABLE_PREPAYMENT_INVOICE_LABEL" : "Activer l'affichage du solde sur la facture",
-      "ENABLE_PREPAYMENT_INVOICE_HELP_TEXT" : "L'activation de cette option permet de voir les montants payés ainsi que le solde pour une facture"
+      "ENABLE_PREPAYMENT_INVOICE_HELP_TEXT" : "L'activation de cette option permet de voir les montants payés ainsi que le solde pour une facture",
+      "ENABLE_BARCODES_LABEL" : "Activer les codes à barres dans l'application",
+      "ENABLE_BARCODES_HELP_TEXT" : "L'activation de cette fonction placera des codes à barres sur la plupart des enregistrements imprimés et activera les options permettant de numériser des codes à barres pour les entrées de document."
     }
   }
 }

--- a/client/src/js/components/bhFindPatient.js
+++ b/client/src/js/components/bhFindPatient.js
@@ -5,8 +5,8 @@ angular.module('bhima.components')
     bindings : {
       patientUuid :       '<', // bind a patient uuid
       onSearchComplete :  '&', // bind callback to call when data is available
-      onRegisterApi :     '&', // expose force refresh API
-      required :          '<', // bind the required (for ng-required)
+      onRegisterApi :     '&?', // expose force refresh API
+      required :          '<?', // bind the required (for ng-required)
       validationTrigger : '<', // bind validation trigger
       suppressReset :     '<', // bind the reset
     },
@@ -37,7 +37,7 @@ FindPatientComponent.$inject = [
  *   - validationTrigger: binds a boolean to indicate if the components validation
  *     should be run
  */
-function FindPatientComponent(Patients, AppCache, Notify, SessionService, bhConstants, Barcode) {
+function FindPatientComponent(Patients, AppCache, Notify, Session, bhConstants, Barcode) {
   const vm = this;
 
   /* cache to remember which the search type of the component */
@@ -62,11 +62,13 @@ function FindPatientComponent(Patients, AppCache, Notify, SessionService, bhCons
         label       : 'FORM.LABELS.PATIENT_NAME',
         placeholder : 'FORM.PLACEHOLDERS.SEARCH_NAME',
       },
-
-      findByBarcode : {
-        label       : 'BARCODE.SCAN',
-      },
     };
+
+    if (Session.isSettingEnabled('barcodes')) {
+      vm.options.findByBarcode = {
+        label : 'BARCODE.SCAN',
+      };
+    }
 
     vm.showSearchView = true;
     vm.loadStatus = null;
@@ -132,7 +134,7 @@ function FindPatientComponent(Patients, AppCache, Notify, SessionService, bhCons
     const isValidNumber = !Number.isNaN(Number(reference));
 
     const ref = isValidNumber
-      ? `${bhConstants.identifiers.PATIENT.key}.${SessionService.project.abbr}.${reference}`
+      ? `${bhConstants.identifiers.PATIENT.key}.${Session.project.abbr}.${reference}`
       : reference;
 
     const options = {

--- a/client/src/js/directives/bhRequireEnterpriseSetting.js
+++ b/client/src/js/directives/bhRequireEnterpriseSetting.js
@@ -1,0 +1,26 @@
+angular.module('bhima.directives')
+  .directive('bhRequireEnterpriseSetting', bhRequireEnterpriseSetting);
+
+bhRequireEnterpriseSetting.$inject = ['SessionService'];
+
+/**
+ * @function bhRequireEnterpriseSetting
+ *
+ * @description
+ * A sort directive to remove the underlying HTML if the Enterprise Setting is
+ * not set.
+ */
+function bhRequireEnterpriseSetting(Session) {
+  return {
+    restrict : 'A',
+    scope : { bhRequireEnterpriseSetting : '@bhRequireEnterpriseSetting' },
+    link : (scope, element, attrs) => {
+      const hasRequiredSetting = Session.isSettingEnabled(attrs.bhRequireEnterpriseSetting);
+
+      // remove setting if not available
+      if (!hasRequiredSetting) {
+        element.remove();
+      }
+    },
+  };
+}

--- a/client/src/modules/cash/cash.html
+++ b/client/src/modules/cash/cash.html
@@ -24,8 +24,8 @@
                 <i class="fa fa-exchange"></i> <span translate>CASH.VOUCHER.CASHBOXES.TRANSFER</span>
               </a>
             </li>
-            <li role="separator" class="divider"></li>
-            <li role="menuitem">
+            <li role="separator" class="divider" bh-require-enterprise-setting="barcodes"></li>
+            <li role="menuitem" bh-require-enterprise-setting="barcodes">
               <!-- TODO(@jniles) remove CashFormInstance -->
               <a href ui-sref="cash.scan({ id: CashCtrl.cashbox.id, CashFormInstance: CashCtrl.Payment })" data-action="scan-barcode">
                 <i class="fa fa-barcode"></i> <span translate>BARCODE.SCAN</span>
@@ -89,7 +89,7 @@
                     NOTE(@jniles): this option is only visible if enable_prepayments
                     is set in the enterprise settings
                   -->
-                  <div class="radio" ng-class="{ 'has-error' : CashVoucherForm.$submitted && CashVoucherForm.type.$invalid }" ng-if="CashCtrl.Payment.hasPrepaymentSupport">
+                  <div class="radio" ng-class="{ 'has-error' : CashVoucherForm.$submitted && CashVoucherForm.type.$invalid }" bh-require-enterprise-setting="prepayments">
                     <p><strong class="control-label" translate>FORM.LABELS.TYPE</strong></p>
                     <label class="radio-inline">
                       <input name="type" type="radio" ng-model="CashCtrl.Payment.details.is_caution" ng-value="1" ng-change="CashCtrl.Payment.setCautionType(CashCtrl.Payment.details.is_caution)" data-caution-option="1" required>
@@ -206,7 +206,7 @@
 
                 <div class="form-group text-right">
 
-                  <div class="checkbox" style="display : inline-block; padding-right:5px;">
+                  <div class="checkbox" style="display: inline-block; padding-right:5px;" bh-require-enterprise-setting="barcodes">
                     <label>
                       <input type="checkbox" ng-model="CashCtrl.openBarcodeModalOnSuccess" ng-true-value="true" ng-false-value="false"> <span translate>CASH.VOUCHER.OPEN_BARCODE_MODAL</span>
                     </label>

--- a/client/src/modules/cash/payments/registry.html
+++ b/client/src/modules/cash/payments/registry.html
@@ -48,8 +48,8 @@
                 <span class="fa fa-file-excel-o"></span> <span translate>DOWNLOADS.EXCEL</span>
               </a>
             </li>
-            <li role="separator" class="divider"></li>
-            <li role="menuitem">
+            <li role="separator" class="divider" bh-require-enterprise-setting="barcodes"></li>
+            <li role="menuitem" bh-require-enterprise-setting="barcodes">
               <a href ng-click="CPRCtrl.openBarcodeScanner()" data-action="scan-barcode">
                 <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN</span>
               </a>

--- a/client/src/modules/cash/payments/registry.js
+++ b/client/src/modules/cash/payments/registry.js
@@ -28,6 +28,7 @@ function CashPaymentRegistryController(
   vm.format = util.formatDate;
   vm.Receipts = Receipts;
   vm.toggleInlineFilter = toggleInlineFilter;
+  vm.isSettingEnabled = Session.isSettingEnabled;
 
   // global variables
   vm.enterprise = Session.enterprise;

--- a/client/src/modules/enterprises/enterprises.html
+++ b/client/src/modules/enterprises/enterprises.html
@@ -215,6 +215,13 @@
               help-text="ENTERPRISE.SETTINGS.ENABLE_PASSWORD_VALIDATION_HELP_TEXT"
               on-change-callback="EnterpriseCtrl.enablePasswordValidationSetting(value)">
             </bh-yes-no-radios>
+
+            <bh-yes-no-radios
+              label="ENTERPRISE.SETTINGS.ENABLE_BARCODES_LABEL"
+              value="EnterpriseCtrl.enterprise.settings.enable_barcodes"
+              help-text="ENTERPRISE.SETTINGS.ENABLE_BARCODES_HELP_TEXT"
+              on-change-callback="EnterpriseCtrl.enableBarcodesSetting(value)">
+            </bh-yes-no-radios>
           </div>
         </div>
 

--- a/client/src/modules/enterprises/enterprises.js
+++ b/client/src/modules/enterprises/enterprises.js
@@ -26,11 +26,6 @@ function EnterpriseController(Enterprises, util, Notify, Projects, Modal, Scroll
   vm.submit = submit;
   vm.onSelectGainAccount = onSelectGainAccount;
   vm.onSelectLossAccount = onSelectLossAccount;
-  vm.enablePriceLockSetting = enablePriceLockSetting;
-  vm.enablePrepaymentsSetting = enablePrepaymentsSetting;
-  vm.enableDeleteRecordsSetting = enableDeleteRecordsSetting;
-  vm.enablePasswordValidationSetting = enablePasswordValidationSetting;
-  vm.enableBalanceOnInvoiceReceipSetting = enableBalanceOnInvoiceReceipSetting;
 
   // fired on startup
   function startup() {
@@ -170,30 +165,28 @@ function EnterpriseController(Enterprises, util, Notify, Projects, Modal, Scroll
       });
   }
 
-  function enablePriceLockSetting(enabled) {
-    vm.enterprise.settings.enable_price_lock = enabled;
-    $touched = true;
+
+  /**
+   * @function proxy
+   *
+   * @description
+   * Proxies requests for different enterprise settings.
+   *
+   * @returns {function}
+   */
+  function proxy(key) {
+    return (enabled) => {
+      vm.enterprise.settings[key] = enabled;
+      $touched = true;
+    };
   }
 
-  function enablePrepaymentsSetting(enabled) {
-    vm.enterprise.settings.enable_prepayments = enabled;
-    $touched = true;
-  }
-
-  function enableDeleteRecordsSetting(enabled) {
-    vm.enterprise.settings.enable_delete_records = enabled;
-    $touched = true;
-  }
-
-  function enablePasswordValidationSetting(enabled) {
-    vm.enterprise.settings.enable_password_validation = enabled;
-    $touched = true;
-  }
-
-  function enableBalanceOnInvoiceReceipSetting(enabled) {
-    vm.enterprise.settings.enable_balance_on_invoice_receipt = enabled;
-    $touched = true;
-  }
+  vm.enablePriceLockSetting = proxy('enable_price_lock');
+  vm.enablePrepaymentsSetting = proxy('enable_prepayments');
+  vm.enableDeleteRecordsSetting = proxy('enable_delete_records');
+  vm.enablePasswordValidationSetting = proxy('enable_password_validation');
+  vm.enableBalanceOnInvoiceReceipSetting = proxy('enable_balance_on_invoice_receipt');
+  vm.enableBarcodesSetting = proxy('enable_barcodes');
 
   startup();
 }

--- a/client/src/modules/invoices/registry/registry.html
+++ b/client/src/modules/invoices/registry/registry.html
@@ -49,8 +49,8 @@
                 <span class="fa fa-file-excel-o"></span> <span translate>DOWNLOADS.EXCEL</span>
               </a>
             </li>
-            <li role="separator" class="divider"></li>
-            <li role="menuitem">
+            <li role="separator" class="divider" bh-require-enterprise-setting="barcodes"></li>
+            <li role="menuitem" bh-require-enterprise-setting="barcodes">
               <a href ng-click="InvoiceRegistryCtrl.openBarcodeScanner()" data-action="scan-barcode">
                 <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN</span>
               </a>

--- a/client/src/modules/patients/registry/registry.html
+++ b/client/src/modules/patients/registry/registry.html
@@ -48,8 +48,8 @@
                 <span class="fa fa-file-excel-o"></span> <span translate>DOWNLOADS.EXCEL</span>
               </a>
             </li>
-            <li role="separator" class="divider"></li>
-            <li role="menuitem">
+            <li role="separator" class="divider" bh-require-enterprise-setting="barcodes"></li>
+            <li role="menuitem" bh-require-enterprise-setting="barcodes">
               <a href ng-click="PatientRegistryCtrl.openBarcodeScanner()" data-action="scan-barcode">
                 <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN</span>
               </a>

--- a/client/src/modules/vouchers/voucher-registry.html
+++ b/client/src/modules/vouchers/voucher-registry.html
@@ -48,8 +48,8 @@
                 <span class="fa fa-file-excel-o"></span> <span translate>DOWNLOADS.EXCEL</span>
               </a>
             </li>
-            <li role="separator" class="divider"></li>
-            <li role="menuitem">
+            <li role="separator" class="divider" bh-require-enterprise-setting="barcodes"></li>
+            <li role="menuitem" bh-require-enterprise-setting="barcodes">
               <a href ng-click="VoucherCtrl.openBarcodeScanner()" data-action="scan-barcode">
                 <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN</span>
               </a>

--- a/server/controllers/admin/enterprises.js
+++ b/server/controllers/admin/enterprises.js
@@ -23,7 +23,8 @@ exports.list = function list(req, res, next) {
       SELECT id, name, abbr, email, po_box, phone,
         BUID(location_id) AS location_id, logo, currency_id,
         gain_account_id, loss_account_id, enable_price_lock, enable_prepayments,
-        enable_delete_records, enable_password_validation, enable_balance_on_invoice_receipt
+        enable_delete_records, enable_password_validation, enable_balance_on_invoice_receipt,
+        enable_barcodes
       FROM enterprise LEFT JOIN enterprise_setting
         ON enterprise.id = enterprise_setting.enterprise_id
       ;`;
@@ -44,6 +45,7 @@ exports.list = function list(req, res, next) {
             'enable_delete_records',
             'enable_password_validation',
             'enable_balance_on_invoice_receipt',
+            'enable_barcodes',
           ];
 
           row.settings = _.pick(row, settings);
@@ -82,7 +84,8 @@ function lookupEnterprise(id) {
       enable_price_lock,
       enable_prepayments,
       enable_password_validation,
-      enable_balance_on_invoice_receipt
+      enable_balance_on_invoice_receipt,
+      enable_barcodes
     FROM enterprise_setting WHERE enterprise_id = ?;
   `;
 

--- a/server/controllers/finance/reports/cash/receipt.handlebars
+++ b/server/controllers/finance/reports/cash/receipt.handlebars
@@ -27,7 +27,9 @@
           </span> <br>
           <strong>{{payment.reference}}</strong> <br>
           <small>{{date payment.date}}</small> <br>
-          <small>{{> barcode value=details.barcode}}</small> <br>
+          {{#if metadata.enterprise.settings.enable_barcodes}}
+            <small>{{> barcode value=details.barcode}}</small> <br>
+          {{/if}}
           <br>
         </h3>
       </div>

--- a/server/controllers/finance/reports/cash/receipt.pos.handlebars
+++ b/server/controllers/finance/reports/cash/receipt.pos.handlebars
@@ -1,13 +1,17 @@
 <head>
   <meta charset="utf-8" />
-  <script src="{{absolutePath}}/vendor/JsBarcode.all.min.js"></script>
+  {{#if metadata.enterprise.settings.enable_barcodes}}
+    <script src="{{absolutePath}}/vendor/JsBarcode.all.min.js"></script>
+  {{/if}}
 </head>
 <body>
 <p><b style="text-transform : uppercase">{{enterprise.name}}</b></p>
 <h2 style="text-align : left; margin : 0px">{{payment.reference}}</h2>
 <p style="margin-top : 0px">{{date payment.date}} {{translate 'FORM.LABELS.BY'}} {{user.display_name}}</p>
 
-<div style="text-align : center;">{{> barcode value=payment.barcode}}</div>
+{{#if metadata.enterprise.settings.enable_barcodes}}
+  <div style="text-align : center;">{{> barcode value=payment.barcode}}</div>
+{{/if}}
 
 <h2 style="margin-bottom : 0px">{{patient.display_name}}</h2>
 ({{patient.reference}}) - {{patient.debtor_group_name}}
@@ -32,7 +36,7 @@
 {{translate "CASH.CAUTION"}}
 {{/if}}
 
-<!-- if !payment.is_caution -->
+{{! if !payment.is_caution }}
 {{#each payment.items as |item| }}
   <p style="font-weight : bold; text-decoration : underline; margin-bottom : 0px;">
     {{translate "FORM.LABELS.INVOICE"}} {{item.reference}} -- {{item.serviceName}}
@@ -73,5 +77,7 @@
 <h2 style="text-align : right;">{{translate "FORM.LABELS.TOTAL_PAID"}}: {{currency payment.amount payment.currency_id}}</h2>
 <h2 style="text-align : right;">{{translate "FORM.LABELS.TOTAL_BALANCE_REMAINING"}} : {{currency debtorTotalBalance enterprise.currency_id}}</h2>
 
-<script>JsBarcode('.barcode').init();</script>
+{{#if metadata.enterprise.settings.enable_barcodes}}
+  <script>JsBarcode('.barcode').init();</script>
+{{/if}}
 </body>

--- a/server/controllers/finance/reports/invoices/receipt.handlebars
+++ b/server/controllers/finance/reports/invoices/receipt.handlebars
@@ -25,7 +25,10 @@
           <span class="text-uppercase">{{translate 'FORM.LABELS.INVOICE'}}</span> <br>
           <strong>{{reference}}</strong> <br>
           <small>{{date date}}</small> <br>
-          <small>{{> barcode value=barcode}}</small><br>
+
+          {{#if metadata.enterprise.settings.enable_barcodes}}
+            <small>{{> barcode value=barcode}}</small><br>
+          {{/if}}
           <br>
         </h3>
       </div>

--- a/server/controllers/finance/reports/vouchers/receipt.handlebars
+++ b/server/controllers/finance/reports/vouchers/receipt.handlebars
@@ -19,7 +19,9 @@
         </h3>
         <div>{{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time></div>
         <div>{{translate "REPORT.PRODUCED_BY"}} {{metadata.user.username}}</div>
-        <div>{{> barcode value=details.barcode}}</div>
+        {{#if metadata.enterprise.settings.enable_barcodes}}
+          <div>{{> barcode value=details.barcode}}</div>
+        {{/if}}
       </div>
     </div>
   </header>
@@ -76,5 +78,7 @@
   <h4>
     <u>{{translate 'FORM.LABELS.SIGNATURE'}}s</u>
   </h4>
-  <script>JsBarcode('.barcode').init();</script>
+  {{#if metadata.enterprise.settings.enable_barcodes}}
+    <script>JsBarcode('.barcode').init();</script>
+  {{/if}}
 </div>

--- a/server/controllers/finance/reports/vouchers/receipt.pos.handlebars
+++ b/server/controllers/finance/reports/vouchers/receipt.pos.handlebars
@@ -1,13 +1,17 @@
 <head>
- <meta charset="utf-8" />
-  <script src="{{absolutePath}}/vendor/JsBarcode.all.min.js"></script>
+  <meta charset="utf-8" />
+  {{#if metadata.enterprise.settings.enable_barcodes}}
+    <script src="{{absolutePath}}/vendor/JsBarcode.all.min.js"></script>
+  {{/if}}
 </head>
 <body>
 <p><b style="text-transform : uppercase">{{enterprise.name}}</b></p>
 <h2 style="text-align : left; margin : 0px">{{details.reference}}</h2>
 <p style="margin-top : 0px">{{date details.date}} {{translate 'FORM.LABELS.BY'}} {{details.display_name}}</p>
 
-<div style="text-align : center;">{{> barcode value=details.barcode}}</div>
+{{#if metadata.enterprise.settings.enable_barcodes}}
+  <div style="text-align : center;">{{> barcode value=details.barcode}}</div>
+{{/if}}
 
 <h2 style="margin-bottom : 0px">{{translate details.text}}</h2>
 
@@ -42,5 +46,7 @@
 
 <h2 style="text-align : right;">{{translate "FORM.LABELS.TOTAL"}}: {{currency details.amount details.currency_id}}</h2>
 
-<script>JsBarcode('.barcode').init();</script>
+{{#if metadata.enterprise.settings.enable_barcodes}}
+  <script>JsBarcode('.barcode').init();</script>
+{{/if}}
 </body>

--- a/server/controllers/medical/reports/patient.pos.handlebars
+++ b/server/controllers/medical/reports/patient.pos.handlebars
@@ -9,7 +9,9 @@
   {{date patient.registration_date}} {{translate 'FORM.LABELS.BY'}} {{patient.userName}}
 </p>
 
-<div style="text-align:center">{{>barcode value=patient.barcode }}</div>
+{{#if metadata.enterprise.settings.enable_barcodes}}
+  <div style="text-align:center;">{{>barcode value=patient.barcode }}</div>
+{{/if}}
 
 <h2 style="margin-bottom : 0px">{{patient.display_name}}</h2>
 ({{patient.reference}}) - {{patient.debtor_group_name}}

--- a/server/controllers/medical/reports/patient.receipt.handlebars
+++ b/server/controllers/medical/reports/patient.receipt.handlebars
@@ -69,6 +69,7 @@
   </div>
   {{/unless}}
 
+  {{#if metadata.enterprise.settings.enable_barcodes}}
   <div class="row" style="margin-top: 1em;">
     <div class="col-xs-12">
       {{> barcode value=patient.barcode }}
@@ -76,4 +77,5 @@
   </div>
 
   <script>JsBarcode('.barcode').init();</script>
+  {{/if}}
 </body>

--- a/server/lib/ReportManager.js
+++ b/server/lib/ReportManager.js
@@ -126,8 +126,7 @@ class ReportManager {
    *    render() function.
    */
   render(data) {
-    const { metadata } = this;
-    const { renderer } = this;
+    const { metadata, renderer } = this;
 
     // set the render timestamp
     metadata.timestamp = new Date();
@@ -139,9 +138,7 @@ class ReportManager {
     // sanitise save report option
     this.options.saveReport = Boolean(Number(this.options.saveReport));
 
-
     // merge the data object before templating
-
     _.merge(data, { metadata });
 
     // some reports(Excel,..) require renaming result's column names
@@ -149,7 +146,6 @@ class ReportManager {
     const { displayNames, renameKeys } = this.options;
 
     const rowsToRename = data.rows || data[this.options.rowsDataKey];
-
 
     data.rows = (renameKeys) ? util.renameKeys(rowsToRename, displayNames) : data.rows;
     //

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -653,6 +653,7 @@ CREATE TABLE `enterprise_setting` (
   `enable_prepayments` TINYINT(1) NOT NULL DEFAULT 1,
   `enable_password_validation` TINYINT(1) NOT NULL DEFAULT 1,
   `enable_balance_on_invoice_receipt` TINYINT(1) NOT NULL DEFAULT 0,
+  `enable_barcodes` TINYINT(1) NOT NULL DEFAULT 1,
   PRIMARY KEY (`enterprise_id`),
   FOREIGN KEY (`enterprise_id`) REFERENCES `enterprise` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/test/client-unit/services/PatientInvoiceForm.spec.js
+++ b/test/client-unit/services/PatientInvoiceForm.spec.js
@@ -1,5 +1,3 @@
-/* global inject, expect, chai */
-/* eslint no-unused-expressions:off */
 describe('PatientInvoiceForm', () => {
   let PatientInvoiceForm;
   let httpBackend;
@@ -236,7 +234,7 @@ describe('PatientInvoiceForm', () => {
 
     // mocks a DOM element for the focus() call
     const mockDOMElement = {
-      focus : () => console.log('Hello World'),
+      focus : () => {},
     };
 
     // replace the top level document with a simple chai spy.


### PR DESCRIPTION
This PR implements the ability to remove barcodes from the application with a single click.  For institutions that will never use barcodes, they are a waste of ink and space.  Now, the option to have barcodes is an enterprise-level setting to either show them or remove them.

A new component `bhRequireEnterpriseSetting` has been added to make life easier when hiding elements based on the enterprise setting.  You just have a stick it to an element and it will be removed if the enterprise does not support that setting.  Such as this:
```html
<div bh-require-enterprise-setting="prepayments">
 <span> I will only be shown if "session.enterprise.settings.enable_prepayments" is true! </span>
</div>
```

Closes #2820.