### PR TITLE
feat(fiscal): correctly calculate closing balance

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -196,7 +196,9 @@
       "SEPARATE_DEBITS_AND_CREDITS" : "Separate Debits and Credits?",
       "SEPARATE_DEBITS_AND_CREDITS_HELP" : "This option breaks out columns from a single positive or negative balance into two columns representing debits and credits.",
       "REMOVE_ZERO_ROWS" : "Hide zero rows?",
-      "REMOVE_ZERO_ROWS_HELP" : "This option will remove rows that do not have any data in them.  Produces a more compact output."
+      "REMOVE_ZERO_ROWS_HELP" : "This option will remove rows that do not have any data in them.  Produces a more compact output.",
+      "INCLUDE_CLOSING_BALANCES" : "Include Closing Balances",
+      "INCLUDE_CLOSING_BALANCES_HELP" : "This option will force the balance sheet to show the entire year's balances, including the closing balances.  Any operations made to close income and expense accounts will be reflected in the balance sheet."
     },
     "OHADA": {
       "BALANCE_SHEET" : "Balance Sheet",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -197,7 +197,9 @@
       "SEPARATE_DEBITS_AND_CREDITS" : "Séparer les débits et les crédits?",
       "SEPARATE_DEBITS_AND_CREDITS_HELP" : "Cette option répartit les colonnes d'un seul solde positif ou négatif en deux colonnes représentant les débits et les crédits.",
       "REMOVE_ZERO_ROWS" : "Cacher les colonnes vide?",
-      "REMOVE_ZERO_ROWS_HELP" : "Cette option supprime les lignes qui ne contiennent aucune donnée. Produit un rapport plus compacte."
+      "REMOVE_ZERO_ROWS_HELP" : "Cette option supprime les lignes qui ne contiennent aucune donnée. Produit un rapport plus compacte.",
+      "INCLUDE_CLOSING_BALANCES" : "Inclure les soldes de clôture",
+      "INCLUDE_CLOSING_BALANCES_HELP" : "Cette option force la balance à afficher les soldes de l’année entière, y compris les soldes de clôture. Toute opération effectuée pour clôturer les comptes de produits et de charges sera reflétée dans la balance."
     },
     "OHADA": {
       "BALANCE_SHEET" : "Bilan",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -196,7 +196,7 @@
       "TOTALS_CURRENCY_HELP" : "Cette option vous permet d'afficher les totaux dans la devise sélectionnée en échangeant les totaux dans la devise sélectionnée en utilisant le taux de change du jour.",
       "SEPARATE_DEBITS_AND_CREDITS" : "Séparer les débits et les crédits?",
       "SEPARATE_DEBITS_AND_CREDITS_HELP" : "Cette option répartit les colonnes d'un seul solde positif ou négatif en deux colonnes représentant les débits et les crédits.",
-      "REMOVE_ZERO_ROWS" : "Cacher les colonnes vide?",
+      "REMOVE_ZERO_ROWS" : "Cacher les lignes vide?",
       "REMOVE_ZERO_ROWS_HELP" : "Cette option supprime les lignes qui ne contiennent aucune donnée. Produit un rapport plus compacte.",
       "INCLUDE_CLOSING_BALANCES" : "Inclure les soldes de clôture",
       "INCLUDE_CLOSING_BALANCES_HELP" : "Cette option force la balance à afficher les soldes de l’année entière, y compris les soldes de clôture. Toute opération effectuée pour clôturer les comptes de produits et de charges sera reflétée dans la balance."

--- a/client/src/js/components/bhPeriodSelection.js
+++ b/client/src/js/components/bhPeriodSelection.js
@@ -6,6 +6,7 @@ angular.module('bhima.components')
       fiscalYearId : '<',
       onSelectCallback : '&',
       periodId : '<?',
+      disable : '<?',
       label  : '@?',
     },
   });

--- a/client/src/modules/fiscal/fiscal.closingBalance.html
+++ b/client/src/modules/fiscal/fiscal.closingBalance.html
@@ -1,18 +1,19 @@
 <div class="row">
+  <div class="col-md-12 text-right" style="margin-bottom: 0.5em;">
+    <bh-filter-toggle on-toggle="FiscalCBCtrl.toggleAccountFilter()">
+    </bh-filter-toggle>
+  </div>
+</div>
+
+<div class="row">
   <div class="col-md-12">
-
     <form name="ClosingAccountForm" ng-submit="FiscalCBCtrl.submit(ClosingAccountForm)" novalidate>
-
       <div class="panel panel-primary">
-
         <!-- heading  -->
-        <div class="panel-heading" style="display: flex; justify-content: space-between;">
+        <div class="panel-heading">
           <span>
-            <span translate>FISCAL.CLOSING_BALANCE</span> <strong>{{ FiscalCBCtrl.fiscal.label }}</strong>
-          </span>
-
-          <span class="text-action" ng-click="FiscalCBCtrl.toggleAccountFilter()">
-             <i class="fa fa-filter"></i> <span translate>FORM.BUTTONS.SEARCH</span>
+            <span translate>FISCAL.CLOSING_BALANCE</span>
+            <strong>{{ FiscalCBCtrl.fiscal.label }}</strong>
           </span>
         </div>
 
@@ -20,7 +21,7 @@
         <section>
           <div
             id="account-balance-grid"
-            style="height : 600px;"
+            style="height : 800px;"
             ui-grid="FiscalCBCtrl.gridOptions">
           </div>
         </section>

--- a/client/src/modules/fiscal/fiscal.closingBalance.js
+++ b/client/src/modules/fiscal/fiscal.closingBalance.js
@@ -13,8 +13,8 @@ FiscalClosingBalanceController.$inject = [
  * This controller is responsible for handling the closing balance of a fiscal year.
  */
 function FiscalClosingBalanceController(
-  $state, Accounts, Fiscal, Notify, Session, uiGridConstants
-  , bhConstants, Tree
+  $state, Accounts, Fiscal, Notify, Session, uiGridConstants, bhConstants,
+  Tree
 ) {
 
   const vm = this;
@@ -155,14 +155,13 @@ function FiscalClosingBalanceController(
   }
 
   /**
-   * loadFinalBalance
-   * load the balance until a given period
+   * @method loadFinalBalance
+   *
+   * @description
+   * Load the balance until a given period.
    */
   function loadFinalBalance(showHiddenAccounts) {
-    Fiscal.getBalance(fiscalYearId, {
-      id : fiscalYearId,
-      period_number : vm.fiscal.number_of_months,
-    })
+    Fiscal.getClosingBalance(fiscalYearId)
       .then(data => {
         let accounts = data;
 

--- a/client/src/modules/fiscal/fiscal.html
+++ b/client/src/modules/fiscal/fiscal.html
@@ -3,9 +3,9 @@
 
     <ol class="headercrumb">
       <li class="static" translate>TREE.FINANCE </li>
-      <li 
-        class="title" 
-        ng-if="FiscalCtrl.state.current.name === 'fiscal.list'" 
+      <li
+        class="title"
+        ng-if="FiscalCtrl.state.current.name === 'fiscal.list'"
         translate>TREE.FISCAL_YEAR
       </li>
 
@@ -16,7 +16,7 @@
 
       <!-- edit fiscal year -->
       <li ng-if="FiscalCtrl.state.current.name === 'fiscal.update'" class="title">
-        {{ FiscalCtrl.state.params.label }} 
+        {{ FiscalCtrl.state.params.label }}
         <span class="label label-info" translate>FORM.LABELS.EDIT</span>
       </li>
 
@@ -59,8 +59,6 @@
 
 <div class="flex-content">
   <div class="container">
-
     <ui-view></ui-view>
-
   </div>
 </div>

--- a/client/src/modules/fiscal/fiscal.js
+++ b/client/src/modules/fiscal/fiscal.js
@@ -43,7 +43,7 @@ function FiscalController($state, Fiscal, ModalService, Notify, $window) {
   }
 
   // Get the fiscal Year By Date
-  Fiscal.fiscalYearDate({ date : today })
+  Fiscal.getFiscalYearByDate({ date : today })
     .then((current) => {
       vm.current = current;
       vm.currentFiscalYearId = vm.current[0].fiscal_year_id;

--- a/client/src/modules/fiscal/fiscal.service.js
+++ b/client/src/modules/fiscal/fiscal.service.js
@@ -15,23 +15,23 @@ FiscalService.$inject = ['PrototypeApiService'];
 function FiscalService(Api) {
   const service = new Api('/fiscal/');
 
-  // TODO - rename this something like 'byDate()'
   service.closeFiscalYear = closeFiscalYear;
-  service.fiscalYearDate = fiscalYearDate;
+  service.getFiscalYearByDate = getFiscalYearByDate;
   service.setOpeningBalance = setOpeningBalance;
   service.getOpeningBalance = getOpeningBalance;
+  service.getClosingBalance = getClosingBalance;
   service.getPeriods = getPeriods;
   service.getEnterpriseFiscalStartDate = getEnterpriseFiscalStartDate;
 
   service.getBalance = getBalance;
 
   /**
-   * @method fiscalYearDate
+   * @method getFiscalYearByDate
    *
    * @description
    * Find the fiscal year for a given date.
    */
-  function fiscalYearDate(params) {
+  function getFiscalYearByDate(params) {
     const url = service.url.concat('date');
     return service.$http.get(url, { params })
       .then(service.util.unwrapHttpResponse);
@@ -49,6 +49,7 @@ function FiscalService(Api) {
     return service.$http.get(url, { params })
       .then(service.util.unwrapHttpResponse);
   }
+
 
   /**
    * @function getOpeningBalance
@@ -70,6 +71,20 @@ function FiscalService(Api) {
   function setOpeningBalance(params) {
     const url = service.url.concat(params.id, '/opening_balance/');
     return service.$http.post(url, { params })
+      .then(service.util.unwrapHttpResponse);
+  }
+
+  /**
+   * @method getClosingBalance
+   *
+   * @description
+   * Finds the closing balance for a fiscal year.  Importantly - this method
+   * looks in the period 0 value of the subsequent year, not as a sum of all
+   * periods to date.
+   */
+  function getClosingBalance(fiscalYearId) {
+    const url = service.url.concat(fiscalYearId, '/closing_balance/');
+    return service.$http.get(url)
       .then(service.util.unwrapHttpResponse);
   }
 

--- a/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.html
+++ b/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.html
@@ -7,9 +7,9 @@
   </div>
 
   <div class="modal-body">
-    <div ng-show="!$ctrl.fiscal.locked">
+    <div ng-if="!$ctrl.fiscal.locked">
 
-      <h2 class="text-center">
+      <h2 class="text-center" style="margin-top:0">
         <span translate>FORM.INFO.CLOSE_FISCAL_YEAR</span>
         <br>
         <strong>{{ $ctrl.fiscal.label }}</strong>
@@ -19,7 +19,11 @@
         <div ng-switch-default>
 
           <!--exploitation grid-->
-          <div id="exploitation-grid" style="max-height: 250px;" ui-grid="$ctrl.gridOptions" ui-grid-resize-columns>
+          <div id="exploitation-grid"
+            style="max-height: 450px;"
+            ui-grid="$ctrl.gridOptions"
+            ui-grid-auto-resize
+            ui-grid-resize-columns>
             <bh-grid-loading-indicator
               loading-state="$ctrl.loading"
               empty-state="$ctrl.gridOptions.data.length === 0">
@@ -29,17 +33,17 @@
           <!-- first step  -->
           <dl class="well well-sm dl-horizontal">
             <!-- incomes  -->
-            <h4 class="text-success">
+            <h4>
               <dt translate>FORM.LABELS.PROFIT</dt>
-              <dd class="text-right">
+              <dd class="text-right text-success">
                 {{ $ctrl.totals.income | currency: $ctrl.currency_id }}
               </dd>
             </h4>
 
-            <!-- expenses  -->
-            <h4 style="margin: 10px 0px;" class="text-danger">
+            <!-- expenses -->
+            <h4 style="margin: 10px 0px;">
               <dt translate>FORM.LABELS.CHARGE</dt>
-              <dd class="text-right">
+              <dd class="text-right text-danger">
                 {{ $ctrl.totals.expense | currency: $ctrl.currency_id }}
               </dd>
             </h4>
@@ -55,8 +59,12 @@
             </h4>
           </dl>
 
-          <bh-account-select account-id="$ctrl.resultAccount.id" account-type-id="'1,2,3,6'" on-select-callback="$ctrl.onSelectAccount(account)"
-            label="FORM.SELECT.RESULT_ACCOUNT_SCT" exclude-title-accounts="true">
+          <bh-account-select
+            account-id="$ctrl.resultAccount.id"
+            account-type-id="'1,2,3,6'"
+            on-select-callback="$ctrl.onSelectAccount(account)"
+            label="FORM.SELECT.RESULT_ACCOUNT_SCT"
+            exclude-title-accounts="true">
           </bh-account-select>
         </div>
 
@@ -73,7 +81,7 @@
       </div>
     </div>
 
-    <div ng-show="$ctrl.fiscal.locked">
+    <div ng-if="$ctrl.fiscal.locked">
       <h1 class="text-center">
         <strong>{{ $ctrl.fiscal.label }}</strong>
         <br>

--- a/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.js
+++ b/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.js
@@ -4,8 +4,7 @@ angular.module('bhima.controllers')
 // dependencies injection
 ClosingFYModalCtrl.$inject = [
   'NotifyService', 'FiscalService', 'ModalService', 'SessionService',
-  '$uibModalInstance', 'data', 'uiGridConstants',
-  'bhConstants', 'TreeService',
+  '$uibModalInstance', 'data', 'uiGridConstants', 'bhConstants', 'TreeService',
 ];
 
 // The closing fiscal year controller
@@ -26,7 +25,6 @@ function ClosingFYModalCtrl(Notify, Fiscal, Modal, Session, Instance, Data, uiGr
     bhConstants.accounts.EXPENSE,
     bhConstants.accounts.TITLE,
   ];
-
 
   function customAggregationFn(columnDefs, column) {
     if (vm.AccountTree) {
@@ -245,9 +243,7 @@ function ClosingFYModalCtrl(Notify, Fiscal, Modal, Session, Instance, Data, uiGr
     const accountTypeFilter = node => !acceptedAccountTypes.includes(node.type_id);
     const emptyTitleAccountFilter = node => (node.isTitleAccount && node.children.length === 0);
 
-    const pruneFn = node =>
-      emptyTitleAccountFilter(node) ||
-      accountTypeFilter(node);
+    const pruneFn = node => emptyTitleAccountFilter(node) || accountTypeFilter(node);
 
     let settled = tree.prune(pruneFn);
     while (settled > 0) {

--- a/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.js
+++ b/client/src/modules/fiscal/templates/modals/fiscal.closing.modal.js
@@ -143,6 +143,8 @@ function ClosingFYModalCtrl(Notify, Fiscal, Modal, Session, Instance, Data, uiGr
 
 
   function startup() {
+    vm.loading = true;
+
     Fiscal.read(fiscalYearId)
       .then(fiscal => {
         vm.fiscal = fiscal;
@@ -179,7 +181,10 @@ function ClosingFYModalCtrl(Notify, Fiscal, Modal, Session, Instance, Data, uiGr
         // compute the totals
         computeGridTotals();
       })
-      .catch(Notify.handleError);
+      .catch(Notify.handleError)
+      .finally(() => {
+        vm.loading = false;
+      });
   }
 
   function stepForward(form) {

--- a/client/src/modules/home/home.ctrl.js
+++ b/client/src/modules/home/home.ctrl.js
@@ -1,5 +1,5 @@
 angular.module('bhima.controllers')
-.controller('HomeController', HomeController);
+  .controller('HomeController', HomeController);
 
 HomeController.$inject = [
   'CurrencyService', 'ExchangeRateService', 'SessionService',
@@ -18,7 +18,7 @@ HomeController.$inject = [
  * services and information.
  */
 function HomeController(Currencies, Rates, Session, Notify, Fiscal, DashboardService, Moment) {
-  var vm = this;
+  const vm = this;
 
   vm.today = new Date();
 
@@ -69,14 +69,14 @@ function HomeController(Currencies, Rates, Session, Notify, Fiscal, DashboardSer
       });
 
       // @TODO Method for selecting primary exchange
-      vm.primaryExchange = vm.currencies[0];
+      [vm.primaryExchange] = vm.currencies;
 
     })
     .catch(Notify.handleError);
 
-  Fiscal.fiscalYearDate({ date : vm.today })
-    .then(function (year) {
-      vm.year = year[0];
+  Fiscal.getFiscalYearByDate({ date : vm.today })
+    .then(([year]) => {
+      vm.year = year;
       vm.year.percentage *= 100;
     })
     .catch(Notify.handleError);

--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -37,6 +37,13 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
     vm.reportDetails.shouldHideTitleAccounts = bool;
   };
 
+  vm.onChangeClosingBalances = bool => {
+    vm.reportDetails.includeClosingBalances = bool;
+    if (bool) {
+      delete vm.reportDetails.period_id;
+    }
+  };
+
   vm.preview = function preview(form) {
     if (form.$invalid) {
       Notify.danger('FORM.ERRORS.RECORD_ERROR');

--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -39,9 +39,6 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
 
   vm.onChangeClosingBalances = bool => {
     vm.reportDetails.includeClosingBalances = bool;
-    if (bool) {
-      delete vm.reportDetails.period_id;
-    }
   };
 
   vm.preview = function preview(form) {

--- a/client/src/modules/reports/generate/balance_report/balance_report.html
+++ b/client/src/modules/reports/generate/balance_report/balance_report.html
@@ -27,10 +27,20 @@
               on-select-fiscal-callback="ReportConfigCtrl.onSelectFiscalYear(fiscalYear)">
             </bh-fiscal-year-select>
 
+            <bh-yes-no-radios
+              label="REPORT.OPTIONS.INCLUDE_CLOSING_BALANCES"
+              id="includeClosingBalances"
+              help-text="REPORT.OPTIONS.INCLUDE_CLOSING_BALANCES_HELP"
+              name="includeClosingBalances"
+              value="ReportConfigCtrl.reportDetails.includeClosingBalances"
+              on-change-callback="ReportConfigCtrl.onChangeClosingBalances(value)">
+            </bh-yes-no-radios>
+
             <bh-period-selection
               fiscal-year-id="ReportConfigCtrl.reportDetails.fiscal_id"
               period-id="ReportConfigCtrl.reportDetails.period_id"
-              on-select-callback="ReportConfigCtrl.onSelectPeriod(period)">
+              on-select-callback="ReportConfigCtrl.onSelectPeriod(period)"
+              disable="ReportConfigCtrl.reportDetails.includeClosingBalances">
             </bh-period-selection>
 
             <bh-yes-no-radios

--- a/client/src/modules/templates/bhPeriodSelection.html
+++ b/client/src/modules/templates/bhPeriodSelection.html
@@ -14,7 +14,8 @@
       name="period"
       ng-options="period as period.hrLabel for period in $ctrl.periods"
       ng-change="$ctrl.onChange($ctrl.selectedPeriod)"
-      required>
+      ng-disabled="$ctrl.disable"
+      ng-required="!$ctrl.disable">
       <option value="" disabled translate>FORM.SELECT.PERIOD</option>
     </select>
     <div class="help-block" ng-messages="PeriodForm.$error" ng-show="PeriodForm.$submitted">

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -230,10 +230,10 @@ exports.configure = function configure(app) {
   app.delete('/fiscal/:id', fiscal.remove);
 
   app.get('/fiscal/:id/balance/:period_number?', fiscal.getBalance);
-  app.get('/fiscal/:id/opening_balance', fiscal.getOpeningBalance);
+  app.get('/fiscal/:id/opening_balance', fiscal.getOpeningBalanceRoute);
   app.post('/fiscal/:id/opening_balance', fiscal.setOpeningBalance);
   app.put('/fiscal/:id/closing', fiscal.closing);
-  app.get('/fiscal/:id/closing_balance', fiscal.getClosingBalance);
+  app.get('/fiscal/:id/closing_balance', fiscal.getClosingBalanceRoute);
 
   app.get('/fiscal/:id/periods', fiscal.getPeriods);
 

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -233,6 +233,7 @@ exports.configure = function configure(app) {
   app.get('/fiscal/:id/opening_balance', fiscal.getOpeningBalance);
   app.post('/fiscal/:id/opening_balance', fiscal.setOpeningBalance);
   app.put('/fiscal/:id/closing', fiscal.closing);
+  app.get('/fiscal/:id/closing_balance', fiscal.getClosingBalance);
 
   app.get('/fiscal/:id/periods', fiscal.getPeriods);
 

--- a/server/controllers/finance/fiscal.js
+++ b/server/controllers/finance/fiscal.js
@@ -13,6 +13,7 @@
 
 const q = require('q');
 const _ = require('lodash');
+const debug = require('debug')('FiscalYear');
 const db = require('../../lib/db');
 const Transaction = require('../../lib/db/transaction');
 const NotFound = require('../../lib/errors/NotFound');
@@ -20,7 +21,6 @@ const BadRequest = require('../../lib/errors/BadRequest');
 const FilterParser = require('../../lib/filter');
 
 const Tree = require('../../lib/Tree');
-const debug = require('debug')('FiscalYear');
 
 // Account Service
 const AccountService = require('./accounts');
@@ -46,6 +46,7 @@ exports.getDateRangeFromPeriods = getDateRangeFromPeriods;
 exports.getPeriodsFromDateRange = getPeriodsFromDateRange;
 exports.getAccountBalancesByTypeId = getAccountBalancesByTypeId;
 exports.getOpeningBalance = getOpeningBalance;
+exports.getClosingBalance = getClosingBalance;
 exports.getFiscalYearByPeriodId = getFiscalYearByPeriodId;
 exports.getEnterpriseFiscalStart = getEnterpriseFiscalStart;
 
@@ -138,16 +139,16 @@ function list(req, res, next) {
         return null;
       }
 
-      return q.all(fiscals.map(fiscal => {
-        return db.exec(periodsSql, fiscal.id);
-      }));
-    }).then(periods => {
+      return q.all(fiscals.map(fiscal => db.exec(periodsSql, fiscal.id)));
+    })
+    .then(periods => {
 
       if (includePeriods) {
         fiscals.forEach((fiscal, index) => {
           fiscal.periods = periods[index];
         });
       }
+
       res.status(200).json(fiscals);
     })
     .catch(next)
@@ -438,6 +439,13 @@ function hasPreviousFiscalYear(id) {
     });
 }
 
+/**
+ * @function loadBalanceByPeriodNumber
+ *
+ * @description
+ * This function fetchs the balance for a given fiscal year and periodNumber.
+ * Note that hidden accounts are hidden by default.
+ */
 function loadBalanceByPeriodNumber(fiscalYearId, periodNumber) {
   const sql = `
     SELECT a.id, a.number, a.label, a.type_id, a.label, a.parent, a.locked, a.hidden,
@@ -450,6 +458,7 @@ function loadBalanceByPeriodNumber(fiscalYearId, periodNumber) {
         AND p.number = ${periodNumber}
       GROUP BY pt.account_id
     )s ON a.id = s.account_id
+    WHERE a.hidden = 0
     ORDER BY CONVERT(a.number, CHAR(8)) ASC;
   `;
 
@@ -508,11 +517,12 @@ function insertOpeningBalance(fiscalYear, accounts) {
         (?, ?, ?, ?, ?, ?)
         ON DUPLICATE KEY UPDATE credit = VALUES(credit), debit = VALUES(debit);
       `;
-      const dbPromise = periodTotalData.map(item =>
-        db.exec(sql, [
-          item.enterprise_id, item.fiscal_year_id, item.period_id,
-          item.account_id, item.credit, item.debit,
-        ]));
+
+      const dbPromise = periodTotalData.map(item => db.exec(sql, [
+        item.enterprise_id, item.fiscal_year_id, item.period_id,
+        item.account_id, item.credit, item.debit,
+      ]));
+
       return q.all(dbPromise);
     });
 }
@@ -547,6 +557,27 @@ function formatPeriodTotal(account, fiscalYear, periodId) {
  */
 function notNullBalance(array, exception) {
   return exception ? array : array.filter(item => (item.debit !== 0 || item.credit !== 0));
+}
+
+/**
+ * @method getClosingBalance
+ *
+ * @description
+ * Returns the closing balance for a fiscal year.
+ */
+function getClosingBalance(req, res, next) {
+  const { id } = req.params;
+
+  const sql = `
+    SELECT id FROM fiscal_year WHERE previous_fiscal_year_id = ?;
+  `;
+
+  db.exec(sql, id)
+    .then(([year]) => loadBalanceByPeriodNumber(year.id, 0))
+    .then(accounts => {
+      res.status(200).json(accounts);
+    })
+    .catch(next);
 }
 
 /**
@@ -693,7 +724,6 @@ function getPeriods(req, res, next) {
 function getAccountBalancesByTypeId() {
   return `
     SELECT ac.id, ac.number, ac.label, ac.parent, IFNULL(s.amount, 0) AS amount, s.type_id
-
     FROM account as ac LEFT JOIN (
     SELECT SUM(pt.credit - pt.debit) as amount, pt.account_id, act.id as type_id
     FROM period_total as pt
@@ -712,4 +742,3 @@ function getAccountBalancesByTypeId() {
     ORDER BY ac.number
   `;
 }
-

--- a/server/controllers/finance/fiscal.js
+++ b/server/controllers/finance/fiscal.js
@@ -637,7 +637,7 @@ function getPeriodByFiscal(fiscalYearId) {
     SELECT period.number, period.id, period.start_date, period.end_date, period.locked
     FROM period
     WHERE period.fiscal_year_id = ?
-      AND period.number <> 0
+      AND period.number <> 0 AND period.number <> 13
     ORDER BY period.start_date;
   `;
 

--- a/server/controllers/finance/fiscal.js
+++ b/server/controllers/finance/fiscal.js
@@ -637,7 +637,7 @@ function getPeriodByFiscal(fiscalYearId) {
     SELECT period.number, period.id, period.start_date, period.end_date, period.locked
     FROM period
     WHERE period.fiscal_year_id = ?
-      AND period.number <> 0 AND period.number <> 13
+      AND period.start_date IS NOT NULL
     ORDER BY period.start_date;
   `;
 

--- a/server/controllers/finance/fiscalPeriod.js
+++ b/server/controllers/finance/fiscalPeriod.js
@@ -48,8 +48,7 @@ function list(req, res, next) {
  * @returns {Promise} - the result of the promise query on the database.
  */
 function find(options) {
-  const sql =
-    `
+  const sql = `
     SELECT
       p.id, p.fiscal_year_id, p.number, p.start_date, p.end_date,
       CONCAT(IFNULL(p.start_date, p.number), '/',  IFNULL(p.end_date, p.number)) AS label,

--- a/server/controllers/finance/reports/balance/index.js
+++ b/server/controllers/finance/reports/balance/index.js
@@ -15,6 +15,7 @@ const _ = require('lodash');
 const db = require('../../../../lib/db');
 const Tree = require('../../../../lib/Tree');
 const ReportManager = require('../../../../lib/ReportManager');
+const Fiscal = require('../../../finance/fiscal');
 
 // report template
 const TEMPLATE = './server/controllers/finance/reports/balance/report.handlebars';
@@ -39,6 +40,8 @@ const TITLE_ID = 6;
  * This function renders the Balance report.  The balance report provides a view
  * of the balances of any account used during the period.
  *
+ * TODO(@jniles): Finish the currency conversion part of this report.
+ *
  * NOTE(@jniles): This file corresponds to the "Balance Report" on the client.
  */
 function document(req, res, next) {
@@ -51,6 +54,7 @@ function document(req, res, next) {
   context.useSeparateDebitsAndCredits = Number.parseInt(params.useSeparateDebitsAndCredits, 10);
   context.shouldPruneEmptyRows = Number.parseInt(params.shouldPruneEmptyRows, 10);
   context.shouldHideTitleAccounts = Number.parseInt(params.shouldHideTitleAccounts, 10);
+  context.includeClosingBalances = Number.parseInt(params.includeClosingBalances, 10);
 
   try {
     report = new ReportManager(TEMPLATE, req.session, params);
@@ -59,43 +63,53 @@ function document(req, res, next) {
     return;
   }
 
-  getBalanceSummary(params.period_id, req.session.enterprise.currency_id, context.shouldPruneEmptyRows)
-    .then(data => {
+  const currencyId = req.session.enterprise.currency_id;
+
+  // either get full year or partial year.
+  const promise = context.includeClosingBalances
+    ? getBalanceForWholeYear(params.fiscal_id, currencyId)
+    : getBalanceForPartialYear(params.period_id, currencyId);
+
+  promise
+    .then(({ period, accounts, totals }) => {
+      _.merge(context, { period, totals });
+      return computeBalanceTree(accounts, totals, context, context.shouldPruneEmptyRows);
+    })
+    .then(({ accounts, totals }) => {
+      _.merge(context, { accounts, totals });
+
       if (context.shouldHideTitleAccounts) {
-        data.accounts = data.accounts.filter(account => account.isTitleAccount === 0);
+        context.accounts = accounts.filter(account => account.isTitleAccount === 0);
       }
-      _.merge(context, data);
+
       return report.render(context);
     })
     .then(result => {
       res.set(result.headers).send(result.report);
     })
-    .catch(next)
-    .done();
+    .catch(next);
 }
 
 /**
- * @function getBalanceSummary(periodId, currencyId)
+ * @function getBalanceForPartialYear
  *
  * @description
- * Returns the balance of the accounts for a given period.
+ * This function constructs the period totals for part of a fiscal year.  It
+ * only tracks the progress up to a period, and does not consider the close of
+ * the fiscal year.
  *
- * The idea is this:
- *  First column set must contain the opening balance of the fiscal year, no
- *  matter what.
- *  Second column set must contain the movements up to and including the
- *  selected month.
- *  Third contains the sum of all up to that month.
- *
- * TODO(@jniles) - use the currencyId to get an exchange rate.
+ * @param {Number} periodId - the period id of the period to stop at
+ * @param {Number} currencyId - the currencyId to render
  */
-function getBalanceSummary(periodId, currencyId, shouldPrune) {
-  const getFiscalYearSQL = `
+async function getBalanceForPartialYear(periodId, currencyId) {
+  const getFiscalSQL = `
     SELECT p.id, p.start_date, p.end_date, p.fiscal_year_id, p.number,
       fy.start_date AS fiscalYearStart, fy.end_date AS fiscalYearEnd
     FROM period p JOIN fiscal_year fy ON p.fiscal_year_id = fy.id
     WHERE p.id = ?;
   `;
+
+  const period = await db.one(getFiscalSQL, [periodId]);
 
   const sql = `
     SELECT a.id, a.number, a.label, a.type_id, a.label, a.parent,
@@ -144,13 +158,120 @@ function getBalanceSummary(periodId, currencyId, shouldPrune) {
       FROM period_total AS pt
         JOIN period p ON pt.period_id = p.id
         JOIN account ac ON pt.account_id = ac.id
-      WHERE pt.fiscal_year_id = ? 
+      WHERE pt.fiscal_year_id = ?
       GROUP BY pt.account_id
     )s;
   `;
 
-  const context = {};
+  const params = _.fill(Array(4), period.number);
 
+  const [accounts, totals] = await Promise.all([
+    db.exec(sql, [currencyId, ...params, period.fiscal_year_id]),
+    db.one(aggregateSQL, [...params, period.fiscal_year_id]),
+  ]);
+
+  _.merge(totals, { currencyId });
+
+  return { period, accounts, totals };
+}
+
+/**
+ * @function getBalanceForWholeYear
+ *
+ * @description
+ * This function constructs the period totals for the entire fiscal
+ * year, including the closing balances.
+ *
+ * @param {Number} fiscalYearId - the fiscal year id of the year
+ * @param {Number} currencyId - the currencyId to render
+ */
+async function getBalanceForWholeYear(fiscalYearId, currencyId) {
+  const [opening, closing, [period]] = await Promise.all([
+    Fiscal.getOpeningBalance(fiscalYearId),
+    Fiscal.getClosingBalance(fiscalYearId),
+    Fiscal.getPeriodByFiscal(fiscalYearId),
+  ]);
+
+  // combine datasets into a single line of accounts
+  let accounts = {};
+
+  const keys = ['id', 'number', 'label', 'type_id', 'label', 'locked', 'hidden', 'parent'];
+  opening.forEach(account => {
+    accounts[account.id] = _.pick(account, keys);
+
+    // add the opening balance values
+    accounts[account.id].before = account.balance;
+    accounts[account.id].before_debit = account.debit;
+    accounts[account.id].before_credit = account.credit;
+  });
+
+  closing.forEach(account => {
+    const isAccountMissing = _.isUndefined(accounts[account.id]);
+
+    if (isAccountMissing) {
+      accounts[account.id] = _.pick(account, keys);
+    }
+
+    // add the closing balance values
+    accounts[account.id].after = account.balance;
+    accounts[account.id].after_debit = account.debit;
+    accounts[account.id].after_credit = account.credit;
+  });
+
+  // short hand to default to 0 if values are undefined;
+  const minus = (a = 0, b = 0) => a - b;
+
+  // compute the movements and convert accounts into an array
+  _.forEach(accounts, (account) => {
+    account.during = minus(account.after, account.before);
+    account.during_credit = minus(account.after_credit, account.before_credit);
+    account.during_debit = minus(account.after_debit, account.before_debit);
+    account.isTitleAccount = account.type_id === TITLE_ID ? 1 : 0;
+  });
+
+  accounts = _.values(accounts);
+
+  // set up the totals
+  let totals = {
+    before : 0,
+    before_debit : 0,
+    before_credit : 0,
+    during : 0,
+    during_debit : 0,
+    during_credit : 0,
+    after : 0,
+    after_debit : 0,
+    after_credit : 0,
+  };
+
+  const totalKeys = [
+    'before', 'before_debit', 'before_credit', 'during', 'during_debit',
+    'during_credit', 'after', 'after_debit', 'after_credit',
+  ];
+
+  // compute the totals
+  totals = accounts.reduce((total, account) => {
+    totalKeys.forEach(key => {
+      total[key] += account[key];
+    });
+
+    return total;
+  }, totals);
+
+  _.merge(totals, { currencyId });
+
+  return { period, accounts, totals };
+}
+
+
+/**
+ * @function computeBalanceTree
+ *
+ * @description
+ * This i
+ *
+ */
+function computeBalanceTree(accounts, totals, context, shouldPrune) {
   // if the after result is 0, that means no movements occurred
   const isEmptyRow = (row) => (
     row.before === 0
@@ -158,58 +279,45 @@ function getBalanceSummary(periodId, currencyId, shouldPrune) {
     && row.after === 0
   );
 
-  return db.one(getFiscalYearSQL, [periodId])
-    .then(period => {
-      const params = _.fill(Array(4), period.number);
-      _.merge(context, { period });
-      return Promise.all([
-        db.exec(sql, [currencyId, ...params, period.fiscal_year_id]),
-        db.one(aggregateSQL, [...params, period.fiscal_year_id]),
-      ]);
-    })
-    .then(([accounts, totals]) => {
-      const tree = new Tree(accounts);
+  const tree = new Tree(accounts);
 
-      // compute the values of the title accounts as the values of their children
-      // takes O(n * m) time, where n is the number of nodes and m is the number
-      // of periods
-      const balanceKeys = [
-        'before', 'before_debit', 'before_credit',
-        'during', 'during_debit', 'during_credit',
-        'after', 'after_debit', 'after_credit',
-      ];
+  // compute the values of the title accounts as the values of their children
+  // takes O(n * m) time, where n is the number of nodes and m is the number
+  // of periods
+  const balanceKeys = [
+    'before', 'before_debit', 'before_credit',
+    'during', 'during_debit', 'during_credit',
+    'after', 'after_debit', 'after_credit',
+  ];
 
-      const bulkSumFn = (currentNode, parentNode) => {
-        balanceKeys.forEach(key => {
-          parentNode[key] = (parentNode[key] || 0) + currentNode[key];
-        });
-      };
-
-      // sum the debits and credits
-      tree.walk(bulkSumFn, false);
-
-      // label depths
-      tree.walk(Tree.common.computeNodeDepth);
-
-      // prune empty rows if needed
-      if (shouldPrune) {
-        tree.prune(isEmptyRow);
-      }
-
-      const balances = tree.toArray();
-
-      // FIXME(@jniles) - figure out how to migrate this to SQL
-      totals.during_debit = 0;
-      totals.during_credit = 0;
-      balances.forEach(account => {
-        if (!account.isTitleAccount) {
-          totals.during_debit += account.during_debit;
-          totals.during_credit += account.during_credit;
-        }
-      });
-
-      _.merge(totals, { currencyId });
-      _.merge(context, { accounts : balances, totals });
-      return context;
+  const bulkSumFn = (currentNode, parentNode) => {
+    balanceKeys.forEach(key => {
+      parentNode[key] = (parentNode[key] || 0) + currentNode[key];
     });
+  };
+
+  // sum the debits and credits
+  tree.walk(bulkSumFn, false);
+
+  // label depths
+  tree.walk(Tree.common.computeNodeDepth);
+
+  // prune empty rows if needed
+  if (shouldPrune) {
+    tree.prune(isEmptyRow);
+  }
+
+  const balances = tree.toArray();
+
+  // FIXME(@jniles) - figure out how to migrate this to SQL
+  totals.during_debit = 0;
+  totals.during_credit = 0;
+  balances.forEach(account => {
+    if (!account.isTitleAccount) {
+      totals.during_debit += account.during_debit;
+      totals.during_credit += account.during_credit;
+    }
+  });
+
+  return { accounts : balances, totals };
 }

--- a/server/controllers/finance/reports/balance/report.handlebars
+++ b/server/controllers/finance/reports/balance/report.handlebars
@@ -16,11 +16,17 @@
         {{translate 'REPORT.BALANCE'}}
       </h2>
 
-      <h4 class="text-center">
-        <strong class="text-capitalize">{{date period.fiscalYearStart "MMMM YYYY"}}</strong>
-         -
-        <strong class="text-capitalize">{{date period.end_date "MMMM YYYY"}}</strong>
-      </h4>
+      {{#if includeClosingBalances}}
+        <h4 class="text-center">
+          <strong class="text-capitalize">{{date period.fiscalYearStart "YYYY"}}</strong>
+        </h4>
+      {{else}}
+        <h4 class="text-center">
+          <strong class="text-capitalize">{{date period.fiscalYearStart "MMMM YYYY"}}</strong>
+           -
+          <strong class="text-capitalize">{{date period.end_date "MMMM YYYY"}}</strong>
+        </h4>
+      {{/if}}
 
       <!-- data  -->
       <table class="table table-condensed table-report">

--- a/server/controllers/finance/reports/ohada_balance_sheet/balanceSheetElement.js
+++ b/server/controllers/finance/reports/ohada_balance_sheet/balanceSheetElement.js
@@ -92,11 +92,11 @@ function getFiscalYearDetails(fiscalYearId) {
    * fiscal year
    */
   const query = `
-    SELECT 
+    SELECT
       p.id AS period_id, fy.end_date,
-      fy.id, fy.label, fy.previous_fiscal_year_id 
-    FROM fiscal_year fy 
-    JOIN period p ON p.fiscal_year_id = fy.id 
+      fy.id, fy.label, fy.previous_fiscal_year_id
+    FROM fiscal_year fy
+    JOIN period p ON p.fiscal_year_id = fy.id
       AND p.number = 0
     WHERE fy.id = ?;
   `;
@@ -107,11 +107,11 @@ function getFiscalYearDetails(fiscalYearId) {
    * temporary ending balance of the selected fiscal year
    */
   const queryTemporary = `
-    SELECT 
+    SELECT
       p.id AS period_id, fy.end_date,
-      fy.id, fy.label, fy.previous_fiscal_year_id 
-    FROM fiscal_year fy 
-    JOIN period p ON p.fiscal_year_id = fy.id 
+      fy.id, fy.label, fy.previous_fiscal_year_id
+    FROM fiscal_year fy
+    JOIN period p ON p.fiscal_year_id = fy.id
       AND p.number = (SELECT MAX(per.number) FROM period per WHERE per.fiscal_year_id = ?)
     WHERE fy.id = ?;
   `;
@@ -121,10 +121,10 @@ function getFiscalYearDetails(fiscalYearId) {
    * the previous fiscal year
    */
   const queryDetails = `
-    SELECT 
+    SELECT
       cur.id, cur.label AS current_fiscal_year, cur.start_date, cur.end_date, cur.locked AS current_locked,
       pre.id AS previous_fiscal_id, pre.label AS previous_fiscal_year, pre.locked AS previous_locked
-    FROM fiscal_year cur 
+    FROM fiscal_year cur
     LEFT JOIN fiscal_year pre ON pre.id = cur.previous_fiscal_year_id
     WHERE cur.id = ?;
   `;

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -193,7 +193,6 @@ function convertStringToNumber(obj) {
  */
 
 function renameKeys(objs, newKeys) {
-
   const formatedKeys = _.isString(newKeys) ? JSON.parse(newKeys) : newKeys;
   if (_.isArray(objs)) {
     _.forEach(objs, (obj, index) => {

--- a/server/models/procedures/time_period.sql
+++ b/server/models/procedures/time_period.sql
@@ -1,8 +1,8 @@
 /*
  Create Fiscal Year and Periods
 
- This procedure help to create fiscal year and fiscal year's periods
- periods include period `0` and period `13`
+This procedure help to create fiscal year and fiscal year's periods
+periods include period `0` and period `13`
 */
 
 CREATE PROCEDURE CreateFiscalYear(
@@ -34,8 +34,7 @@ CREATE PROCEDURE GetPeriodRange(
   IN periodNumberIndex SMALLINT(5),
   OUT periodStartDate DATE,
   OUT periodEndDate DATE
-)
-BEGIN
+) BEGIN
   DECLARE `innerDate` DATE;
 
   SET innerDate = (SELECT DATE_ADD(fiscalYearStartDate, INTERVAL periodNumberIndex-1 MONTH));
@@ -76,13 +75,20 @@ BEGIN
   FROM fiscal_year WHERE id = fiscalYearId;
 
   -- insert N+1 period
-  WHILE periodNumber <= fyNumberOfMonths DO
+  WHILE periodNumber <= fyNumberOfMonths + 1 DO
 
     IF periodNumber = 0 THEN
       -- Extremum periods 0 and N+1
       -- Insert periods with null dates - period id is YYYY00
       INSERT INTO period (`id`, `fiscal_year_id`, `number`, `start_date`, `end_date`, `locked`)
       VALUES (CONCAT(YEAR(fyStartDate), periodNumber), fiscalYearId, periodNumber, NULL, NULL, 0);
+
+    ELSEIF periodNumber = 13 THEN
+      -- Extremum periods N+1
+      -- Insert periods with null dates - period id is YYYY13
+      INSERT INTO period (`id`, `fiscal_year_id`, `number`, `start_date`, `end_date`, `locked`)
+      VALUES (CONCAT(YEAR(fyStartDate), periodNumber), fiscalYearId, periodNumber, NULL, NULL, 0);
+
     ELSE
       -- Normal periods
       -- Get period dates range

--- a/test/end-to-end/reports/balance_report/balance_report.page.js
+++ b/test/end-to-end/reports/balance_report/balance_report.page.js
@@ -12,6 +12,7 @@ class BalanceReportPage {
     components.fiscalYearSelect.set(year);
     components.periodSelection.set(month);
     components.yesNoRadios.set('yes', 'useSeparateDebitsAndCredits');
+    components.yesNoRadios.set('no', 'includeClosingBalances');
     components.yesNoRadios.set('yes', 'shouldPruneEmptyRows');
     components.yesNoRadios.set('yes', 'shouldHideTitleAccounts');
     this.page.preview();

--- a/test/integration/fiscalYear.extra.js
+++ b/test/integration/fiscalYear.extra.js
@@ -111,19 +111,17 @@ describe('(/fiscal) Fiscal Year extra operations', () => {
   it('GET /fiscal/:id/periods returns periods of the given fiscal year', () => {
     return agent.get(url.concat(`/${fiscalYear2017.id}/periods`))
       .then(res => {
-        // checks if the number of returned periods equals total of periods + period 0
-        expect(res.body).to.have.length(fiscalYear2017MonthsNumber + 1);
+        // checks if the number of returned periods equals total of periods
+        // (w/o extremum periods)
+        expect(res.body).to.have.length(fiscalYear2017MonthsNumber);
 
-        // checks if each periods are returned in order of their `number`
-        // and if each period has the correct number
-        for (let i = 0; i < res.body.length; i++) {
-          expect(res.body[i].number).to.be.equal(i);
-        }
+        // sort the periods by number to make sure they are ordered
+        res.body.sort((a, b) => a.number - b.number);
 
         // pick two periods as sample, and checks their dates values
         // we pick periods which correspond to january and december
-        const jan = res.body[1];
-        const dec = res.body[12];
+        const jan = res.body[0];
+        const dec = res.body[11];
 
         expect(flatDate(jan.start_date)).to.be.equal('2017-01-01');
         expect(flatDate(jan.end_date)).to.be.equal('2017-01-31');


### PR DESCRIPTION
This commit adds a special route for the closing balance which no longer sums the entire period total before it.  Instead, it simply fetches period 0 of the next fiscal year.  I've also made some cosmetic changes by expanding the ui-grid to be larger and therefore more readable and using the bhFilterToggle component.

Closes https://github.com/IMA-WorldHealth/bhima-2.X/issues/3288