### PR TITLE
report(inventory stock sheet): Add filter by created at in the inventory stock sheet

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -87,6 +87,7 @@
     "MONTH_OF_STOCK"  : "Stock Months - Months until Stock Out",
     "MONTHLY_CONSUM"  : "Average Monthly Consumption",
     "MOTIF"           : "Motif",
+    "MOVEMENT"        : "Movement",
     "MOVEMENTS"       : "Movements",
     "NO_ORDER"        : "No Orders",
     "NO_DATA"         : "No Data",
@@ -140,6 +141,10 @@
     "SUCCESS"         : "Successfully created a movement",
     "TO"              : "Destination",
     "UNIT_COST"       : "Unit cost"
+  },
+  "SETTINGS" : {
+    "ORDER_BY_CREATED_AT" : "Sort lots movements by their true creation date",
+    "ORDER_BY_CREATED_AT_HELP_TEXT" : "This option allow to sort lots movements by their true creation date into the system"
   },
   "STOCK_FLUX" : {
     "FROM_PURCHASE"    : "From Purchase Order",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -87,6 +87,7 @@
     "MONTH_OF_STOCK"  : "Mois de stock - Nombre de mois avant epuisement du stock",
     "MONTHLY_CONSUM"  : "Consommation Mensuelle Moyenne",
     "MOTIF"           : "Motif",
+    "MOVEMENT"        : "Mouvement",
     "MOVEMENTS"       : "Mouvements",
     "NO_ORDER"        : "Pas de commandes",
     "NO_DATA"         : "Aucune données",
@@ -140,6 +141,10 @@
     "SUCCESS"         : "Mouvement realisé avec success",
     "TO"              : "Destination",
     "UNIT_COST"       : "Coût unitaire"
+  },
+  "SETTINGS" : {
+    "ORDER_BY_CREATED_AT" : "Ordonner les mouvements de lots par leurs dates de création",
+    "ORDER_BY_CREATED_AT_HELP_TEXT" : "Cette option permet d'ordonner les movements de lots par leurs dates réelles de création dans le système"
   },
   "STOCK_FLUX" : {
     "FROM_PURCHASE"    : "Commande d'achat",

--- a/client/src/modules/reports/generate/inventory_file/inventory_file.config.js
+++ b/client/src/modules/reports/generate/inventory_file/inventory_file.config.js
@@ -12,11 +12,15 @@ function InventoryFileConfigController($sce, Notify, SavedReports, AppCache, rep
   const reportUrl = 'reports/stock/inventory';
 
   vm.previewGenerated = false;
-
+  vm.orderByCreatedAt = 0;
   vm.dateTo = new Date();
 
   vm.onDateChange = (date) => {
     vm.dateTo = date;
+  };
+
+  vm.setOrderByCreatedAt = value => {
+    vm.orderByCreatedAt = value;
   };
 
   // check cached configuration
@@ -46,6 +50,7 @@ function InventoryFileConfigController($sce, Notify, SavedReports, AppCache, rep
       depot_uuid : vm.depot.uuid,
       inventory_uuid : vm.inventory.uuid,
       dateTo : vm.dateTo,
+      orderByCreatedAt : vm.orderByCreatedAt,
     };
 
     // update cached configuration

--- a/client/src/modules/reports/generate/inventory_file/inventory_file.html
+++ b/client/src/modules/reports/generate/inventory_file/inventory_file.html
@@ -50,6 +50,14 @@
             on-change="ReportConfigCtrl.onDateChange(date)">
           </bh-date-editor>
 
+          <!-- sort by real movement date -->
+          <bh-yes-no-radios
+            label="SETTINGS.ORDER_BY_CREATED_AT"
+            value="ReportConfigCtrl.orderByCreatedAt"
+            help-text="SETTINGS.ORDER_BY_CREATED_AT_HELP_TEXT"
+            on-change-callback="ReportConfigCtrl.setOrderByCreatedAt(value)">
+          </bh-yes-no-radios>
+
           <!-- preview -->
           <bh-loading-button loading-state="ConfigForm.$loading">
             <span translate>REPORT.UTIL.PREVIEW</span>

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -550,7 +550,9 @@ function getInventoryMovements(params) {
     LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
   `;
 
-  return getLots(sql, params, ' ORDER BY m.date ASC ')
+  const orderBy = params.orderByCreatedAt ? 'm.created_at' : 'm.date';
+
+  return getLots(sql, params, ` ORDER BY ${orderBy} ASC `)
     .then((rows) => {
       bundle.movements = rows;
 
@@ -562,6 +564,7 @@ function getInventoryMovements(params) {
       // stock method CUMP : cout unitaire moyen pondere
       const movements = bundle.movements.map(line => {
         const movement = {
+          reference : line.documentReference,
           date : line.date,
           entry : { quantity : 0, unit_cost : 0, value : 0 },
           exit : { quantity : 0, unit_cost : 0, value : 0 },

--- a/server/controllers/stock/reports/stock_inventory.report.handlebars
+++ b/server/controllers/stock/reports/stock_inventory.report.handlebars
@@ -30,11 +30,13 @@
         <thead>
           <tr style="background-color:#ddd;">
             <th></th>
+            <th></th>
             <th class="text-center" colspan="3">{{translate 'REPORT.STOCK.ENTRIES'}}</th>
             <th class="text-center" colspan="3">{{translate 'REPORT.STOCK.EXITS'}}</th>
             <th class="text-center" colspan="3">{{translate 'REPORT.STOCK.STOCKS'}}</th>
           </tr>
           <tr style="background-color:#ddd;">
+            <th class="text-center" style="border-right: 1px solid #000;">{{translate 'TABLE.COLUMNS.REFERENCE'}}</th>
             <th class="text-center" style="border-right: 1px solid #000;">{{translate 'TABLE.COLUMNS.DATE'}}</th>
 
             <th class="text-center">{{translate 'STOCK.QUANTITY'}}</th>
@@ -53,31 +55,33 @@
         <tbody>
           {{#each rows}}
             <tr>
+              <td style="border-left: 1px solid #000;">{{reference}}</td>
               <td style="border-right: 1px solid #000;">{{date date}}</td>
               {{!-- entry --}}
               <td class="text-right">{{#if entry.quantity}}{{entry.quantity}}{{/if}}</td>
-              <td class="text-right">{{#if entry.unit_cost}}{{currency entry.unit_cost ../../metadata.enterprise.currency_id}}{{/if}}</td>
+              <td class="text-right">{{#if entry.unit_cost}}{{precision entry.unit_cost 4}}{{/if}}</td>
               <td class="text-right" style="border-right: 1px solid #000;">{{#if entry.value}}{{currency entry.value ../../metadata.enterprise.currency_id}}{{/if}}</td>
 
               {{!-- exit --}}
               <td class="text-right">{{#if exit.quantity}}{{exit.quantity}}{{/if}}</td>
-              <td class="text-right">{{#if exit.unit_cost}}{{currency exit.unit_cost ../metadata.enterprise.currency_id}}{{/if}}</td>
+              <td class="text-right">{{#if exit.unit_cost}}{{precision exit.unit_cost 4}}{{/if}}</td>
               <td class="text-right" style="border-right: 1px solid #000;">{{#if exit.value}}{{currency exit.value ../../metadata.enterprise.currency_id}}{{/if}}</td>
 
               {{!-- stock --}}
               <td class="text-right" style="background-color:#efefef;">{{stock.quantity}}</td>
-              <td class="text-right" style="background-color:#efefef;">{{currency stock.unit_cost ../../metadata.enterprise.currency_id}}</td>
-              <td class="text-right" style="background-color:#efefef;">{{currency stock.value ../../metadata.enterprise.currency_id}}</td>
+              <td class="text-right" style="background-color:#efefef;">{{precision stock.unit_cost 4}}</td>
+              <td class="text-right" style="background-color:#efefef;border-right: 1px solid #000;">{{currency stock.value ../../metadata.enterprise.currency_id}}</td>
             </tr>
           {{/each}}
         </tbody>
-        <tfoot>
+        <tfoot style="border-top: 1px solid #000;">
           <tr class="text-right" style="font-weight: bold; background-color: #efefef;">
+            <th></th>
             <th></th>
             <th class="text-right">{{ totals.entry}}</th> <th></th> <th></th>
             <th class="text-right">{{ totals.exit}}</th> <th></th> <th></th>
             <th class="text-right">{{ result.stock.quantity}}</th>
-            <th class="text-right">{{currency result.stock.unit_cost ../../metadata.enterprise.currency_id}}</th>
+            <th class="text-right">{{precision result.stock.unit_cost 4}}</th>
             <th class="text-right">{{currency result.stock.value ../../metadata.enterprise.currency_id}}</th>
           </tr>
         </tfoot>

--- a/server/lib/template/helpers/finance.js
+++ b/server/lib/template/helpers/finance.js
@@ -59,11 +59,16 @@ function debcred(value = 0, currencyId) {
   `);
 }
 
-function percentage(value = 0, precision = 2) {
+function percentage(value = 0, decimal = 2) {
   if (!value || !Number.isFinite(value) || Number.isNaN(value)) { return ''; }
 
-  const str = (value * 100).toFixed(precision);
+  const str = (value * 100).toFixed(decimal);
   return `${str}%`;
+}
+
+function precision(value = 0, decimal = 2) {
+  if (!value || !Number.isFinite(value) || Number.isNaN(value)) { return ''; }
+  return new Handlebars.SafeString(value.toFixed(decimal));
 }
 
 exports.debcred = debcred;
@@ -71,3 +76,4 @@ exports.currency = currency;
 exports.indentAccount = indentAccount;
 exports.numberToText = numberToText;
 exports.percentage = percentage;
+exports.precision = precision;

--- a/server/lib/template/index.js
+++ b/server/lib/template/index.js
@@ -39,6 +39,7 @@ const hbs = exphbs.create({
     indentAccount : finance.indentAccount,
     percentage    : finance.percentage,
     debcred       : finance.debcred,
+    precision     : finance.precision,
     look          : objects.look,
     equal         : logic.equal,
     gt            : logic.gt,

--- a/server/models/migrations/v0.8.0-v0.9.0/migrate.sql
+++ b/server/models/migrations/v0.8.0-v0.9.0/migrate.sql
@@ -173,3 +173,10 @@ Add stock import module in the navigation tree
 */
 INSERT IGNORE INTO unit VALUES
 (208, 'Import Stock From File','TREE.IMPORT_STOCK_FROM_FILE','',160,'/modules/stock/import','/stock/import');
+
+/*
+@author bruce
+@description
+Add created_at column in stock_movement for having the true date
+*/
+ALTER TABLE `stock_movement` ADD COLUMN `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/server/models/migrations/v0.8.0-v0.9.0/migrate.sql
+++ b/server/models/migrations/v0.8.0-v0.9.0/migrate.sql
@@ -180,3 +180,64 @@ INSERT IGNORE INTO unit VALUES
 Add created_at column in stock_movement for having the true date
 */
 ALTER TABLE `stock_movement` ADD COLUMN `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+
+/*
+@author bruce
+@description
+This procedure add missing stock movement reference inside the table document_map
+it fixes the problem of nothing as reference in the stock movement registry
+*/
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS AddMissingMovementReference$$
+CREATE PROCEDURE AddMissingMovementReference()
+BEGIN
+  -- declaration
+  DECLARE v_document_uuid BINARY(16);
+  DECLARE v_reference INT(11);
+
+  -- cursor variable declaration
+  DECLARE v_finished INTEGER DEFAULT 0;
+
+  -- cursor declaration
+  DECLARE stage_missing_movement_document_cursor CURSOR FOR 
+  	SELECT temp.document_uuid
+	FROM missing_movement_document as temp;
+
+  -- variables for the cursor
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_finished = 1;
+
+  -- temporary table for movement which doesn't have movement reference identifier
+  DROP TABLE IF EXISTS missing_movement_document;
+
+  CREATE TEMPORARY TABLE missing_movement_document (
+    SELECT m.document_uuid FROM stock_movement m 
+    LEFT JOIN document_map dm ON dm.uuid IS NULL
+    GROUP BY m.document_uuid
+  );
+
+  -- open the cursor
+  OPEN stage_missing_movement_document_cursor;
+
+  -- loop inside the cursor
+  missing_document : LOOP
+
+    /* fetch data into variables */
+    FETCH stage_missing_movement_document_cursor INTO v_document_uuid;
+
+    IF v_finished = 1 THEN 
+      LEAVE missing_document;
+    END IF;
+
+    CALL ComputeMovementReference(v_document_uuid);
+
+  END LOOP missing_document;
+
+  -- close the cursor
+  CLOSE stage_missing_movement_document_cursor;
+
+  DROP TEMPORARY TABLE missing_movement_document;
+END $$
+
+DELIMITER ;

--- a/server/models/procedures/stock.sql
+++ b/server/models/procedures/stock.sql
@@ -183,6 +183,63 @@ BEGIN
 
 END $$
 
+/*
+  ---------------------------------------------------
+  Add Missing Movement Reference
+  ---------------------------------------------------
+  Add the stock movement reference for movements which doesn't have
+  document uuid in document_map table
+*/
+DROP PROCEDURE IF EXISTS AddMissingMovementReference$$
+CREATE PROCEDURE AddMissingMovementReference()
+BEGIN
+  -- declaration
+  DECLARE v_document_uuid BINARY(16);
+  DECLARE v_reference INT(11);
+
+  -- cursor variable declaration
+  DECLARE v_finished INTEGER DEFAULT 0;
+
+  -- cursor declaration
+  DECLARE stage_missing_movement_document_cursor CURSOR FOR 
+  	SELECT temp.document_uuid
+	FROM missing_movement_document as temp;
+
+  -- variables for the cursor
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_finished = 1;
+
+  -- temporary table for movement which doesn't have movement reference identifier
+  DROP TABLE IF EXISTS missing_movement_document;
+
+  CREATE TEMPORARY TABLE missing_movement_document (
+    SELECT m.document_uuid FROM stock_movement m 
+    LEFT JOIN document_map dm ON dm.uuid IS NULL
+    GROUP BY m.document_uuid
+  );
+
+  -- open the cursor
+  OPEN stage_missing_movement_document_cursor;
+
+  -- loop inside the cursor
+  missing_document : LOOP
+
+    /* fetch data into variables */
+    FETCH stage_missing_movement_document_cursor INTO v_document_uuid;
+
+    IF v_finished = 1 THEN 
+      LEAVE missing_document;
+    END IF;
+
+    CALL ComputeMovementReference(v_document_uuid);
+
+  END LOOP missing_document;
+
+  -- close the cursor
+  CLOSE stage_missing_movement_document_cursor;
+
+  DROP TEMPORARY TABLE missing_movement_document;
+END $$
+
 
 /*
   ---------------------------------------------------

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1894,6 +1894,7 @@ CREATE TABLE `stock_movement` (
   `user_id`         SMALLINT(5) UNSIGNED NOT NULL,
   `reference`       INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
   `invoice_uuid`    BINARY(16) NULL,
+  `created_at`      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`reference`),
   UNIQUE KEY `stock_movement_uuid` (`uuid`),
   KEY `depot_uuid` (`depot_uuid`),


### PR DESCRIPTION
This issue add a filter for ordering lots movements of an inventory in the inventory stock sheet by `created_at` or `date` which useful for seeing real entry without care about the stock movement date.

![image](https://user-images.githubusercontent.com/5445251/45806024-e6adff80-bcb7-11e8-835a-b100a45bfeb6.png)

Also, it adds a column `Reference` for lot movement reference in the report generated

![image](https://user-images.githubusercontent.com/5445251/45806135-312f7c00-bcb8-11e8-9b7f-d1a7587daa50.png)

It also add a stored procedure : `AddMissingMovementReference()` for calculate and add missing stock movement document reference in the table `document_map`
