### PR TITLE
deps: bump ui-grid

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "angular-messages": "1.7.5",
     "angular-bootstrap": "2.5.0",
     "angular-ui-router": "1.0.0-rc.1",
-    "angular-ui-grid": "4.6.3",
+    "angular-ui-grid": "4.6.4",
     "angular-translate": "2.18.1",
     "angular-translate-loader-static-files": "2.18.1",
     "angular-translate-loader-url": "2.18.1",


### PR DESCRIPTION
This commit fixes the ui-grid sorting behavior by bumping the version to 4.6.4.

Closes #3258