### PR TITLE
chore(accounts): rewrite end to end tests

### DIFF
--- a/client/src/modules/account_reference/templates/action.cell.html
+++ b/client/src/modules/account_reference/templates/action.cell.html
@@ -1,23 +1,24 @@
 <div class="ui-grid-cell-contents text-right"
   uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
-  
+
   <a href>
     <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
 
   <ul data-action="{{ rowRenderIndex}}"  class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
-   
     <li class="dropdown-header">
-      <a href>
-        <span>{{row.entity.abbr}}</span>
-      </a>
+      <a href><span>{{row.entity.abbr}}</span></a>
     </li>
 
     <li class="divider"></li>
 
-    <li><a data-method="edit" ng-click="grid.appScope.edit(row.entity)" href><i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span></a></li>
-    
+    <li>
+      <a data-method="edit" ng-click="grid.appScope.edit(row.entity)" href>
+        <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
+      </a>
+    </li>
+
     <li class="divider"></li>
 
     <li>

--- a/client/src/modules/accounts/accounts.js
+++ b/client/src/modules/accounts/accounts.js
@@ -9,7 +9,8 @@ AccountsController.$inject = [
 /**
  * @module AccountsController
  *
- * @todo there are performance issues on this page - this should be because of  row/cell templates, investigate
+ * @todo
+ * there are performance issues on this page - this should be because of  row/cell templates, investigate
  *
  * @description
  * This controller is responsible for configuring the Accounts Management UI grid
@@ -70,9 +71,8 @@ function AccountsController(
   // parent state into the onEnter callback. for this reason $rootScope is used for now
   $rootScope.$on('ACCOUNT_CREATED', vm.Accounts.updateViewInsert.bind(vm.Accounts));
   $rootScope.$on('ACCOUNT_UPDATED', handleUpdatedAccount);
-  $rootScope.$on('ACCOUNT_IMPORTED', () => {
-    init(true);
-  });
+  $rootScope.$on('ACCOUNT_IMPORTED', () => init(true));
+
   function gridColumns() {
     return [
       {

--- a/client/src/modules/accounts/templates/grid.actionsCell.tmpl.html
+++ b/client/src/modules/accounts/templates/grid.actionsCell.tmpl.html
@@ -1,17 +1,17 @@
-<div class="ui-grid-cell-contents" uib-dropdown dropdown-append-to-body data-action="{{ row.entity.id }}">
-  <a href uib-dropdown-toggle>
-    <span data-action="open-dropdown-menu" translate>FORM.BUTTONS.ACTIONS</span>
+<div class="ui-grid-cell-contents" uib-dropdown dropdown-append-to-body data-row="{{row.entity.number}}">
+  <a href uib-dropdown-toggle data-action="open-dropdown-menu">
+    <span translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
 
-  <ul data-row-menu="{{ row.entity.id }}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+  <ul data-row-menu="{{row.entity.number}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
     <!-- make ellipsis overflow to prevent long titles from pushing panel around -->
     <li class="dropdown-header text-ellipsis"  style="max-width:250px;">
       <span>{{row.entity.number}} - {{row.entity.label}}</span>
     </li>
 
     <li>
-      <a href data-method="edit"
+      <a href data-method="edit-record"
         ui-sref="accounts.edit({id : row.entity.id})">
         <i class="fa fa-edit"></i>
         <span translate>TABLE.COLUMNS.EDIT</span>
@@ -55,7 +55,7 @@
     <li class="divider"></li>
 
     <li>
-      <a href data-method="delete" ng-click="grid.appScope.remove(row.entity.id)">
+      <a href data-method="delete-record" ng-click="grid.appScope.remove(row.entity.id)">
         <span class="text-danger">
           <i class="fa fa-trash"></i> <span translate>FORM.BUTTONS.DELETE</span>
         </span>

--- a/client/src/modules/accounts/templates/grid.indentCell.tmpl.html
+++ b/client/src/modules/accounts/templates/grid.indentCell.tmpl.html
@@ -1,4 +1,4 @@
-<div class="ui-grid-cell-contents" data-row="{{ row.entity.id }}">
+<div class="ui-grid-cell-contents" data-title-row="{{ row.entity.number }}">
   <!-- Clickable label area - on parent accounts expands/ collapses -->
   <span
     data-account-title

--- a/client/src/modules/accounts/templates/grid.leafRow.tmpl.html
+++ b/client/src/modules/accounts/templates/grid.leafRow.tmpl.html
@@ -9,4 +9,3 @@
   role="{{col.isRowHeader ? 'rowheader' : 'gridcell'}}"
   ui-grid-cell>
 </div>
-

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -14,6 +14,8 @@ helpers.configure(chai);
 const config = {
   specs : ['test/end-to-end/**/*.spec.js'],
 
+  // SELENIUM_PROMISE_MANAGER: false,
+
   framework : 'mocha',
   baseUrl   : 'http://localhost:8080/',
 

--- a/test/end-to-end/accounts/accounts.page.js
+++ b/test/end-to-end/accounts/accounts.page.js
@@ -1,84 +1,86 @@
 /* global element, by, browser  */
+/* eslint class-methods-use-this:off */
 const path = require('path');
 const EC = require('protractor').ExpectedConditions;
 const FU = require('../shared/FormUtils');
 const GU = require('../shared/GridUtils.js');
 const components = require('../shared/components');
+const GridRow = require('../shared/GridRow');
 
+const fixtures = path.resolve(__dirname, '../../fixtures/');
 
-function AccountsPage() {
-  const page = this;
-  const gridId = 'account-grid';
-  const fixtures = path.resolve(__dirname, '../../fixtures/');
+class AccountsPage {
+  constructor() {
+    this.gridId = 'account-grid';
 
-  const getRow = (id) => $(`[data-row="${id}"]`);
-  const openMenu = id => {
-    const cell = $(`[data-action="${id}"]`);
-    cell.$(`[data-action="open-dropdown-menu"]`).click();
-  };
+    this.EditModal = {
+      parent : () => element(by.model('AccountEditCtrl.account.parent')).getText(),
+    };
+  }
 
-  page.expectGridRowsAtLeast = function expectGridRowsAtLeast(numRows) {
-    GU.expectRowCountAbove(gridId, numRows);
-  };
+  getGrid() {
+    return element(by.id(this.gridId));
+  }
 
-  page.expectRowVisible = function isVisible(id) {
-    FU.exists(by.css(`[data-row="${id}"]`), true);
-  };
+  getTitleRow(number) {
+    return this.getGrid().$(`[data-title-row="${number}"]`);
+  }
 
-  page.expectRowHidden = function isHidden(id) {
-    FU.exists(by.css(`[data-row="${id}"]`), false);
-  };
+  expectGridRowsAtLeast(numRows) {
+    GU.expectRowCountAbove(this.gridId, numRows);
+  }
 
-  page.toggleTitleRow = function toggleTitleRow(accountId) {
-    getRow(accountId).$('[data-account-title]').click();
-  };
+  expectRowVisible(number) {
+    FU.exists(by.css(`[data-row="${number}"]`), true);
+  }
 
-  page.openAddChild = function openAddChild(accountId) {
-    getRow(accountId).$('[data-action="add-child"]').click();
-  };
+  expectRowHidden(number) {
+    FU.exists(by.css(`[data-row="${number}"]`), false);
+  }
 
-  page.openEdit = function openEdit(accountId) {
-    // open the menu
-    openMenu(accountId);
+  toggleTitleRow(number) {
+    this.getTitleRow(number)
+      .$('[data-account-title]')
+      .click();
+  }
 
-    // click the right thing
-    const menu = $(`[data-row-menu="${accountId}"`);
-    menu.$(`[data-method="edit"]`).click();
-  };
+  openAddChild(number) {
+    this.getTitleRow(number)
+      .$('[data-action="add-child"]')
+      .click();
+  }
 
-  page.openImportMenu = () => {
+  openEdit(number) {
+    const row = new GridRow(number);
+    row.dropdown().click();
+    row.edit().click();
+  }
+
+  deleteAccount(number) {
+    const row = new GridRow(number);
+    row.dropdown().click();
+    row.remove().click();
+    components.modalAction.confirm();
+  }
+
+  openImportMenu() {
     $('[data-action="open-tools"]').click();
     $('[data-action="import-accounts"]').click();
     browser.wait(EC.visibilityOf(element(by.css('[data-import-modal]'))), 3000, 'Could not find import modal.');
-  };
+  }
 
-  page.chooseImportOption = option => {
+  chooseImportOption(option) {
     FU.radio('ImportAccountsCtrl.option', option);
-  };
+  }
 
-  page.uploadFile = fileToUpload => {
+  uploadFile(fileToUpload) {
     const absolutePath = path.resolve(fixtures, fileToUpload);
     element(by.id('import-input')).sendKeys(absolutePath);
-  };
+  }
 
-  page.EditModal = {
-    parent : () => element(by.model('AccountEditCtrl.account.parent')).getText(),
-  };
-
-  page.toggleBatchCreate = function toggleBatchCreate() {
+  toggleBatchCreate() {
     element(by.model('AccountEditCtrl.batchCreate')).click();
-  };
-
-  page.deleteAccount = function deleteAccount(accountId) {
-    // open the menu
-    openMenu(accountId);
-
-    // click the right thing
-    const menu = $(`[data-row-menu="${accountId}"`);
-    menu.$(`[data-method="delete"]`).click();
-
-    components.modalAction.confirm();
-  };
+  }
 }
 
 module.exports = AccountsPage;

--- a/test/end-to-end/accounts/accounts.spec.js
+++ b/test/end-to-end/accounts/accounts.spec.js
@@ -15,22 +15,21 @@ describe('Account Management', () => {
   const OHADA_ACCOUNTS_CSV_CHARACTERS_FILE = 'ohada-accounts-characters.csv';
   const BAD_OHADA_ACCOUNTS_CSV_FILE = 'bad-ohada-accounts.csv';
 
-  // this is an account at the top of the grid - until this test is improved it relies
-  // on the account being visible to verify each test
+  // this is an account at the top of the grid - until this test is improved it
+  // relies on the account being visible to verify each test
   const assetAccountGroup = {
-    id : 9,
-    child_id : 74, // this is an id of a child account in the group with id 9
+    number : 10,
+    child_number : 105, // this is the number ofthe  child account in the group
   };
 
   const account = {
-    id : 90,
     number : '10911010',
-    type : 'Titre',
-    label : 'Actionnaire, Capital souscrit, non appelé *',
+    type : 'Capital',
+    label : 'Compte Actionnaire, Capital souscrit, non appelé',
     parent : { number : '1091' },
   };
 
-  const DELETE_ACCOUNT_ID = 87;
+  const DELETE_ACCOUNT_NUMBER = 10541010;
 
   const page = new AccountsPage();
 
@@ -39,20 +38,22 @@ describe('Account Management', () => {
   });
 
   it('expands and collapses title accounts on title click', () => {
-    page.expectRowVisible(assetAccountGroup.child_id);
-    page.toggleTitleRow(assetAccountGroup.id);
-    page.expectRowHidden(assetAccountGroup.child_id);
-    page.toggleTitleRow(assetAccountGroup.id);
+    page.expectRowVisible(assetAccountGroup.child_number);
+    page.toggleTitleRow(assetAccountGroup.number);
+    page.expectRowHidden(assetAccountGroup.child_number);
+    page.toggleTitleRow(assetAccountGroup.number);
   });
 
   it('create state populates parent field through in-line create', () => {
-    page.openAddChild(account.id);
+    page.openAddChild(account.parent.number);
 
     // this relies on the account select to display the account with account number
     expect(page.EditModal.parent()).to.eventually.include(account.parent.number);
+    FU.modal.cancel();
   });
 
   it('creates a single account', () => {
+    page.openAddChild(account.parent.number);
     FU.input('AccountEditCtrl.account.number', '41111019');
     FU.input('AccountEditCtrl.account.label', 'IMA World Health Account');
 
@@ -64,11 +65,11 @@ describe('Account Management', () => {
   });
 
   it('edit state populates account data on clicking edit', () => {
-    page.openEdit(account.id);
-    expect(element(by.id('number-static')).getText()).to.eventually.equal(String(account.parent.number));
+    page.openEdit(account.number);
+    expect(element(by.id('number-static')).getText()).to.eventually.equal(String(account.number));
 
     // @todo removed to allow types to be updated - this should be reintroduced
-    // expect(element(by.id('type-static')).getText()).to.eventually.equal(account.type);
+    expect(element(by.id('type-static')).getText()).to.eventually.equal(account.type);
     expect(element(by.model('AccountEditCtrl.account.label')).getAttribute('value')).to.eventually.equal(account.label);
   });
 
@@ -131,12 +132,12 @@ describe('Account Management', () => {
   it('can delete a specific account', () => {
     // FIXME(@jniles) - account page does not refresh the grid on updates
     browser.refresh();
-    page.deleteAccount(DELETE_ACCOUNT_ID);
+    page.deleteAccount(DELETE_ACCOUNT_NUMBER);
     components.notification.hasSuccess();
   });
 
   it('cannot delete an account with children', () => {
-    page.deleteAccount(assetAccountGroup.id);
+    page.deleteAccount(assetAccountGroup.number);
     components.notification.hasError();
   });
 

--- a/test/end-to-end/shared/GridRow.js
+++ b/test/end-to-end/shared/GridRow.js
@@ -34,6 +34,10 @@ class GridRow {
     return this.menu.$('[data-method="receipt"]');
   }
 
+  method(methodName) {
+    return this.menu.$(`[data-method="${methodName}"]`);
+  }
+
   goToInvoice() {
     return this.menu.$('[data-method="view-invoice"]');
   }
@@ -57,7 +61,6 @@ class GridRow {
   goToVoucher() {
     return this.menu.$('[data-method="view-voucher"]');
   }
-
 }
 
 module.exports = GridRow;


### PR DESCRIPTION
This commit reworks the account tests to remove unused code and use the `class` pattern for the page objects.  It also standardizes the grid to use `GridRow` instead of the custom test scripts and uses the human readable account number instead of the account id.