### PR TITLE
Update Travis CI to use Node v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 language: node_js
 node_js:
   - "8"
-  - node
+  - "10:
 
 before_script:
   - sudo /etc/init.d/mysql restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 language: node_js
 node_js:
   - "8"
-  - "10:
+  -  10
 
 before_script:
   - sudo /etc/init.d/mysql restart


### PR DESCRIPTION
It seems like v11 is breaking on our archive tool.