### PR TITLE
Fix build process: Glyphicon path issue and corrupt css minification

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -10,7 +10,7 @@
 
   <!-- Compiled bootstrap style definition -->
   <link rel="stylesheet" href="vendor/angular-ui-select/dist/select.css">
-  <link rel="stylesheet" href="css/bootstrap/bhima-bootstrap.css">
+  <link rel="stylesheet" href="css/bhima-bootstrap.css">
   <link rel="stylesheet" href="vendor/angular-ui-grid/ui-grid.min.css">
   <link rel="stylesheet" href="vendor/components-font-awesome/css/font-awesome.min.css">
   <link rel="stylesheet" href="css/bhima/bhima.min.css">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,8 +148,7 @@ gulp.task('less', () => {
   return gulp.src(paths.client.less)
     .pipe(gulp.dest(lessConfig.paths[0])) // move less file into actual bootstrap folder, this feels wrong
     .pipe(less(lessConfig))
-    .pipe(cssnano({ zindex : false }))
-    .pipe(gulp.dest(`${CLIENT_FOLDER}/css/bootstrap/`));
+    .pipe(gulp.dest(`${CLIENT_FOLDER}/css`));
 });
 
 gulp.task('i18n', ['lint-i18n', 'clean-i18n'], () => {


### PR DESCRIPTION
This commit resolves two issues that were introduced by changes in the
build process:
1. The bootstrap less font paths are relative, that means the
bhima-bootstrap file must be located relative to the `../fonts` folder.
This is moved.

2. Minifying the bootstrap CSS with out current minifier `cssnano` seems
to override some styles and animations causing issues on `ui-grid` row
validation. This has been reverted until it can be determined why this
minification causes this.

This pull request actually closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/3161

https://github.com/IMA-WorldHealth/bhima-2.X/pull/3162 should still be merged to ensure users are never accidentally met with an entire application shifting experience through a quirk of building CSS.