### PR TITLE
test(bhFilterToggle): write client-unit test

### DIFF
--- a/client/src/js/components/bhFilterToggle.js
+++ b/client/src/js/components/bhFilterToggle.js
@@ -1,33 +1,35 @@
 angular.module('bhima.components')
   .component('bhFilterToggle', {
-    templateUrl: '/modules/templates/bhFilterToggle.tmpl.html',
-    controller: ToggleFillterController,
+    templateUrl : 'modules/templates/bhFilterToggle.tmpl.html',
+    controller : ToggleFillterController,
     bindings : {
-      onToggle: '&', // use a callback to handle on click function
+      onToggle : '&', // use a callback to handle on click function
     },
   });
 
 
 /**
- * bhToggleFillter Component
- * @module components/bhToggleFillter
- * 
- * usage :
- * <bh-filter-toggle on-toggle="AccountsCtrl.toggleInlineFilter()"></bh-filter-toggle>
+ * @component bhFilterToggle
+ *
+ * @description
+ * An easy way to add the standard filtering button to the ui-grid.  Note that
+ * this component only contains the view, not the filtering logic.  The parent
+ * controller is responsible for controlling the logic by binding the "onToggle"
+ * callback.
+ *
+ * USAGE:
+ * <bh-filter-toggle on-toggle="SomeController.toggleInlineFilter()">
+ * </bh-filter-toggle>
  */
 function ToggleFillterController() {
-
   const $ctrl = this;
 
   $ctrl.$onInit = function onInit() {
     $ctrl.filterEnabled = false;
-
-    $ctrl.onToggle = $ctrl.onToggle;
-
-    $ctrl.toggle = function () {
-      $ctrl.filterEnabled = !$ctrl.filterEnabled;
-      $ctrl.onToggle();
-    }
   };
 
+  $ctrl.toggle = () => {
+    $ctrl.filterEnabled = !$ctrl.filterEnabled;
+    $ctrl.onToggle();
+  };
 }

--- a/client/src/modules/templates/bhFilterToggle.tmpl.html
+++ b/client/src/modules/templates/bhFilterToggle.tmpl.html
@@ -1,4 +1,3 @@
-
 <div class="toolbar-item">
   <button
     type="button"

--- a/test/client-unit/components/bhFilterToggle.spec.js
+++ b/test/client-unit/components/bhFilterToggle.spec.js
@@ -1,0 +1,32 @@
+/* eslint no-unused-expressions:off */
+/* global inject, expect, chai */
+describe('bhFilterToggle', bhFilterToggleTests);
+
+function bhFilterToggleTests() {
+  let $scope;
+  let element;
+
+  const template = `
+    <bh-filter-toggle on-toggle="callback()">
+    </bh-filter-toggle>
+  `;
+
+  beforeEach(module('templates', 'bhima.components'));
+
+  beforeEach(inject(($rootScope, $compile) => {
+    $scope = $rootScope.$new();
+    element = $compile(angular.element(template))($scope);
+    $scope.callback = chai.spy();
+    $scope.$digest();
+  }));
+
+  const find = (elm, selector) => elm[0].querySelector(selector);
+
+  it('calls the onToggle() callback when clicked', () => {
+    const btn = find(element, '[data-method=filter');
+
+    expect($scope.callback).to.not.have.been.called;
+    angular.element(btn).click();
+    expect($scope.callback).to.have.been.called.once;
+  });
+}


### PR DESCRIPTION
This commit adds a client unit tests for the bhFilterToggle to ensure the onToggle() callback is always fired.  It also tightens up the code slightly by adding doc comments and moving all callbacks to the component border.

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/2652