### PR TITLE
Fix simple vouchers state transition to patient debt transfer tool

### DIFF
--- a/client/src/modules/vouchers/simple-voucher.ctrl.js
+++ b/client/src/modules/vouchers/simple-voucher.ctrl.js
@@ -61,7 +61,7 @@ function SimpleJournalVoucherController(Vouchers, util, Notify, Receipts, bhCons
     // stop submission if the form is invalid
     if (form.$invalid) {
       Notify.danger('FORM.ERRORS.RECORD_ERROR');
-      return;
+      return null;
     }
 
     // CONVENTION: 0 is debit, 1 is credit
@@ -76,7 +76,7 @@ function SimpleJournalVoucherController(Vouchers, util, Notify, Receipts, bhCons
 
     if (!valid) {
       Notify.danger(vm.Voucher._error);
-      return;
+      return null;
     }
 
     const voucher = vm.Voucher.details;

--- a/client/src/modules/vouchers/simple-voucher.html
+++ b/client/src/modules/vouchers/simple-voucher.html
@@ -13,7 +13,9 @@
           </a>
           <ul uib-dropdown-menu role="menu" class="dropdown-menu-right">
             <li role="menuitem">
-              <a href ui-sref="simpleVouchers.barcode" data-action="patient-invoice-debt-transfer">
+              <!-- Without binding an object through simpleVouchers.barcode the state transition -->
+              <!-- is not respected unless the /barcode route has already been loaded -->
+              <a href ui-sref="simpleVouchers.barcode({})" data-action="patient-invoice-debt-transfer">
                 <i class="fa fa-barcode"></i> <span translate>VOUCHERS.SIMPLE.TRANSFER_PATIENT_INVOICE_AMOUNT</span>
               </a>
             </li>


### PR DESCRIPTION
Addresses lack of functionality issue found in https://github.com/IMA-WorldHealth/bhima-2.X/issues/3141. If another developer could verify this is an issue on `master` before merging this patch that would be great. I can't think of a reason this behaviour should change.

This commit fixes an issue with the state transition on the Simple
Vouchers module. The Simple Vouchers barcode scanning route does not
define any `params` but the transition was not being respected unless an
empty object was bound through the `ui-sref` definition.

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/3141
