### PR TITLE
Fix Journal Search: Full Transactions (3055)

### DIFF
--- a/client/src/modules/journal/modals/search.modal.html
+++ b/client/src/modules/journal/modals/search.modal.html
@@ -160,10 +160,12 @@
 
           <!-- Full Transaction applies to the Journal, not the Account Statement -->
           <div ng-if="!ModalCtrl.hasDefaultAccount">
+
+            <!-- Given this components architecture, `value` on onChangeCallback -->
+            <!-- refers to the ng-value of the currently selcted radio button -->
             <bh-yes-no-radios
-              default-value="true"
               value ="ModalCtrl.defaultQueries.showFullTransactions"
-              on-change-callback="ModalCtrl.toggleFullTransaction(ModalCtrl.defaultQueries.showFullTransactions)"
+              on-change-callback="ModalCtrl.toggleFullTransaction(value)"
               label="POSTING_JOURNAL.SHOW_FULL_TRANSACTION_RECORDS"
               help-text="POSTING_JOURNAL.SHOW_FULL_TRANSACTION_RECORDS_HELP">
             </bh-yes-no-radios>

--- a/client/src/modules/journal/modals/search.modal.html
+++ b/client/src/modules/journal/modals/search.modal.html
@@ -14,7 +14,7 @@
   <div class="modal-body" style="padding : 0px;">
 
     <uib-tabset>
-      <uib-tab index="0" heading="{{ 'FORM.LABELS.SEARCH_QUERIES' | translate}}">
+      <uib-tab index="0" data-custom-filter-tab heading="{{ 'FORM.LABELS.SEARCH_QUERIES' | translate}}">
         <!-- acting body class="tab-body" -->
         <div class="tab-body">
 
@@ -141,7 +141,7 @@
         </div>
       </uib-tab>
 
-      <uib-tab index="1" heading="{{ 'FORM.LABELS.DEFAULTS' | translate }}">
+      <uib-tab index="1" data-default-filter-tab heading="{{ 'FORM.LABELS.DEFAULTS' | translate }}">
         <div class="tab-body">
 
           <!--

--- a/test/end-to-end/journal/journal.config.js
+++ b/test/end-to-end/journal/journal.config.js
@@ -43,6 +43,27 @@ function JournalConfigurationModal() {
 
     page.expectColumnCount(defaultVisibleColumnCount);
   });
+
+  it('correctly fetches full transactions together with `showFullTransactions` flag', () => {
+    const PATIENT_REFERENCE = 'PA.TPA.2';
+    const NUMBER_OF_REFERENCED_LINES = 4;
+    const TOTAL_TRANSACTION_LINES_REFERENCED = 8;
+
+    // limit to patient reference rows
+    page.openGridSearchModal();
+    FU.input('ModalCtrl.searchQueries.hrEntity', PATIENT_REFERENCE);
+    FU.modal.submit();
+
+    // check there are exclusively the rows referenced
+    page.expectRowCount(NUMBER_OF_REFERENCED_LINES);
+
+    // select `showAllTransactionRows`
+    page.showFullTransactions(true);
+
+    // check there are now full transactions shown for these rows
+    page.expectRowCount(TOTAL_TRANSACTION_LINES_REFERENCED);
+    page.resetSearchFilters();
+  });
 }
 
 module.exports = JournalConfigurationModal;

--- a/test/end-to-end/journal/journal.page.js
+++ b/test/end-to-end/journal/journal.page.js
@@ -2,6 +2,7 @@
 
 const FU = require('../shared/FormUtils');
 const GU = require('../shared/GridUtils');
+const Filters = require('../shared/components/bhFilters');
 
 function JournalCorePage() {
   const page = this;
@@ -15,6 +16,10 @@ function JournalCorePage() {
     return $('[data-method="configure"]').click();
   }
 
+  function openGridSearchModal() {
+    return $('[data-method="search"').click();
+  }
+
   // toggle the column checkboxes to the following values
   // NOTE - these values come from the database column names, not the i18n text
   // name
@@ -24,17 +29,15 @@ function JournalCorePage() {
     // deselect inputs that are selected and shouldn't be
     const clear = inputs
       .filter(element => element.isSelected())
-      .filter(element =>
-        element.getAttribute('data-column')
-          .then(field => !includes(array, field)))
+      .filter(element => element.getAttribute('data-column')
+        .then(field => !includes(array, field)))
       .map(element => element.click());
 
     // select inputs that are not selected and should be
     const unclear = inputs
       .filter(element => element.isSelected().then(bool => !bool))
-      .filter(element =>
-        element.getAttribute('data-column')
-          .then(field => includes(array, field)))
+      .filter(element => element.getAttribute('data-column')
+        .then(field => includes(array, field)))
       .map(element => element.click());
 
     // trick protractor into treating this as a promise
@@ -55,15 +58,41 @@ function JournalCorePage() {
     return $('[data-method="trial"]').click();
   }
 
+  function resetSearchFilters() {
+    const filters = new Filters();
+
+    // reset custom filters
+    filters.resetFilters();
+
+    // reset default filter negative value
+    showFullTransactions(false);
+  }
+
+  // @TODO(sfount) A significantly better selector should be used here but
+  //               the model on the component is `$ctrl.value`. Something
+  //               less ambiguos should be used.
+  function showFullTransactions(value) {
+    const selection = value ? 'yes' : 'no';
+
+    openGridSearchModal();
+    $('[data-default-filter-tab]').click();
+    $(`[data-choice="${selection}"]`).click();
+    FU.modal.submit();
+  }
+
   // expose methods
   page.openGridConfigurationModal = openGridConfigurationModal;
+  page.openGridSearchModal = openGridSearchModal;
   page.setColumnCheckboxes = setColumnCheckboxes;
   page.setDefaultColumnCheckboxes = setDefaultColumnCheckboxes;
   page.checkRow = checkRow;
   page.openTrialBalanceModal = openTrialBalanceModal;
+  page.resetSearchFilters = resetSearchFilters;
+  page.showFullTransactions = showFullTransactions;
 
   // custom wrappers for GU functionality
   page.expectColumnCount = (number) => GU.expectColumnCount(gridId, number);
+  page.expectRowCount = (number) => GU.expectRowCount(gridId, number);
   page.expectRowCountAbove = (number) => GU.expectRowCountAbove(gridId, number);
   page.expectHeaderColumns = (headerColumns) => GU.expectHeaderColumns(gridId, headerColumns);
 }


### PR DESCRIPTION
This commit changes the value that it is passed into the `onChange`
callback used with the `bh-yes-no` component for the 'Show Full
Transactions' option with the Posting Journal.

Previously the value 0 was always being set which meant the setting
would never reflect a change.

The `default-value` flag was removed from the component as it is
meaningless and not supported, however the current behaviour in
`journal.service.js` is to default `showFullTransactions` to 0 if it has not
yet been defined. A final decision should be made as to the default non-set
value for this flag.

It also includes a test case to catch this case with further repository changes. 

Closes #3055 