### PR TITLE
Order Transaction Types by 'fixed' and then 'text' (3059)

### DIFF
--- a/client/src/js/constants/bhConstants.js
+++ b/client/src/js/constants/bhConstants.js
@@ -144,7 +144,7 @@ function constantConfig() {
       { id : 5, label : 'FORM.LABELS.WEEK_DAYS.FRIDAY' },
       { id : 6, label : 'FORM.LABELS.WEEK_DAYS.SATURDAY' },
     ],
-    transactionTypesMap : {
+    transactionTypeMap : {
       income : { label : 'VOUCHERS.SIMPLE.INCOME', value : 'income' },
       expense : { label : 'VOUCHERS.SIMPLE.EXPENSE', value : 'expense' },
       other : { label : 'FORM.LABELS.OTHER', value : 'other' },

--- a/client/src/js/constants/bhConstants.js
+++ b/client/src/js/constants/bhConstants.js
@@ -6,8 +6,8 @@ angular.module('bhima.constants')
  * populated according to the enterprise configuration.
  */
 function constantConfig() {
-  var UTIL_BAR_HEIGHT = '106px';
-  var JOURNAL_UTIL_HEIGHT = '150px';
+  const UTIL_BAR_HEIGHT = '106px';
+  const JOURNAL_UTIL_HEIGHT = '150px';
 
   return {
     actions : {
@@ -122,8 +122,18 @@ function constantConfig() {
     },
     defaultFilters : [
       { key : 'period', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
-      { key : 'custom_period_start', label : 'PERIODS.START', comparitor : '>', valueFilter : 'date' },
-      { key : 'custom_period_end', label : 'PERIODS.END', comparitor : '<', valueFilter : 'date' },
+      {
+        key : 'custom_period_start',
+        label : 'PERIODS.START',
+        comparitor : '>',
+        valueFilter : 'date',
+      },
+      {
+        key : 'custom_period_end',
+        label : 'PERIODS.END',
+        comparitor : '<',
+        valueFilter : 'date',
+      },
       { key : 'limit', label : 'FORM.LABELS.LIMIT' }],
     weekDays : [
       { id : 0, label : 'FORM.LABELS.WEEK_DAYS.SUNDAY' },
@@ -134,6 +144,10 @@ function constantConfig() {
       { id : 5, label : 'FORM.LABELS.WEEK_DAYS.FRIDAY' },
       { id : 6, label : 'FORM.LABELS.WEEK_DAYS.SATURDAY' },
     ],
+    transactionTypesMap : {
+      income : { label : 'VOUCHERS.SIMPLE.INCOME', value : 'income' },
+      expense : { label : 'VOUCHERS.SIMPLE.EXPENSE', value : 'expense' },
+      other : { label : 'FORM.LABELS.OTHER', value : 'other' },
+    },
   };
 }
-

--- a/client/src/modules/templates/modals/transactionType.modal.js
+++ b/client/src/modules/templates/modals/transactionType.modal.js
@@ -13,8 +13,8 @@ function TransactionTypeModalController(Instance, TransactionType, Notify, Data,
   vm.isUpdateState = Data.action === 'edit';
 
   // Convert bhConstants transaction type map object into an array of elements
-  vm.types = Object.keys(bhConstants.transactionTypesMap)
-    .map(key => bhConstants.transactionTypesMap[key]);
+  vm.types = Object.keys(bhConstants.transactionTypeMap)
+    .map(key => bhConstants.transactionTypeMap[key]);
 
   vm.transactionType = {};
 
@@ -36,9 +36,9 @@ function TransactionTypeModalController(Instance, TransactionType, Notify, Data,
 
     const transactionType = angular.copy(vm.transactionType);
 
-    const promise = (vm.isCreateState) ?
-      TransactionType.create(transactionType) :
-      TransactionType.update(transactionType.id, transactionType);
+    const promise = (vm.isCreateState)
+      ? TransactionType.create(transactionType)
+      : TransactionType.update(transactionType.id, transactionType);
 
     return promise
       .then(() => {

--- a/client/src/modules/templates/modals/transactionType.modal.js
+++ b/client/src/modules/templates/modals/transactionType.modal.js
@@ -3,20 +3,18 @@ angular.module('bhima.controllers')
 
 // dependencies injections
 TransactionTypeModalController.$inject = [
-  '$uibModalInstance', 'TransactionTypeService', 'NotifyService', 'data',
+  '$uibModalInstance', 'TransactionTypeService', 'NotifyService', 'data', 'bhConstants',
 ];
 
-function TransactionTypeModalController(Instance, TransactionType, Notify, Data) {
+function TransactionTypeModalController(Instance, TransactionType, Notify, Data, bhConstants) {
   const vm = this;
 
   vm.isCreateState = Data.action === 'create';
   vm.isUpdateState = Data.action === 'edit';
 
-  vm.types = [
-    { label : 'VOUCHERS.SIMPLE.INCOME', value : 'income' },
-    { label : 'VOUCHERS.SIMPLE.EXPENSE', value : 'expense' },
-    { label : 'FORM.LABELS.OTHER', value : 'other' },
-  ];
+  // Convert bhConstants transaction type map object into an array of elements
+  vm.types = Object.keys(bhConstants.transactionTypesMap)
+    .map(key => bhConstants.transactionTypesMap[key]);
 
   vm.transactionType = {};
 

--- a/client/src/modules/transaction-type/templates/fixedStatus.cell.html
+++ b/client/src/modules/transaction-type/templates/fixedStatus.cell.html
@@ -4,15 +4,17 @@
       uib-popover="{{ 'TRANSACTION_TYPE.FIXED_INFO' | translate }}"
       popover-placement="left"
       popover-trigger="'mouseenter'"
-      popover-append-to-body="true"
-      data-edit-type="{{ row.entity.text }}">
+      popover-append-to-body="true">
       <i class="fa fa-lock"></i> <span translate>FORM.LABELS.LOCKED</span>
     </span>
   </span>
 
   <span ng-if="!row.entity.fixed">
     <!-- edit transaction type tool -->
-    <a href ng-click="grid.appScope.editType(row.entity)">
+    <a
+      href
+      ng-click="grid.appScope.editType(row.entity)"
+      data-edit-type="{{ row.entity.text }}">
       <i class="fa fa-edit"></i> <span translate>FORM.LABELS.EDIT</span>
     </a>
   </span>

--- a/client/src/modules/transaction-type/templates/fixedStatus.cell.html
+++ b/client/src/modules/transaction-type/templates/fixedStatus.cell.html
@@ -1,0 +1,19 @@
+<div class="ui-grid-cell-contents">
+  <span ng-if="row.entity.fixed">
+    <span
+      uib-popover="{{ 'TRANSACTION_TYPE.FIXED_INFO' | translate }}"
+      popover-placement="left"
+      popover-trigger="'mouseenter'"
+      popover-append-to-body="true"
+      data-edit-type="{{ row.entity.text }}">
+      <i class="fa fa-lock"></i> <span translate>FORM.LABELS.LOCKED</span>
+    </span>
+  </span>
+
+  <span ng-if="!row.entity.fixed">
+    <!-- edit transaction type tool -->
+    <a href ng-click="grid.appScope.editType(row.entity)">
+      <i class="fa fa-edit"></i> <span translate>FORM.LABELS.EDIT</span>
+    </a>
+  </span>
+</div>

--- a/client/src/modules/transaction-type/transaction-type.ctrl.js
+++ b/client/src/modules/transaction-type/transaction-type.ctrl.js
@@ -2,8 +2,8 @@ angular.module('bhima.controllers')
   .controller('TransactionTypeController', TransactionTypeController);
 
 TransactionTypeController.$inject = [
-  'TransactionTypeService', 'TransactionTypeStoreService', 'NotifyService',
-  'ModalService', '$translate', 'uiGridConstants',
+  'TransactionTypeService', 'NotifyService',
+  'ModalService', 'uiGridConstants',
 ];
 
 /**
@@ -12,33 +12,12 @@ TransactionTypeController.$inject = [
  * @description
  * This controller powers the transaction type grid.
  */
-function TransactionTypeController(TransactionType, TransactionTypeStore, Notify, Modal, $translate, uiGridConstants) {
+function TransactionTypeController(TransactionType, Notify, Modal, uiGridConstants) {
   const vm = this;
 
   // global variables
   vm.gridOptions = {};
   vm.gridApi = {};
-
-  // edit button template
-  const editTemplate = `
-    <div class="ui-grid-cell-contents text-right">
-      <a
-        href
-        ng-click="grid.appScope.editType(row.entity)"
-        uib-popover="{{row.entity._popover}}"
-        popover-placement="left"
-        popover-trigger="'mouseenter'"
-        popover-append-to-body="true"
-        data-edit-type="{{ row.entity.text }}">
-        <span ng-show="row.entity.fixed">
-          <i class="fa fa-lock"></i> <span translate>FORM.LABELS.LOCKED</span>
-        </span>
-        <span ng-hide="row.entity.fixed">
-          <i class="fa fa-edit"></i> <span translate>FORM.LABELS.EDIT</span>
-        </span>
-      </a>
-    </div>
-    `;
 
   // grid default options
   vm.gridOptions.appScopeProvider = vm;
@@ -60,8 +39,9 @@ function TransactionTypeController(TransactionType, TransactionTypeStore, Notify
     enableColumnMenu : false,
   }, {
     field : 'fixed',
-    displayName : '...',
-    cellTemplate : editTemplate,
+    displayName : '',
+    maxWidth : '150',
+    cellTemplate : '/modules/transaction-type/templates/fixedStatus.cell.html',
     enableFiltering : false,
     enableColumnMenu : false,
     sort : {
@@ -89,7 +69,7 @@ function TransactionTypeController(TransactionType, TransactionTypeStore, Notify
       .then(res => {
         if (!res) { return; }
         Notify.success('FORM.INFO.SAVE_SUCCESS');
-        load();
+        loadTransactionTypes();
       })
       .catch(Notify.handleError);
   }
@@ -104,25 +84,21 @@ function TransactionTypeController(TransactionType, TransactionTypeStore, Notify
       .then(res => {
         if (!res) { return; }
         Notify.success('FORM.INFO.UPDATE_SUCCESS');
-        load();
+        loadTransactionTypes();
       })
       .catch(Notify.handleError);
   }
 
-  function load() {
+  function loadTransactionTypes() {
     TransactionType.read()
       .then(list => {
         vm.gridOptions.data = list;
-
-        list.forEach(type => {
-          type._popover = type.fixed ? $translate.instant('TRANSACTION_TYPE.FIXED_INFO') : '';
-        });
       })
       .catch(Notify.handleError);
   }
 
   function startup() {
-    load();
+    loadTransactionTypes();
   }
 
   // startup the module

--- a/client/src/modules/transaction-type/transaction-type.ctrl.js
+++ b/client/src/modules/transaction-type/transaction-type.ctrl.js
@@ -3,7 +3,7 @@ angular.module('bhima.controllers')
 
 TransactionTypeController.$inject = [
   'TransactionTypeService', 'TransactionTypeStoreService', 'NotifyService',
-  'ModalService', '$translate',
+  'ModalService', '$translate', 'uiGridConstants',
 ];
 
 /**
@@ -12,7 +12,7 @@ TransactionTypeController.$inject = [
  * @description
  * This controller powers the transaction type grid.
  */
-function TransactionTypeController(TransactionType, TransactionTypeStore, Notify, Modal, $translate) {
+function TransactionTypeController(TransactionType, TransactionTypeStore, Notify, Modal, $translate, uiGridConstants) {
   const vm = this;
 
   // global variables
@@ -48,6 +48,10 @@ function TransactionTypeController(TransactionType, TransactionTypeStore, Notify
     headerCellFilter : 'translate',
     cellFilter : 'translate',
     enableColumnMenu : false,
+    sort : {
+      direction : uiGridConstants.ASC,
+      priority : 1,
+    },
   }, {
     field : 'type',
     displayName : 'FORM.LABELS.TYPE',
@@ -55,11 +59,15 @@ function TransactionTypeController(TransactionType, TransactionTypeStore, Notify
     cellFilter : 'translate',
     enableColumnMenu : false,
   }, {
-    field : 'action',
+    field : 'fixed',
     displayName : '...',
     cellTemplate : editTemplate,
     enableFiltering : false,
     enableColumnMenu : false,
+    sort : {
+      direction : uiGridConstants.DESC,
+      priority : 0,
+    },
   }];
 
   // register API

--- a/client/src/modules/transaction-type/transaction-type.ctrl.js
+++ b/client/src/modules/transaction-type/transaction-type.ctrl.js
@@ -3,7 +3,7 @@ angular.module('bhima.controllers')
 
 TransactionTypeController.$inject = [
   'TransactionTypeService', 'NotifyService',
-  'ModalService', 'uiGridConstants',
+  'ModalService', 'uiGridConstants', 'bhConstants',
 ];
 
 /**
@@ -12,7 +12,7 @@ TransactionTypeController.$inject = [
  * @description
  * This controller powers the transaction type grid.
  */
-function TransactionTypeController(TransactionType, Notify, Modal, uiGridConstants) {
+function TransactionTypeController(TransactionType, Notify, Modal, uiGridConstants, bhConstants) {
   const vm = this;
 
   // global variables
@@ -32,7 +32,7 @@ function TransactionTypeController(TransactionType, Notify, Modal, uiGridConstan
       priority : 1,
     },
   }, {
-    field : 'type',
+    field : 'typeLabel',
     displayName : 'FORM.LABELS.TYPE',
     headerCellFilter : 'translate',
     cellFilter : 'translate',
@@ -92,9 +92,20 @@ function TransactionTypeController(TransactionType, Notify, Modal, uiGridConstan
   function loadTransactionTypes() {
     TransactionType.read()
       .then(list => {
-        vm.gridOptions.data = list;
+        vm.gridOptions.data = list.map(assignTransactionTypeLabels);
       })
       .catch(Notify.handleError);
+  }
+
+  // Assign translatable labels to each transaction type based on the hardcoded
+  // database strings
+  function assignTransactionTypeLabels(transactionType) {
+    // @TODO(sfount) The `transaction_type` database currently hard codes 'income',
+    //               'expense' and 'other' transaction types. When this is updated
+    //               with a more data driven approach it should include translatable
+    //               labels
+    transactionType.typeLabel = bhConstants.transactionTypesMap[transactionType.type].label;
+    return transactionType;
   }
 
   function startup() {

--- a/client/src/modules/transaction-type/transaction-type.routes.js
+++ b/client/src/modules/transaction-type/transaction-type.routes.js
@@ -1,5 +1,5 @@
 angular.module('bhima.routes')
-  .config(['$stateProvider', function ($stateProvider) {
+  .config(['$stateProvider', $stateProvider => {
     $stateProvider
       .state('transactionType', {
         url         : '/transaction_type',


### PR DESCRIPTION
This commit orders the Transaction Type Management `ui-grid`. It first
orders by the 'fixed' property (if the transaction type is part of the
system of a custom user type) and then alphabetically.

It also updates the `ui-grid` according to a number of other similar UI patterns found in the application.

Addresses a user facing bug resulting in the Transaction Type 'types' rendering hard-coded database values. 

**Current master:**
![screenshot from 2018-08-30 17-47-08](https://user-images.githubusercontent.com/2844572/44866439-28312900-ac7d-11e8-99fd-dba9c1ef7a18.png)

Note: French translation with English hard-coded values 

**Updated branch:**
![screenshot from 2018-08-30 17-35-57](https://user-images.githubusercontent.com/2844572/44866467-3aab6280-ac7d-11e8-8d1e-fd5d868f65ca.png)

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/3059
