### PR TITLE
Fixed fiscal year/period selection input fields to improve error handling

### DIFF
--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -40,7 +40,7 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
   vm.preview = function preview(form) {
     if (form.$invalid) {
       Notify.danger('FORM.ERRORS.RECORD_ERROR');
-      return;
+      return 0;
     }
 
     // update cached configuration

--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -38,7 +38,10 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
   };
 
   vm.preview = function preview(form) {
-    if (form.$invalid) { return 0; }
+    if (form.$invalid) {
+      Notify.danger('FORM.ERRORS.RECORD_ERROR');
+      return;
+    }
 
     // update cached configuration
     cache.reportDetails = angular.copy(vm.reportDetails);

--- a/client/src/modules/templates/bhFiscalYearSelect.tmpl.html
+++ b/client/src/modules/templates/bhFiscalYearSelect.tmpl.html
@@ -4,7 +4,7 @@
   bh-fiscal-year-select>
 
   <div class="form-group"
-      ng-class="{ 'has-error' : $ctrl.validationTrigger && FiscalYearSelectForm.fiscal.$invalid }">
+      ng-class="{ 'has-error' : FiscalYearSelectForm.$submitted && FiscalYearSelectForm.fiscal.$invalid }">
       <label class="control-label" translate>FORM.LABELS.FISCAL_YEAR</label>
       <select
         class="form-control"
@@ -15,5 +15,8 @@
         required>
         <option value="" disabled translate>FORM.SELECT.FISCAL_YEAR</option>
       </select>
+      <div class="help-block" ng-messages="FiscalYearSelectForm.fiscal.$error" ng-show="FiscalYearSelectForm.$submitted">
+        <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+      </div>
   </div>
 </fieldset>

--- a/client/src/modules/templates/bhPeriodSelection.html
+++ b/client/src/modules/templates/bhPeriodSelection.html
@@ -1,21 +1,25 @@
-<div
-  class="form-group"
-  ng-class="{ 'has-error' : $ctrl.validationTrigger && PeriodForm.period.$invalid }"
+<fieldset
+  ng-form="PeriodForm"
+  novalidate
   bh-period-selection>
-  <label class="control-label" translate>
-    {{ $ctrl.label }}
-  </label>
 
-  <select
-    class="form-control"
-    ng-model="$ctrl.selectedPeriod"
-    name="period"
-    ng-options="period as period.hrLabel for period in $ctrl.periods"
-    ng-change="$ctrl.onChange($ctrl.selectedPeriod)"
-    required>
-    <option value="" disabled translate>FORM.SELECT.PERIOD</option>
-  </select>
-  <div class="help-block" ng-messages="PeriodForm.$error" ng-show="$ctrl.validationTrigger">
-    <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+  <div class="form-group"
+    ng-class="{ 'has-error' : PeriodForm.$submitted && PeriodForm.period.$invalid }"
+    bh-period-selection>
+    <label class="control-label" translate>
+      {{ $ctrl.label }}
+    </label>
+    <select
+      class="form-control"
+      ng-model="$ctrl.selectedPeriod"
+      name="period"
+      ng-options="period as period.hrLabel for period in $ctrl.periods"
+      ng-change="$ctrl.onChange($ctrl.selectedPeriod)"
+      required>
+      <option value="" disabled translate>FORM.SELECT.PERIOD</option>
+    </select>
+    <div class="help-block" ng-messages="PeriodForm.$error" ng-show="PeriodForm.$submitted">
+      <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+    </div>
   </div>
-</div>
+</fieldset>


### PR DESCRIPTION
fixes #3039 

This fixes the error handling in "Reports/Balance of Accounts" report when the user presses the [Preview] button without selecting the fiscal year and/or period.   

**Notes:**  I had to update the <bh-select-fiscal-year> input field replacement html in the templates file to get this to work.  There were several fixes that were needed in the two inputs files:

- $ctrl.validationTrigger does not seem to work.  When I replaced them with  xyzForm.$submitted, they worked.
- The period select form did not have the ng-form angular setup at the top so even xyzForm.$submitted did not work until I added it.
- The fiscal year selection field did not have the error-only message beneath it so I added it.  The period selection one did.

I tried these fields out on on several other reports such as the aged debtors/creditors and they seem to work okay.   I did not do an exhaustive check on all reports that use these input fields.

It is likely that all of these input field templates need review may need some TLC.

-Jonathan C