### PR TITLE
Remove custom date filter for 'allTime' period selected

### DIFF
--- a/client/src/js/services/FilterService.js
+++ b/client/src/js/services/FilterService.js
@@ -95,20 +95,20 @@ function FilterService() {
      * In case there are period='allTime' and custom_period_start or custom_period_end
      * just considere period='allTime'
      */
-    alltimeOverCustomFilter(this);
+    alltimeOverCustomFilter.call(this);
   };
 
-  function alltimeOverCustomFilter(context) {
-    const filters = context._filterActiveFilters();
-    const alltime = filters.some(f => f._key === 'period' && f._value === 'allTime');
-    const customPeriodStart = filters.some(f => f._key === 'custom_period_start');
-    const customPeriodEnd = filters.some(f => f._key === 'custom_period_end');
+  function alltimeOverCustomFilter() {
+    const alltime = this._filterIndex.period && this._filterIndex.period._value === 'allTime';
+    const customPeriodStart = this._filterIndex.custom_period_start && this._filterIndex.custom_period_start._value;
+    const customPeriodEnd = this._filterIndex.custom_period_end && this._filterIndex.custom_period_end._value;
+
     if (alltime && customPeriodStart) {
-      context.resetFilterState('custom_period_start');
+      this.resetFilterState('custom_period_start');
     }
 
     if (alltime && customPeriodEnd) {
-      context.resetFilterState('custom_period_end');
+      this.resetFilterState('custom_period_end');
     }
   }
 

--- a/client/src/js/services/FilterService.js
+++ b/client/src/js/services/FilterService.js
@@ -90,7 +90,27 @@ function FilterService() {
     valueList.forEach(valueMap => {
       this.assignFilter(valueMap.key, valueMap.value, valueMap.displayValue, valueMap.comparitor);
     });
+
+    /**
+     * In case there are period='allTime' and custom_period_start or custom_period_end
+     * just considere period='allTime'
+     */
+    alltimeOverCustomFilter(this);
   };
+
+  function alltimeOverCustomFilter(context) {
+    const filters = context._filterActiveFilters();
+    const alltime = filters.some(f => f._key === 'period' && f._value === 'allTime');
+    const customPeriodStart = filters.some(f => f._key === 'custom_period_start');
+    const customPeriodEnd = filters.some(f => f._key === 'custom_period_end');
+    if (alltime && customPeriodStart) {
+      context.resetFilterState('custom_period_start');
+    }
+
+    if (alltime && customPeriodEnd) {
+      context.resetFilterState('custom_period_end');
+    }
+  }
 
   // alias for `assignFilters`, clears the currently active filters before
   // calling the referenced method

--- a/client/src/modules/journal/journal.js
+++ b/client/src/modules/journal/journal.js
@@ -542,6 +542,7 @@ function JournalController(
   // runs on startup
   function startup() {
     const { filters } = $state.params;
+
     if (filters.length > 0) {
       Journal.filters.replaceFiltersFromState(filters);
     } else {
@@ -572,9 +573,9 @@ function JournalController(
     // 4. A dismissable alert will always be shown to the user reminding them their data may be out of date
     Journal.openTransactionEditModal(transactionUuid, false)
       .then((result) => {
-        return result.deleted ?
-          handleDeleteTransactionResult(result) :
-          handleEditTransactionResult(result);
+        return result.deleted
+          ? handleDeleteTransactionResult(result)
+          : handleEditTransactionResult(result);
       });
   }
 


### PR DESCRIPTION
This PR fix the issue #3195 by removing `custom_period_start` and `custom_period_end` filters when the filter period with value `allTime` is selected.

Close #3195 