### PR TITLE
Date components - limit min date fiscal year feature (2785)

### DIFF
--- a/client/src/js/components/bhDateEditor.js
+++ b/client/src/js/components/bhDateEditor.js
@@ -12,10 +12,11 @@ angular.module('bhima.components')
       disabled : '<?',
       dateFormat : '@?',
       label : '@?',
+      limitMinFiscal : '@?',
     },
   });
 
-bhDateEditorController.$inject = ['bhConstants'];
+bhDateEditorController.$inject = ['bhConstants', 'SessionService', 'FiscalService'];
 
 /**
  * bhDateEditor Component
@@ -23,6 +24,11 @@ bhDateEditorController.$inject = ['bhConstants'];
  * A component to deal with date, it lets a user choose a date by either typing
  * into an <input> or clicking a calendar dropdown.  It wraps the
  * uib-date-picker to provide the dropdown calendar functionality.
+ *
+ * An optional limit-min-fiscal flag can be provided that will limit the date
+ * selection to after the start of enterprise financial records - note that
+ * limit-min-fiscal will *not* override min-date, it will only be applied if
+ * min-date has not been set.
  *
  * @example
  * <bh-date-editor
@@ -32,12 +38,13 @@ bhDateEditorController.$inject = ['bhConstants'];
  *  min-date="Ctrl.min"
  *  max-date="Ctrl.max"
  *  validation-trigger="Form.$submitted"
+ *  limit-min-fiscal
  *  disabled="Ctrl.isDisabled">
  * </bh-date-editor>
  *
  * @module components/bhDateEditor
  */
-function bhDateEditorController(bhConstants) {
+function bhDateEditorController(bhConstants, Session, Fiscal) {
   const $ctrl = this;
 
   $ctrl.editMode = false;
@@ -52,6 +59,15 @@ function bhDateEditorController(bhConstants) {
     };
     if (!$ctrl.allowFutureDate) {
       $ctrl.options.maxDate = $ctrl.maxDate || new Date();
+    }
+
+    // fetch and apply the first fiscal year start date ONLY if a min date hasn't
+    // been specified
+    if (angular.isDefined($ctrl.limitMinFiscal) && !angular.isDefined($ctrl.minDate)) {
+      Fiscal.getEnterpriseFiscalStartDate(Session.enterprise.id)
+        .then((response) => {
+          $ctrl.options.minDate = new Date(response.start_date);
+        });
     }
   };
 

--- a/client/src/js/components/bhDateInterval.js
+++ b/client/src/js/components/bhDateInterval.js
@@ -3,7 +3,11 @@
  * @description
  * The `bhDateInterval` component provide a mean to select dates plage between
  * two dates. The dates values returned are send to dates models given in
- * date-from and date-to attributes
+ * date-from and date-to attributes.
+ *
+ * An optional flag `limit-min-fiscal` can be provided that limits the from and
+ * to date inputs to not allow dates before the start of the first enterprise
+ * fiscal year.
  *
  * @example
  * ```html
@@ -25,96 +29,106 @@ angular.module('bhima.components')
       canClear : '<?', // flag for displaying clear button
       label : '@?',
       mode : '@?', // the date mode (day|month|year)
+      limitMinFiscal : '@?', // do not allow the minimum date to be before the first fiscal year
     },
   });
 
 // dependencies injection
-bhDateInterval.$inject = ['moment', 'bhConstants'];
+bhDateInterval.$inject = ['moment', 'bhConstants', 'FiscalService', 'SessionService'];
 
 // controller definition
-function bhDateInterval(moment, bhConstants) {
-  const vm = this;
+function bhDateInterval(moment, bhConstants, Fiscal, Session) {
+  const $ctrl = this;
 
+  // Fiscal.getEnterpriseFiscalStartDate();
   // expose to the viewe
-  vm.search = search;
-  vm.clear = clear;
+  $ctrl.search = search;
+  $ctrl.clear = clear;
 
-  vm.$onInit = function $onInit() {
+  $ctrl.$onInit = function $onInit() {
     // specify if clear button can be displayed
-    if (!angular.isDefined(vm.canClear)) {
-      vm.canClear = true;
+    if (!angular.isDefined($ctrl.canClear)) {
+      $ctrl.canClear = true;
     }
 
-    vm.options = [
+    $ctrl.options = [
       { translateKey : 'FORM.LABELS.TODAY', fn : day, range : 'day' },
       { translateKey : 'FORM.LABELS.THIS_WEEK', fn : week, range : 'week' },
       { translateKey : 'FORM.LABELS.THIS_MONTH', fn : month, range : 'month' },
       { translateKey : 'FORM.LABELS.THIS_YEAR', fn : year, range : 'year' },
     ];
 
-    vm.label = vm.label || 'FORM.SELECT.DATE_INTERVAL';
-    vm.dateFormat = bhConstants.dayOptions.format;
-    vm.pickerOptions = { showWeeks : false };
+    $ctrl.label = $ctrl.label || 'FORM.SELECT.DATE_INTERVAL';
+    $ctrl.dateFormat = bhConstants.dayOptions.format;
+    $ctrl.pickerOptions = { showWeeks : false };
+
+    // if controller has requested limit-min-fiscal, fetch required information
+    if (angular.isDefined($ctrl.limitMinFiscal)) {
+      Fiscal.getEnterpriseFiscalStartDate(Session.enterprise.id)
+        .then((response) => {
+          $ctrl.pickerOptions.minDate = new Date(response.start_date);
+        });
+    }
 
     startup();
 
-    vm.pickerToOptions = { showWeeks : false, minDate : vm.dateFrom };
+    $ctrl.pickerToOptions = { showWeeks : false, minDate : $ctrl.dateFrom };
   };
 
   function search(selection) {
-    vm.selected = selection.translateKey;
+    $ctrl.selected = selection.translateKey;
     selection.fn();
   }
 
   function day() {
-    vm.dateFrom = new Date();
-    vm.dateTo = new Date();
+    $ctrl.dateFrom = new Date();
+    $ctrl.dateTo = new Date();
   }
 
   function week() {
     // Fix me if is necessary the first day of week is Sunday or Monday
-    vm.dateFrom = moment().startOf('week').toDate();
-    vm.dateTo = new Date();
+    $ctrl.dateFrom = moment().startOf('week').toDate();
+    $ctrl.dateTo = new Date();
   }
 
   function month() {
-    vm.dateFrom = moment().startOf('month').toDate();
-    vm.dateTo = moment().endOf('month').toDate();
+    $ctrl.dateFrom = moment().startOf('month').toDate();
+    $ctrl.dateTo = moment().endOf('month').toDate();
   }
 
   function year() {
-    vm.dateFrom = moment().startOf('year').toDate();
-    vm.dateTo = moment().endOf('year').toDate();
+    $ctrl.dateFrom = moment().startOf('year').toDate();
+    $ctrl.dateTo = moment().endOf('year').toDate();
   }
 
   function custom() {
-    if (vm.dateFrom) {
-      vm.dateFrom = new Date(vm.dateFrom);
+    if ($ctrl.dateFrom) {
+      $ctrl.dateFrom = new Date($ctrl.dateFrom);
     }
 
-    if (vm.dateTo) {
-      vm.dateTo = new Date(vm.dateTo);
+    if ($ctrl.dateTo) {
+      $ctrl.dateTo = new Date($ctrl.dateTo);
     }
   }
 
   function clear() {
-    delete vm.dateFrom;
-    delete vm.dateTo;
+    delete $ctrl.dateFrom;
+    delete $ctrl.dateTo;
   }
 
   function startup() {
-    const option = ['day', 'week', 'month', 'year'].indexOf(vm.mode);
+    const option = ['day', 'week', 'month', 'year'].indexOf($ctrl.mode);
 
     // set the default option according the mode
     if (option !== -1) {
-      search(vm.options[option]);
-      vm.pickerOptions = vm.mode;
+      search($ctrl.options[option]);
+      $ctrl.pickerOptions = $ctrl.mode;
     } else {
       custom();
     }
 
     // set clean mode
-    if (vm.mode === 'clean') {
+    if ($ctrl.mode === 'clean') {
       clear();
     }
   }

--- a/client/src/js/components/bhDateInterval.js
+++ b/client/src/js/components/bhDateInterval.js
@@ -40,8 +40,7 @@ bhDateInterval.$inject = ['moment', 'bhConstants', 'FiscalService', 'SessionServ
 function bhDateInterval(moment, bhConstants, Fiscal, Session) {
   const $ctrl = this;
 
-  // Fiscal.getEnterpriseFiscalStartDate();
-  // expose to the viewe
+  // expose to the view
   $ctrl.search = search;
   $ctrl.clear = clear;
 
@@ -60,13 +59,13 @@ function bhDateInterval(moment, bhConstants, Fiscal, Session) {
 
     $ctrl.label = $ctrl.label || 'FORM.SELECT.DATE_INTERVAL';
     $ctrl.dateFormat = bhConstants.dayOptions.format;
-    $ctrl.pickerOptions = { showWeeks : false };
+    $ctrl.pickerFromOptions = { showWeeks : false };
 
     // if controller has requested limit-min-fiscal, fetch required information
     if (angular.isDefined($ctrl.limitMinFiscal)) {
       Fiscal.getEnterpriseFiscalStartDate(Session.enterprise.id)
         .then((response) => {
-          $ctrl.pickerOptions.minDate = new Date(response.start_date);
+          $ctrl.pickerFromOptions.minDate = new Date(response.start_date);
         });
     }
 
@@ -122,7 +121,7 @@ function bhDateInterval(moment, bhConstants, Fiscal, Session) {
     // set the default option according the mode
     if (option !== -1) {
       search($ctrl.options[option]);
-      $ctrl.pickerOptions = $ctrl.mode;
+      $ctrl.pickerFromOptions = $ctrl.mode;
     } else {
       custom();
     }

--- a/client/src/modules/fiscal/fiscal.service.js
+++ b/client/src/modules/fiscal/fiscal.service.js
@@ -21,6 +21,7 @@ function FiscalService(Api) {
   service.setOpeningBalance = setOpeningBalance;
   service.getOpeningBalance = getOpeningBalance;
   service.getPeriods = getPeriods;
+  service.getEnterpriseFiscalStartDate = getEnterpriseFiscalStartDate;
 
   service.getBalance = getBalance;
 
@@ -73,13 +74,26 @@ function FiscalService(Api) {
   }
 
   /**
-   * @method closing
+   * @method closeFiscalYear
    *
    * @description closing a fiscal year
    */
   function closeFiscalYear(id, params) {
     const url = service.url.concat(id, '/closing');
     return service.$http.put(url, { params })
+      .then(service.util.unwrapHttpResponse);
+  }
+
+  /**
+   * @method getEnterpriseFiscalStartDate
+   *
+   * @description
+   * Returns a single date representing the earliest start date of all
+   * the enterprise fiscal years.
+   */
+  function getEnterpriseFiscalStartDate(enterpriseId) {
+    const url = `/enterprises/${enterpriseId}/fiscal_start`;
+    return service.$http.get(url)
       .then(service.util.unwrapHttpResponse);
   }
 
@@ -93,11 +107,12 @@ function FiscalService(Api) {
     const url = service.url.concat(id, '/periods');
     return service.$http.get(url)
       .then(service.util.unwrapHttpResponse)
-      .then(periods => periods.map(p => {
-        p.start_date = new Date(p.start_date);
-        p.end_date = new Date(p.end_date);
-        return p;
-      }));
+      .then(periods => periods
+        .map(p => {
+          p.start_date = new Date(p.start_date);
+          p.end_date = new Date(p.end_date);
+          return p;
+        }));
   }
 
   return service;

--- a/client/src/modules/reports/generate/account_report/account_report.html
+++ b/client/src/modules/reports/generate/account_report/account_report.html
@@ -40,6 +40,7 @@
               date-from="ReportConfigCtrl.reportDetails.dateFrom"
               date-to="ReportConfigCtrl.reportDetails.dateTo"
               required="true"
+              limit-min-fiscal
               validation-trigger="ConfigForm.$submitted">
             </bh-date-interval>
 

--- a/client/src/modules/reports/generate/balance_sheet_report/balance_sheet_report.html
+++ b/client/src/modules/reports/generate/balance_sheet_report/balance_sheet_report.html
@@ -26,7 +26,8 @@
             <!-- choose date until  -->
             <bh-date-editor
               date-value="ReportConfigCtrl.reportDetails.date"
-              on-change="ReportConfigCtrl.onDateChange(date)">
+              on-change="ReportConfigCtrl.onDateChange(date)"
+              limit-min-fiscal>
             </bh-date-editor>
 
             <!--display also revenue and expense-->

--- a/client/src/modules/reports/generate/cash_report/cash_report.html
+++ b/client/src/modules/reports/generate/cash_report/cash_report.html
@@ -25,7 +25,7 @@
             <!-- report format seletion -->
             <div class="form-group"
                 ng-class="{ 'has-error' : ConfigForm.$submitted && ConfigForm.reportFormat.$invalid }">
-                <label 
+                <label
                   ng-repeat="reportFormat in ReportConfigCtrl.reportFormats"
                   class="radio-inline">
                   <input
@@ -36,12 +36,12 @@
                     data-report-format-option="{{ reportFormat.id }}"
                     required>
                   <span translate>{{reportFormat.label}}</span>
-                </label>               
+                </label>
                 <div class="help-block" ng-messages="ConfigForm.reportFormat.$error" ng-show="ConfigForm.$submitted">
                     <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
                 </div>
             </div>
-            
+
             <!-- report type selection  -->
             <div class="form-group"
                 ng-class="{ 'has-error' : ConfigForm.$submitted && ConfigForm.type.$invalid }">
@@ -53,7 +53,7 @@
                     name="type"
                     ng-model="ReportConfigCtrl.reportDetails.type"
                     ng-options="type.id as (type.label | translate) for type in ReportConfigCtrl.reportTypes"
-                    ng-disabled="ReportConfigCtrl.reportDetails.format === 1"                    
+                    ng-disabled="ReportConfigCtrl.reportDetails.format === 1"
                     required>
                     <option value="" disabled>{{ "FORM.SELECT.REPORT_TYPE" | translate }}<option>
                 </select>
@@ -74,6 +74,7 @@
               date-from="ReportConfigCtrl.reportDetails.dateFrom"
               date-to="ReportConfigCtrl.reportDetails.dateTo"
               required="true"
+              limit-min-fiscal
               validation-trigger="ConfigForm.$submitted">
             </bh-date-interval>
 

--- a/client/src/modules/reports/generate/cashflow/cashflow.html
+++ b/client/src/modules/reports/generate/cashflow/cashflow.html
@@ -26,6 +26,7 @@
             <bh-date-interval
               date-from="ReportConfigCtrl.reportDetails.dateFrom"
               date-to="ReportConfigCtrl.reportDetails.dateTo"
+              limit-min-fiscal
               required="true">
             </bh-date-interval>
 

--- a/client/src/modules/reports/generate/cashflowByService/cashflowByService.html
+++ b/client/src/modules/reports/generate/cashflowByService/cashflowByService.html
@@ -33,6 +33,7 @@
             <bh-date-interval
               date-from="ReportConfigCtrl.reportDetails.dateFrom"
               date-to="ReportConfigCtrl.reportDetails.dateTo"
+              limit-min-fiscal
               required="true">
             </bh-date-interval>
 

--- a/client/src/modules/reports/generate/clients_report/clients_report.html
+++ b/client/src/modules/reports/generate/clients_report/clients_report.html
@@ -34,7 +34,8 @@
             <bh-date-interval
               ng-if="!ReportConfigCtrl.reportDetails.simplePreview"
               date-from="ReportConfigCtrl.reportDetails.dateFrom"
-              date-to="ReportConfigCtrl.reportDetails.dateTo">
+              date-to="ReportConfigCtrl.reportDetails.dateTo"
+              limit-min-fiscal>
             </bh-date-interval>
 
             <!-- detail the previous year flag  -->

--- a/client/src/modules/reports/generate/inventory_file/inventory_file.html
+++ b/client/src/modules/reports/generate/inventory_file/inventory_file.html
@@ -45,6 +45,7 @@
           <!-- choose date until  -->
           <bh-date-editor
             label="FORM.LABELS.UNTIL_DATE"
+            limit-min-fiscal
             date-value="ReportConfigCtrl.dateTo"
             on-change="ReportConfigCtrl.onDateChange(date)">
           </bh-date-editor>

--- a/client/src/modules/reports/generate/stock_exit/stock_exit.html
+++ b/client/src/modules/reports/generate/stock_exit/stock_exit.html
@@ -33,10 +33,11 @@
           </bh-depot-select>
 
           <!-- date interval -->
-          <bh-date-interval 
-            date-from="ReportConfigCtrl.dateFrom" 
+          <bh-date-interval
+            date-from="ReportConfigCtrl.dateFrom"
             date-to="ReportConfigCtrl.dateTo"
             validation-trigger="ConfigForm.$submitted"
+            limit-min-fiscal
             required="true">
           </bh-date-interval>
 
@@ -48,21 +49,21 @@
                 <span translate>REPORT.STOCK.INCLUDE_PATIENT_EXIT</span>
               </label>
             </div>
-  
+
             <div class="checkbox">
               <label>
                 <input type="checkbox" ng-true-value="1" ng-false-value="0" ng-change="ReportConfigCtrl.onExitTypeChange()" ng-model="ReportConfigCtrl.includeServiceExit">
                 <span translate>REPORT.STOCK.INCLUDE_SERVICE_EXIT</span>
               </label>
             </div>
-  
+
             <div class="checkbox">
               <label>
                 <input type="checkbox" ng-true-value="1" ng-false-value="0" ng-change="ReportConfigCtrl.onExitTypeChange()" ng-model="ReportConfigCtrl.includeDepotExit">
                 <span translate>REPORT.STOCK.INCLUDE_DEPOT_EXIT</span>
               </label>
             </div>
-  
+
             <div class="checkbox">
               <label>
                 <input type="checkbox" ng-true-value="1" ng-false-value="0" ng-change="ReportConfigCtrl.onExitTypeChange()" ng-model="ReportConfigCtrl.includeLossExit">
@@ -80,7 +81,6 @@
               <span translate>REPORT.STOCK.SHOW_DETAILS</span>
             </label>
           </div>
-          
 
           <!-- preview -->
           <bh-loading-button loading-state="ConfigForm.$loading">

--- a/client/src/modules/templates/bhDateInterval.tmpl.html
+++ b/client/src/modules/templates/bhDateInterval.tmpl.html
@@ -1,4 +1,4 @@
-<fieldset 
+<fieldset
   ng-form="DateIntervalForm"
   novalidate
   bh-date-interval>
@@ -36,7 +36,7 @@
           type="text"
           class="form-control"
           uib-datepicker-popup="{{ $ctrl.dateFormat }}"
-          datepicker-options="$ctrl.pickerOptions"
+          datepicker-options="$ctrl.pickerFromOptions"
           is-open="$ctrl.dateFromIsOpen"
           show-button-bar="false"
           ng-model="$ctrl.dateFrom"

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -520,6 +520,7 @@ exports.configure = function configure(app) {
   app.get('/enterprises/:id', enterprises.detail);
   app.post('/enterprises', enterprises.create);
   app.put('/enterprises/:id', enterprises.update);
+  app.get('/enterprises/:id/fiscal_start', fiscal.getEnterpriseFiscalStart);
 
   // employees
   app.get('/employees/search', employees.search);

--- a/server/controllers/finance/fiscal.js
+++ b/server/controllers/finance/fiscal.js
@@ -47,6 +47,7 @@ exports.getPeriodsFromDateRange = getPeriodsFromDateRange;
 exports.getAccountBalancesByTypeId = getAccountBalancesByTypeId;
 exports.getOpeningBalance = getOpeningBalance;
 exports.getFiscalYearByPeriodId = getFiscalYearByPeriodId;
+exports.getEnterpriseFiscalStart = getEnterpriseFiscalStart;
 
 /**
  * @method lookupFiscalYear
@@ -103,7 +104,7 @@ function list(req, res, next) {
   `;
 
   const periodsSql = `
-    SELECT p.id, p.start_date, p.end_date, p.locked, p.number , 
+    SELECT p.id, p.start_date, p.end_date, p.locked, p.number ,
     CONCAT('TABLE.COLUMNS.DATE_MONTH.',
     UPPER(DATE_FORMAT(p.start_date, "%M"))) AS translate_key,
     CONCAT('balance', number) AS 'balance'
@@ -316,6 +317,16 @@ function getOpeningBalance(req, res, next) {
     })
     .catch(next)
     .done();
+}
+
+async function getEnterpriseFiscalStart(req, res, next) {
+  try {
+    const { id } = req.params;
+    const startDate = await getFirstDateOfFirstFiscalYear(id);
+    res.status(200).json(startDate);
+  } catch (error) {
+    next(error);
+  }
 }
 
 /**

--- a/test/client-unit/components/bhDateEditor.spec.js
+++ b/test/client-unit/components/bhDateEditor.spec.js
@@ -24,7 +24,8 @@ function bhDateEditorTests() {
     'bhima.components',
     'bhima.constants',
     'templates',
-    'bhima.mocks'
+    'bhima.mocks',
+    'ui.router'
   ));
 
   let $scope;

--- a/test/client-unit/components/bhDateEditor.spec.js
+++ b/test/client-unit/components/bhDateEditor.spec.js
@@ -16,18 +16,35 @@ function bhDateEditorTests() {
   `;
 
   // make sure the modules are correctly loaded.
-  beforeEach(module('pascalprecht.translate', 'bhima.services', 'bhima.components', 'bhima.constants', 'templates'));
+  beforeEach(module(
+    'bhima.services',
+    'angularMoment',
+    'ngStorage',
+    'pascalprecht.translate',
+    'bhima.components',
+    'bhima.constants',
+    'templates',
+    'bhima.mocks'
+  ));
 
   let $scope;
   let $compile;
   let element;
+  let Session;
+  let Mocks;
+
   const futureDate = '20120-01-20';
   // utility fns
   const find = (elm, selector) => elm[0].querySelector(selector);
 
-  beforeEach(inject((_$rootScope_, _$compile_) => {
+  beforeEach(inject((_$rootScope_, _$compile_, _SessionService_, _MockDataService_) => {
+    Session = _SessionService_;
+    Mocks = _MockDataService_;
+
     $compile = _$compile_;
     $scope = _$rootScope_.$new();
+
+    Session.create(Mocks.user(), Mocks.enterprise(), Mocks.project());
 
     // spy on the onChange callback
     $scope.date = new Date();

--- a/test/client-unit/components/bhDateEditor.spec.js
+++ b/test/client-unit/components/bhDateEditor.spec.js
@@ -31,15 +31,26 @@ function bhDateEditorTests() {
   let $compile;
   let element;
   let Session;
+  let Fiscal;
   let Mocks;
+  let httpBackend;
 
-  const futureDate = '20120-01-20';
+  const enterpriseFiscalStartDate = '2015-01-01T00:00:00.000Z';
+  const futureDate = '2200-01-20';
+  const invalidOldDate = '2001-01-20';
+
   // utility fns
   const find = (elm, selector) => elm[0].querySelector(selector);
 
-  beforeEach(inject((_$rootScope_, _$compile_, _SessionService_, _MockDataService_) => {
+  beforeEach(inject((_$rootScope_, _$compile_, $httpBackend, _SessionService_, _FiscalService_, _MockDataService_) => {
     Session = _SessionService_;
     Mocks = _MockDataService_;
+    Fiscal = _FiscalService_;
+
+    httpBackend = $httpBackend;
+
+    httpBackend.when('GET', `/enterprises/${Mocks.enterprise().id}/fiscal_start`)
+      .respond(200, { start_date : enterpriseFiscalStartDate });
 
     $compile = _$compile_;
     $scope = _$rootScope_.$new();
@@ -125,4 +136,18 @@ function bhDateEditorTests() {
     expect(ngModel.$modelValue).to.be.equal(futureDate);
   });
 
+  describe('limit-min-fiscal flag', () => {
+    let fiscalLimitElement = `
+      <bh-date-editor date-value="date" limit-min-fiscal></bh-date-editor>
+    `;
+    let fiscalElement;
+
+    it('limit fiscal year requests start date', () => {
+      fiscalElement = $compile(angular.element(fiscalLimitElement))($scope);
+      const spy = chai.spy.on(Fiscal, 'getEnterpriseFiscalStartDate');
+
+      $scope.$digest();
+      expect(spy).to.have.been.called.exactly(1);
+    });
+  });
 }

--- a/test/integration/fiscalYear.js
+++ b/test/integration/fiscalYear.js
@@ -115,4 +115,33 @@ describe('(/fiscal) Fiscal Year', () => {
       })
       .catch(helpers.handler);
   });
+
+  it('GET /enterprises/:id/fiscal_start getting the earliest fiscal year date', () => {
+    const mockEnterpriseFiscalEntity = {
+      enterpriseId: 1,
+      earliestFiscalDate: {
+        string: '2015-01-01T00:00:00.000Z',
+        year: 2015,
+        day: 1,
+        month: 0,
+      }
+    };
+
+    return agent.get(`/enterprises/${mockEnterpriseFiscalEntity.enterpriseId}/fiscal_start`)
+      .then((result) => {
+        // set up date objects to ensure the correct date is returned
+        // matching on the exact MySQL string may differ given different machines
+        // or database configurations
+        expect(result).to.have.status(200);
+        expect(result).to.be.json;
+        expect(result.body).to.have.all.keys(['start_date']);
+
+        const startDate = new Date(result.body.start_date);
+
+        expect(startDate.getFullYear()).to.equal(mockEnterpriseFiscalEntity.earliestFiscalDate.year);
+        expect(startDate.getDate()).to.equal(mockEnterpriseFiscalEntity.earliestFiscalDate.day);
+        expect(startDate.getMonth()).to.equal(mockEnterpriseFiscalEntity.earliestFiscalDate.month);
+      });
+
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7225,9 +7225,9 @@ snyk-go-plugin@1.5.2:
     tmp "0.0.33"
     toml "^2.3.2"
 
-snyk-gradle-plugin@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/snyk-gradle-plugin/-/snyk-gradle-plugin-1.3.0.tgz#7a589155825ec613e24cc2bcf0d738438fb06216"
+snyk-gradle-plugin@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/snyk-gradle-plugin/-/snyk-gradle-plugin-1.3.1.tgz#9bd080f9d9ee0b9186fa0e34e682613766a13637"
   dependencies:
     clone-deep "^0.3.0"
 
@@ -7238,9 +7238,9 @@ snyk-module@1.8.2, snyk-module@^1.6.0, snyk-module@^1.8.2:
     debug "^3.1.0"
     hosted-git-info "^2.1.4"
 
-snyk-mvn-plugin@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/snyk-mvn-plugin/-/snyk-mvn-plugin-1.2.0.tgz#e23c60e35457ce5a26fd4252ddf120dbd7e9ef2a"
+snyk-mvn-plugin@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/snyk-mvn-plugin/-/snyk-mvn-plugin-1.2.2.tgz#1ffbd0696aa548ab0ae55fb842b7d4a7d9c50f90"
 
 snyk-nodejs-lockfile-parser@1.4.1:
   version "1.4.1"
@@ -7313,11 +7313,9 @@ snyk-resolve@1.0.1, snyk-resolve@^1.0.0, snyk-resolve@^1.0.1:
     debug "^3.1.0"
     then-fs "^2.0.0"
 
-snyk-sbt-plugin@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/snyk-sbt-plugin/-/snyk-sbt-plugin-1.3.1.tgz#15b4a212672dfba33f26aec953229db1a962f29e"
-  dependencies:
-    debug "^3.1.0"
+snyk-sbt-plugin@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/snyk-sbt-plugin/-/snyk-sbt-plugin-1.3.2.tgz#f724219c7084da30505b90492a672c5e9493945f"
 
 snyk-tree@^1.0.0:
   version "1.0.0"
@@ -7334,9 +7332,9 @@ snyk-try-require@1.3.1, snyk-try-require@^1.1.1:
     lru-cache "^4.0.0"
     then-fs "^2.0.0"
 
-snyk@1.94.0:
-  version "1.94.0"
-  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.94.0.tgz#1d2d685fc4cfd21e844f79cb307ccf41d0f6f790"
+snyk@1.95.3:
+  version "1.95.3"
+  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.95.3.tgz#3747b8e5f1eb4b3ed8389145e67c70be59d733ab"
   dependencies:
     abbrev "^1.1.1"
     ansi-escapes "^3.1.0"
@@ -7356,9 +7354,9 @@ snyk@1.94.0:
     snyk-config "2.2.0"
     snyk-docker-plugin "1.10.4"
     snyk-go-plugin "1.5.2"
-    snyk-gradle-plugin "1.3.0"
+    snyk-gradle-plugin "1.3.1"
     snyk-module "1.8.2"
-    snyk-mvn-plugin "1.2.0"
+    snyk-mvn-plugin "1.2.2"
     snyk-nodejs-lockfile-parser "1.4.1"
     snyk-nuget-plugin "1.6.5"
     snyk-php-plugin "1.5.1"
@@ -7366,7 +7364,7 @@ snyk@1.94.0:
     snyk-python-plugin "1.8.1"
     snyk-resolve "1.0.1"
     snyk-resolve-deps "3.1.0"
-    snyk-sbt-plugin "1.3.1"
+    snyk-sbt-plugin "1.3.2"
     snyk-tree "^1.0.0"
     snyk-try-require "1.3.1"
     tempfile "^2.0.0"


### PR DESCRIPTION
This PR implements the functionality described in https://github.com/IMA-WorldHealth/bhima-2.X/issues/2785. 

The flag `limit-min-fiscal` has been applied to the `bh-date-interval` and `bh-date-editor` components, these are the two primarily used for reports. 

This flag will limit the date editor so that it can only select up to the beginning of the enterprises first fiscal year. 

This PR applies the `limit-min-fiscal` flag to the following modules: 
* Cash report 
* Cashflow by service 
* Client report 
* Cashflow 
* Stock exit 
* Balance sheet 
* Stock inventory

Dates in 2015, this is the earliest fiscal year so these are valid
![screenshot from 2018-09-02 19-51-53](https://user-images.githubusercontent.com/2844572/44959645-c0334a80-aee9-11e8-8b6e-0c0cf10222f7.png)

Dates in 2014 are before the opening fiscal year, these are invalid
![screenshot from 2018-09-02 19-52-06](https://user-images.githubusercontent.com/2844572/44959652-d3461a80-aee9-11e8-84f5-a9d562b98a21.png)

Year view 
![screenshot from 2018-09-02 19-52-25](https://user-images.githubusercontent.com/2844572/44959655-d6d9a180-aee9-11e8-9d95-b5596c2e2065.png)

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/2785.