### PR TITLE
chore: remove Topic

### DIFF
--- a/client/src/js/services/System.js
+++ b/client/src/js/services/System.js
@@ -1,6 +1,6 @@
 /* global EventSource */
 angular.module('bhima.services')
-.service('SystemService', SystemService);
+  .service('SystemService', SystemService);
 
 SystemService.$inject = ['$http', 'util'];
 
@@ -8,50 +8,17 @@ SystemService.$inject = ['$http', 'util'];
  * System Service
  */
 function SystemService($http, util) {
-  var service = this;
-  var baseUrl = '/system';
+  const service = this;
+  const baseUrl = '/system';
 
   // exposed API
   service.information = information;
-  service.events = events;
-  service.stream = [];
 
   function information() {
     return $http.get(baseUrl.concat('/information'))
       .then(util.unwrapHttpResponse);
   }
 
-  function events() {
-    // forcibly clear the event queue
-    service.stream.length = 0;
-
-    return $http.get(baseUrl.concat('/events'))
-      .then(util.unwrapHttpResponse);
-  }
-
-  function handleServerSentEvent(event) {
-    console.log('Got Event:', event);
-    service.stream.push(JSON.parse(event.data));
-  }
-
-  function handleErrorEvent(event) {
-    if (event.readyState === EventSource.CLOSED) {
-      console.log('Connection was closed.');
-    }
-  }
-
-  function handleOpenEvent(event) {
-    console.log('Connection was open.');
-  }
-
-  /*
-  // set up event stream
-  var source = new EventSource(baseUrl.concat('/stream'));
-
-  source.addEventListener('open', handleOpenEvent, false);
-  source.addEventListener('message', handleServerSentEvent, false);
-  source.addEventListener('error', handleErrorEvent, false);
-  */
 
   return service;
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "jeremielodi"
   ],
   "dependencies": {
-    "@ima-worldhealth/topic": "^1.0.1",
     "@types/angular": "^1.6.41",
     "accounting-js": "^1.1.1",
     "body-parser": "^1.15.0",

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -117,8 +117,6 @@ exports.configure = function configure(app) {
   app.post('/auth/reload', auth.reload);
 
   // system and event helpers
-  app.get('/system/events', system.events);
-  app.get('/system/stream', system.stream);
   app.get('/system/information', system.info);
 
   // dashbord stats

--- a/server/controllers/admin/locations.js
+++ b/server/controllers/admin/locations.js
@@ -16,8 +16,6 @@
 
 
 const uuid = require('uuid/v4');
-const Topic = require('@ima-worldhealth/topic');
-
 const db = require('../../lib/db');
 
 exports.lookupVillage = lookupVillage;
@@ -310,13 +308,6 @@ exports.create.country = function createCountry(req, res, next) {
 
   db.exec(sql, [db.bid(req.body.uuid), req.body.name])
     .then(() => {
-      Topic.publish(Topic.channels.ADMIN, {
-        event : Topic.events.CREATE,
-        entity : Topic.entities.LOCATION,
-        user_id : req.session.user.id,
-        uuid : req.body.uuid,
-      });
-
       res.status(201).json({ uuid : req.body.uuid });
     })
     .catch(next)
@@ -345,13 +336,6 @@ exports.create.province = function createProvince(req, res, next) {
 
   db.exec(sql, [[db.bid(data.uuid), data.name, data.country_uuid]])
     .then(() => {
-      Topic.publish(Topic.channels.ADMIN, {
-        event : Topic.events.CREATE,
-        entity : Topic.entities.LOCATION,
-        user_id : req.session.user.id,
-        uuid : data.uuid,
-      });
-
       res.status(201).json({ uuid : data.uuid });
     })
     .catch(next)
@@ -379,13 +363,6 @@ exports.create.sector = function createSector(req, res, next) {
 
   db.exec(sql, [[db.bid(data.uuid), data.name, data.province_uuid]])
     .then(() => {
-      Topic.publish(Topic.channels.ADMIN, {
-        event : Topic.events.CREATE,
-        entity : Topic.entities.LOCATION,
-        user_id : req.session.user.id,
-        uuid : data.uuid,
-      });
-
       res.status(201).json({ uuid : data.uuid });
     })
     .catch(next)
@@ -412,13 +389,6 @@ exports.create.village = function createVillage(req, res, next) {
 
   db.exec(sql, [[db.bid(data.uuid), data.name, data.sector_uuid, data.longitude, data.latitude]])
     .then(() => {
-      Topic.publish(Topic.channels.ADMIN, {
-        event : Topic.events.CREATE,
-        entity : Topic.entities.LOCATION,
-        user_id : req.session.user.id,
-        uuid : data.uuid,
-      });
-
       res.status(201).json({ uuid : data.uuid });
     })
     .catch(next)

--- a/server/controllers/admin/services.js
+++ b/server/controllers/admin/services.js
@@ -11,12 +11,10 @@
  * @requires db
  * @requires NotFound
  * @requires BadRequest
- * @requires Topic
  */
 
 
 const uuid = require('uuid/v4');
-const Topic = require('@ima-worldhealth/topic');
 
 const db = require('../../lib/db');
 const NotFound = require('../../lib/errors/NotFound');
@@ -72,13 +70,6 @@ function create(req, res, next) {
 
   db.exec(sql, [record])
     .then((result) => {
-      Topic.publish(Topic.channels.ADMIN, {
-        event : Topic.events.CREATE,
-        entity : Topic.entities.SERVICE,
-        user_id : req.session.user.id,
-        id : result.insertId,
-      });
-
       res.status(201).json({ id : result.insertId });
     })
     .catch(next)
@@ -115,13 +106,6 @@ function update(req, res, next) {
       return lookupService(req.params.id);
     })
     .then((service) => {
-      Topic.publish(Topic.channels.ADMIN, {
-        event : Topic.events.UPDATE,
-        entity : Topic.entities.SERVICE,
-        user_id : req.session.user.id,
-        id : req.params.id,
-      });
-
       res.status(200).json(service);
     })
     .catch(next)
@@ -142,13 +126,6 @@ function remove(req, res, next) {
       if (!result.affectedRows) {
         throw new NotFound(`Could not find a service with id ${req.params.id}.`);
       }
-
-      Topic.publish(Topic.channels.ADMIN, {
-        event : Topic.events.DELETE,
-        entity : Topic.entities.SERVICE,
-        user_id : req.session.user.id,
-        id : req.params.id,
-      });
 
       res.sendStatus(204);
     })

--- a/server/controllers/admin/suppliers.js
+++ b/server/controllers/admin/suppliers.js
@@ -7,7 +7,6 @@
  */
 
 const uuid = require('uuid/v4');
-const Topic = require('@ima-worldhealth/topic');
 
 const db = require('../../lib/db');
 
@@ -106,12 +105,6 @@ function create(req, res, next) {
 
   transaction.execute()
     .then(() => {
-      Topic.publish(Topic.channels.INVENTORY, {
-        event : Topic.events.CREATE,
-        entity : Topic.entities.SUPPLIER,
-        user_id : req.session.user.id,
-        uuid : recordUuid,
-      });
       res.status(201).json({ uuid : recordUuid });
     })
     .catch(next)
@@ -156,12 +149,6 @@ function update(req, res, next) {
 
   transaction.execute()
     .then(() => {
-      Topic.publish(Topic.channels.INVENTORY, {
-        event : Topic.events.UPDATE,
-        entity : Topic.entities.SUPPLIER,
-        user_id : req.session.user.id,
-        uuid : req.params.uuid,
-      });
       return lookupSupplier(req.params.uuid);
     })
     .then(record => {

--- a/server/controllers/admin/users/index.js
+++ b/server/controllers/admin/users/index.js
@@ -13,7 +13,6 @@
 
 
 const _ = require('lodash');
-const Topic = require('@ima-worldhealth/topic');
 const db = require('../../../lib/db');
 const NotFound = require('../../../lib/errors/NotFound');
 const BadRequest = require('../../../lib/errors/BadRequest');
@@ -174,13 +173,6 @@ function create(req, res, next) {
       return db.exec(sql, [projects]);
     })
     .then(() => {
-      Topic.publish(Topic.channels.ADMIN, {
-        event : Topic.events.CREATE,
-        entity : Topic.entities.USER,
-        user_id : req.session.user.id,
-        id : userId,
-      });
-
       // send the ID back to the client
       res.status(201).json({ id : userId });
     })
@@ -248,13 +240,6 @@ function update(req, res, next) {
   transaction.execute()
     .then(() => lookupUser(req.params.id))
     .then((result) => {
-      Topic.publish(Topic.channels.ADMIN, {
-        event : Topic.events.UPDATE,
-        entity : Topic.entities.USER,
-        user_id : req.session.user.id,
-        id : req.params.id,
-      });
-
       res.status(200).json(result);
     })
     .catch(next)
@@ -301,13 +286,6 @@ function remove(req, res, next) {
       if (row.affectedRows === 0) {
         throw new NotFound(`Could not find a user with id ${req.params.id}`);
       }
-
-      Topic.publish(Topic.channels.ADMIN, {
-        event : Topic.events.DELETE,
-        entity : Topic.entities.USER,
-        user_id : req.session.user.id,
-        id : req.params.id,
-      });
 
       res.sendStatus(204);
     })

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -10,7 +10,6 @@
  *
  * @requires lib/db
  * @requires q
- * @requires @ima-worldhealth/Topic
  * @requires lodash
  * @requires lib/errors/Unauthorized
  * @requires lib/errors/Forbidden
@@ -19,7 +18,6 @@
 
 const _ = require('lodash');
 const q = require('q');
-const Topic = require('@ima-worldhealth/topic');
 const db = require('../lib/db');
 const Unauthorized = require('../lib/errors/Unauthorized');
 const InternalServerError = require('../lib/errors/InternalServerError');
@@ -104,14 +102,6 @@ function login(req, res, next) {
       // bind the session variables
       _.merge(req.session, session);
 
-      // broadcast LOGIN event
-      Topic.publish(Topic.channels.APP, {
-        event : Topic.events.LOGIN,
-        entity : Topic.entities.USER,
-        user_id : req.session.user.id,
-        id : session.user.id,
-      });
-
       // send the session data back to the client
       res.status(200).json(session);
     })
@@ -129,14 +119,6 @@ function logout(req, res, next) {
 
   db.exec(sql, [req.session.user.id])
     .then(() => {
-      // broadcast LOGOUT event
-      Topic.publish(Topic.channels.APP, {
-        event : Topic.events.LOGOUT,
-        entity : Topic.entities.USER,
-        user_id : req.session.user.id,
-        id : req.session.user.id,
-      });
-
       // destroy the session
       req.session.destroy();
       res.sendStatus(200);
@@ -287,14 +269,6 @@ function reload(req, res, next) {
     .then(session => {
       // bind the session  variables
       _.merge(req.session, session);
-
-      // broadcast LOGIN event
-      Topic.publish(Topic.channels.APP, {
-        event : Topic.events.RELOAD,
-        entity : Topic.entities.USER,
-        user_id : req.session.user.id,
-        id : session.user.id,
-      });
 
       // send the session data back to the client
       res.status(200).json(session);

--- a/server/controllers/finance/cash.create.js
+++ b/server/controllers/finance/cash.create.js
@@ -1,6 +1,5 @@
 const uuid = require('uuid/v4');
 const _ = require('lodash');
-const Topic = require('@ima-worldhealth/topic');
 
 const db = require('../../lib/db');
 const BadRequest = require('../../lib/errors/BadRequest');
@@ -142,16 +141,7 @@ function create(req, res, next) {
   transaction.execute()
     .then(() => {
       res.status(201).json({ uuid : cashUuidString });
-
-      Topic.publish(Topic.channels.FINANCE, {
-        event   : Topic.events.CREATE,
-        entity  : Topic.entities.PAYMENT,
-        user_id : req.session.user.id,
-        user    : req.session.user.display_name,
-        uuid    : cashUuidString,
-      });
     })
     .catch(next)
     .done();
 }
-

--- a/server/controllers/finance/cashboxes/currencies.js
+++ b/server/controllers/finance/cashboxes/currencies.js
@@ -7,13 +7,11 @@
  *
  * @requires db
  * @requires NotFound
- * @requires @ima-worldhealth/topic
  */
 
 
 const db = require('../../../lib/db');
 const NotFound = require('../../../lib/errors/NotFound');
-const Topic = require('@ima-worldhealth/topic');
 
 exports.list = list;
 exports.detail = detail;
@@ -86,13 +84,6 @@ function create(req, res, next) {
   db.exec(sql, [data])
     .then((row) => {
       // currency account changes are still a cashbox update
-      Topic.publish(Topic.channels.FINANCE, {
-        event : Topic.events.UPDATE,
-        entity : Topic.entities.CASHBOX,
-        user_id : req.session.user.id,
-        id : data.cashbox_id,
-      });
-
       res.status(201).json({ id : row.insertId });
     })
     .catch(next)
@@ -131,14 +122,6 @@ function update(req, res, next) {
         res.status(200).json({});
         return;
       }
-
-      // currency account changes are still a cashbox update
-      Topic.publish(Topic.channels.FINANCE, {
-        event : Topic.events.UPDATE,
-        entity : Topic.entities.CASHBOX,
-        user_id : req.session.user.id,
-        id : req.params.id,
-      });
 
       res.status(200).json(rows[0]);
     })

--- a/server/controllers/finance/cashboxes/index.js
+++ b/server/controllers/finance/cashboxes/index.js
@@ -8,13 +8,10 @@
  *
  * @requires db
  * @requires NotFound
- * @requires Topic
  * @requires Cashboxes/Currencies
  * @requires FilterParser
- * @requires @ima-worldhealth/topic
  */
 
-const Topic = require('@ima-worldhealth/topic');
 const db = require('../../../lib/db');
 const NotFound = require('../../../lib/errors/NotFound');
 const FilterParser = require('../../../lib/filter');
@@ -141,13 +138,6 @@ function create(req, res, next) {
 
   db.exec(sql, [box])
     .then((row) => {
-      Topic.publish(Topic.channels.FINANCE, {
-        event   : Topic.events.CREATE,
-        entity  : Topic.entities.CASHBOX,
-        user_id : req.session.user.id,
-        id      : row.insertId,
-      });
-
       res.status(201).json({ id : row.insertId });
     })
     .catch(next)
@@ -169,13 +159,6 @@ function update(req, res, next) {
   db.exec(sql, [req.body, req.params.id])
     .then(() => helperGetCashbox(req.params.id))
     .then((cashbox) => {
-      Topic.publish(Topic.channels.FINANCE, {
-        event   : Topic.events.UPDATE,
-        entity  : Topic.entities.CASHBOX,
-        user_id : req.session.user.id,
-        id      : req.params.id,
-      });
-
       res.status(200).json(cashbox);
     })
     .catch(next)
@@ -197,13 +180,6 @@ function remove(req, res, next) {
       if (!rows.affectedRows) {
         throw new NotFound(`Could not find a cash box with id ${req.params.id}.`);
       }
-
-      Topic.publish(Topic.channels.FINANCE, {
-        event   : Topic.events.DELETE,
-        entity  : Topic.entities.CASHBOX,
-        user_id : req.session.user.id,
-        id      : req.params.id,
-      });
 
       res.sendStatus(204);
     })

--- a/server/controllers/medical/patientGroups.js
+++ b/server/controllers/medical/patientGroups.js
@@ -10,11 +10,9 @@
  * @requires db
  * @requires uuid/v4
  * @requires NotFound
- * @requires @ima-worldhealth/topic
  */
 
 const uuid = require('uuid/v4');
-const Topic = require('@ima-worldhealth/topic');
 const Q = require('q');
 
 const db = require('../../lib/db');
@@ -106,13 +104,6 @@ function create(req, res, next) {
 
   transaction.execute()
     .then(() => {
-      Topic.publish(Topic.channels.MEDICAL, {
-        event : Topic.events.CREATE,
-        entity : Topic.entities.PATIENT_GROUP,
-        user_id : req.session.user.id,
-        uuid : uid,
-      });
-
       res.status(201).json({ uuid : uid });
     })
     .catch(next)
@@ -183,13 +174,6 @@ function update(req, res, next) {
   transaction.execute()
     .then(() => lookupPatientGroup(req.params.uuid))
     .then(group => {
-      Topic.publish(Topic.channels.MEDICAL, {
-        event : Topic.events.UPDATE,
-        entity : Topic.entities.PATIENT_GROUP,
-        user_id : req.session.user.id,
-        uuid : req.params.uuid,
-      });
-
       res.status(200).json(group);
     })
     .catch(next)

--- a/server/controllers/medical/patients/documents.js
+++ b/server/controllers/medical/patients/documents.js
@@ -20,7 +20,6 @@
 const uuid = require('uuid/v4');
 
 const db = require('../../../lib/db');
-const Topic = require('@ima-worldhealth/topic');
 
 const BadRequest = require('../../../lib/errors/BadRequest');
 const NotFound = require('../../../lib/errors/NotFound');
@@ -67,14 +66,6 @@ function create(req, res, next) {
 
   db.exec(sql, [records])
     .then(() => {
-      // publish a patient update event
-      Topic.publish(Topic.channels.MEDICAL, {
-        event : Topic.events.UPDATE,
-        entity : Topic.entities.PATIENT,
-        user_id : req.session.user.id,
-        id : req.params.uuid,
-      });
-
       res.status(201).json({
         uuids : req.files.map(file => file.filename),
       });
@@ -104,14 +95,6 @@ function list(req, res, next) {
 
   db.exec(sql, [db.bid(patientUuid)])
     .then(rows => {
-    // publish a patient update event
-      Topic.publish(Topic.channels.MEDICAL, {
-        event : Topic.events.UPDATE,
-        entity : Topic.entities.PATIENT,
-        user_id : req.session.user.id,
-        id : req.params.uuid,
-      });
-
       res.status(200).json(rows);
     })
     .catch(next)
@@ -165,15 +148,6 @@ function remove(req, res, next) {
       if (!rows.affectedRows) {
         throw new NotFound(`Could not find document with uuid ${documentUuid}.`);
       }
-
-      // publish an update event
-      Topic.publish(Topic.channels.MEDICAL, {
-        event : Topic.events.UPDATE,
-        entity : Topic.entities.PATIENT,
-        user_id : req.session.user.id,
-        id : req.params.uuid,
-      });
-
       res.sendStatus(204);
     })
     .catch(next)

--- a/server/controllers/medical/patients/groups.js
+++ b/server/controllers/medical/patients/groups.js
@@ -11,12 +11,10 @@
  * @requires lib/uuid/v4
  * @requires lib/errors/BadRequest
  * @requires lib/errors/NotFound
- * @requires @ima-worldhealth/topic
  */
 
 const _ = require('lodash');
 const uuid = require('uuid/v4');
-const Topic = require('@ima-worldhealth/topic');
 
 const db = require('../../../lib/db');
 const BadRequest = require('../../../lib/errors/BadRequest');
@@ -113,13 +111,6 @@ function update(req, res, next) {
 
   transaction.execute()
     .then(result => {
-      Topic.publish(Topic.channels.MEDICAL, {
-        event : Topic.events.UPDATE,
-        entity : Topic.entities.PATIENT,
-        user_id : req.session.user.id,
-        uuid : req.params.uuid,
-      });
-
       // TODO send back correct ids
       res.status(200).json(result);
     })

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -11,7 +11,6 @@
  *
  * @requires q
  * @requires lodash
- * @requires @ima-worldhealth/topic
  * @requires lib/db
  * @requires lib/uuid/v4
  * @requires lib/errors/BadRequest
@@ -29,7 +28,6 @@
 
 const _ = require('lodash');
 const uuid = require('uuid/v4');
-const topic = require('@ima-worldhealth/topic');
 
 const identifiers = require('../../../config/identifiers');
 
@@ -135,14 +133,6 @@ function create(req, res, next) {
       res.status(201).json({
         uuid : medicalUuid,
       });
-
-      // publish a CREATE event on the medical channel
-      topic.publish(topic.channels.MEDICAL, {
-        event : topic.events.CREATE,
-        entity : topic.entities.PATIENT,
-        user_id : req.session.user.id,
-        uuid : medicalUuid,
-      });
     })
     .catch(next)
     .done();
@@ -201,14 +191,6 @@ function update(req, res, next) {
     .then(() => lookupPatient(patientUuid))
     .then((updatedPatient) => {
       res.status(200).json(updatedPatient);
-
-      // publish an UPDATE event on the medical channel
-      topic.publish(topic.channels.MEDICAL, {
-        event : topic.events.UPDATE,
-        entity : topic.entities.PATIENT,
-        user_id : req.session.user.id,
-        uuid : patientUuid,
-      });
     })
     .catch(next)
     .done();
@@ -563,13 +545,6 @@ function patientEntityQuery(detailed) {
 function read(req, res, next) {
   find(req.query)
     .then((rows) => {
-      // publish a SEARCH event on the medical channel
-      topic.publish(topic.channels.MEDICAL, {
-        event : topic.events.SEARCH,
-        entity : topic.entities.PATIENT,
-        user_id : req.session.user.id,
-      });
-
       res.status(200).json(rows);
     })
     .catch(next)

--- a/server/controllers/payroll/employees/index.js
+++ b/server/controllers/payroll/employees/index.js
@@ -12,13 +12,11 @@
  * @requires db
  * @requires uuid
  * @requires NotFound
- * @requires @ima-worldhealth/topic
  * @requires filter
  */
 
 
 const uuid = require('uuid/v4');
-const topic = require('@ima-worldhealth/topic');
 
 const db = require('./../../../lib/db');
 const NotFound = require('./../../../lib/errors/NotFound');
@@ -299,13 +297,6 @@ function update(req, res, next) {
         throw new NotFound(`Could not find an employee with Uuid ${req.params.uuid}.`);
       }
 
-      topic.publish(topic.channels.ADMIN, {
-        event : topic.events.UPDATE,
-        entity : topic.entities.EMPLOYEE,
-        user_id : req.session.user.id,
-        uuid : req.params.uuid,
-      });
-
       return lookupEmployee(req.params.uuid);
     })
     .then(rows => {
@@ -425,13 +416,6 @@ function create(req, res, next) {
 
   transaction.execute()
     .then(() => {
-      topic.publish(topic.channels.ADMIN, {
-        event : topic.events.CREATE,
-        entity : topic.entities.EMPLOYEE,
-        user_id : req.session.user.id,
-        uuid : employeeUuid,
-      });
-
       res.status(201).json({ uuid : employeeUuid, patient_uuid : patientID });
     })
     .catch(next)
@@ -453,13 +437,6 @@ function create(req, res, next) {
 function search(req, res, next) {
   find(req.query)
     .then((rows) => {
-    // publish a SEARCH event on the medical channel
-      topic.publish(topic.channels.MEDICAL, {
-        event   : topic.events.SEARCH,
-        entity  : topic.entities.PATIENT,
-        user_id : req.session.user.id,
-      });
-
       res.status(200).json(rows);
     })
     .catch(next)
@@ -616,13 +593,6 @@ function patientToEmployee(req, res, next) {
 
   transaction.execute()
     .then(() => {
-      topic.publish(topic.channels.ADMIN, {
-        event : topic.events.CREATE,
-        entity : topic.entities.EMPLOYEE,
-        user_id : req.session.user.id,
-        uuid : employeeUuid,
-      });
-
       res.status(201).json({ uuid : employeeUuid, patient_uuid : patientUuid });
     })
     .catch(next)

--- a/server/controllers/system.js
+++ b/server/controllers/system.js
@@ -1,84 +1,19 @@
 /* eslint import/no-unresolved:off */
 /**
  * @overview
- * This controller uses the Topic library to broadcast events to the client
- * along a server-sent events channel.  It includes two channels:
- *  1. `/stream` for real-time event broadcasts.
- *  2. `/events` for eventsing all events in the last day
+ * This file provides system information for the /settings page.
  *
  * @requires os
  * @requires lib/db
- * @requires @ima-worldhealth/topic
  */
 
 const os = require('os');
-const db = require('../lib/db');
-const Topic = require('@ima-worldhealth/topic');
 
 // this path is correct _when compiled_
 const pkg = require('../../../package.json');
 
-// GET system/stream
-exports.stream = stream;
-
-// GET system/events
-exports.events = events;
-
 // GET system/info
 exports.info = info;
-
-/**
- * @method stream
- *
- * @description
- * This is a server-sent event stream to be send data to the client in real
- * time.  This is useful for system activity monitoring.
- */
-function stream(req, res) {
-  // ensure the socket hangs open forever
-  res.set('Content-Type', 'text/event-stream');
-  res.set('Content-Control', 'no-cache');
-  res.set('Connection', 'keep-alive');
-
-  // this listener publishes events to the client as server-sent events
-  function listener(data) {
-    res.write(`retry: 10000\ndata: ${JSON.stringify(data)}\n\n`);
-    res.flush();
-  }
-
-  // listener for server events and echo them to the client
-  const subscription = Topic.subscribe(Topic.channels.ALL, listener);
-
-  // remove listener on when the client closes the connection
-  res.on('close', () => {
-    Topic.unsubscribe(Topic.channels.ALL, subscription);
-  });
-}
-
-/**
- * @method events
- *
- * @description
- * Retrieved cached events from the database. Events are stored with a
- * timestamp, some metadata, and a large TEXT blob.  The TEXT blob must
- * be parsed into valid JSON structure before being shipped to the client.
- *
- * @todo - should the parsing happen on the client?
- */
-function events(req, res, next) {
-  const sql = `
-    SELECT event.data FROM event LIMIT 1000;
-  `;
-
-  db.exec(sql)
-    .then(rows => {
-      // events are stored as TEXT, that need to be parsed into JSON data.
-      const eventString = rows.map(row => row.data);
-      res.status(200).json(eventString);
-    })
-    .catch(next)
-    .done();
-}
 
 // send operating system information
 function info(req, res) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@ima-worldhealth/topic@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@ima-worldhealth/topic/-/topic-1.0.1.tgz#ccd3af2feb9e9872c795b4e81a4953446d2ebfd1"
-  dependencies:
-    debug "^3.1.0"
-    ioredis "^3.2.2"
-
 "@types/angular@^1.6.41":
   version "1.6.47"
   resolved "https://registry.yarnpkg.com/@types/angular/-/angular-1.6.47.tgz#f7a31279a02c0892ed9aa76aae2da1b17791bacd"
@@ -481,10 +474,6 @@ base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
 
-base64-js@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.2.tgz#024f0f72afa25b75f9c0ee73cd4f55ec1bed9784"
-
 base64id@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-1.0.0.tgz#47688cb99bb6804f0e06d3e763b1c32e57d8e6b6"
@@ -593,13 +582,6 @@ boom@2.x.x:
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
     hoek "2.x.x"
-
-bops@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/bops/-/bops-0.1.1.tgz#062e02a8daa801fa10f2e5dbe6740cff801fe17e"
-  dependencies:
-    base64-js "0.0.2"
-    to-utf8 "0.0.1"
 
 bower-npm-resolver@^0.9.0:
   version "0.9.1"
@@ -3740,7 +3722,7 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-ioredis@^3.1.2, ioredis@^3.2.2:
+ioredis@^3.1.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-3.2.2.tgz#b7d5ff3afd77bb9718bb2821329b894b9a44c00b"
   dependencies:
@@ -4212,7 +4194,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jszip@3.1.5, jszip@^3.1.3:
+jszip@3.1.5, jszip@^3.1.3, jszip@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.1.5.tgz#e3c2a6c6d706ac6e603314036d43cd40beefdf37"
   dependencies:
@@ -4641,6 +4623,10 @@ lodash.values@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
 
+lodash@4.17.10, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.16.2, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.1, lodash@^4.8.2:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 lodash@4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -4652,10 +4638,6 @@ lodash@4.17.5:
 lodash@^3.1.0, lodash@^3.6.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-
-lodash@^4.11.1, lodash@^4.13.1, lodash@^4.16.2, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.1, lodash@^4.8.2:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 lodash@~1.0.1:
   version "1.0.2"
@@ -5885,10 +5867,6 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
-pkginfo@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
-
 platform@1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
@@ -6671,7 +6649,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.78.0, request@^2.83.0, request@^2.87.0:
+request@^2.78.0, request@^2.83.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -7087,14 +7065,13 @@ snyk-config@2.2.0:
     lodash "^4.17.5"
     nconf "^0.10.0"
 
-snyk-docker-plugin@1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-1.10.3.tgz#2ac2f05ab821e122a5e1851240d3c021bbb8223f"
+snyk-docker-plugin@1.10.4:
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-1.10.4.tgz#ae8fa9ce29b3c11e7177f292143d111f57d6038c"
   dependencies:
     debug "^3.1.0"
     fs-extra "^5.0.0"
-    pkginfo "^0.4.1"
-    request "^2.87.0"
+    needle "^2.0.1"
     temp-dir "^1.0.0"
 
 snyk-go-plugin@1.5.2:
@@ -7122,14 +7099,22 @@ snyk-mvn-plugin@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/snyk-mvn-plugin/-/snyk-mvn-plugin-1.2.0.tgz#e23c60e35457ce5a26fd4252ddf120dbd7e9ef2a"
 
-snyk-nuget-plugin@1.6.4:
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/snyk-nuget-plugin/-/snyk-nuget-plugin-1.6.4.tgz#83cb3e699667ea808803d4020aa0e053e6f3bab4"
+snyk-nodejs-lockfile-parser@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.4.1.tgz#bfa090168be78bdb7ba2d28fbe67197e1a39d1f1"
+  dependencies:
+    lodash "4.17.10"
+    path "0.12.7"
+    source-map-support "^0.5.7"
+
+snyk-nuget-plugin@1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/snyk-nuget-plugin/-/snyk-nuget-plugin-1.6.5.tgz#0a5d53ba47a8bbdc82e245171446ec0485cc591b"
   dependencies:
     debug "^3.1.0"
+    jszip "^3.1.5"
     lodash "^4.17.10"
     xml2js "^0.4.17"
-    zip "^1.2.0"
 
 snyk-php-plugin@1.5.1:
   version "1.5.1"
@@ -7206,9 +7191,9 @@ snyk-try-require@1.3.1, snyk-try-require@^1.1.1:
     lru-cache "^4.0.0"
     then-fs "^2.0.0"
 
-snyk@1.90.1:
-  version "1.90.1"
-  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.90.1.tgz#1e9ff071441512af5eaab1747fa50033adaa93b0"
+snyk@1.94.0:
+  version "1.94.0"
+  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.94.0.tgz#1d2d685fc4cfd21e844f79cb307ccf41d0f6f790"
   dependencies:
     abbrev "^1.1.1"
     ansi-escapes "^3.1.0"
@@ -7226,12 +7211,13 @@ snyk@1.90.1:
     recursive-readdir "^2.2.2"
     semver "^5.5.0"
     snyk-config "2.2.0"
-    snyk-docker-plugin "1.10.3"
+    snyk-docker-plugin "1.10.4"
     snyk-go-plugin "1.5.2"
     snyk-gradle-plugin "1.3.0"
     snyk-module "1.8.2"
     snyk-mvn-plugin "1.2.0"
-    snyk-nuget-plugin "1.6.4"
+    snyk-nodejs-lockfile-parser "1.4.1"
+    snyk-nuget-plugin "1.6.5"
     snyk-php-plugin "1.5.1"
     snyk-policy "1.12.0"
     snyk-python-plugin "1.8.1"
@@ -7344,6 +7330,13 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.5.7:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@~0.4.0:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
@@ -7370,7 +7363,7 @@ source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -7927,10 +7920,6 @@ to-through@^2.0.0:
   resolved "https://registry.yarnpkg.com/to-through/-/to-through-2.0.0.tgz#fc92adaba072647bc0b67d6b03664aa195093af6"
   dependencies:
     through2 "^2.0.3"
-
-to-utf8@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/to-utf8/-/to-utf8-0.0.1.tgz#d17aea72ff2fba39b9e43601be7b3ff72e089852"
 
 toml@^2.3.2:
   version "2.3.3"
@@ -8556,9 +8545,3 @@ yargs@~3.10.0:
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
-
-zip@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/zip/-/zip-1.2.0.tgz#ad0ad42265309be42eb56fc86194e17c24e66a9c"
-  dependencies:
-    bops "~0.1.1"


### PR DESCRIPTION
The Topic library is an event emitter with no consumers implemented.  At our production sites, we do not even write to the database the events. Thus, this commit removes Topic until we have a real use case for it.

It should also improve performances slightly since we will not be Pub/Sub-ing events to Redis.

Closes #3091.