### PR TITLE
fix(reports): polish P&L Statement

### DIFF
--- a/client/src/i18n/en/errors.json
+++ b/client/src/i18n/en/errors.json
@@ -1,6 +1,6 @@
 {
   "ERRORS" : {
-    "BAD_DATE_INTERVAL" : "Bad date interval",
+    "BAD_DATE_INTERVAL" : "Incorrect date interval.  Please check that both fields are filled out in the correct order.",
     "BAD_REQUEST" : "You are not allowed to perform this operation",
     "ERR_INTERNET_DISCONNECTED" : "You are not connected to the network.",
     "HOLIDAY_NESTED" : "The vacation period defined for this employee is nested with another period",
@@ -29,6 +29,7 @@
     "ER_NO_STOCK_DESTINATION" : "No stock destination defined",
     "ER_NO_STOCK_SOURCE" : "No stock origin defined",
     "NO_NEXT_FISCAL_YEAR" : "Fiscal years can only be closed into a subsequent year.  Please open a new year before closing this one.",
-    "MISSING_UPLOAD_FILES" : "Missing files to upload"
+    "MISSING_UPLOAD_FILES" : "It doesn't look like you have selected files to upload.  Please choose one or more file to upload.",
+    "NO_DATA_FOUND" : "No records matched your criteria."
   }
 }

--- a/client/src/i18n/fr/errors.json
+++ b/client/src/i18n/fr/errors.json
@@ -29,6 +29,7 @@
     "ER_NO_STOCK_DESTINATION" : "Aucune destination de stock n'a été définie",
     "ER_NO_STOCK_SOURCE" : "Aucune source de stock n'a été définie",
     "NO_NEXT_FISCAL_YEAR" : "Vous ne pouvez clôturer une année financière que si vous avez défini une année suivante. Veuillez créer un exercice financier avant de fermer celui-ci.",
-    "MISSING_UPLOAD_FILES" : "Fichiers à envoyer manquant"
+    "MISSING_UPLOAD_FILES" : "Fichiers à envoyer manquant",
+    "NO_DATA_FOUND" : "Aucun enregistrement correspondant à vos critères"
   }
 }

--- a/server/controllers/finance/reports/income_expense/report.handlebars
+++ b/server/controllers/finance/reports/income_expense/report.handlebars
@@ -35,9 +35,9 @@
             <tr {{#if account.isTitleAccount}} class="text-bold" {{/if}}>
               <td>{{account.number}}</td>
               <td style="padding-left:calc(({{account.depth}} - 1) * 15px);">{{account.label}}</td>
-              <td class="text-right">{{debcred account.previousBalance metadata.enterprise.currency_id}}</td>
-              <td class="text-right">{{debcred account.balance metadata.enterprise.currency_id}}</td>
-              <td class="text-right">{{debcred account.difference metadata.enterprise.currency_id}}</td>
+              <td class="text-right">{{debcred account.previousBalance ../metadata.enterprise.currency_id}}</td>
+              <td class="text-right">{{debcred account.balance ../metadata.enterprise.currency_id}}</td>
+              <td class="text-right">{{debcred account.difference ../metadata.enterprise.currency_id}}</td>
               <td class="text-right">{{percentage account.variance}}</td>
             </tr>
           {{/each}}
@@ -46,7 +46,7 @@
             <td class="text-right">{{debcred totals.income.previousBalance metadata.enterprise.currency_id}}</td>
             <td class="text-right">{{debcred totals.income.balance metadata.enterprise.currency_id}}</td>
             <td class="text-right">{{debcred totals.income.difference metadata.enterprise.currency_id}}</td>
-            <td class="text-right">{{debcred totals.income.variance metadata.enterprise.currency_id}}</td>
+            <td class="text-right">{{percentage totals.income.variance}}</td>
           </tr>
         </tbody>
       </table>
@@ -74,9 +74,9 @@
             <tr {{#if account.isTitleAccount}} class="text-bold" {{/if}}>
               <td>{{account.number}}</td>
               <td style="padding-left:calc(({{account.depth}} - 1) * 15px);">{{account.label}}</td>
-              <td class="text-right">{{debcred account.previousBalance metadata.enterprise.currency_id}}</td>
-              <td class="text-right">{{debcred account.balance metadata.enterprise.currency_id}}</td>
-              <td class="text-right">{{debcred account.difference metadata.enterprise.currency_id}}</td>
+              <td class="text-right">{{debcred account.previousBalance ../metadata.enterprise.currency_id}}</td>
+              <td class="text-right">{{debcred account.balance ../metadata.enterprise.currency_id}}</td>
+              <td class="text-right">{{debcred account.difference ../metadata.enterprise.currency_id}}</td>
               <td class="text-right">{{percentage account.variance}}</td>
             </tr>
           {{else}}
@@ -87,7 +87,7 @@
             <td class="text-right">{{debcred totals.expense.previousBalance metadata.enterprise.currency_id}}</td>
             <td class="text-right">{{debcred totals.expense.balance metadata.enterprise.currency_id}}</td>
             <td class="text-right">{{debcred totals.expense.difference metadata.enterprise.currency_id}}</td>
-            <td class="text-right">{{debcred totals.expense.variance metadata.enterprise.currency_id}}</td>
+            <td class="text-right">{{percentage totals.expense.variance}}</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
This commit fixes a few bugs in the profit and loss statement:
 1. Renders the enterprise currency properly.
 2. Calculates the balance/difference between the profit and loss.
 3. No longer renders variance totals as a currency.
 4. Throws an error if there isn't a matching set of data.

Closes #3044.