### PR TITLE
fix: remove done() calls from native promises

### DIFF
--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -656,8 +656,7 @@ function getFinancialStatus(req, res, next) {
 
       res.status(200).send(data);
     })
-    .catch(next)
-    .done();
+    .catch(next);
 }
 
 /**
@@ -671,12 +670,9 @@ function getFinancialStatus(req, res, next) {
 function getDebtorBalance(req, res, next) {
   const uid = req.params.uuid;
   lookupPatient(uid)
-    .then(patient => {
-      return Debtors.balance(patient.debtor_uuid);
-    })
+    .then(patient => Debtors.balance(patient.debtor_uuid))
     .then(([balance]) => {
       res.status(200).send(balance);
     })
-    .catch(next)
-    .done();
+    .catch(next);
 }

--- a/server/controllers/report.js
+++ b/server/controllers/report.js
@@ -240,8 +240,7 @@ function barcodeLookup(req, res, next) {
 
   barcode.reverseLookup(key)
     .then(result => res.send(result))
-    .catch(next)
-    .done();
+    .catch(next);
 }
 
 function barcodeRedirect(req, res, next) {
@@ -255,6 +254,5 @@ function barcodeRedirect(req, res, next) {
       }
       res.redirect(result._redirectPath);
     })
-    .catch(next)
-    .done();
+    .catch(next);
 }

--- a/test/integration/barcodes.js
+++ b/test/integration/barcodes.js
@@ -11,7 +11,7 @@ describe('(/barcode) Barcode Reverse Lookup', () => {
 
   const invalidBarcodeType = 'ZZinvalidcode';
 
-  it(`/barcode/:key looks up Patient for valid barcode key ${validPatientBarcode}`, () => {
+  it(`/barcode/:key looks up patient for valid barcode key ${validPatientBarcode}`, () => {
     return agent.get(`/barcode/${validPatientBarcode}`)
       .then((res) => {
         const patientKeys = ['uuid', 'debtor_uuid', 'display_name', 'hospital_no'];
@@ -36,4 +36,6 @@ describe('(/barcode) Barcode Reverse Lookup', () => {
         helpers.api.errored(res, 400);
       });
   });
+
+
 });


### PR DESCRIPTION
This commit removes the done() calls from async functions that use native promises.  A few of these slipped through the cracks.

Closes #3335