### PR TITLE
Fix cash box access permission update

### DIFF
--- a/client/src/js/components/bhMultipleCashboxSelect.js
+++ b/client/src/js/components/bhMultipleCashboxSelect.js
@@ -20,28 +20,25 @@ MultipleCashboxSelectController.$inject = [
  *
  */
 function MultipleCashboxSelectController(Cashbox, Notify) {
-  var $ctrl = this;
+  const $ctrl = this;
 
   $ctrl.$onInit = function onInit() {
     // label to display
     $ctrl.label = $ctrl.label || 'FORM.LABELS.CASHBOX';
-
-    // fired when a Cashbox has been selected or removed from the list
-    $ctrl.onChange = $ctrl.onChange;
 
     // init the model
     $ctrl.cashboxIds = $ctrl.cashboxIds || [];
 
     // load all Cashbox
     Cashbox.read()
-      .then(function (cashboxes) {
+      .then((cashboxes) => {
         $ctrl.cashboxes = cashboxes;
       })
       .catch(Notify.handleError);
   };
 
   // fires the onSelectCallback bound to the component
-  $ctrl.handleChange = function (models) {
+  $ctrl.handleChange = (models) => {
     $ctrl.onChange({ cashboxes : models });
   };
 }

--- a/client/src/modules/users/UserCashBoxManagementModal.html
+++ b/client/src/modules/users/UserCashBoxManagementModal.html
@@ -22,7 +22,7 @@
 
     <bh-multiple-cashbox-select
       on-change="UsersCashBoxModalCtrl.onCashBoxChange(cashboxes)"
-      cashbox-ids="UsersCashBoxModalCtrl.cashboxes">
+      cashbox-ids="UsersCashBoxModalCtrl.initialUserCashboxes">
     </bh-multiple-cashbox-select>
 
   </div>

--- a/server/controllers/admin/users/cashboxes.js
+++ b/server/controllers/admin/users/cashboxes.js
@@ -57,7 +57,10 @@ function create(req, res, next) {
   }
 
   if (!cashboxPermissionIds) {
-    next(new BadRequest('You must provide a list of cashbox ids to update the users permissions'));
+    next(new BadRequest(
+      'You must provide a list of cashbox ids to update the users permissions',
+      'ERRORS.BAD_DATA_FORMAT'
+    ));
     return;
   }
 

--- a/server/controllers/admin/users/cashboxes.js
+++ b/server/controllers/admin/users/cashboxes.js
@@ -6,10 +6,12 @@
  * cashboxes-related functionality in the same place.
  *
  * @requires lib/db
+ * @requires BadRequest
  */
 
 
 const db = require('../../../lib/db');
+const BadRequest = require('../../../lib/errors/BadRequest');
 
 exports.list = list;
 exports.create = create;
@@ -45,22 +47,37 @@ function list(req, res, next) {
 function create(req, res, next) {
   const transaction = db.transaction();
 
-  transaction
-    .addQuery('DELETE FROM cashbox_permission WHERE user_id = ?;', [req.params.id]);
+  // route specific parameters
+  const userId = req.params.id;
+  const cashboxPermissionIds = req.body.cashboxes;
 
-  // if an array of permission has been sent, add them to an INSERT query
-  if (req.body.cashboxes.length) {
-    const data = req.body.cashboxes.map((id) => {
-      return [id, req.params.id];
-    });
+  if (!userId) {
+    next(new BadRequest('You must provide a user ID to update the users cashbox permissions'));
+    return;
+  }
+
+  if (!cashboxPermissionIds) {
+    next(new BadRequest('You must provide a list of cashbox ids to update the users permissions'));
+    return;
+  }
+
+  // the request now has enough data to carry out the transaction
+  // remove all cashbox permissions for this user
+  transaction
+    .addQuery('DELETE FROM cashbox_permission WHERE user_id = ?;', [userId]);
+
+  // only insert new cashbox permissions if the provided list contains elements
+  if (cashboxPermissionIds.length) {
+    // bundle provided permission ids with the userid
+    const formattedPermissions = cashboxPermissionIds.map((id) => [id, userId]);
 
     transaction
-      .addQuery('INSERT INTO cashbox_permission (cashbox_id, user_id) VALUES ?', [data]);
+      .addQuery('INSERT INTO cashbox_permission (cashbox_id, user_id) VALUES ?', [formattedPermissions]);
   }
 
   transaction.execute()
     .then(() => {
-      res.sendStatus(201);
+      res.status(201).json({ userId });
     })
     .catch(next)
     .done();

--- a/server/controllers/admin/users/index.js
+++ b/server/controllers/admin/users/index.js
@@ -61,7 +61,7 @@ function lookupUser(id) {
       }
 
       // bind user data to ship back
-      data = rows[0];
+      [data] = rows;
 
       // query project permissions
       sql = `
@@ -91,9 +91,7 @@ function lookupUser(id) {
  * GET /users
  */
 function list(req, res, next) {
-  const sql =
-    `SELECT user.id, display_name,
-      user.username, user.deactivated FROM user;`;
+  const sql = 'SELECT user.id, display_name, user.username, user.deactivated FROM user;';
 
   db.exec(sql)
     .then((rows) => {

--- a/test/integration/users.js
+++ b/test/integration/users.js
@@ -279,4 +279,13 @@ describe('(/users) Users and Permissions', () => {
       })
       .catch(helpers.handler);
   });
+
+  it('POST /users/:id/cashboxes will reject invalid data formats', () => {
+    return agent.post(`/users/${newUser.id}/cashboxes`)
+      .send({ })
+      .then((result) => {
+        helpers.api.errored(result, 400, 'ERRORS.BAD_DATA_FORMAT');
+      })
+      .catch(helpers.handler);
+  });
 });


### PR DESCRIPTION
This commit introduces two checks on the server `/users/:id/cashboxes`
route that ensure that the correct data is provided before continuing,
this lets the client know if a request is badly formed in order to tell
the user.

It also updates the client controller to remove the default case where
it would send a badly formed request if no changes were made.

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/3118