### PR TITLE
Feature fee center

### DIFF
--- a/client/src/i18n/en/fee_center.json
+++ b/client/src/i18n/en/fee_center.json
@@ -1,0 +1,8 @@
+{
+  "FEE_CENTER" : {
+    "ADD_FEE_CENTER" : "Add a Fee Center",
+    "DELETE": "Delete This Fee Center",
+    "EDIT_FEE_CENTER" : "Update the Fee Center Information",
+    "TITLE" : "Fees Centers"
+  }
+}

--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -124,6 +124,9 @@
             "STOCK_LINE": "Stock line"
         },
         "INFO": {
+            "ASSIGNED_COST_CENTER" : "Assigned a cost center",
+            "ASSIGNED_PROFIT_CENTER" : "Assigned a profit center",
+            "ASSIGNED_PROJECTS" : "Assigned to projects",          
             "BY": "by",
             "CANCEL_CASH": "Cancellation of payment",
             "CLEAR_FILTERS": "Remove Filters",
@@ -510,6 +513,7 @@
             "PRICE": "Price",
             "PRICE_LIST": "Price List",
             "PRINCIPAL": "Principal",
+            "PRINCIPAL_2": "Principal",
             "PRINT": "Print",
             "PROFIT": "Profit",
             "PROFIT_CENTER": "Profit Center",
@@ -671,6 +675,7 @@
         "PLACEHOLDERS": {
             "ABBREVIATION": "Abbreviation",
             "ACCOUNT": "Enter an account",
+            "ACCOUNT_REFERENCE" : "Accounts References",
             "CASHBOX": "Enter the cashbox",
             "CODE": "Enter code",
             "COUNTRY": "Enter country",

--- a/client/src/i18n/en/tree.json
+++ b/client/src/i18n/en/tree.json
@@ -29,6 +29,7 @@
     "EMPLOYEE_STANDING_REPORT" : "Employee Standing Report",
     "ENTERPRISE" : "Enterprise",
     "EXCHANGE" : "Exchange Rate",
+    "FEE_CENTER": "Fees Centers",
     "FINANCE" : "Finance",
     "FISCAL_YEAR" : "Fiscal Year",
     "PROFESSION" : "Job titles management",

--- a/client/src/i18n/fr/fee_center.json
+++ b/client/src/i18n/fr/fee_center.json
@@ -1,0 +1,8 @@
+{
+  "FEE_CENTER" : {
+    "ADD_FEE_CENTER" : "Ajouter un centre de frais",
+    "DELETE": "Supprimer le Centre de frais",
+    "EDIT_FEE_CENTER" : "Mise à jour des informations du centre de frais",
+    "TITLE" : "Centres de frais"
+  }
+}

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -124,6 +124,9 @@
             "STOCK_LINE": "Ligne de Stock"
         },
         "INFO": {
+            "ASSIGNED_COST_CENTER" : "Assigné un centre de coût",
+            "ASSIGNED_PROFIT_CENTER" : "Assigné un centre de profit",
+            "ASSIGNED_PROJECTS" : "Assignée à des projets",
             "BY": "Par",
             "CANCEL_CASH": "Annulation de paiement",
             "CLEAR_FILTERS": "Supprimer les filtres",
@@ -508,6 +511,7 @@
             "PRICE": "Prix",
             "PRICE_LIST": "Liste de Prix",
             "PRINCIPAL": "Principale",
+            "PRINCIPAL_2": "Principal",
             "PRINT": "Imprimer",
             "PROFESSION": "Profession",
             "PROFIT": "Profit",
@@ -670,6 +674,7 @@
         "PLACEHOLDERS": {
             "ABBREVIATION": "Abbreviation",
             "ACCOUNT": "Entrer le compte",
+            "ACCOUNT_REFERENCE" : "Références de comptes",
             "CASHBOX": "Entrer la caisse",
             "CODE": "Entrer le code",
             "COUNTRY": "Entrer le nom du pays",

--- a/client/src/i18n/fr/tree.json
+++ b/client/src/i18n/fr/tree.json
@@ -29,6 +29,7 @@
     "EMPLOYEE_STANDING_REPORT" : "Rapport des employés",
     "ENTERPRISE":"Entreprise",
     "EXCHANGE":"Taux de change",
+    "FEE_CENTER": "Centres de Frais",
     "FINANCE":"Finances",
     "FISCAL_YEAR":"Année Fiscale",
     "PROFESSION":"Gestion des Professions",

--- a/client/src/js/components/bhAccountReferenceSelect.js
+++ b/client/src/js/components/bhAccountReferenceSelect.js
@@ -21,7 +21,7 @@ AccountReferenceSelectController.$inject = [
  * Account Reference Select Controller
  */
 function AccountReferenceSelectController(AccountReferences, $timeout, $scope, Notify) {
-  var $ctrl = this;
+  const $ctrl = this;
 
   // fired at the beginning of the account configuration select
   $ctrl.$onInit = function $onInit() {

--- a/client/src/js/components/bhAccountReferenceSelect.js
+++ b/client/src/js/components/bhAccountReferenceSelect.js
@@ -1,0 +1,64 @@
+angular.module('bhima.components')
+  .component('bhAccountReferenceSelect', {
+    templateUrl : 'modules/templates/bhAccountReferenceSelect.tmpl.html',
+    controller  : AccountReferenceSelectController,
+    transclude  : true,
+    bindings    : {
+      accountReferenceId : '<',
+      onSelectCallback : '&',
+      required         : '<?',
+      label            : '@?',
+      name             : '@?',
+      validationTrigger :  '<?',
+    },
+  });
+
+AccountReferenceSelectController.$inject = [
+  'AccountReferenceService', '$timeout', '$scope', 'NotifyService',
+];
+
+/**
+ * Account Reference Select Controller
+ */
+function AccountReferenceSelectController(AccountReferences, $timeout, $scope, Notify) {
+  var $ctrl = this;
+
+  // fired at the beginning of the account configuration select
+  $ctrl.$onInit = function $onInit() {
+    // translated label for the form input
+    $ctrl.label = $ctrl.label || 'FORM.LABELS.ACCOUNT_CONFIGURATION';
+
+    // fired when an account configuration has been selected
+    $ctrl.onSelectCallback = $ctrl.onSelectCallback || angular.noop;
+
+    // default for form name
+    $ctrl.name = $ctrl.name || 'AccountReferenceForm';
+
+
+    if (!angular.isDefined($ctrl.required)) {
+      $ctrl.required = true;
+    }
+
+    AccountReferences.read()
+      .then(accountReferences => {
+        $ctrl.accountReferences = accountReferences;
+      })
+      .catch(Notify.handleError);
+
+    // alias the name as AccountReferenceForm
+    $timeout(aliasComponentForm);
+  };
+
+  // this makes the HTML much more readable by reference AccountReferenceForm instead of the name
+  function aliasComponentForm() {
+    $scope.AccountReferenceForm = $scope[$ctrl.name];
+  }
+
+  // fires the onSelectCallback bound to the component boundary
+  $ctrl.onSelect = function onSelect($item) {
+    $ctrl.onSelectCallback({ accountReference : $item });
+
+    // alias the AccountReferenceForm name so that we can find it via filterFormElements
+    $scope[$ctrl.name].$bhValue = $item.id;
+  };
+}

--- a/client/src/js/components/bhProjectsMultipleSelect.js
+++ b/client/src/js/components/bhProjectsMultipleSelect.js
@@ -1,0 +1,47 @@
+angular.module('bhima.components')
+  .component('bhProjectsMultipleSelect', {
+    templateUrl : 'modules/templates/bhProjectsMultipleSelect.tmpl.html',
+    controller  : ProjectsMultipleSelectController,
+    bindings    : {
+      onChange : '&',
+      projectsIds : '<?',
+      label : '@?',
+      required : '<?',
+      validationTrigger : '<?',
+    },
+  });
+
+ProjectsMultipleSelectController.$inject = [
+  'ProjectService', 'NotifyService',
+];
+
+/**
+ * Projects Selection Component
+ *
+ */
+function ProjectsMultipleSelectController(Projects, Notify) {
+  const $ctrl = this;
+
+  $ctrl.$onInit = function onInit() {
+    // label to display
+    $ctrl.label = $ctrl.label || 'FORM.LABELS.PROJECT';
+
+    // fired when the Projects has been selected or removed from the list
+    $ctrl.onChange = $ctrl.onChange;
+
+    // init the model
+    $ctrl.selectedProjects = $ctrl.projectsIds || [];
+
+    // load all Projects
+    Projects.read()
+      .then((projects) => {
+        $ctrl.projects = projects;
+      })
+      .catch(Notify.handleError);
+  };
+
+  // fires the onSelectCallback bound to the component
+  $ctrl.handleChange = function handleChange(models) {
+    $ctrl.onChange({ projects : models });
+  };
+}

--- a/client/src/modules/fee_center/fee_center.html
+++ b/client/src/modules/fee_center/fee_center.html
@@ -7,21 +7,15 @@
       
       <div class="toolbar"> 
         <div class="toolbar-item"> 
-          <button class="btn btn-default text-capitalize" id="create" ui-sref="fee_center.create" data-method="create"> 
+          <button class="btn btn-default text-capitalize" ui-sref="fee_center.create" data-method="create"> 
             <span class="fa fa-plus"></span> <span translate>FEE_CENTER.TITLE</span> 
           </button> 
         </div> 
         
         <div class="toolbar-item"> 
-          <button 
-            type="button" 
-            ng-click="FeeCenterCtrl.toggleFilter()" 
-            data-method="filter" 
-            class="btn btn-default" 
-            ng-class="{ 'btn-info' : FeeCenterCtrl.filterEnabled }"> 
-            <i class="fa fa-filter"></i> 
-          </button> 
-        </div> 
+          <bh-filter-toggle on-toggle="FeeCenterCtrl.toggleFilter()">
+          </bh-filter-toggle>
+        </div>
       </div> 
     </div> 
   </div> 

--- a/client/src/modules/fee_center/fee_center.html
+++ b/client/src/modules/fee_center/fee_center.html
@@ -1,0 +1,45 @@
+  <div class="flex-header"> 
+    <div class="bhima-title"> 
+      <ol class="headercrumb"> 
+        <li class="static" translate> TREE.ADMIN </li> 
+        <li class="title" translate> FEE_CENTER.TITLE </li> 
+      </ol> 
+      
+      <div class="toolbar"> 
+        <div class="toolbar-item"> 
+          <button class="btn btn-default text-capitalize" id="create" ui-sref="fee_center.create" data-method="create"> 
+            <span class="fa fa-plus"></span> <span translate>FEE_CENTER.TITLE</span> 
+          </button> 
+        </div> 
+        
+        <div class="toolbar-item"> 
+          <button 
+            type="button" 
+            ng-click="FeeCenterCtrl.toggleFilter()" 
+            data-method="filter" 
+            class="btn btn-default" 
+            ng-class="{ 'btn-info' : FeeCenterCtrl.filterEnabled }"> 
+            <i class="fa fa-filter"></i> 
+          </button> 
+        </div> 
+      </div> 
+    </div> 
+  </div> 
+  
+  <!-- main content --> 
+  <div class="flex-content"> 
+    <div class="container-fluid"> 
+      <div id="fee-center-grid" 
+        ui-grid="FeeCenterCtrl.gridOptions" 
+        class="grid-full-height" 
+        ui-grid-auto-resize 
+        ui-grid-resize-columns> 
+        
+        <bh-grid-loading-indicator 
+          loading-state="FeeCenterCtrl.loading" 
+          empty-state="FeeCenterCtrl.gridOptions.data.length === 0" 
+          error-state="FeeCenterCtrl.hasError"> 
+        </bh-grid-loading-indicator> 
+      </div> 
+    </div> 
+  </div> 

--- a/client/src/modules/fee_center/fee_center.js
+++ b/client/src/modules/fee_center/fee_center.js
@@ -18,7 +18,6 @@ function FeeCenterController(FeeCenters, ModalService,
 
   // bind methods
   vm.deleteFeeCenter = deleteFeeCenter;
-  vm.createFeeCenter = createFeeCenter;
   vm.toggleFilter = toggleFilter;
 
   // global variables
@@ -40,7 +39,7 @@ function FeeCenterController(FeeCenters, ModalService,
         displayName : '',
         headerCellFilter : 'translate',
         enableFiltering : false,
-        enableSorting : false,
+        enableSorting : true,
         cellTemplate : '/modules/fee_center/templates/feeCenterType.tmpl.html',
       },
       {
@@ -90,11 +89,6 @@ function FeeCenterController(FeeCenters, ModalService,
           })
           .catch(Notify.handleError);
       });
-  }
-
-  // create a new FeeCenter
-  function createFeeCenter() {
-    $state.go('fee_center.create');
   }
 
   loadFeeCenters();

--- a/client/src/modules/fee_center/fee_center.js
+++ b/client/src/modules/fee_center/fee_center.js
@@ -1,0 +1,100 @@
+angular.module('bhima.controllers')
+.controller('FeeCenterController', FeeCenterController);
+
+FeeCenterController.$inject = [
+  'FeeCenterService', 'ModalService',
+  'NotifyService', 'uiGridConstants', '$state', 'SessionService',
+];
+
+/**
+ * Fee Center Controller
+ *
+ * This controller is about the Fee Center module in the admin zone
+ * It's responsible for creating, editing and updating a Fee Center
+ */
+function FeeCenterController(FeeCenters, ModalService,
+  Notify, uiGridConstants, $state, Session) {
+  var vm = this;
+
+  // bind methods
+  vm.deleteFeeCenter = deleteFeeCenter;
+  vm.createFeeCenter = createFeeCenter;
+  vm.toggleFilter = toggleFilter;
+
+  // global variables
+  vm.gridApi = {};
+  vm.filterEnabled = false;
+
+  // options for the UI grid
+  vm.gridOptions = {
+    appScopeProvider  : vm,
+    enableColumnMenus : false,
+    fastWatch         : true,
+    flatEntityAccess  : true,
+    enableSorting     : true,
+    onRegisterApi     : onRegisterApiFn,
+    columnDefs : [
+      { field : 'label', displayName : 'FORM.LABELS.DESIGNATION', headerCellFilter : 'translate' },
+      {
+        field : 'is_principal',
+        displayName : '',
+        headerCellFilter : 'translate',
+        enableFiltering : false,
+        enableSorting : false,
+        cellTemplate : '/modules/fee_center/templates/feeCenterType.tmpl.html',
+      },
+      { field : 'action',
+        width : 80,
+        displayName : '',
+        cellTemplate : '/modules/fee_center/templates/action.tmpl.html',
+        enableSorting : false,
+        enableFiltering : false,
+      },
+    ],
+  };
+
+  function onRegisterApiFn(gridApi) {
+    vm.gridApi = gridApi;
+  }
+
+  function toggleFilter() {
+    vm.filterEnabled = !vm.filterEnabled;
+    vm.gridOptions.enableFiltering = vm.filterEnabled;
+    vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
+  }
+
+  function loadFeeCenters() {
+    vm.loading = true;
+
+    FeeCenters.read()
+    .then(function (data) {
+      vm.gridOptions.data = data;
+    })
+    .catch(Notify.handleError)
+    .finally(function () {
+      vm.loading = false;
+    });
+  }
+
+  // switch to delete warning mode
+  function deleteFeeCenter(feeCenter) {
+    ModalService.confirm('FORM.DIALOGS.CONFIRM_DELETE')
+    .then(function (bool) {
+      if (!bool) { return; }
+
+      FeeCenters.delete(feeCenter.id)
+      .then(function () {
+        Notify.success('FORM.INFO.DELETE_SUCCESS');
+        loadFeeCenters();
+      })
+      .catch(Notify.handleError);
+    });
+  }
+
+  // create a new FeeCenter
+  function createFeeCenter() {
+    $state.go('fee_center.create');
+  }
+
+  loadFeeCenters();
+}

--- a/client/src/modules/fee_center/fee_center.js
+++ b/client/src/modules/fee_center/fee_center.js
@@ -1,9 +1,9 @@
 angular.module('bhima.controllers')
-.controller('FeeCenterController', FeeCenterController);
+  .controller('FeeCenterController', FeeCenterController);
 
 FeeCenterController.$inject = [
   'FeeCenterService', 'ModalService',
-  'NotifyService', 'uiGridConstants', '$state', 'SessionService',
+  'NotifyService', 'uiGridConstants', '$state',
 ];
 
 /**
@@ -13,8 +13,8 @@ FeeCenterController.$inject = [
  * It's responsible for creating, editing and updating a Fee Center
  */
 function FeeCenterController(FeeCenters, ModalService,
-  Notify, uiGridConstants, $state, Session) {
-  var vm = this;
+  Notify, uiGridConstants, $state) {
+  const vm = this;
 
   // bind methods
   vm.deleteFeeCenter = deleteFeeCenter;
@@ -43,7 +43,8 @@ function FeeCenterController(FeeCenters, ModalService,
         enableSorting : false,
         cellTemplate : '/modules/fee_center/templates/feeCenterType.tmpl.html',
       },
-      { field : 'action',
+      {
+        field : 'action',
         width : 80,
         displayName : '',
         cellTemplate : '/modules/fee_center/templates/action.tmpl.html',
@@ -67,28 +68,28 @@ function FeeCenterController(FeeCenters, ModalService,
     vm.loading = true;
 
     FeeCenters.read()
-    .then(function (data) {
-      vm.gridOptions.data = data;
-    })
-    .catch(Notify.handleError)
-    .finally(function () {
-      vm.loading = false;
-    });
+      .then((data) => {
+        vm.gridOptions.data = data;
+      })
+      .catch(Notify.handleError)
+      .finally(() => {
+        vm.loading = false;
+      });
   }
 
   // switch to delete warning mode
   function deleteFeeCenter(feeCenter) {
     ModalService.confirm('FORM.DIALOGS.CONFIRM_DELETE')
-    .then(function (bool) {
-      if (!bool) { return; }
+      .then((bool) => {
+        if (!bool) { return; }
 
-      FeeCenters.delete(feeCenter.id)
-      .then(function () {
-        Notify.success('FORM.INFO.DELETE_SUCCESS');
-        loadFeeCenters();
-      })
-      .catch(Notify.handleError);
-    });
+        FeeCenters.delete(feeCenter.id)
+          .then(() => {
+            Notify.success('FORM.INFO.DELETE_SUCCESS');
+            loadFeeCenters();
+          })
+          .catch(Notify.handleError);
+      });
   }
 
   // create a new FeeCenter

--- a/client/src/modules/fee_center/fee_center.js
+++ b/client/src/modules/fee_center/fee_center.js
@@ -2,8 +2,7 @@ angular.module('bhima.controllers')
   .controller('FeeCenterController', FeeCenterController);
 
 FeeCenterController.$inject = [
-  'FeeCenterService', 'ModalService',
-  'NotifyService', 'uiGridConstants', '$state',
+  'FeeCenterService', 'ModalService', 'NotifyService', 'uiGridConstants',
 ];
 
 /**
@@ -12,8 +11,7 @@ FeeCenterController.$inject = [
  * This controller is about the Fee Center module in the admin zone
  * It's responsible for creating, editing and updating a Fee Center
  */
-function FeeCenterController(FeeCenters, ModalService,
-  Notify, uiGridConstants, $state) {
+function FeeCenterController(FeeCenters, ModalService, Notify, uiGridConstants) {
   const vm = this;
 
   // bind methods

--- a/client/src/modules/fee_center/fee_center.routes.js
+++ b/client/src/modules/fee_center/fee_center.routes.js
@@ -1,0 +1,41 @@
+angular.module('bhima.routes')
+  .config(['$stateProvider', function ($stateProvider) {
+    $stateProvider
+      .state('fee_center', {
+        url         : '/fee_center',
+        controller  : 'FeeCenterController as FeeCenterCtrl',
+        templateUrl : 'modules/fee_center/fee_center.html',
+      })
+      .state('fee_center.create', {
+        url : '/create',
+        params : {
+          fee_center : { value : null },
+          creating : { value : true },
+        },
+        onEnter : ['$uibModal', feeCenterModal],
+        onExit : ['$uibModalStack', closeModal],
+      })
+
+      .state('fee_center.edit', {
+        url : '/:id/edit',
+        params : {
+          fee_center : { value : null },
+          creating : { value : false },
+        },
+        onEnter : ['$uibModal', feeCenterModal],
+        onExit : ['$uibModalStack', closeModal],
+      });
+  }]);
+
+function feeCenterModal($modal) {
+  $modal.open({
+    keyboard : false,
+    backdrop : 'static',
+    templateUrl : 'modules/fee_center/modals/fee_center.modal.html',
+    controller : 'FeeCenterModalController as FeeCenterModalCtrl',
+  });
+}
+
+function closeModal(ModalStack) {
+  ModalStack.dismissAll();
+}

--- a/client/src/modules/fee_center/fee_center.routes.js
+++ b/client/src/modules/fee_center/fee_center.routes.js
@@ -1,5 +1,5 @@
 angular.module('bhima.routes')
-  .config(['$stateProvider', function ($stateProvider) {
+  .config(['$stateProvider', $stateProvider => {
     $stateProvider
       .state('fee_center', {
         url         : '/fee_center',

--- a/client/src/modules/fee_center/fee_center.service.js
+++ b/client/src/modules/fee_center/fee_center.service.js
@@ -1,0 +1,17 @@
+angular.module('bhima.services')
+  .service('FeeCenterService', FeeCenterService);
+
+FeeCenterService.$inject = ['PrototypeApiService', '$uibModal'];
+
+/**
+ * @class FeeCenterService 
+ * @extends PrototypeApiService 
+ * 
+ * @description 
+ * Encapsulates common requests to the /fee_center/ URL. 
+ */ 
+function FeeCenterService(Api, Modal) { 
+  var service = new Api('/fee_center/'); 
+  
+  return service; 
+} 

--- a/client/src/modules/fee_center/fee_center.service.js
+++ b/client/src/modules/fee_center/fee_center.service.js
@@ -4,14 +4,14 @@ angular.module('bhima.services')
 FeeCenterService.$inject = ['PrototypeApiService', '$uibModal'];
 
 /**
- * @class FeeCenterService 
- * @extends PrototypeApiService 
- * 
- * @description 
- * Encapsulates common requests to the /fee_center/ URL. 
- */ 
-function FeeCenterService(Api, Modal) { 
-  var service = new Api('/fee_center/'); 
-  
-  return service; 
-} 
+ * @class FeeCenterService
+ * @extends PrototypeApiService
+ *
+ * @description
+ * Encapsulates common requests to the /fee_center/ URL.
+ */
+function FeeCenterService(Api, Modal) {
+  const service = new Api('/fee_center/');
+
+  return service;
+}

--- a/client/src/modules/fee_center/fee_center.service.js
+++ b/client/src/modules/fee_center/fee_center.service.js
@@ -1,7 +1,7 @@
 angular.module('bhima.services')
   .service('FeeCenterService', FeeCenterService);
 
-FeeCenterService.$inject = ['PrototypeApiService', '$uibModal'];
+FeeCenterService.$inject = ['PrototypeApiService'];
 
 /**
  * @class FeeCenterService
@@ -10,7 +10,7 @@ FeeCenterService.$inject = ['PrototypeApiService', '$uibModal'];
  * @description
  * Encapsulates common requests to the /fee_center/ URL.
  */
-function FeeCenterService(Api, Modal) {
+function FeeCenterService(Api) {
   const service = new Api('/fee_center/');
 
   return service;

--- a/client/src/modules/fee_center/modals/fee_center.modal.html
+++ b/client/src/modules/fee_center/modals/fee_center.modal.html
@@ -1,0 +1,176 @@
+<form name="FeeCenterForm" bh-submit="FeeCenterModalCtrl.submit(FeeCenterForm)" novalidate>
+  <div class="modal-header">
+  <ol class="headercrumb">
+    <li ng-if="FeeCenterModalCtrl.isCreating" class="title">
+      <span translate> FEE_CENTER.ADD_FEE_CENTER </span>
+      <label class="badge badge-warning" translate>FORM.LABELS.CREATE</label>
+    </li>
+    <li ng-if="!FeeCenterModalCtrl.isCreating" class="title">
+      <span translate> FEE_CENTER.EDIT_FEE_CENTER </span>
+      <label class="badge badge-warning" translate>FORM.LABELS.UPDATE</label>
+    </li>
+  </ol>
+</div>
+
+  <div class="modal-body">
+    <div class="form-group" ng-class="{ 'has-error' : FeeCenterForm.$submitted && FeeCenterForm.label.$invalid }">
+      <label class="control-label" translate>FORM.LABELS.DESIGNATION</label>
+      <input name="label" ng-model="FeeCenterModalCtrl.feeCenter.label" autocomplete="off" class="form-control" required>
+      <div class="help-block" ng-messages="FeeCenterForm.label.$error" ng-show="FeeCenterForm.$submitted">
+        <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label translate>FORM.LABELS.TYPE</label>
+      <div class="radio">
+        <label class="radio-inline">
+          <input
+            type="radio"
+            name="is_principal"
+            ng-value="1"
+            ng-model="FeeCenterModalCtrl.feeCenter.is_principal"
+            ng-click="FeeCenterModalCtrl.auxiliaryFee(false)"
+            id="principal"
+            >
+          <span translate>FORM.LABELS.PRINCIPAL_2</span>
+        </label>
+
+        <label class="radio-inline">
+          <input
+            type="radio"
+            name="is_principal"
+            ng-value="0"
+            ng-model="FeeCenterModalCtrl.feeCenter.is_principal"
+            ng-click="FeeCenterModalCtrl.auxiliaryFee(true)"
+            id="auxiliary"
+            >
+          <span translate>FORM.LABELS.AUXILIARY</span>
+        </label>
+      </div>
+    </div>
+    <hr />
+
+    <div style="padding-left: 5%" class="form-group">
+      <div ng-if="FeeCenterModalCtrl.auxiliaryCenter" class="form-group">
+        <div class="radio">
+          <label class="radio-inline">
+            <input
+              type="radio"
+              name="auxiliary"
+              ng-value="1"
+              ng-model="FeeCenterModalCtrl.feeCenter.is_cost"
+              ng-click="FeeCenterModalCtrl.costCenter(true)"
+              id="is_cost"
+              >
+            <span translate>FORM.LABELS.COST_CENTER </span>
+          </label>
+
+          <label class="radio-inline">
+            <input
+              type="radio"
+              name="auxiliary"
+              ng-value="0"
+              ng-model="FeeCenterModalCtrl.feeCenter.is_cost"
+              ng-click="FeeCenterModalCtrl.costCenter(false)"
+              id="is_profit"
+              >
+            <span translate>FORM.LABELS.PROFIT_CENTER </span>
+          </label>
+        </div>
+      </div>  
+
+      <div ng-if="FeeCenterModalCtrl.feeCenter.is_principal" class="checkbox">
+        <label>
+          <input
+            type="checkbox"
+            name="has_profit_center"
+            ng-true-value="1"
+            ng-false-value="0"
+            ng-model="FeeCenterModalCtrl.hasProfitCenter">
+          <span translate>
+            <strong>
+              FORM.INFO.ASSIGNED_PROFIT_CENTER
+            </strong>
+          </span>
+        </label>
+      </div>
+      <div ng-if="(FeeCenterModalCtrl.feeCenter.is_principal && FeeCenterModalCtrl.hasProfitCenter) || (FeeCenterModalCtrl.auxiliaryCenter && FeeCenterModalCtrl.isProfitCenter)">
+        <bh-account-reference-select
+          id="account_profit_reference_id"
+          account-reference-id="FeeCenterModalCtrl.feeCenter.reference_profit_id"
+          label="FORM.LABELS.PROFIT_CENTER"
+          on-select-callback="FeeCenterModalCtrl.onSelectAccountReference(accountReference, 0)"
+          required="true"
+          validation-trigger="FeeCenterForm.$submitted">
+        </bh-account-config-select>
+      </div>
+      
+      <span ng-if="FeeCenterModalCtrl.feeCenter.is_principal">
+        <hr />
+      </span>
+
+      <div ng-if="FeeCenterModalCtrl.feeCenter.is_principal" class="checkbox">
+        <label>
+          <input
+            type="checkbox"
+            name="has_cost_center"
+            ng-true-value="1"
+            ng-false-value="0"
+            ng-model="FeeCenterModalCtrl.hasCostCenter">
+          <span translate>
+            <strong>
+              FORM.INFO.ASSIGNED_COST_CENTER
+            </strong>
+          </span>
+        </label>
+      </div>
+
+      <div ng-if="(FeeCenterModalCtrl.feeCenter.is_principal && FeeCenterModalCtrl.hasCostCenter) || (FeeCenterModalCtrl.auxiliaryCenter && FeeCenterModalCtrl.isCostCenter)">
+        <bh-account-reference-select
+          id="account_cost_reference_id"
+          account-reference-id="FeeCenterModalCtrl.feeCenter.reference_cost_id"
+          label="FORM.LABELS.COST_CENTER"
+          on-select-callback="FeeCenterModalCtrl.onSelectAccountReference(accountReference, 1)"
+          required="true"
+          validation-trigger="FeeCenterForm.$submitted">
+        </bh-account-config-select>
+      </div>
+    </div>
+    <hr />
+
+    <div class="checkbox">
+      <label>
+        <input
+          type="checkbox"
+          name="has_profit_center"
+          ng-true-value="1"
+          ng-false-value="0"
+          ng-model="FeeCenterModalCtrl.assignedProjects">
+        <span translate>
+          <strong>
+            FORM.INFO.ASSIGNED_PROJECTS
+          </strong>
+        </span>
+      </label>
+    </div>
+    <div ng-if="FeeCenterModalCtrl.assignedProjects">
+      <bh-projects-multiple-select
+        on-change="FeeCenterModalCtrl.onProjectsChange(projects)"
+        projects-ids="FeeCenterModalCtrl.projects"
+        required="true"
+        validation-trigger="FeeCenterForm.$submitted">
+      </bh-projects-multiple-select>
+    </div>
+  </div>
+
+  <div class="modal-footer">
+    <button data-method="cancel" type="button" class="btn btn-default" ui-sref="fee_center">
+      <span translate>FORM.BUTTONS.CANCEL</span>
+    </button>
+
+    <bh-loading-button loading-state="FeeCenterForm.$loading">
+      <span translate>FORM.BUTTONS.SUBMIT</span>
+    </bh-loading-button>
+  </div>
+</form>

--- a/client/src/modules/fee_center/modals/fee_center.modal.html
+++ b/client/src/modules/fee_center/modals/fee_center.modal.html
@@ -84,7 +84,7 @@
         <label>
           <input
             type="checkbox"
-            name="has_profit_center"
+            id="has_profit_center"
             ng-true-value="1"
             ng-false-value="0"
             ng-model="FeeCenterModalCtrl.hasProfitCenter">
@@ -114,7 +114,7 @@
         <label>
           <input
             type="checkbox"
-            name="has_cost_center"
+            id="has_cost_center"
             ng-true-value="1"
             ng-false-value="0"
             ng-model="FeeCenterModalCtrl.hasCostCenter">
@@ -143,7 +143,7 @@
       <label>
         <input
           type="checkbox"
-          name="has_profit_center"
+          id="assigned_projects"
           ng-true-value="1"
           ng-false-value="0"
           ng-model="FeeCenterModalCtrl.assignedProjects">

--- a/client/src/modules/fee_center/modals/fee_center.modal.html
+++ b/client/src/modules/fee_center/modals/fee_center.modal.html
@@ -21,7 +21,7 @@
       </div>
     </div>
 
-    <div class="form-group">
+    <div class="form-group" ng-class="{'has-error' : FeeCenterForm.$submitted && FeeCenterForm.is_principal.$invalid }">
       <label translate>FORM.LABELS.TYPE</label>
       <div class="radio">
         <label class="radio-inline">
@@ -32,6 +32,7 @@
             ng-model="FeeCenterModalCtrl.feeCenter.is_principal"
             ng-click="FeeCenterModalCtrl.auxiliaryFee(false)"
             id="principal"
+            required
             >
           <span translate>FORM.LABELS.PRINCIPAL_2</span>
         </label>
@@ -44,9 +45,14 @@
             ng-model="FeeCenterModalCtrl.feeCenter.is_principal"
             ng-click="FeeCenterModalCtrl.auxiliaryFee(true)"
             id="auxiliary"
+            required
             >
           <span translate>FORM.LABELS.AUXILIARY</span>
         </label>
+
+        <div class="help-block" ng-messages="FeeCenterForm.is_principal.$error" ng-show="FeeCenterForm.$submitted">
+          <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+        </div>        
       </div>
     </div>
     <hr />
@@ -103,7 +109,7 @@
           on-select-callback="FeeCenterModalCtrl.onSelectAccountReference(accountReference, 0)"
           required="true"
           validation-trigger="FeeCenterForm.$submitted">
-        </bh-account-config-select>
+        </bh-account-reference-select>
       </div>
       
       <span ng-if="FeeCenterModalCtrl.feeCenter.is_principal">
@@ -134,33 +140,8 @@
           on-select-callback="FeeCenterModalCtrl.onSelectAccountReference(accountReference, 1)"
           required="true"
           validation-trigger="FeeCenterForm.$submitted">
-        </bh-account-config-select>
+        </bh-account-reference-select>
       </div>
-    </div>
-    <hr />
-
-    <div class="checkbox">
-      <label>
-        <input
-          type="checkbox"
-          id="assigned_projects"
-          ng-true-value="1"
-          ng-false-value="0"
-          ng-model="FeeCenterModalCtrl.assignedProjects">
-        <span translate>
-          <strong>
-            FORM.INFO.ASSIGNED_PROJECTS
-          </strong>
-        </span>
-      </label>
-    </div>
-    <div ng-if="FeeCenterModalCtrl.assignedProjects">
-      <bh-projects-multiple-select
-        on-change="FeeCenterModalCtrl.onProjectsChange(projects)"
-        projects-ids="FeeCenterModalCtrl.projects"
-        required="true"
-        validation-trigger="FeeCenterForm.$submitted">
-      </bh-projects-multiple-select>
     </div>
   </div>
 

--- a/client/src/modules/fee_center/modals/fee_center.modal.js
+++ b/client/src/modules/fee_center/modals/fee_center.modal.js
@@ -22,60 +22,55 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
 
   // exposed methods
   vm.submit = submit;
-  vm.closeModal = closeModal;
   vm.auxiliaryFee = auxiliaryFee;
   vm.costCenter = costCenter;
   vm.onSelectAccountReference = onSelectAccountReference;
-  vm.onProjectsChange = onProjectsChange;
 
   if (!vm.isCreating) {
     FeeCenter.read(vm.stateParams.id)
       .then((data) => {
         vm.feeCenter = data.feeCenter[0];
-
-        if (data.projects) {
-          vm.assignedProjects = data.projects.length ? 1 : 0;
-          vm.projects = data.projects;
-        }
-
-        if (data.references) {
-          data.references.forEach((reference) => {
-            if (reference.is_cost) {
-              if (vm.feeCenter.is_principal) {
-                vm.hasCostCenter = 1;
-              } else {
-                vm.isCostCenter = 1;
-                vm.auxiliaryCenter = 1;
-              }
-              vm.feeCenter.is_cost = reference.is_cost;
-              vm.feeCenter.reference_cost_id = reference.account_reference_id;
-              vm.costCenterReference = {
-                account_reference_id : reference.account_reference_id,
-                is_cost : reference.is_cost,
-              };
-            }
-
-            if (!reference.is_cost) {
-              if (vm.feeCenter.is_principal) {
-                vm.hasProfitCenter = 1;
-              } else {
-                vm.isProfitCenter = 1;
-                vm.auxiliaryCenter = 1;
-              }
-
-              vm.feeCenter.is_cost = reference.is_cost;
-              vm.feeCenter.reference_profit_id = reference.account_reference_id;
-              vm.profitCenterReference = {
-                account_reference_id : reference.account_reference_id,
-                is_cost : reference.is_cost,
-              };
-            }
-          });
-        }
-
+        const dataReferences = processReference(data.references);
         vm.setting = true;
       })
       .catch(Notify.handleError);
+  }
+
+  function processReference(references) {
+    if (references) {
+      references.forEach((reference) => {
+        if (reference.is_cost) {
+          if (vm.feeCenter.is_principal) {
+            vm.hasCostCenter = 1;
+          } else {
+            vm.isCostCenter = 1;
+            vm.auxiliaryCenter = 1;
+          }
+          vm.feeCenter.is_cost = reference.is_cost;
+          vm.feeCenter.reference_cost_id = reference.account_reference_id;
+          vm.costCenterReference = {
+            account_reference_id : reference.account_reference_id,
+            is_cost : reference.is_cost,
+          };
+        }
+
+        if (!reference.is_cost) {
+          if (vm.feeCenter.is_principal) {
+            vm.hasProfitCenter = 1;
+          } else {
+            vm.isProfitCenter = 1;
+            vm.auxiliaryCenter = 1;
+          }
+
+          vm.feeCenter.is_cost = reference.is_cost;
+          vm.feeCenter.reference_profit_id = reference.account_reference_id;
+          vm.profitCenterReference = {
+            account_reference_id : reference.account_reference_id,
+            is_cost : reference.is_cost,
+          };
+        }
+      });
+    }
   }
 
   function auxiliaryFee(value) {
@@ -105,10 +100,6 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
     }
   }
 
-  function onProjectsChange(projects) {
-    vm.projects = projects;
-  }
-
   function costCenter(value) {
     vm.isCostCenter = value;
     vm.isProfitCenter = !value;
@@ -126,13 +117,10 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
       vm.referenceFeeCenter.push(vm.profitCenterReference);
     }
 
-    vm.projects = vm.assignedProjects ? vm.projects : [];
-
     const data = {
       label : vm.feeCenter.label,
       is_principal : vm.feeCenter.is_principal,
       reference_fee_center : vm.referenceFeeCenter,
-      projects : vm.projects,
     };
 
     const promise = (vm.isCreating)
@@ -146,9 +134,5 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
         $state.go('fee_center', null, { reload : true });
       })
       .catch(Notify.handleError);
-  }
-
-  function closeModal() {
-    $state.go('fee_center');
   }
 }

--- a/client/src/modules/fee_center/modals/fee_center.modal.js
+++ b/client/src/modules/fee_center/modals/fee_center.modal.js
@@ -30,7 +30,7 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
     FeeCenter.read(vm.stateParams.id)
       .then((data) => {
         vm.feeCenter = data.feeCenter[0];
-        const dataReferences = processReference(data.references);
+        processReference(data.references);
         vm.setting = true;
       })
       .catch(Notify.handleError);

--- a/client/src/modules/fee_center/modals/fee_center.modal.js
+++ b/client/src/modules/fee_center/modals/fee_center.modal.js
@@ -13,7 +13,8 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
   const cache = AppCache('FeeCenterModal');
 
   if ($state.params.creating || $state.params.id) {
-    vm.stateParams = cache.stateParams = $state.params;
+    cache.stateParams = $state.params;
+    vm.stateParams = cache.stateParams;
   } else {
     vm.stateParams = cache.stateParams;
   }
@@ -115,9 +116,6 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
 
   // submit the data to the server from all two forms (update, create)
   function submit(feeCenterForm) {
-    let promise;
-
-
     if (feeCenterForm.$invalid) { return 0; }
 
     if (vm.isCostCenter || vm.hasCostCenter) {
@@ -137,7 +135,7 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
       projects : vm.projects,
     };
 
-    promise = (vm.isCreating)
+    const promise = (vm.isCreating)
       ? FeeCenter.create(data)
       : FeeCenter.update(vm.feeCenter.id, data);
 

--- a/client/src/modules/fee_center/modals/fee_center.modal.js
+++ b/client/src/modules/fee_center/modals/fee_center.modal.js
@@ -45,9 +45,13 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
               } else {
                 vm.isCostCenter = 1;
                 vm.auxiliaryCenter = 1;
-              }              
-              vm.feeCenter.is_cost =  reference.is_cost;
+              }
+              vm.feeCenter.is_cost = reference.is_cost;
               vm.feeCenter.reference_cost_id = reference.account_reference_id;
+              vm.costCenterReference = {
+                account_reference_id : reference.account_reference_id,
+                is_cost : reference.is_cost,
+              };
             }
 
             if (!reference.is_cost) {
@@ -60,6 +64,10 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
 
               vm.feeCenter.is_cost = reference.is_cost;
               vm.feeCenter.reference_profit_id = reference.account_reference_id;
+              vm.profitCenterReference = {
+                account_reference_id : reference.account_reference_id,
+                is_cost : reference.is_cost,
+              };
             }
           });
         }
@@ -110,7 +118,7 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
     let promise;
 
 
-    if (feeCenterForm.$invalid || feeCenterForm.$pristine) { return 0; }
+    if (feeCenterForm.$invalid) { return 0; }
 
     if (vm.isCostCenter || vm.hasCostCenter) {
       vm.referenceFeeCenter.push(vm.costCenterReference);
@@ -127,9 +135,9 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
       projects : vm.projects,
     };
 
-    promise = (vm.isCreating) ?
-      FeeCenter.create(data) :
-      FeeCenter.update(vm.feeCenter.id, data);
+    promise = (vm.isCreating)
+      ? FeeCenter.create(data)
+      : FeeCenter.update(vm.feeCenter.id, data);
 
     return promise
       .then(() => {

--- a/client/src/modules/fee_center/modals/fee_center.modal.js
+++ b/client/src/modules/fee_center/modals/fee_center.modal.js
@@ -128,6 +128,8 @@ function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCa
       vm.referenceFeeCenter.push(vm.profitCenterReference);
     }
 
+    vm.projects = vm.assignedProjects ? vm.projects : [];
+
     const data = {
       label : vm.feeCenter.label,
       is_principal : vm.feeCenter.is_principal,

--- a/client/src/modules/fee_center/modals/fee_center.modal.js
+++ b/client/src/modules/fee_center/modals/fee_center.modal.js
@@ -1,0 +1,146 @@
+angular.module('bhima.controllers')
+  .controller('FeeCenterModalController', FeeCenterModalController);
+
+FeeCenterModalController.$inject = [
+  '$state', 'FeeCenterService', 'ModalService', 'NotifyService', 'appcache',
+];
+
+function FeeCenterModalController($state, FeeCenter, ModalService, Notify, AppCache) {
+  const vm = this;
+  vm.feeCenter = {};
+  vm.referenceFeeCenter = [];
+
+  const cache = AppCache('FeeCenterModal');
+
+  if ($state.params.creating || $state.params.id) {
+    vm.stateParams = cache.stateParams = $state.params;
+  } else {
+    vm.stateParams = cache.stateParams;
+  }
+  vm.isCreating = vm.stateParams.creating;
+
+  // exposed methods
+  vm.submit = submit;
+  vm.closeModal = closeModal;
+  vm.auxiliaryFee = auxiliaryFee;
+  vm.costCenter = costCenter;
+  vm.onSelectAccountReference = onSelectAccountReference;
+  vm.onProjectsChange = onProjectsChange;
+
+  if (!vm.isCreating) {
+    FeeCenter.read(vm.stateParams.id)
+      .then((data) => {
+        vm.feeCenter = data.feeCenter[0];
+
+        if (data.projects) {
+          vm.assignedProjects = data.projects.length ? 1 : 0;
+          vm.projects = data.projects;
+        }
+
+        if (data.references) {
+          data.references.forEach((reference) => {
+            if (reference.is_cost) {
+              if (vm.feeCenter.is_principal) {
+                vm.hasCostCenter = 1;
+              } else {
+                vm.isCostCenter = 1;
+                vm.auxiliaryCenter = 1;
+              }              
+              vm.feeCenter.is_cost =  reference.is_cost;
+              vm.feeCenter.reference_cost_id = reference.account_reference_id;
+            }
+
+            if (!reference.is_cost) {
+              if (vm.feeCenter.is_principal) {
+                vm.hasProfitCenter = 1;
+              } else {
+                vm.isProfitCenter = 1;
+                vm.auxiliaryCenter = 1;
+              }
+
+              vm.feeCenter.is_cost = reference.is_cost;
+              vm.feeCenter.reference_profit_id = reference.account_reference_id;
+            }
+          });
+        }
+
+        vm.setting = true;
+      })
+      .catch(Notify.handleError);
+  }
+
+  function auxiliaryFee(value) {
+    vm.auxiliaryCenter = value ? 1 : 0;
+    if (value) {
+      vm.hasProfitCenter = !value;
+      vm.hasCostCenter = !value;
+    }
+
+    if (vm.auxiliaryCenter) {
+      vm.isCostCenter = 0;
+      vm.isProfitCenter = 0;
+    }
+  }
+
+  function onSelectAccountReference(accountReference, isCostCenter) {
+    if (isCostCenter) {
+      vm.costCenterReference = {
+        account_reference_id : accountReference.id,
+        is_cost : isCostCenter,
+      };
+    } else {
+      vm.profitCenterReference = {
+        account_reference_id : accountReference.id,
+        is_cost : isCostCenter,
+      };
+    }
+  }
+
+  function onProjectsChange(projects) {
+    vm.projects = projects;
+  }
+
+  function costCenter(value) {
+    vm.isCostCenter = value;
+    vm.isProfitCenter = !value;
+  }
+
+  // submit the data to the server from all two forms (update, create)
+  function submit(feeCenterForm) {
+    let promise;
+
+
+    if (feeCenterForm.$invalid || feeCenterForm.$pristine) { return 0; }
+
+    if (vm.isCostCenter || vm.hasCostCenter) {
+      vm.referenceFeeCenter.push(vm.costCenterReference);
+    }
+
+    if (vm.isProfitCenter || vm.hasProfitCenter) {
+      vm.referenceFeeCenter.push(vm.profitCenterReference);
+    }
+
+    const data = {
+      label : vm.feeCenter.label,
+      is_principal : vm.feeCenter.is_principal,
+      reference_fee_center : vm.referenceFeeCenter,
+      projects : vm.projects,
+    };
+
+    promise = (vm.isCreating) ?
+      FeeCenter.create(data) :
+      FeeCenter.update(vm.feeCenter.id, data);
+
+    return promise
+      .then(() => {
+        const translateKey = (vm.isCreating) ? 'FORM.INFO.CREATE_SUCCESS' : 'FORM.INFO.UPDATE_SUCCESS';
+        Notify.success(translateKey);
+        $state.go('fee_center', null, { reload : true });
+      })
+      .catch(Notify.handleError);
+  }
+
+  function closeModal() {
+    $state.go('fee_center');
+  }
+}

--- a/client/src/modules/fee_center/templates/action.tmpl.html
+++ b/client/src/modules/fee_center/templates/action.tmpl.html
@@ -1,0 +1,22 @@
+<div class="ui-grid-cell-contents" uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
+  <a href>
+    <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
+    <span class="caret"></span>
+  </a>
+
+  <ul data-action="{{ rowRenderIndex}}"  class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+    <li class="dropdown-header">{{row.entity.label}}</li>
+    <li>
+      <a data-method="edit" ui-sref="fee_center.edit({id : row.entity.id})" href>
+        <span class="fa fa-edit"></span> <span translate>TABLE.COLUMNS.EDIT</span>
+      </a>
+    </li>
+    <li>
+      <a data-method="delete" ng-click="grid.appScope.deleteFeeCenter(row.entity)" href>
+        <span class="text-danger">
+          <i class="fa fa-trash"></i> <span translate>FEE_CENTER.DELETE</span>
+        </span>
+      </a>
+    </li>
+  </ul>
+</div>

--- a/client/src/modules/fee_center/templates/feeCenterType.tmpl.html
+++ b/client/src/modules/fee_center/templates/feeCenterType.tmpl.html
@@ -1,0 +1,4 @@
+<div class="ui-grid-cell-contents">
+  <span ng-if="row.entity.is_principal == 0" translate> FORM.LABELS.AUXILIARY </span>
+  <span ng-if="row.entity.is_principal == 1" translate> FORM.LABELS.PRINCIPAL_2 </span>
+</div>

--- a/client/src/modules/templates/bhAccountReferenceSelect.tmpl.html
+++ b/client/src/modules/templates/bhAccountReferenceSelect.tmpl.html
@@ -1,0 +1,34 @@
+<div ng-form="{{ $ctrl.name }}" bh-account-reference-select ng-model-options="{ updateOn: 'default' }">
+  <div
+    class="form-group"
+    ng-class="{ 'has-error' : $ctrl.validationTrigger && AccountReferenceForm.account_reference_id.$invalid }">
+
+    <label class="control-label" translate>
+      {{ ::$ctrl.label }}
+    </label>
+    <ng-transclude></ng-transclude>
+    <div class="text-danger" ng-if="!$ctrl.accountReferences.length">
+      <i class="fa fa-exclamation-triangle"></i> <span translate> FORM.WARNINGS.NO_CONFIGURATION_FOUND </span>  
+    </div>       
+
+    <ui-select
+      name="account_reference_id"
+      ng-model="$ctrl.accountReferenceId"
+      on-select="$ctrl.onSelect($item, $model)"
+      ng-required="$ctrl.required">
+      <ui-select-match placeholder="{{ ::'FORM.PLACEHOLDERS.ACCOUNT_REFERENCE' | translate }}">
+        <span><strong>{{$select.selected.abbr}}</strong> : {{$select.selected.description}}</span>
+      </ui-select-match>
+      <ui-select-choices
+        ui-select-focus-patch
+        repeat="accountReference.id as accountReference in $ctrl.accountReferences | filter: { 'description': $select.search }">        
+        <strong ng-bind-html="accountReference.abbr | highlight:$select.search"></strong> :
+        <span ng-bind-html="accountReference.description | highlight:$select.search"></span>
+      </ui-select-choices>
+    </ui-select>
+
+    <div class="help-block" ng-messages="AccountReferenceForm.account_reference_id.$error" ng-show="$ctrl.validationTrigger && AccountReferenceForm.account_reference_id.$invalid">
+      <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+    </div>
+  </div>
+</div>

--- a/client/src/modules/templates/bhProjectsMultipleSelect.tmpl.html
+++ b/client/src/modules/templates/bhProjectsMultipleSelect.tmpl.html
@@ -1,0 +1,29 @@
+<div ng-form="ProjectsMultipleForm" bh-projects-multiple-select ng-model-options="{ updateOn: 'default' }">
+  <div
+    class="form-group"
+    ng-class="{ 'has-error' : $ctrl.validationTrigger && ProjectsMultipleForm.projects.$invalid }">
+    <label class="control-label" translate>
+      {{ $ctrl.label }}
+    </label>
+
+    <ui-select
+        multiple
+        name="projects"
+        ng-model="$ctrl.selectedProjects"
+        on-select="$ctrl.handleChange($ctrl.selectedProjects)"
+        on-remove="$ctrl.handleChange($ctrl.selectedProjects)"
+        close-on-select="false"
+        required>
+      <ui-select-match placeholder="{{ 'FORM.SELECT.STATUS' | translate }}">
+        <span>{{ $item.name }}</span>
+      </ui-select-match>
+      <ui-select-choices ui-select-focus-patch repeat="project.id as project in ($ctrl.projects | filter: { name : $select.search })">
+        <span ng-bind-html="project.name | highlight:$select.search"></span>
+      </ui-select-choices>
+    </ui-select>
+
+    <div class="help-block" ng-messages="ProjectsMultipleForm.$error" ng-show="$ctrl.validationTrigger">
+      <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+    </div>
+  </div>
+</div>

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -102,6 +102,8 @@ const referenceLookup = require('../lib/referenceLookup');
 
 const operating = require('../controllers/finance/reports/operating/index');
 
+const feeCenter = require('../controllers/finance/feeCenter');
+
 // expose routes to the server.
 exports.configure = function configure(app) {
   debug('configuring routes.');
@@ -743,4 +745,11 @@ exports.configure = function configure(app) {
 
   // unit
   app.get('/unit/:roleUuid', unitCtrl.list);
+
+  // Fees Centers API
+  app.get('/fee_center', feeCenter.list);
+  app.get('/fee_center/:id', feeCenter.detail);
+  app.post('/fee_center', feeCenter.create);
+  app.put('/fee_center/:id', feeCenter.update);
+  app.delete('/fee_center/:id', feeCenter.delete);
 };

--- a/server/controllers/finance/feeCenter.js
+++ b/server/controllers/finance/feeCenter.js
@@ -1,0 +1,243 @@
+/**
+* Fee Center Controller
+*
+* This controller exposes an API to the client for reading and writing Fee Center
+*/
+
+const db = require('../../lib/db');
+const NotFound = require('../../lib/errors/NotFound');
+const q = require('q');
+
+// GET /fee_center
+function lookupFeeCenter(id) {
+
+  const sqlFeeCenter = `
+    SELECT id, label, is_principal FROM fee_center WHERE id = ?`;
+
+  const sqlReferenceFeeCenter = `
+    SELECT id, fee_center_id, account_reference_id, is_cost 
+    FROM reference_fee_center 
+    WHERE fee_center_id = ?`;
+
+  const sqlProjectsFeeCenter = `
+    SELECT id, fee_center_id, project_id FROM project_fee_center WHERE fee_center_id = ?`;
+
+  return q.all([
+    db.exec(sqlFeeCenter, [id]),
+    db.exec(sqlReferenceFeeCenter, [id]),
+    db.exec(sqlProjectsFeeCenter, [id]),
+  ])
+    .spread((feeCenter, references, projectsFeeCenter) => {
+      const projects = projectsFeeCenter.map(project => project.project_id);
+
+      const data = {
+        feeCenter,
+        references,
+        projects,
+      };
+
+      return data;
+    });
+}
+
+// Lists
+function list(req, res, next) {
+  const sql = `SELECT id, label, is_principal FROM fee_center;`;
+
+  db.exec(sql)
+    .then((rows) => {
+      res.status(200).json(rows);
+    })
+    .catch(next)
+    .done();
+}
+
+/**
+* GET /fee_center/:ID
+*
+* Returns the detail of a single fee_center
+*/
+function detail(req, res, next) {
+  const { id } = req.params;
+
+  lookupFeeCenter(id)
+    .then((record) => {
+      res.status(200).json(record);
+    })
+    .catch(next)
+    .done();
+}
+
+
+// POST /fee_center
+function create(req, res, next) {
+  const sql = `INSERT INTO fee_center SET ?`;
+  const data = req.body;
+
+  const feeCenterData = {
+    label : data.label,
+    is_principal : data.is_principal,
+  };
+
+  db.exec(sql, [feeCenterData])
+    .then((row) => {
+      const feeCenterId = row.insertId;
+      const dataReferences = [];
+      const dataProjects = [];
+
+      if (data.reference_fee_center) {
+        data.reference_fee_center.forEach(item => {
+          dataReferences.push([
+            feeCenterId,
+            item.account_reference_id,
+            item.is_cost,
+          ]);
+        });
+      }
+
+      if (data.projects) {
+        data.projects.forEach(item => {
+          dataProjects.push([
+            feeCenterId,
+            item,
+          ]);
+        });
+      }
+
+      const transaction = db.transaction();
+
+      if (data.reference_fee_center.length) {
+        const sqlReferences = `
+          INSERT INTO reference_fee_center (fee_center_id, account_reference_id, is_cost) VALUES ?`;
+
+        transaction
+          .addQuery(sqlReferences, [dataReferences]);
+      }
+
+      if (dataProjects.length) {
+        const sqlProjects = `
+          INSERT INTO project_fee_center (fee_center_id, project_id) VALUES ?`;
+        transaction
+          .addQuery(sqlProjects, [dataProjects]);
+      }
+
+      return transaction.execute();
+    })
+    .then(() => {
+      res.sendStatus(201);
+    })
+    .catch(next)
+    .done();
+}
+
+
+// PUT /fee_center /:id
+function update(req, res, next) {
+  const data = req.body;
+  const transaction = db.transaction();
+
+  const feeCenterData = {
+    label : data.label,
+    is_principal : data.is_principal,
+  };
+
+  const sql = `UPDATE fee_center SET ? WHERE id = ?;`;
+  const delReferences = `DELETE FROM reference_fee_center WHERE fee_center_id = ?;`;
+  const delProjects = `DELETE FROM project_fee_center WHERE fee_center_id = ?;`;
+
+  const feeCenterId = req.params.id;
+  const dataReferences = [];
+  const dataProjects = [];
+
+  if (data.reference_fee_center) {
+    data.reference_fee_center.forEach(item => {
+      dataReferences.push([
+        feeCenterId,
+        item.account_reference_id,
+        item.is_cost,
+      ]);
+    });
+  }
+
+  if (data.projects) {
+    data.projects.forEach(item => {
+      dataProjects.push([
+        feeCenterId,
+        item,
+      ]);
+    });
+  }
+
+  transaction
+    .addQuery(sql, [feeCenterData, feeCenterId])
+    .addQuery(delReferences, [feeCenterId])
+    .addQuery(delProjects, [feeCenterId]);
+
+  if (data.reference_fee_center.length) {
+    const sqlReferences = `
+      INSERT INTO reference_fee_center (fee_center_id, account_reference_id, is_cost) VALUES ?`;
+
+    transaction
+      .addQuery(sqlReferences, [dataReferences]);
+  }
+
+  if (dataProjects.length) {
+    const sqlProjects = `
+      INSERT INTO project_fee_center (fee_center_id, project_id) VALUES ?`;
+    transaction
+      .addQuery(sqlProjects, [dataProjects]);
+  }
+
+  return transaction.execute()
+    .then(() => {
+      return lookupFeeCenter(feeCenterId);
+    })
+    .then((record) => {
+      // all updates completed successfull, return full object to client
+      res.status(200).json(record);
+    })
+    .catch(next)
+    .done();
+}
+
+// DELETE /fee_center/:id
+function del(req, res, next) {
+  const transaction = db.transaction();
+  const feeCenterId = req.params.id;
+
+  const sql = `DELETE FROM fee_center WHERE id = ?;`;
+  const delReferences = `DELETE FROM reference_fee_center WHERE fee_center_id = ?;`;
+  const delProjects = `DELETE FROM project_fee_center WHERE fee_center_id = ?;`;
+
+  transaction
+    .addQuery(delReferences, [feeCenterId])
+    .addQuery(delProjects, [feeCenterId])
+    .addQuery(sql, [feeCenterId]);
+
+  transaction.execute()
+    .then((rows) => {
+      // if nothing happened, let the client know via a 404 error
+      if (rows[0].affectedRows === 0) {
+        throw new NotFound(`Could not find a Fee Center with id ${feeCenterId}`);
+      }
+
+      res.status(204).json();
+    })
+    .catch(next)
+    .done();
+}
+
+// get list of feeCenter
+exports.list = list;
+
+// get details of a feeCenter
+exports.detail = detail;
+
+// create a new feeCenter
+exports.create = create;
+
+// update feeCenter informations
+exports.update = update;
+
+// Delete a feeCenter
+exports.delete = del;

--- a/server/controllers/finance/feeCenter.js
+++ b/server/controllers/finance/feeCenter.js
@@ -112,9 +112,7 @@ function update(req, res, next) {
 
   const sql = `UPDATE fee_center SET ? WHERE id = ?;`;
   const delReferences = `DELETE FROM reference_fee_center WHERE fee_center_id = ?;`;
-
   const feeCenterId = req.params.id;
-  const dataReferences = [];
 
   transaction
     .addQuery(sql, [feeCenterData, feeCenterId])

--- a/server/controllers/finance/feeCenter.js
+++ b/server/controllers/finance/feeCenter.js
@@ -27,17 +27,17 @@ function lookupFeeCenter(id) {
     db.exec(sqlReferenceFeeCenter, [id]),
     db.exec(sqlProjectsFeeCenter, [id]),
   ])
-    .spread((feeCenter, references, projectsFeeCenter) => {
-      const projects = projectsFeeCenter.map(project => project.project_id);
+  .spread((feeCenter, references, projectsFeeCenter) => {
+    const projects = projectsFeeCenter.map(project => project.project_id);
 
-      const data = {
-        feeCenter,
-        references,
-        projects,
-      };
+    const data = {
+      feeCenter,
+      references,
+      projects,
+    };
 
-      return data;
-    });
+    return data;
+  });
 }
 
 // Lists
@@ -123,8 +123,8 @@ function create(req, res, next) {
 
       return transaction.execute();
     })
-    .then(() => {
-      res.sendStatus(201);
+    .then((rows) => {
+      res.status(201).json(rows);
     })
     .catch(next)
     .done();
@@ -241,3 +241,4 @@ exports.update = update;
 
 // Delete a feeCenter
 exports.delete = del;
+

--- a/server/models/Update/add_account_reference_module.sql
+++ b/server/models/Update/add_account_reference_module.sql
@@ -30,7 +30,7 @@ CREATE TABLE `account_reference_item` (
 
 INSERT INTO unit VALUES 
 (205, 'Account Reference Management','TREE.ACCOUNT_REFERENCE_MANAGEMENT','',1,'/modules/account_reference','/account_reference'),
-(206, 'Account Reference Report','TREE.ACCOUNT_REFERENCE_REPORT','',144,'/modules/reports/account_reference','/reports/account_reference');
+(207, 'Account Reference Report','TREE.ACCOUNT_REFERENCE_REPORT','',144,'/modules/reports/account_reference','/reports/account_reference');
 
 INSERT INTO `report` (`id`, `report_key`, `title_key`) VALUES
 (20, 'account_reference', 'REPORT.ACCOUNT_REFERENCE.TITLE');

--- a/server/models/Update/add_fee_center_module.sql
+++ b/server/models/Update/add_fee_center_module.sql
@@ -12,19 +12,6 @@ CREATE TABLE `fee_center` (
   UNIQUE KEY `fee_center_1` (`label`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-DROP TABLE IF EXISTS `project_fee_center`;
-CREATE TABLE `project_fee_center` (
-  `id` MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,
-  `fee_center_id` MEDIUMINT(8) UNSIGNED NOT NULL,
-  `project_id` SMALLINT(5) UNSIGNED NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `project_fee_center_1` (`fee_center_id`,`project_id`),
-  KEY `fee_center_id` (`fee_center_id`),
-  KEY `project_id` (`project_id`),
-  FOREIGN KEY (`project_id`) REFERENCES `project` (`id`),
-  FOREIGN KEY (`fee_center_id`) REFERENCES `fee_center` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
 DROP TABLE IF EXISTS `reference_fee_center`;
 CREATE TABLE `reference_fee_center` (
   `id` MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/server/models/Update/add_fee_center_module.sql
+++ b/server/models/Update/add_fee_center_module.sql
@@ -1,0 +1,49 @@
+/*
+  ADD FEE CENTER MODULES @lomamech : 
+  ===================================
+*/
+
+DROP TABLE IF EXISTS `fee_center`;
+CREATE TABLE `fee_center` (
+  `id` MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `label` VARCHAR(200) NOT NULL,
+  `is_principal` tinyint(1) UNSIGNED DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `fee_center_1` (`label`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+DROP TABLE IF EXISTS `project_fee_center`;
+CREATE TABLE `project_fee_center` (
+  `id` MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `fee_center_id` MEDIUMINT(8) UNSIGNED NOT NULL,
+  `project_id` SMALLINT(5) UNSIGNED NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `project_fee_center_1` (`fee_center_id`,`project_id`),
+  KEY `fee_center_id` (`fee_center_id`),
+  KEY `project_id` (`project_id`),
+  FOREIGN KEY (`project_id`) REFERENCES `project` (`id`),
+  FOREIGN KEY (`fee_center_id`) REFERENCES `fee_center` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+DROP TABLE IF EXISTS `reference_fee_center`;
+CREATE TABLE `reference_fee_center` (
+  `id` MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `fee_center_id` MEDIUMINT(8) UNSIGNED NOT NULL,
+  `account_reference_id` MEDIUMINT(8) UNSIGNED NOT NULL,
+  `is_cost` tinyint(1) DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `reference_fee_center_1` (`account_reference_id`),
+  KEY `fee_center_id` (`fee_center_id`),
+  KEY `account_reference_id` (`account_reference_id`),
+  FOREIGN KEY (`fee_center_id`) REFERENCES `fee_center` (`id`),
+  FOREIGN KEY (`account_reference_id`) REFERENCES `account_reference` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+INSERT INTO unit VALUES
+(208, 'Fee Center Management','TREE.FEE_CENTER','',1,'/modules/fee_center','/fee_center');
+
+/*
+  END : ADD FEE CENTER MODULES @lomamech : 2018-08-17
+  ===================================================
+*/

--- a/server/models/bhima.sql
+++ b/server/models/bhima.sql
@@ -99,7 +99,7 @@ INSERT INTO unit VALUES
   (205, 'Account Reference Management','TREE.ACCOUNT_REFERENCE_MANAGEMENT','',1,'/modules/account_reference','/account_reference'),
   (206, '[OHADA] Bilan','TREE.OHADA_BALANCE_SHEET','',144,'/modules/reports/ohada_balance_sheet_report','/reports/ohada_balance_sheet_report'),
   (207, 'Account Reference Report','TREE.ACCOUNT_REFERENCE_REPORT','',144,'/modules/reports/account_reference','/reports/account_reference'),
-  (208, 'Fee Center Management','TREE.FEE_CENTER','',1,'/modules/fee_center','/fee_center');
+  (209, 'Fee Center Management','TREE.FEE_CENTER','',1,'/modules/fee_center','/fee_center');
 
 -- Reserved system account type
 INSERT INTO `account_category` VALUES

--- a/server/models/bhima.sql
+++ b/server/models/bhima.sql
@@ -98,7 +98,8 @@ INSERT INTO unit VALUES
   (204, 'Exchange Rate','TREE.EXCHANGE','',1,'/modules/exchange/exchange','/exchange'),
   (205, 'Account Reference Management','TREE.ACCOUNT_REFERENCE_MANAGEMENT','',1,'/modules/account_reference','/account_reference'),
   (206, '[OHADA] Bilan','TREE.OHADA_BALANCE_SHEET','',144,'/modules/reports/ohada_balance_sheet_report','/reports/ohada_balance_sheet_report'),
-  (207, 'Account Reference Report','TREE.ACCOUNT_REFERENCE_REPORT','',144,'/modules/reports/account_reference','/reports/account_reference');
+  (207, 'Account Reference Report','TREE.ACCOUNT_REFERENCE_REPORT','',144,'/modules/reports/account_reference','/reports/account_reference'),
+  (208, 'Fee Center Management','TREE.FEE_CENTER','',1,'/modules/fee_center','/fee_center');
 
 -- Reserved system account type
 INSERT INTO `account_category` VALUES

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -2035,5 +2035,40 @@ CREATE TABLE `config_employee_item` (
   FOREIGN KEY (`employee_uuid`) REFERENCES `employee` (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
+DROP TABLE IF EXISTS `fee_center`;
+CREATE TABLE `fee_center` (
+  `id` MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `label` VARCHAR(200) NOT NULL,
+  `is_principal` tinyint(1) UNSIGNED DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `fee_center_1` (`label`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+DROP TABLE IF EXISTS `project_fee_center`;
+CREATE TABLE `project_fee_center` (
+  `id` MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `fee_center_id` MEDIUMINT(8) UNSIGNED NOT NULL,
+  `project_id` SMALLINT(5) UNSIGNED NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `project_fee_center_1` (`fee_center_id`,`project_id`),
+  KEY `fee_center_id` (`fee_center_id`),
+  KEY `project_id` (`project_id`),
+  FOREIGN KEY (`project_id`) REFERENCES `project` (`id`),
+  FOREIGN KEY (`fee_center_id`) REFERENCES `fee_center` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+DROP TABLE IF EXISTS `reference_fee_center`;
+CREATE TABLE `reference_fee_center` (
+  `id` MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `fee_center_id` MEDIUMINT(8) UNSIGNED NOT NULL,
+  `account_reference_id` MEDIUMINT(8) UNSIGNED NOT NULL,
+  `is_cost` tinyint(1) DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `reference_fee_center_1` (`account_reference_id`),
+  KEY `fee_center_id` (`fee_center_id`),
+  KEY `account_reference_id` (`account_reference_id`),
+  FOREIGN KEY (`fee_center_id`) REFERENCES `fee_center` (`id`),
+  FOREIGN KEY (`account_reference_id`) REFERENCES `account_reference` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 SET foreign_key_checks = 1;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -2044,19 +2044,6 @@ CREATE TABLE `fee_center` (
   UNIQUE KEY `fee_center_1` (`label`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-DROP TABLE IF EXISTS `project_fee_center`;
-CREATE TABLE `project_fee_center` (
-  `id` MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,
-  `fee_center_id` MEDIUMINT(8) UNSIGNED NOT NULL,
-  `project_id` SMALLINT(5) UNSIGNED NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `project_fee_center_1` (`fee_center_id`,`project_id`),
-  KEY `fee_center_id` (`fee_center_id`),
-  KEY `project_id` (`project_id`),
-  FOREIGN KEY (`project_id`) REFERENCES `project` (`id`),
-  FOREIGN KEY (`fee_center_id`) REFERENCES `fee_center` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
 DROP TABLE IF EXISTS `reference_fee_center`;
 CREATE TABLE `reference_fee_center` (
   `id` MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/test/data.sql
+++ b/test/data.sql
@@ -981,18 +981,14 @@ INSERT INTO `account_reference_item` (`id`, `account_reference_id`, `account_id`
 -- FEE CENTER 
 INSERT INTO `fee_center` (`id`, `label`, `is_principal`) VALUES
 (1, 'Administration', 1),
-(2, 'Principale TPA', 1),
-(3, 'Section Auxiliaire 1', 0),
-(4, 'Profit Auxiliaire 2', 0);
+(2, 'Principale TPA', 1);
 
 -- REFERENCE FEE CENTER
 INSERT INTO `reference_fee_center` (`id`, `fee_center_id`, `account_reference_id`, `is_cost`) VALUES 
 (1, 1, 1, 1),
 (2, 1, 2, 0),
 (3, 2, 6, 1),
-(4, 2, 3, 0),
-(5, 3, 4, 1),
-(6, 4, 7, 0);
+(4, 2, 3, 0);
 
 -- PROJECT FEE CENTER
 INSERT INTO `project_fee_center` (`id`, `fee_center_id`, `project_id`) VALUES (1, 2, 1);

--- a/test/data.sql
+++ b/test/data.sql
@@ -989,7 +989,4 @@ INSERT INTO `reference_fee_center` (`id`, `fee_center_id`, `account_reference_id
 (2, 1, 2, 0),
 (3, 2, 6, 1),
 (4, 2, 3, 0);
-
--- PROJECT FEE CENTER
-INSERT INTO `project_fee_center` (`id`, `fee_center_id`, `project_id`) VALUES (1, 2, 1);
 -- ----------------------------------------------------------------------------------------

--- a/test/data.sql
+++ b/test/data.sql
@@ -951,4 +951,49 @@ INSERT INTO role_unit
 INSERT INTO `user_role`(uuid, user_id, role_uuid)
 VALUES(HUID(uuid()), 2, @regularRoleUUID);
 
+-- ACCOUNT REFERENCE 
+INSERT INTO `account_reference` (`id`, `abbr`, `description`, `parent`, `is_amo_dep`) VALUES
+(1, 'c_admin', 'Section Administration', NULL, 0),
+(2, 'p_admin', 'Profit Administration', NULL, 0),
+(3, 'p_test_1', 'Profit Test 1', NULL, 0),
+(4, 'p_test_2', 'Profit Test 2', NULL, 0),
+(5, 'c_test_1', 'Cost Test 1', NULL, 0),
+(6, 'c_test_2', 'Cost Test 2', NULL, 0),
+(7, 'p_test_3', 'Profit Test 3', NULL, 0),
+(8, 'p_test_4', 'Profit Test 4', NULL, 0),
+(9, 'c_test_3', 'Cost Test 3', NULL, 0);
+
+-- ACCOUNT REFERENCE ITEM
+INSERT INTO `account_reference_item` (`id`, `account_reference_id`, `account_id`, `is_exception`) VALUES
+(1, 1, 347, 0),
+(2, 1, 220, 0),
+(3, 2, 246, 0),
+(4, 2, 249, 0),
+(5, 2, 248, 0),
+(6, 3, 258, 0),
+(7, 4, 258, 0),
+(8, 5, 201, 0),
+(9, 6, 210, 0),
+(10, 7, 256, 0),
+(11, 9, 215, 0),
+(12, 8, 256, 0);
+
+-- FEE CENTER 
+INSERT INTO `fee_center` (`id`, `label`, `is_principal`) VALUES
+(1, 'Administration', 1),
+(2, 'Principale TPA', 1),
+(3, 'Section Auxiliaire 1', 0),
+(4, 'Profit Auxiliaire 2', 0);
+
+-- REFERENCE FEE CENTER
+INSERT INTO `reference_fee_center` (`id`, `fee_center_id`, `account_reference_id`, `is_cost`) VALUES 
+(1, 1, 1, 1),
+(2, 1, 2, 0),
+(3, 2, 6, 1),
+(4, 2, 3, 0),
+(5, 3, 4, 1),
+(6, 4, 7, 0);
+
+-- PROJECT FEE CENTER
+INSERT INTO `project_fee_center` (`id`, `fee_center_id`, `project_id`) VALUES (1, 2, 1);
 -- ----------------------------------------------------------------------------------------

--- a/test/end-to-end/account-reference/account-reference.spec.js
+++ b/test/end-to-end/account-reference/account-reference.spec.js
@@ -38,7 +38,7 @@ describe('AccountReference Management Page', () => {
     accounts : ['31110010', '31110011'],
     accountsException : ['31110011'],
   };
-  let accountReferenceCount = 0;
+  let accountReferenceCount = 9;
 
   before(() => helpers.navigate(path));
 
@@ -56,7 +56,7 @@ describe('AccountReference Management Page', () => {
   });
 
   it('edits an accounts reference successfully', () => {
-    accountReferencePage.editAccountReference(0);
+    accountReferencePage.editAccountReference(9);
     accountReferenceCreateUpdatePage.clearSelectedItems();
     accountReferenceCreateUpdatePage.setAbbr(mockEdit.abbr);
     accountReferenceCreateUpdatePage.setDescription(mockEdit.description);
@@ -82,7 +82,7 @@ describe('AccountReference Management Page', () => {
   });
 
   it('delete an accounts reference successfully', () => {
-    accountReferencePage.deleteAccountReference(1);
+    accountReferencePage.deleteAccountReference(10);
     components.notification.hasSuccess();
     accountReferenceCount--;
   });

--- a/test/end-to-end/feeCenter/fee_center.page.js
+++ b/test/end-to-end/feeCenter/fee_center.page.js
@@ -53,11 +53,6 @@ class FeeCenterPage {
     }
     components.accountReferenceSelect.set(feeCenter.reference_cost_id, 'account_cost_reference_id');
 
-    if (feeCenter.projects) {
-      element(by.id('assigned_projects')).click();
-      components.projectsMultipleSelect.set(feeCenter.projects);
-    }
-
     FU.buttons.submit();
     components.notification.hasSuccess();
   }
@@ -81,11 +76,6 @@ class FeeCenterPage {
       element(by.id('has_cost_center')).click();
     }
     components.accountReferenceSelect.set(feeCenter.reference_cost_id, 'account_cost_reference_id');
-
-    if (feeCenter.projects) {
-      element(by.id('assigned_projects')).click();
-      components.projectsMultipleSelect.set(feeCenter.projects);
-    }
 
     FU.buttons.submit();
     FU.buttons.cancel();
@@ -128,13 +118,6 @@ class FeeCenterPage {
           } 
         }
 
-        if (updateFeeCenter.is_update_projects) {
-          element(by.id('assigned_projects')).click();
-          if (updateFeeCenter.is_set_projects) {
-            components.projectsMultipleSelect.set(updateFeeCenter.projects);  
-          }
-        }
-
         FU.buttons.submit();
         components.notification.hasSuccess();
       });
@@ -164,13 +147,6 @@ class FeeCenterPage {
           if (!updateFeeCenter.is_profit) {
             components.accountReferenceSelect.set(updateFeeCenter.reference_cost_id, 'account_cost_reference_id');  
           } 
-        }
-
-        if (updateFeeCenter.is_update_projects) {
-          element(by.id('assigned_projects')).click();
-          if (updateFeeCenter.is_set_projects) {
-            components.projectsMultipleSelect.set(updateFeeCenter.projects);  
-          }
         }
 
         FU.buttons.submit();

--- a/test/end-to-end/feeCenter/fee_center.page.js
+++ b/test/end-to-end/feeCenter/fee_center.page.js
@@ -1,0 +1,197 @@
+/* global element, by */
+
+/**
+ * This class is represents a Fee Center page in term of structure and
+ * behaviour so it is a Fee Center page object
+ */
+
+const chai = require('chai');
+const helpers = require('../shared/helpers');
+
+helpers.configure(chai);
+
+/* loading grid actions */
+const GA = require('../shared/GridAction');
+const GU = require('../shared/GridUtils');
+const FU = require('../shared/FormUtils');
+const components = require('../shared/components');
+
+class FeeCenterPage {
+  constructor() {
+    this.gridId = 'fee-center-grid';
+    this.rubricGrid = element(by.id(this.gridId));
+    this.actionLinkColumn = 2;
+  }
+
+  /**
+   * send back the number of Fees Centers in the grid
+   */
+  getFeeCenterCount() {
+    return this.rubricGrid
+      .element(by.css('.ui-grid-render-container-body'))
+      .all(by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index'))
+      .count();
+  }
+
+  /**
+   * simulate the create Fee Center button click to show the dialog of creation
+   */
+  createFeeCenter(feeCenter) {
+    FU.buttons.create();
+    FU.input('FeeCenterModalCtrl.feeCenter.label', feeCenter.label);
+
+    const isPrincipal = (feeCenter.is_principal) ? 'principal' : 'auxiliary';
+    element(by.id(isPrincipal)).click();
+
+    if (feeCenter.has_profit_center) {
+      element(by.id('has_profit_center')).click();
+    }
+    components.accountReferenceSelect.set(feeCenter.reference_profit_id, 'account_profit_reference_id');
+
+    if (feeCenter.has_cost_center) {
+      element(by.id('has_cost_center')).click();
+    }
+    components.accountReferenceSelect.set(feeCenter.reference_cost_id, 'account_cost_reference_id');
+
+    if (feeCenter.projects) {
+      element(by.id('assigned_projects')).click();
+      components.projectsMultipleSelect.set(feeCenter.projects);
+    }
+
+    FU.buttons.submit();
+    components.notification.hasSuccess();
+  }
+
+  /**
+   * simulate the unableing to assign to another expense center a reference already used in another expense center when creating
+   */
+  errorCreateFeeCenter(feeCenter) {
+    FU.buttons.create();
+    FU.input('FeeCenterModalCtrl.feeCenter.label', feeCenter.label);
+
+    const isPrincipal = (feeCenter.is_principal) ? 'principal' : 'auxiliary';
+    element(by.id(isPrincipal)).click();
+
+    if (feeCenter.has_profit_center) {
+      element(by.id('has_profit_center')).click();
+    }
+    components.accountReferenceSelect.set(feeCenter.reference_profit_id, 'account_profit_reference_id');
+
+    if (feeCenter.has_cost_center) {
+      element(by.id('has_cost_center')).click();
+    }
+    components.accountReferenceSelect.set(feeCenter.reference_cost_id, 'account_cost_reference_id');
+
+    if (feeCenter.projects) {
+      element(by.id('assigned_projects')).click();
+      components.projectsMultipleSelect.set(feeCenter.projects);
+    }
+
+    FU.buttons.submit();
+    FU.buttons.cancel();
+    components.notification.hasError();
+  }
+
+  /**
+   * block creation without the function name
+   */
+  errorOnCreateFeeCenter(feeCenter) {
+    FU.buttons.create();
+    FU.buttons.submit();
+    FU.validation.error('FeeCenterModalCtrl.feeCenter.label');
+    FU.buttons.cancel();
+  }
+
+  /**
+   * simulate a click on the edit link of a function
+   */
+  editFeeCenter(label, updateFeeCenter) {
+    GU.getGridIndexesMatchingText(this.gridId, label)
+      .then(indices => {
+        const { rowIndex } = indices;
+        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'edit', this.gridId);
+        FU.input('FeeCenterModalCtrl.feeCenter.label', updateFeeCenter.label);
+
+        if (updateFeeCenter.is_update_reference) {
+          const isPrincipal = (updateFeeCenter.is_principal) ? 'principal' : 'auxiliary';
+          element(by.id(isPrincipal)).click();
+
+          const isCostProfit = (updateFeeCenter.is_profit) ? 'is_profit' : 'is_cost';
+          element(by.id(isCostProfit)).click();
+
+          if (updateFeeCenter.is_profit) {
+            components.accountReferenceSelect.set(updateFeeCenter.reference_profit_id, 'account_profit_reference_id');  
+          }
+          
+          if (!updateFeeCenter.is_profit) {
+            components.accountReferenceSelect.set(updateFeeCenter.reference_cost_id, 'account_cost_reference_id');  
+          } 
+        }
+
+        if (updateFeeCenter.is_update_projects) {
+          element(by.id('assigned_projects')).click();
+          if (updateFeeCenter.is_set_projects) {
+            components.projectsMultipleSelect.set(updateFeeCenter.projects);  
+          }
+        }
+
+        FU.buttons.submit();
+        components.notification.hasSuccess();
+      });
+  }
+
+  /**
+   * simulate the unableing to assign to another expense center a reference already used in another expense center when Updating
+   */
+  errorEditFeeCenter(label, updateFeeCenter) {
+    GU.getGridIndexesMatchingText(this.gridId, label)
+      .then(indices => {
+        const { rowIndex } = indices;
+        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'edit', this.gridId);
+        FU.input('FeeCenterModalCtrl.feeCenter.label', updateFeeCenter.label);
+
+        if (updateFeeCenter.is_update_reference) {
+          const isPrincipal = (updateFeeCenter.is_principal) ? 'principal' : 'auxiliary';
+          element(by.id(isPrincipal)).click();
+
+          const isCostProfit = (updateFeeCenter.is_profit) ? 'is_profit' : 'is_cost';
+          element(by.id(isCostProfit)).click();
+
+          if (updateFeeCenter.is_profit) {
+            components.accountReferenceSelect.set(updateFeeCenter.reference_profit_id, 'account_profit_reference_id');  
+          }
+          
+          if (!updateFeeCenter.is_profit) {
+            components.accountReferenceSelect.set(updateFeeCenter.reference_cost_id, 'account_cost_reference_id');  
+          } 
+        }
+
+        if (updateFeeCenter.is_update_projects) {
+          element(by.id('assigned_projects')).click();
+          if (updateFeeCenter.is_set_projects) {
+            components.projectsMultipleSelect.set(updateFeeCenter.projects);  
+          }
+        }
+
+        FU.buttons.submit();
+        FU.buttons.cancel();
+        components.notification.hasError();
+      });
+  }
+
+
+  /**
+   * simulate a click on the delete link of a function
+   */
+  deleteFeeCenter(label) {
+    GU.getGridIndexesMatchingText(this.gridId, label)
+      .then(indices => {
+        const { rowIndex } = indices;
+        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'delete', this.gridId);
+        components.modalAction.confirm();
+        components.notification.hasSuccess();
+      });
+  }
+}
+
+module.exports = FeeCenterPage;

--- a/test/end-to-end/feeCenter/fee_center.spec.js
+++ b/test/end-to-end/feeCenter/fee_center.spec.js
@@ -1,0 +1,112 @@
+const helpers = require('../shared/helpers');
+const FeeCenterPage = require('./fee_center.page');
+const chai = require('chai');
+
+
+/** configuring helpers**/
+helpers.configure(chai);
+
+describe('Fee Center Management', () => {
+  // navigate to the page
+  before(() => helpers.navigate('#!/fee_center'));
+
+  const Page = new FeeCenterPage();
+
+  const feeCenter = {
+    label : 'Special Fee Center',
+    is_principal : 1,
+    has_profit_center : 1,
+    reference_profit_id : 'Profit Test 2',
+    has_cost_center : 1,
+    reference_cost_id : 'Cost Test 3',
+    projects : ['Test Project A', 'Test Project B'],
+  };
+
+  const updateFeeCenter = {
+    label : 'Updated Fee Center',
+  };
+
+  const updateAuxiliary = {
+    label : 'Updated Fee Center',
+    is_principal : 0,
+    is_update_reference : 1,
+    is_profit : 1,
+    reference_profit_id : 'Profit Test 3',
+    is_update_projects : 0,
+    is_set_projects : 0,
+    is_unset_projects : 0, 
+  };
+
+  const updateProjects = {
+    label : 'Updated Fee Center',
+    is_update_projects : 1,
+    is_set_projects : 0, 
+  };
+
+  const updateProfitToCost = {
+    label : 'Updated Fee Center',
+    is_update_reference : 1,
+    is_profit : 0,
+    reference_cost_id : 'Cost Test 1',
+    is_update_projects : 1,
+    is_set_projects : 1,
+    projects : ['Test Project C'], 
+  };
+
+  const ErrorfeeCenterUpdate = {
+    label : 'Principale TPA',
+    is_principal : 0,
+    is_update_reference : 1,
+    is_profit : 0,
+    reference_cost_id : 'Section Administration',
+    is_update_projects : 0,
+    is_set_projects : 0,
+    is_unset_projects : 0, 
+  };
+
+  const ErrorfeeCenterInsert = {
+    label : 'Special Fee Center',
+    is_principal : 1,
+    has_profit_center : 1,
+    reference_profit_id : 'Profit Administration',
+    has_cost_center : 1,
+    reference_cost_id : 'Cost Test 1',
+    projects : ['Test Project A', 'Test Project B'],
+  };
+
+  it('successfully creates a new Fee Center', () => {
+    Page.createFeeCenter(feeCenter);
+  });
+
+  it('successfully edits a Fee Center label', () => {
+    Page.editFeeCenter(feeCenter.label, updateFeeCenter);
+  });
+
+  it('successfully Change of the Principal Fee Center to Auxiliary and the modification of the expense center', () => {
+    Page.editFeeCenter(updateAuxiliary.label, updateAuxiliary);
+  });
+
+  it('successfully Change Projects assigned to the cost center', () => {
+    Page.editFeeCenter(updateAuxiliary.label, updateProjects);
+  });
+
+  it('successfully Change profit center in cost center in assigns to a project', () => {
+    Page.editFeeCenter(updateProfitToCost.label, updateProfitToCost);
+  });
+
+  it('successfully delete a Fee Center', () => {
+    Page.deleteFeeCenter(updateProfitToCost.label);
+  });
+
+  it('unable to assign to another expense center a reference already used in another expense center when creating', () => {
+    Page.errorCreateFeeCenter(ErrorfeeCenterInsert);
+  });
+
+  it('unable to assign to another expense center a reference already used in another expense center when updating', () => {
+    Page.errorEditFeeCenter(ErrorfeeCenterUpdate.label, ErrorfeeCenterUpdate);
+  });
+
+  it('don\'t create when incorrect Fee Center', () => {
+    Page.errorOnCreateFeeCenter();
+  });
+});

--- a/test/end-to-end/feeCenter/fee_center.spec.js
+++ b/test/end-to-end/feeCenter/fee_center.spec.js
@@ -19,7 +19,6 @@ describe('Fee Center Management', () => {
     reference_profit_id : 'Profit Test 2',
     has_cost_center : 1,
     reference_cost_id : 'Cost Test 3',
-    projects : ['Test Project A', 'Test Project B'],
   };
 
   const updateFeeCenter = {
@@ -32,15 +31,6 @@ describe('Fee Center Management', () => {
     is_update_reference : 1,
     is_profit : 1,
     reference_profit_id : 'Profit Test 3',
-    is_update_projects : 0,
-    is_set_projects : 0,
-    is_unset_projects : 0, 
-  };
-
-  const updateProjects = {
-    label : 'Updated Fee Center',
-    is_update_projects : 1,
-    is_set_projects : 0, 
   };
 
   const updateProfitToCost = {
@@ -48,9 +38,6 @@ describe('Fee Center Management', () => {
     is_update_reference : 1,
     is_profit : 0,
     reference_cost_id : 'Cost Test 1',
-    is_update_projects : 1,
-    is_set_projects : 1,
-    projects : ['Test Project C'], 
   };
 
   const ErrorfeeCenterUpdate = {
@@ -59,9 +46,6 @@ describe('Fee Center Management', () => {
     is_update_reference : 1,
     is_profit : 0,
     reference_cost_id : 'Section Administration',
-    is_update_projects : 0,
-    is_set_projects : 0,
-    is_unset_projects : 0, 
   };
 
   const ErrorfeeCenterInsert = {
@@ -71,7 +55,6 @@ describe('Fee Center Management', () => {
     reference_profit_id : 'Profit Administration',
     has_cost_center : 1,
     reference_cost_id : 'Cost Test 1',
-    projects : ['Test Project A', 'Test Project B'],
   };
 
   it('successfully creates a new Fee Center', () => {
@@ -84,14 +67,6 @@ describe('Fee Center Management', () => {
 
   it('successfully Change of the Principal Fee Center to Auxiliary and the modification of the expense center', () => {
     Page.editFeeCenter(updateAuxiliary.label, updateAuxiliary);
-  });
-
-  it('successfully Change Projects assigned to the cost center', () => {
-    Page.editFeeCenter(updateAuxiliary.label, updateProjects);
-  });
-
-  it('successfully Change profit center in cost center in assigns to a project', () => {
-    Page.editFeeCenter(updateProfitToCost.label, updateProfitToCost);
   });
 
   it('successfully delete a Fee Center', () => {

--- a/test/end-to-end/shared/components/bhAccountReferenceSelect.js
+++ b/test/end-to-end/shared/components/bhAccountReferenceSelect.js
@@ -1,0 +1,17 @@
+/* global element, by */
+
+const FU = require('../FormUtils');
+
+module.exports = {
+  selector : '[bh-account-reference-select]',
+  set      : function set(accountReference, id) {
+    const locator = (id) ? by.id(id) : by.css(this.selector);
+    const target = element(locator);
+
+    // hack to make sure previous 'blur' event fires if we are using
+    // ngModelOptions updateOn 'blur' for every input
+    target.click();
+
+    FU.uiSelect('$ctrl.accountReferenceId', accountReference, target);
+  },
+};

--- a/test/end-to-end/shared/components/bhProjectsMultipleSelect.js
+++ b/test/end-to-end/shared/components/bhProjectsMultipleSelect.js
@@ -1,0 +1,17 @@
+/* global browser, element, by */
+
+const FU = require('../FormUtils');
+
+module.exports = {
+  selector : '[bh-projects-multiple-select]',
+  set      : function set(projectsMultipleStatus, id) {
+    const locator = (id) ? by.id(id) : by.css(this.selector);
+    const target = element(locator);
+
+    target.click();
+
+    projectsMultipleStatus.forEach(function (projects){
+        FU.uiSelect('$ctrl.selectedProjects', projects);
+    });
+  },
+};

--- a/test/end-to-end/shared/components/index.js
+++ b/test/end-to-end/shared/components/index.js
@@ -56,4 +56,6 @@ module.exports = {
   payrollPeriodSelect : require('./bhPayrollPeriodSelect'),
   periodSelection : require('./bhPeriodSelection'),
   employeeConfigSelect : require('./bhEmployeeConfigSelect'),
+  projectsMultipleSelect : require('./bhProjectsMultipleSelect'),
+  accountReferenceSelect : require('./bhAccountReferenceSelect'),
 };

--- a/test/integration/accountReferences.js
+++ b/test/integration/accountReferences.js
@@ -2,7 +2,7 @@
 const helpers = require('./helpers');
 
 describe('(/accounts/references) Accounts References', () => {
-  const numAccountReference = 1;
+  const numAccountReference = 10;
 
   const newAccountReference = {
     abbr : 'TX',

--- a/test/integration/feesCenters.js
+++ b/test/integration/feesCenters.js
@@ -47,8 +47,8 @@ describe('(/fee_center) The /fee_center  API endpoint', () => {
     projects: [ 1 ] 
   };
 
-  const numFeeCenter = 4;
-  const feeCenterId = 5;
+  const numFeeCenter = 2;
+  const feeCenterId = 3;
 
   it('GET /FEE_CENTER returns a list of Fees Centers', () => {
     return agent.get('/fee_center')

--- a/test/integration/feesCenters.js
+++ b/test/integration/feesCenters.js
@@ -1,0 +1,125 @@
+/* global expect, agent */
+
+const helpers = require('./helpers');
+
+/*
+ * The /fee_center  API endpoint
+ *
+ * This test suite implements full CRUD on the /fee_center  HTTP API endpoint.
+ */
+describe('(/fee_center) The /fee_center  API endpoint', () => {
+  // Fee Center we will add during this test suite.
+  
+  const feeCenter = {
+    id : 10,
+    label : 'Centre de Frais Test',
+    is_principal : 1,
+    reference_fee_center : [{
+      account_reference_id : 9,
+      is_cost : 1,
+    }, {
+      account_reference_id : 8,
+      is_cost : 0,
+    }],
+    projects : [1, 2],
+  };
+
+  const feeCenterUpt1 = {
+    label : 'Update Test',
+    is_principal : 1,
+    reference_fee_center : [{ 
+      account_reference_id : 9, 
+      is_cost : 1 
+    }, { 
+      account_reference_id : 8, 
+      is_cost : 0
+    }],
+    projects : [1, 2],
+  };
+
+  const feeCenterUpt2 = { 
+    label: 'Update Test',
+    is_principal: 0,
+    reference_fee_center: [{ 
+      account_reference_id: 8, 
+      is_cost: 0 
+    }],
+    projects: [ 1 ] 
+  };
+
+  const numFeeCenter = 4;
+  const feeCenterId = 5;
+
+  it('GET /FEE_CENTER returns a list of Fees Centers', () => {
+    return agent.get('/fee_center')
+      .then((res) => {
+        helpers.api.listed(res, numFeeCenter);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('POST /FEE_CENTER should create a new Fee Center', () => {
+    return agent.post('/fee_center')
+      .send(feeCenter)
+      .then((res) => {
+        const response = res.body;
+
+        expect(response.length).to.equal(2);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /FEE_CENTER/:ID should not be found for unknown id', () => {
+    return agent.get('/fee_center/unknownRubric')
+      .then((res) => {
+        const response = res.body;
+
+        expect(response.feeCenter.length).to.equal(0);
+        expect(response.references.length).to.equal(0);
+        expect(response.projects.length).to.equal(0);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('PUT /FEE_CENTER  should update the Label for an existing Fee Center ', () => {
+    return agent.put('/fee_center/'.concat(feeCenterId))
+      .send(feeCenterUpt1)
+      .then((res) => {
+        const response = res.body;
+        expect(res).to.have.status(200);
+        expect(response.feeCenter[0].label).to.equal('Update Test');
+      })
+      .catch(helpers.handler);
+  });
+
+
+  it('PUT /FEE_CENTER  should update Fee Center Type, Reference fee Center and Projects for an existing Fee Center ', () => {
+    return agent.put('/fee_center/'.concat(feeCenterId))
+      .send(feeCenterUpt2)
+      .then((res) => {
+        const response = res.body;
+        expect(res).to.have.status(200);
+        expect(response.feeCenter[0].is_principal).to.equal(feeCenterUpt2.is_principal);
+        expect(response.references[0].account_reference_id).to.equal(feeCenterUpt2.reference_fee_center[0].account_reference_id);
+        expect(response.references[0].is_cost).to.equal(feeCenterUpt2.reference_fee_center[0].is_cost);
+        expect(response.projects[0]).to.equal(feeCenterUpt2.projects[0]);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /FEE_CENTER/:ID will send back a 404 if the Fee Center does not exist', function () {
+    return agent.delete('/fee_center/inknowRubric')
+      .then(function (res) {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /FEE_CENTER/:ID should delete a Fee Center', function () {
+    return agent.delete('/fee_center/'.concat(feeCenterId))
+      .then(function (res) {
+        helpers.api.deleted(res);
+      })
+      .catch(helpers.handler);
+  });
+});

--- a/test/integration/feesCenters.js
+++ b/test/integration/feesCenters.js
@@ -9,7 +9,7 @@ const helpers = require('./helpers');
  */
 describe('(/fee_center) The /fee_center  API endpoint', () => {
   // Fee Center we will add during this test suite.
-  
+
   const feeCenter = {
     id : 10,
     label : 'Centre de Frais Test',
@@ -21,30 +21,27 @@ describe('(/fee_center) The /fee_center  API endpoint', () => {
       account_reference_id : 8,
       is_cost : 0,
     }],
-    projects : [1, 2],
   };
 
   const feeCenterUpt1 = {
     label : 'Update Test',
     is_principal : 1,
-    reference_fee_center : [{ 
-      account_reference_id : 9, 
-      is_cost : 1 
-    }, { 
-      account_reference_id : 8, 
-      is_cost : 0
+    reference_fee_center : [{
+      account_reference_id : 9,
+      is_cost : 1,
+    }, {
+      account_reference_id : 8,
+      is_cost : 0,
     }],
-    projects : [1, 2],
   };
 
-  const feeCenterUpt2 = { 
-    label: 'Update Test',
-    is_principal: 0,
-    reference_fee_center: [{ 
-      account_reference_id: 8, 
-      is_cost: 0 
+  const feeCenterUpt2 = {
+    label : 'Update Test',
+    is_principal : 0,
+    reference_fee_center : [{
+      account_reference_id : 8,
+      is_cost : 0,
     }],
-    projects: [ 1 ] 
   };
 
   const numFeeCenter = 2;
@@ -63,8 +60,7 @@ describe('(/fee_center) The /fee_center  API endpoint', () => {
       .send(feeCenter)
       .then((res) => {
         const response = res.body;
-
-        expect(response.length).to.equal(2);
+        expect(response.length).to.equal(1);
       })
       .catch(helpers.handler);
   });
@@ -76,7 +72,6 @@ describe('(/fee_center) The /fee_center  API endpoint', () => {
 
         expect(response.feeCenter.length).to.equal(0);
         expect(response.references.length).to.equal(0);
-        expect(response.projects.length).to.equal(0);
       })
       .catch(helpers.handler);
   });
@@ -93,7 +88,7 @@ describe('(/fee_center) The /fee_center  API endpoint', () => {
   });
 
 
-  it('PUT /FEE_CENTER  should update Fee Center Type, Reference fee Center and Projects for an existing Fee Center ', () => {
+  it('PUT /FEE_CENTER  should update Fee Center Type, Reference fee Center for an existing Fee Center ', () => {
     return agent.put('/fee_center/'.concat(feeCenterId))
       .send(feeCenterUpt2)
       .then((res) => {
@@ -102,22 +97,21 @@ describe('(/fee_center) The /fee_center  API endpoint', () => {
         expect(response.feeCenter[0].is_principal).to.equal(feeCenterUpt2.is_principal);
         expect(response.references[0].account_reference_id).to.equal(feeCenterUpt2.reference_fee_center[0].account_reference_id);
         expect(response.references[0].is_cost).to.equal(feeCenterUpt2.reference_fee_center[0].is_cost);
-        expect(response.projects[0]).to.equal(feeCenterUpt2.projects[0]);
       })
       .catch(helpers.handler);
   });
 
-  it('DELETE /FEE_CENTER/:ID will send back a 404 if the Fee Center does not exist', function () {
+  it('DELETE /FEE_CENTER/:ID will send back a 404 if the Fee Center does not exist', () => {
     return agent.delete('/fee_center/inknowRubric')
-      .then(function (res) {
+      .then((res) => {
         helpers.api.errored(res, 404);
       })
       .catch(helpers.handler);
   });
 
-  it('DELETE /FEE_CENTER/:ID should delete a Fee Center', function () {
+  it('DELETE /FEE_CENTER/:ID should delete a Fee Center', () => {
     return agent.delete('/fee_center/'.concat(feeCenterId))
-      .then(function (res) {
+      .then((res) => {
         helpers.api.deleted(res);
       })
       .catch(helpers.handler);


### PR DESCRIPTION
This PR reconstructs the modeling of the Fee center analysis all, this first step allows to define a Fee Center while specifying if it is a Principal or auxiliary center,
 - for the Principal center it is necessary to assign a reference of Profit account and a reference for the cost 
- for the auxiliary center it is necessary to specify whether it is a cost center or a profit center, 

There is also the possibility of assigning a cost center to a Project or several, for the account reference we had to reuse the one that already exists in the system

- Implement API for Fees Centers
- Implement Client Side for Fees Centers
- Add components for Accounts References and Select Multiples Projects
- Implementation of integration test for Fee Center Manager
- Update and Improve client side for Fee Center
- Implement Fee Center E2E test
- Set Data for Database for test
- Update E2E test for Account-Reference
- Add in shared Components for bhAccountReferenceSelect and

closes #3006 