### PR TITLE
fix(vouchers): close barcode modal after hit

### DIFF
--- a/client/src/modules/vouchers/complex-voucher.ctrl.js
+++ b/client/src/modules/vouchers/complex-voucher.ctrl.js
@@ -122,7 +122,6 @@ function ComplexJournalVoucherController(
     gridManager(Toolkit.openPaymentEmployees);
   };
 
-
   // @TODO fixed me to display correctly selected items(invoices, ..) accounts
   // without adding empty items before
   function gridManager(modal) {
@@ -173,7 +172,6 @@ function ComplexJournalVoucherController(
       vm.Voucher.details.currency_id = result.currency_id || vm.Voucher.details.currency_id;
 
       removeNullRows();
-
     }, 0);
   }
 

--- a/client/src/modules/vouchers/vouchers.routes.js
+++ b/client/src/modules/vouchers/vouchers.routes.js
@@ -1,6 +1,5 @@
-
 angular.module('bhima.routes')
-  .config(['$stateProvider', function ($stateProvider) {
+  .config(['$stateProvider', ($stateProvider) => {
     $stateProvider
       .state('simpleVouchers', {
         url         : '/vouchers/simple',
@@ -30,18 +29,11 @@ angular.module('bhima.routes')
       });
   }]);
 
-
-/**
- * Piggy-backing off the Cash scan barcode modal because these
- * are mad hacks that should never be made in production, but
- * this is a one-man developer team.  Yay!
- */
 function scanBarcodeModal($state, Modal) {
   Modal.open({
     controller  : 'VoucherScanBarcodeController as BarcodeModalCtrl',
-    templateUrl : 'modules/cash/modals/barcode-scanner-modal.html',
+    templateUrl : 'modules/templates/barcode-scanner-modal.html',
     size        : 'lg',
-    backdrop    : 'static',
     keyboard    : true,
   }).result.finally(() => {
     $state.go('simpleVouchers');


### PR DESCRIPTION
The scan barcode modal no longer closed itself after locating the barcode, keeping the users from being able to use the modal's scanning ability.  This commit fixes that error as well and removing legacy cruft from the controller.

Closes #3050.