### PR TITLE
fix(bhPeriodSelection): timezone insensitivity

### DIFF
--- a/client/src/js/components/bhPeriodSelection.js
+++ b/client/src/js/components/bhPeriodSelection.js
@@ -48,7 +48,8 @@ function PeriodSelectionController(Fiscal, moment) {
     Fiscal.getPeriods(fiscalYearId)
       .then(periods => {
         periods.forEach(period => {
-          period.hrLabel = moment(period.start_date).format('MMMM YYYY');
+          // add 2 days to make sure timezone is accounted for
+          period.hrLabel = moment(period.start_date).add(2, 'days').format('MMMM YYYY');
         });
 
         $ctrl.periods = periods.filter(p => p.number !== 0);


### PR DESCRIPTION
This commit adds two days to the bhPeriodSelection to make the month display timezone insensitive.