### PR TITLE
Reload user session on successful role permissions update (3043)

### DIFF
--- a/client/src/modules/roles/modal/rolesPermissions.js
+++ b/client/src/modules/roles/modal/rolesPermissions.js
@@ -25,7 +25,7 @@ function RolesPermissionsController(data, $state, $uibModalInstance, AppCache, R
       vm.tree = vm.sortUnit(res.data);
     });
 
-  // close modal
+  // cancel modal without returning success result (`dismiss`)
   function close() {
     $uibModalInstance.dismiss();
   }
@@ -83,6 +83,8 @@ function RolesPermissionsController(data, $state, $uibModalInstance, AppCache, R
     RolesService.affectPages(params)
       .then(() => {
         Notify.success('FORM.LABELS.PERMISSION_ASSIGNED_SUCCESS');
+
+        // modal action was a success `close` will return correctly
         $uibModalInstance.close();
       })
       .catch(Notify.handleError);

--- a/client/src/modules/roles/modal/rolesPermissions.js
+++ b/client/src/modules/roles/modal/rolesPermissions.js
@@ -27,7 +27,7 @@ function RolesPermissionsController(data, $state, $uibModalInstance, AppCache, R
 
   // close modal
   function close() {
-    $uibModalInstance.close();
+    $uibModalInstance.dismiss();
   }
 
   function sortUnit(units) {
@@ -83,7 +83,7 @@ function RolesPermissionsController(data, $state, $uibModalInstance, AppCache, R
     RolesService.affectPages(params)
       .then(() => {
         Notify.success('FORM.LABELS.PERMISSION_ASSIGNED_SUCCESS');
-        vm.close();
+        $uibModalInstance.close();
       })
       .catch(Notify.handleError);
   }

--- a/client/src/modules/roles/roles.ctrl.js
+++ b/client/src/modules/roles/roles.ctrl.js
@@ -6,12 +6,12 @@ RolesController.$inject = [
   'NotifyService', 'bhConstants',
 ];
 
-function RolesController($uibModal, Roles, session, Modal, Notify, bhConstants) {
+function RolesController($uibModal, Roles, Session, Modal, Notify, bhConstants) {
   const vm = this;
 
   vm.canEditRoles = false;
 
-  vm.add = (role = { project_id : session.project.id }) => {
+  vm.add = (role = { project_id : Session.project.id }) => {
     $uibModal.open({
       templateUrl : 'modules/roles/create.html',
       controller : 'RolesAddController as RolesAddCtrl',
@@ -28,12 +28,19 @@ function RolesController($uibModal, Roles, session, Modal, Notify, bhConstants) 
   };
 
   // pages to affect to this role
-  vm.pages = function pages(role) {
+  vm.updateRolePermissionsModal = function updateRolePermissionsModal(selectedRole) {
     $uibModal.open({
       templateUrl : 'modules/roles/modal/rolesPermissions.html',
       controller : 'RolesPermissionsController as RolesPermissionsCtrl',
-      resolve : { data : () => role },
-    });
+      resolve : { data : () => selectedRole },
+    }).result
+      .then(() => {
+        // refresh the application session to ensure the latest versions of roles
+        // and permissions are applied, this will only run on submission
+        // @TODO(sfount) if the session information kept track of the current users
+        //               role, this method could only update if the current role is changed
+        Session.reload();
+      });
   };
 
   vm.remove = function remove(uuid) {
@@ -85,7 +92,7 @@ function RolesController($uibModal, Roles, session, Modal, Notify, bhConstants) 
     width : 100,
     displayName : '',
     headerCellFilter : 'translate',
-    cellTemplate : 'modules/roles/templates/action.tmpl.html',
+    cellTemplate : 'modules/roles/templates/action.cell.html',
   }];
 
   // ng-click="

--- a/client/src/modules/roles/roles.ctrl.js
+++ b/client/src/modules/roles/roles.ctrl.js
@@ -11,7 +11,10 @@ function RolesController($uibModal, Roles, Session, Modal, Notify, bhConstants) 
 
   vm.canEditRoles = false;
 
-  vm.add = (role = { project_id : Session.project.id }) => {
+  vm.createUpdateRoleModal = function createUpdateRoleModal(selectedRole) {
+    // if no selected role was passed this means we are creating a new role
+    // set the default role parameters to pass the modal (set project ID)
+    const role = selectedRole || { project_id : Session.project.id };
     $uibModal.open({
       templateUrl : 'modules/roles/create.html',
       controller : 'RolesAddController as RolesAddCtrl',
@@ -19,11 +22,11 @@ function RolesController($uibModal, Roles, Session, Modal, Notify, bhConstants) 
     });
   };
 
-  vm.editActions = (role) => {
+  vm.updateRoleActionsModal = function updateRoleActionsModal(selectedRole) {
     $uibModal.open({
       templateUrl : 'modules/roles/modal/roleActions.html',
       controller : 'RoleActionsController as RoleActionsCtrl',
-      resolve : { data : () => role },
+      resolve : { data : () => selectedRole },
     });
   };
 

--- a/client/src/modules/roles/roles.html
+++ b/client/src/modules/roles/roles.html
@@ -7,7 +7,7 @@
 
     <div class="toolbar" ng-show="RolesCtrl.canEditRoles">
       <div class="toolbar-item">
-        <button class="btn btn-default" ng-click="RolesCtrl.add()" data-method="create">
+        <button class="btn btn-default" ng-click="RolesCtrl.createUpdateRoleModal()" data-method="create">
           <span class="fa fa-plus"></span>
           <span translate class="text-capitalize">FORM.LABELS.ADD</span>
         </button>

--- a/client/src/modules/roles/roles.service.js
+++ b/client/src/modules/roles/roles.service.js
@@ -7,6 +7,10 @@ RolesService.$inject = ['PrototypeApiService'];
  * Role Service
  *
  * A service wrapper for the /roles HTTP endpoint.
+ *
+ * @TODO(sfount) some routes on the Roles API server/client service aren't
+ *               clear in English. These should be revised requiring a update
+ *               across client, server and DB.
  */
 function RolesService(Api) {
   const service = new Api('/roles/');
@@ -40,6 +44,20 @@ function RolesService(Api) {
     return service.$http.get(url);
   };
 
+  /**
+   * @method affectPages
+   *
+   * @description
+   * Updates the route permissions that are assigned to a specific role. This
+   * method is responsible for both removing existing and assigning new route
+   * permissions to existing roles.
+   *
+   * It expects a `roleUuid` and a list of route permissions `unitIds`, the server
+   * is responsible for determining which route permissions need to added or removed.
+   *
+   * @param {Object} data - the new role permission specification
+   * @returns {Promise} - $http promise with API response
+   */
   service.affectPages = function affectPages(data) {
     return service.$http.post('/roles/affectUnits', data);
   };

--- a/client/src/modules/roles/templates/action.cell.html
+++ b/client/src/modules/roles/templates/action.cell.html
@@ -16,7 +16,7 @@
       </a>
     </li>
     <li>
-      <a data-method="edit-permissions" ng-click="grid.appScope.pages(row.entity)" href>
+      <a data-method="edit-permissions" ng-click="grid.appScope.updateRolePermissionsModal(row.entity)" href>
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT_PERMISSIONS</span>
       </a>
     </li>

--- a/client/src/modules/roles/templates/action.cell.html
+++ b/client/src/modules/roles/templates/action.cell.html
@@ -11,7 +11,7 @@
 
   <ul data-row-menu="{{ row.entity.label }}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
     <li>
-      <a data-method="edit-record" ng-click="grid.appScope.add(row.entity)" href>
+      <a data-method="edit-record" ng-click="grid.appScope.createUpdateRoleModal(row.entity)" href>
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
       </a>
     </li>
@@ -21,7 +21,7 @@
       </a>
     </li>
     <li>
-      <a data-method="edit-actions" ng-click="grid.appScope.editActions(row.entity)" href>
+      <a data-method="edit-actions" ng-click="grid.appScope.updateRoleActionsModal(row.entity)" href>
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.ACTIONS</span>
       </a>
     </li>


### PR DESCRIPTION
This PR follows the discussion in https://github.com/IMA-WorldHealth/bhima-2.X/issues/3043.

Specifically it uses `SessionService.reload` to ensure the users current session information is up to date following a successful role permissions update. 

It also refactors client code for updating role permissions to improve legibility.

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/3043