### PR TITLE
use date string for avoiding timezone info on fiscal year date range

### DIFF
--- a/client/src/modules/fiscal/fiscal.manage.js
+++ b/client/src/modules/fiscal/fiscal.manage.js
@@ -109,6 +109,10 @@ function FiscalManagementController($state, Fiscal, Notify, Modal, util, moment)
     // get the number of months
     numberOfMonths();
 
+    // remove timezone information by considering just date
+    vm.fiscal.start_date = moment(vm.fiscal.start_date).format('YYYY-MM-DD');
+    vm.fiscal.end_date = moment(vm.fiscal.end_date).format('YYYY-MM-DD');
+
     const promise = isUpdate ? Fiscal.update(id, vm.fiscal) : Fiscal.create(vm.fiscal);
 
     return promise


### PR DESCRIPTION
This PR remove timezone information in fiscal year for avoiding timezone influence on the fiscal year date range.

Issue : Dates are depending on the timezone
![2018-09-07_10-34-03](https://user-images.githubusercontent.com/5445251/45211366-0261e080-b28a-11e8-8f20-1f8e3dd29291.gif)

Fix : Remove dependency to timezone by using date string in the format `YYYY-MM-DD`
![2018-09-07_10-32-27](https://user-images.githubusercontent.com/5445251/45211444-34734280-b28a-11e8-8c0b-d7945286c99d.gif)
