### PR TITLE
refactor(patients): use async/await

### DIFF
--- a/server/controllers/finance/reports/financial.patient.js
+++ b/server/controllers/finance/reports/financial.patient.js
@@ -56,8 +56,7 @@ function build(req, res, next) {
     .then(result => {
       res.set(result.headers).send(result.report);
     })
-    .catch(next)
-    .done();
+    .catch(next);
 }
 
 exports.report = build;

--- a/server/controllers/medical/reports/checkins.js
+++ b/server/controllers/medical/reports/checkins.js
@@ -101,8 +101,7 @@ function build(req, res, next) {
     .then(result => {
       res.set(result.headers).send(result.report);
     })
-    .catch(next)
-    .done();
+    .catch(next);
 }
 
 module.exports = build;

--- a/server/controllers/medical/reports/patient.receipt.js
+++ b/server/controllers/medical/reports/patient.receipt.js
@@ -81,6 +81,5 @@ function build(req, res, next) {
     .then(result => {
       res.set(result.headers).send(result.report);
     })
-    .catch(next)
-    .done();
+    .catch(next);
 }


### PR DESCRIPTION
This commit migrates the patients controller on the server to use async/await where possible.  It also updates the patient reference calculation to pull the values from the entity_map table.  Finally, it makes sure that the entity_map table is kept up to date with any changes made to the patient name.

Contributes to #2458.