### PR TITLE
Fixed defaults on radio items on 'Balance des comptes' report

### DIFF
--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -71,5 +71,12 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
     if (cache.reportDetails) {
       vm.reportDetails = angular.copy(cache.reportDetails);
     }
+    // Set the defaults for the radio items
+    if (!angular.isDefined(vm.reportDetails.useSeparateDebitsAndCredits))
+      vm.reportDetails.useSeparateDebitsAndCredits = 1;
+    if (!angular.isDefined(vm.reportDetails.shouldPruneEmptyRows))
+      vm.reportDetails.shouldPruneEmptyRows = 1;
+    if (!angular.isDefined(vm.reportDetails.shouldHideTitleAccounts))
+      vm.reportDetails.shouldHideTitleAccounts = 0;
   }
 }

--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -72,11 +72,16 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
       vm.reportDetails = angular.copy(cache.reportDetails);
     }
     // Set the defaults for the radio items
-    if (!angular.isDefined(vm.reportDetails.useSeparateDebitsAndCredits))
+    if (!angular.isDefined(vm.reportDetails.useSeparateDebitsAndCredits)) {
       vm.reportDetails.useSeparateDebitsAndCredits = 1;
-    if (!angular.isDefined(vm.reportDetails.shouldPruneEmptyRows))
+    }
+    if (!angular.isDefined(vm.reportDetails.shouldPruneEmptyRows)) {
       vm.reportDetails.shouldPruneEmptyRows = 1;
-    if (!angular.isDefined(vm.reportDetails.shouldHideTitleAccounts))
+    }
+    if (!angular.isDefined(vm.reportDetails.shouldHideTitleAccounts)) {
       vm.reportDetails.shouldHideTitleAccounts = 0;
+    }
   }
 }
+
+

--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -83,5 +83,3 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
     }
   }
 }
-
-


### PR DESCRIPTION
This fix makes sure that the values for the radio items on this report respect the cached value (if defined), otherwise use default values per Jonathan Nile's suggestions.  Note that it not necessary to define reportDetails = {} in the else clause of the cache check since the containing function defines it already.   

Partial fix for Issue https://github.com/IMA-WorldHealth/bhima-2.X/issues/3039