### PR TITLE
feat: add zUpdatePatientText()

### DIFF
--- a/server/models/admin.sql
+++ b/server/models/admin.sql
@@ -138,4 +138,10 @@ BEGIN
   UPDATE account SET classe = LEFT(number, 1);
 END $$
 
+CREATE PROCEDURE zUpdatePatientText()
+BEGIN
+  UPDATE `debtor` JOIN `patient` ON debtor.uuid = patient.debtor_uuid
+    SET debtor.text = CONCAT('Patient/', patient.display_name);
+END $$
+
 DELIMITER ;


### PR DESCRIPTION
This commit adds an admin SP `zUpdatePatientText()` to recompute the debtor text for each patient.  Super user solution to #3213.