### PR TITLE
Extend bhInventorySelect with consumable filter

### DIFF
--- a/client/src/js/components/bhInventorySelect.js
+++ b/client/src/js/components/bhInventorySelect.js
@@ -7,34 +7,39 @@ angular.module('bhima.components')
       inventoryUuid    : '<',
       onSelectCallback : '&',
       required         : '<?',
-      validateTrigger  : '<?',      
+      validateTrigger  : '<?',
+      onlyConsumable   : '<?',
     },
   });
 
 InventorySelectController.$inject = [
-  'InventoryService', 'NotifyService'
+  'InventoryService', 'NotifyService',
 ];
 
 /**
  * Inventory selection component
  */
 function InventorySelectController(Inventory, Notify) {
-  var $ctrl = this;
+  const $ctrl = this;
 
-  $ctrl.$onInit = function onInit() {    
+  $ctrl.$onInit = function onInit() {
     // fired when an inventory has been selected
     $ctrl.onSelectCallback = $ctrl.onSelectCallback || angular.noop;
 
+    const promise = $ctrl.onlyConsumable
+      ? Inventory.read(null, { consumable : 1 })
+      : Inventory.read();
+
     // load all inventories
-    Inventory.read()
-      .then(function (inventories) { 
+    promise
+      .then((inventories) => {
         $ctrl.inventories = inventories;
       })
       .catch(Notify.handleError);
   };
 
   // fires the onSelectCallback bound to the component boundary
-  $ctrl.onSelect = function ($item, $model) {
+  $ctrl.onSelect = ($item) => {
     $ctrl.onSelectCallback({ inventory : $item });
   };
 }

--- a/client/src/modules/reports/generate/inventory_file/inventory_file.html
+++ b/client/src/modules/reports/generate/inventory_file/inventory_file.html
@@ -38,7 +38,8 @@
             inventory-uuid="ReportConfigCtrl.inventory.uuid"
             on-select-callback="ReportConfigCtrl.onSelectInventory(inventory)"
             required="true"
-            validate-trigger="ConfigForm.$submitted">
+            validate-trigger="ConfigForm.$submitted"
+            only-consumable="true">
             <bh-clear on-clear="ReportConfigCtrl.clear('inventory')"></bh-clear>
           </bh-inventory-select>
 

--- a/client/src/modules/reports/generate/inventory_report/inventory_report.html
+++ b/client/src/modules/reports/generate/inventory_report/inventory_report.html
@@ -97,7 +97,8 @@
               inventory-uuid="ReportConfigCtrl.inventory.uuid"
               on-select-callback="ReportConfigCtrl.onSelectInventory(inventory)"
               required="true"
-              validate-trigger="ConfigForm.$submitted">
+              validate-trigger="ConfigForm.$submitted"
+              only-consumable="true">
               <bh-clear on-clear="ReportConfigCtrl.clear('inventory')"></bh-clear>
             </bh-inventory-select>
           </div>

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -96,6 +96,7 @@ function getLots(sqlQuery, parameters, finalClauseParameter) {
   filters.equals('document_uuid', 'document_uuid', 'm');
   filters.equals('lot_uuid', 'lot_uuid', 'm');
   filters.equals('inventory_uuid', 'uuid', 'i');
+  filters.equals('consumable', 'consumable', 'i');
   filters.equals('group_uuid', 'uuid', 'ig');
   filters.equals('text', 'text', 'i');
   filters.equals('label', 'label', 'l');

--- a/server/controllers/stock/reports/stock/inventory_report.js
+++ b/server/controllers/stock/reports/stock/inventory_report.js
@@ -36,7 +36,6 @@ function stockInventoryReport(req, res, next) {
     })
     .then((depot) => {
       data.depot = depot;
-
       return Stock.getInventoryMovements(options);
     })
     .then((rows) => {


### PR DESCRIPTION
This PR add the attribute `only-consumable` to the `bh-inventory-select` component so that we can get or not only inventory which are consumable.

Close #3186 