### PR TITLE
fix(reports): translate P&L

### DIFF
--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -53,7 +53,7 @@
     },
     "EXPENSE_REPORT":"Rapport des dépenses",
     "GENERATED":"Rapport généré",
-    "INCOME_EXPENSE":"Rapport  des recettes et des dépenses",
+    "INCOME_EXPENSE":"Rapport des Produits et Charges",
     "INCOME_REPORT":"Rapport des recettes",
     "MONTHLY_BALANCE":"Balance mensuelle",
     "OPEN_DEBTORS": {


### PR DESCRIPTION
This commit fixes the translation for the P&L Statement.