### PR TITLE
fix(patients): typo in display name trim()

### DIFF
--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -185,8 +185,8 @@ function update(req, res, next) {
     data.dob = new Date(data.dob);
   }
 
-  // Remove whitespace from Patient display_name
-  if (data.dob) {
+  // Remove whitespace from patient display_name
+  if (data.display_name) {
     data.display_name = data.display_name.trim();
   }
 

--- a/server/controllers/payroll/employees/index.js
+++ b/server/controllers/payroll/employees/index.js
@@ -55,13 +55,14 @@ function list(req, res, next) {
  */
 exports.listHolidays = function listHolidays(req, res, next) {
   const pp = JSON.parse(req.params.pp);
-  const sql =
-    `SELECT holiday.id, holiday.label, holiday.dateFrom, holiday.percentage, holiday.dateTo
+  const sql = `
+    SELECT holiday.id, holiday.label, holiday.dateFrom, holiday.percentage, holiday.dateTo
      FROM holiday WHERE
-      ((holiday.dateFrom >= ? AND holiday.dateFrom <= ?)
-      (holiday.dateTo >= ? AND holiday.dateTo <= ?) OR
-      (holiday.dateFrom <= ? AND holiday.dateTo >= ?)) AND
-      holiday.employee_uuid = ?;`;
+       ((holiday.dateFrom >= ? AND holiday.dateFrom <= ?)
+       (holiday.dateTo >= ? AND holiday.dateTo <= ?) OR
+       (holiday.dateFrom <= ? AND holiday.dateTo >= ?)) AND
+       holiday.employee_uuid = ?;
+ `;
 
   const data = [
     pp.dateFrom, pp.dateTo,
@@ -83,7 +84,7 @@ exports.listHolidays = function listHolidays(req, res, next) {
  */
 exports.checkHoliday = function checkHoliday(req, res, next) {
   let sql = `
-    SELECT id, BUID(employee_uuid) AS employee_uuid, label, dateTo, percentage, dateFrom FROM holiday 
+    SELECT id, BUID(employee_uuid) AS employee_uuid, label, dateTo, percentage, dateFrom FROM holiday
     WHERE employee_uuid = ?
     AND ((dateFrom >= ?) OR (dateTo >= ?) OR (dateFrom >= ?) OR (dateTo >= ?))
     AND ((dateFrom <= ?) OR (dateTo <= ?) OR (dateFrom <= ?) OR (dateTo <= ?))`;
@@ -130,8 +131,7 @@ exports.checkOffday = function checkHoliday(req, res, next) {
  * @returns {Promise} - the result of the database query.
  */
 function lookupEmployee(uid) {
-  const sql =
-    `
+  const sql = `
     SELECT
       BUID(employee.uuid) AS uuid, employee.code, patient.display_name, patient.sex,
       patient.dob, employee.date_embauche, employee.service_id,
@@ -192,9 +192,9 @@ function advantage(req, res, next) {
 
 function lookupEmployeeAdvantages(uid) {
   const sql = `
-    SELECT employee_advantage.employee_uuid, employee_advantage.rubric_payroll_id, employee_advantage.value 
+    SELECT employee_advantage.employee_uuid, employee_advantage.rubric_payroll_id, employee_advantage.value
     FROM employee_advantage
-    WHERE employee_uuid = ?  
+    WHERE employee_uuid = ?
   `;
 
   return db.exec(sql, [db.bid(uid)]);
@@ -215,7 +215,7 @@ function update(req, res, next) {
   ]);
 
   // Remove whitespace from Patient display_name
-  if (employee.dob) {
+  if (employee.display_name) {
     employee.display_name = employee.display_name.trim();
   }
 
@@ -478,13 +478,13 @@ function search(req, res, next) {
  */
 function find(options) {
 
-  const sql =
-    `SELECT 
-      BUID(employee.uuid) AS uuid, employee.code, patient.display_name, patient.sex, 
-      patient.dob, employee.date_embauche, employee.service_id, employee.nb_spouse, 
+  const sql = `
+    SELECT
+      BUID(employee.uuid) AS uuid, employee.code, patient.display_name, patient.sex,
+      patient.dob, employee.date_embauche, employee.service_id, employee.nb_spouse,
       employee.nb_enfant, BUID(employee.grade_uuid) as grade_uuid, employee.locked,
       grade.text, grade.basic_salary, fonction.id AS fonction_id, fonction.fonction_txt, patient.hospital_no,
-      patient.phone, patient.email, patient.address_1 AS adresse, BUID(employee.patient_uuid) AS patient_uuid, 
+      patient.phone, patient.email, patient.address_1 AS adresse, BUID(employee.patient_uuid) AS patient_uuid,
       employee.bank, employee.bank_account,
       employee.individual_salary, employee.is_medical, grade.code AS code_grade, BUID(debtor.uuid) as debtor_uuid,
       debtor.text AS debtor_text, BUID(debtor.group_uuid) as debtor_group_uuid,
@@ -502,6 +502,7 @@ function find(options) {
      LEFT JOIN service ON service.id = employee.service_id
      LEFT JOIN entity_map ON entity_map.uuid = employee.creditor_uuid
   `;
+
   // ensure epected options are parsed appropriately as binary
   db.convert(options, ['uuid', 'grade_uuid', 'creditor_uuid', 'patient_uuid']);
 

--- a/test/integration/patients.js
+++ b/test/integration/patients.js
@@ -1,10 +1,8 @@
 /* global expect, agent */
-'use strict';
 
 const helpers = require('./helpers');
-const q = require('q');
 
-describe('(/patients) Patients', function () {
+describe('(/patients) Patients', () => {
   // TODO Should this import UUID library and track mock patient throughout?
   const mockPatientUuid = '85bf7a85-16d9-4ae5-b5c0-1fec9748d2f9';
   const mockDebtorUuid = 'ec4241e4-3558-493b-9d78-dbaa47e3cefd';
@@ -54,35 +52,18 @@ describe('(/patients) Patients', function () {
     incorrectTest : mockPatient,
   };
 
-  const simultaneousPatient = {
-    display_name : 'Simultaneous Patient Mocks',
-    dob : new Date('1993-06-01'),
-    current_location_id : '1f162a10-9f67-4788-9eff-c1fea42fcc9b',
-    origin_location_id : '1f162a10-9f67-4788-9eff-c1fea42fcc9b',
-    sex : 'M',
-    project_id : 1,
-    hospital_no : 122,
-  };
-
-  const simultaneousRequest = {
-    finance : {
-      debtor_group_uuid : '4de0fe47-177f-4d30-b95f-cff8166400b4',
-    },
-    medical : simultaneousPatient,
-  };
-
   // HTTP API Test for /patients/  routes
-  describe('Patient Search', function () {
+  describe('Patient Search', () => {
 
-    it('GET /patients with missing necessary parameters should succeed', function () {
+    it('GET /patients with missing necessary parameters should succeed', () => {
       return agent.get('/patients/?')
-        .then(function (res) {
+        .then(res => {
           helpers.api.listed(res, 5);
         })
         .catch(helpers.handler);
     });
 
-    it('GET /patients with \'reference\' parameter', function () {
+    it('GET /patients with \'reference\' parameter', () => {
       const conditions = { reference : 'PA.TPA.1' };
       return agent.get('/patients')
         .query(conditions)
@@ -92,7 +73,7 @@ describe('(/patients) Patients', function () {
         .catch(helpers.handler);
     });
 
-    it('GET /patients with \'display_name\' parameter', function () {
+    it('GET /patients with \'display_name\' parameter', () => {
       const conditions = { display_name : 'Test' };
       return agent.get('/patients/')
         .query(conditions)
@@ -102,7 +83,7 @@ describe('(/patients) Patients', function () {
         .catch(helpers.handler);
     });
 
-    it('GET /patients/search/name with display_name parameter should return only a small subset of patient information', function () {
+    it('GET /patients/search/name with display_name parameter should return a subset of patient information', () => {
       const conditions = { display_name : 'Test' };
       return agent.get('/patients/search/name')
         .query(conditions)
@@ -115,7 +96,7 @@ describe('(/patients) Patients', function () {
         .catch(helpers.handler);
     });
 
-    it('GET /patients/search/name results in bad request with no name provided', function () {
+    it('GET /patients/search/name results in bad request with no name provided', () => {
       const conditions = {};
       return agent.get('/patients/search/name')
         .query(conditions)
@@ -125,8 +106,8 @@ describe('(/patients) Patients', function () {
         .catch(helpers.handler);
     });
 
-    it('GET /patients should be composable', function () {
-      const conditions = { sex: 'M', display_name : 2 };
+    it('GET /patients should be composable', () => {
+      const conditions = { sex : 'M', display_name : 2 };
       return agent.get('/patients')
         .query(conditions)
         .then((res) => {
@@ -135,19 +116,20 @@ describe('(/patients) Patients', function () {
         .catch(helpers.handler);
     });
 
-    it('GET /patients with `name` and `reference` parameters for the priority of reference', function () {
+    it('GET /patients with `name` and `reference` parameters for the priority of reference', () => {
       const conditions = { display_name : 'Test', reference : 'PA.TPA.1' };
       return agent.get('/patients')
         .query(conditions)
         .then((res) => {
           helpers.api.listed(res, 1);
+          // eslint-disable-next-line no-unused-expressions
           expect(res.body[0].reference).to.exist;
           expect(res.body[0].reference).to.be.equals(conditions.reference);
         })
         .catch(helpers.handler);
     });
 
-    it('GET /patients with debtor_uuid retrieves the patients with that debtor_uuid', function () {
+    it('GET /patients with debtor_uuid retrieves the patients with that debtor_uuid', () => {
       const conditions = { debtor_uuid : '3be232f9-a4b9-4af6-984c-5d3f87d5c107' };
       return agent.get('/patients')
         .query(conditions)
@@ -157,7 +139,7 @@ describe('(/patients) Patients', function () {
         .catch(helpers.handler);
     });
 
-    it('GET /patients with detailed and limit parameters', function () {
+    it('GET /patients with detailed and limit parameters', () => {
       const conditions = { detailed : 1, limit : 5, display_name : 'Test' };
       return agent.get('/patients')
         .query(conditions)
@@ -182,8 +164,8 @@ describe('(/patients) Patients', function () {
     });
   });
 
-  it('GET /patients returns a list of patients', function () {
-    var INITIAL_TEST_PATIENTS = 4;
+  it('GET /patients returns a list of patients', () => {
+    const INITIAL_TEST_PATIENTS = 4;
     return agent.get('/patients')
       .then((res) => {
         helpers.api.listed(res, INITIAL_TEST_PATIENTS);
@@ -191,7 +173,7 @@ describe('(/patients) Patients', function () {
       .catch(helpers.handler);
   });
 
-  it('POST /patients will register a valid patient', function () {
+  it('POST /patients will register a valid patient', () => {
     return agent.post('/patients')
       .send(mockRequest)
       .then((res) => {
@@ -200,14 +182,15 @@ describe('(/patients) Patients', function () {
       .catch(helpers.handler);
   });
 
-  it('GET /patients/:uuid finds and retrieves the details of the registered patient', function () {
-    return agent.get('/patients/' + mockPatientUuid)
+  it('GET /patients/:uuid finds and retrieves the details of the registered patient', () => {
+    return agent.get(`/patients/${mockPatientUuid}`)
       .then((res) => {
         const expectedKeys = ['uuid', 'display_name', 'sex', 'origin_location_id'];
 
         expect(res).to.have.status(200);
         const retrievedDetails = res.body;
 
+        // eslint-disable-next-line no-unused-expressions
         expect(retrievedDetails).to.not.be.empty;
         expect(retrievedDetails).to.contain.keys(expectedKeys);
 
@@ -217,14 +200,14 @@ describe('(/patients) Patients', function () {
       });
   });
 
-  it('GET /patients/:uuid will return not found for invalid id', function () {
+  it('GET /patients/:uuid will return not found for invalid id', () => {
     return agent.get('/patients/unknownid')
       .then((res) => {
         helpers.api.errored(res, 404);
       });
   });
 
-  it('POST /patients will reject a patient with missing information', function () {
+  it('POST /patients will reject a patient with missing information', () => {
     return agent.post('/patients')
       .send(mockMissingRequest)
       .then((res) => {
@@ -233,12 +216,24 @@ describe('(/patients) Patients', function () {
       .catch(helpers.handler);
   });
 
-  it('POST /patients will reject a patient with an incorrectly formatted request object', function () {
+  it('POST /patients will reject a patient with an incorrectly formatted request object', () => {
     return agent.post('/patients')
       .send(badRequest)
       .then((res) => {
         helpers.api.errored(res, 400);
         expect(res.body.code).to.be.equal('ERRORS.BAD_REQUEST');
+      })
+      .catch(helpers.handler);
+  });
+
+  it(`PUT /patients/${mockPatientUuid} will update a patient's date of birth`, () => {
+    const date = new Date('06-06-1992');
+    return agent.put(`/patients/${mockPatientUuid}`)
+      .send({ dob : date })
+      .then((res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.property('uuid');
+        expect(res.body.dob).to.equal(date.toISOString());
       })
       .catch(helpers.handler);
   });
@@ -261,7 +256,7 @@ function PatientGroups() {
   const patientUuid = '81af634f-321a-40de-bc6f-ceb1167a9f65';
   const subscribedPatientGroups = 1;
 
-  it('GET /patients/:uuid/groups will return a list of the patients groups', function () {
+  it('GET /patients/:uuid/groups will return a list of the patients groups', () => {
     return agent.get(`/patients/${patientUuid}/groups`)
       .then((res) => {
         helpers.api.listed(res, subscribedPatientGroups);
@@ -269,7 +264,7 @@ function PatientGroups() {
       .catch(helpers.handler);
   });
 
-  it('GET /patients/:uuid/groups will return 404 not found for invalid request', () =>{
+  it('GET /patients/:uuid/groups will return 404 not found for invalid request', () => {
     return agent.get('/patients/unknownid/groups')
       .then((res) => {
         helpers.api.errored(res, 404);
@@ -281,13 +276,14 @@ function PatientGroups() {
     const assignments = ['112a9fb5-847d-4c6a-9b20-710fa8b4da24'];
 
     return agent.post(`/patients/${patientUuid}/groups`)
-     .send({ assignments })
-     .then((res) => {
-       expect(res).to.have.status(200);
-       expect(res.body).to.not.be.empty;
-       expect(res.body[0].affectedRows).to.equal(assignments.length);
-     })
-     .catch(helpers.handler);
+      .send({ assignments })
+      .then(res => {
+        expect(res).to.have.status(200);
+        // eslint-disable-next-line no-unused-expressions
+        expect(res.body).to.not.be.empty;
+        expect(res.body[0].affectedRows).to.equal(assignments.length);
+      })
+      .catch(helpers.handler);
   });
 }
 
@@ -297,7 +293,7 @@ function HospitalNumber() {
   const existingNumber = 100;
   const absentNumber = 3.3;
 
-  it('GET /patients/hospital_number/:id/exists returns true for a used number', function () {
+  it('GET /patients/hospital_number/:id/exists returns true for a used number', () => {
     return agent.get(`/patients/hospital_number/${existingNumber}/exists`)
       .then((res) => {
         expect(res).to.have.status(200);
@@ -306,7 +302,7 @@ function HospitalNumber() {
       .catch(helpers.handler);
   });
 
-  it('GET /patients/hospital_number/:id/exists false for a new number', function () {
+  it('GET /patients/hospital_number/:id/exists false for a new number', () => {
     return agent.get(`/patients/hospital_number/${absentNumber}/exists`)
       .then((res) => {
         expect(res).to.have.status(200);
@@ -320,7 +316,7 @@ function billingServices() {
   const patientUuid = '85bf7a85-16d9-4ae5-b5c0-1fec9748d2f9';
   const billingServiceAttached = 2;
 
-  it('GET /patients/:uuid/services will return a list of the patients billing services', function () {
+  it('GET /patients/:uuid/services will return a list of the patients billing services', () => {
     return agent.get(`/patients/${patientUuid}/services`)
       .then((res) => {
         helpers.api.listed(res, billingServiceAttached);
@@ -333,7 +329,7 @@ function subsidies() {
   const patientUuid = '85bf7a85-16d9-4ae5-b5c0-1fec9748d2f9';
   const subsidiesAttached = 1;
 
-  it('GET /patients/:uuid/subsidies will return a list of the patients subsidies', function () {
+  it('GET /patients/:uuid/subsidies will return a list of the patients subsidies', () => {
     return agent.get(`/patients/${patientUuid}/subsidies`)
       .then((res) => {
         helpers.api.listed(res, subsidiesAttached);


### PR DESCRIPTION
The patients (and employees) API check for the existence of the date of birth instead of the display_name when attempting to trim() the display_name.  This also happens for employees and is corrected here.

I've also added a test to prove that the API is fixed.

Introduced in #2909.  Fixes #3049.