### PR TITLE
refactor(bhFluxSelect): lint & update code

### DIFF
--- a/client/src/js/components/bhFluxSelect.js
+++ b/client/src/js/components/bhFluxSelect.js
@@ -7,44 +7,40 @@ angular.module('bhima.components')
       fluxIds : '<?',
       label : '@?',
       required : '<?',
-      validationTrigger : '<?',
     },
   });
 
 FluxSelectController.$inject = [
-  'FluxService', 'NotifyService', '$translate',
+  'FluxService', 'NotifyService',
 ];
 
 /**
  * Flux Selection Component
  *
+ * @description
+ * Provides a ui-select of the flux options from the database.
  */
-function FluxSelectController(Flux, Notify, $translate) {
-  var $ctrl = this;
+function FluxSelectController(Flux, Notify) {
+  const $ctrl = this;
 
   $ctrl.$onInit = function onInit() {
     // label to display
     $ctrl.label = $ctrl.label || 'STOCK.FLUX';
-
-    // fired when a Flux has been selected or removed from the list
-    $ctrl.onChange = $ctrl.onChange || angular.noop;
 
     // init the model
     $ctrl.selectedFlux = $ctrl.fluxIds || [];
 
     // load all Flux
     Flux.read()
-      .then(function (flux) {
-        flux.forEach(function (item) {
-          item.plainText = $translate.instant(item.label);
-        });
-        $ctrl.fluxes = flux;
+      .then(flux => {
+        $ctrl.fluxes = Flux.addI18nLabelToItems(flux);
+
+        // sort the array in alphabetical order
+        $ctrl.fluxes.sort((a, b) => a.plainText.localeCompare(b.plainText));
       })
       .catch(Notify.handleError);
   };
 
   // fires the onSelectCallback bound to the component
-  $ctrl.handleChange = function (models) {
-    $ctrl.onChange({ flux : models });
-  };
+  $ctrl.handleChange = flux => $ctrl.onChange({ flux });
 }

--- a/client/src/js/services/FluxService.js
+++ b/client/src/js/services/FluxService.js
@@ -1,12 +1,12 @@
 angular.module('bhima.services')
-.service('FluxService', FluxService);
+  .service('FluxService', FluxService);
 
 // dependencies injection
-FluxService.$inject = ['PrototypeApiService'];
+FluxService.$inject = ['PrototypeApiService', '$translate'];
 
 // service definition
-function FluxService(Api) {
-  var service = new Api('/stock/flux');
+function FluxService(Api, $translate) {
+  const service = new Api('/stock/flux');
 
   service.translate = {
     1  : 'STOCK_FLUX.FROM_PURCHASE',
@@ -24,6 +24,22 @@ function FluxService(Api) {
     13 : 'STOCK_FLUX.FROM_INTEGRATION',
   };
 
+
+  /**
+   * @method addI18nLabelToItems
+   *
+   * @description
+   * Translates the "label" property into a human readable "plainText" label.
+   *
+   * @param {Array} items - an array of fluxes
+   * @returns {Array} - an array of fluxes with translation label
+   */
+  service.addI18nLabelToItems = (items) => {
+    return items.map(item => {
+      item.plainText = $translate.instant(item.label);
+      return item;
+    });
+  };
+
   return service;
 }
-

--- a/client/src/modules/templates/bhFluxSelect.tmpl.html
+++ b/client/src/modules/templates/bhFluxSelect.tmpl.html
@@ -1,7 +1,7 @@
 <div ng-form="FluxForm" bh-flux-select ng-model-options="{ updateOn: 'default' }">
   <div
     class="form-group"
-    ng-class="{ 'has-error' : $ctrl.validationTrigger && FluxForm.flux.$invalid }">
+    ng-class="{ 'has-error' : FluxForm.$submitted && FluxForm.flux.$invalid }">
     <label class="control-label" translate>
       {{ $ctrl.label }}
     </label>
@@ -17,12 +17,12 @@
       <ui-select-match placeholder="{{ 'STOCK.FLUX' | translate }}">
         <span>{{ $item.plainText }}</span>
       </ui-select-match>
-      <ui-select-choices ui-select-focus-patch repeat="flux.id as flux in ($ctrl.fluxes | filter: { plainText : $select.search } | orderBy: 'plainText')">
+      <ui-select-choices ui-select-focus-patch repeat="flux.id as flux in $ctrl.fluxes | filter: { plainText: $select.search }">
         <span ng-bind-html="flux.plainText | highlight:$select.search"></span>
       </ui-select-choices>
     </ui-select>
 
-    <div class="help-block" ng-messages="FluxForm.$error" ng-show="$ctrl.validationTrigger">
+    <div class="help-block" ng-messages="FluxForm.$error" ng-show="FluxForm.$submitted">
       <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
     </div>
   </div>


### PR DESCRIPTION
This commit lints the bhFluxSelect as well as makes several improvements overall to the component such as:
 1. Pre-sorting the values in the array instead of using Angular's
 orderBy filter.
 2. Moving translation into the FluxService.
 3. Using FluxForm.$submitted instead of validationTrigger
 4. Remove the `angular.noop()` default value for the callback.

Partially addresses #3134.