### PR TITLE
fix(fiscal): fix fiscal year loading error

### DIFF
--- a/client/src/modules/fiscal/fiscal.js
+++ b/client/src/modules/fiscal/fiscal.js
@@ -28,13 +28,13 @@ function FiscalController($state, Fiscal, ModalService, Notify, $window) {
   vm.loadingState = true;
   vm.loadingError = false;
 
-
   // refresh Fiscal Year
-  function refreshFiscalYear() {
-    return Fiscal.read(null, { detailed : 1 })
-      .then((fiscalYears) => {
+  function refreshFiscalYear(option = {}) {
+    option.detailed = 1;
+    return Fiscal.read(null, option)
+      .then(fiscalYears => {
         vm.fiscalYears = fiscalYears;
-      }).catch((err) => {
+      }).catch(err => {
         vm.loadingError = true;
         Notify.handleError(err);
       }).finally(() => {
@@ -100,16 +100,7 @@ function FiscalController($state, Fiscal, ModalService, Notify, $window) {
       vm.nbMonthDesc = 'down';
     }
 
-    Fiscal.read(null, option)
-      .then((fiscalYears) => {
-        vm.fiscalYears = fiscalYears;
-      })
-      .catch((err) => {
-        vm.loadingError = true;
-        Notify.handleError(err);
-      }).finally(() => {
-        vm.loadingState = false;
-      });
+    refreshFiscalYear(option);
   }
 
   refreshFiscalYear();

--- a/client/src/modules/fiscal/fiscal.list.html
+++ b/client/src/modules/fiscal/fiscal.list.html
@@ -56,7 +56,7 @@
           <span class="fa fa-circle-o-notch fa-spin"></span>
           <span translate>TABLE.COLUMNS.LOADING</span>
         </p>
-        <p ng-show="(FiscalCtrl.fiscalYears.length == 0) && !FiscalCtrl.loadingError"
+        <p ng-show="(FiscalCtrl.fiscalYears.length == 0) && !FiscalCtrl.loadingError && !FiscalCtrl.loadingState"
           class="text-center text-danger" translate>
           FORM.LABELS.NO_FISCALYEAR_REGISTERED
         </p>


### PR DESCRIPTION
This commit hides the "no fiscal years found" error case until it is certain that no fiscal years are actually located in the database.

Closes #3207 

![2018-10-01_14-39-42](https://user-images.githubusercontent.com/896472/46292229-4645be00-c588-11e8-923b-157840c0a6a9.gif)
