### PR TITLE
refactor(general-ledger): better hide title accounts

### DIFF
--- a/client/src/modules/general-ledger/general-ledger.html
+++ b/client/src/modules/general-ledger/general-ledger.html
@@ -71,10 +71,8 @@
           data-method="hide_titles"
           class="btn btn-default"
           ng-class="{ 'btn-info' : GeneralLedgerCtrl.hideTitleAccount }">
-          <i 
-            ng-class=" { 'fa-eye-slash': !GeneralLedgerCtrl.hideTitleAccount,
-             'fa-eye': GeneralLedgerCtrl.hideTitleAccount }"
-            class="fa"></i>
+          <i class="fa" ng-class="{ 'fa-eye-slash': !GeneralLedgerCtrl.hideTitleAccount, 'fa-eye': GeneralLedgerCtrl.hideTitleAccount }"></i>
+          <span class="hidden-xs text-capitalize" translate>REPORT.OPTIONS.HIDE_TITLE_ACCOUNT</span>
         </button>
       </div>
     </div>

--- a/client/src/modules/templates/modals/export.modal.js
+++ b/client/src/modules/templates/modals/export.modal.js
@@ -33,8 +33,6 @@ function ExportGridModalController(Instance, uiGridConstants, $filter,
     gridOptions.exporterCsvFilename = filename.concat('.csv');
     gridOptions.exporterHeaderFilter = exporterHeaderFilter;
     gridOptions.exporterOlderExcelCompatibility = true;
-
-    window.gridApi = gridApi;
     gridApi.exporter.csvExport(vm.exportRowType, vm.exportColType, myElement);
     Instance.close(true);
   }


### PR DESCRIPTION
This commit improves the hide title account feature on the general ledger by completely removing the tree view when the title accounts are toggled.  It also adds text to the button on larger screens.

![2018-10-22_11-20-38](https://user-images.githubusercontent.com/896472/47288152-c04bee80-d5ec-11e8-9cc0-aecdae131e8b.gif)
_GIF 1: Usage of Hide Title Accounts_