### PR TITLE
fix(transaction type): rm async/await from client

### DIFF
--- a/client/src/modules/transaction-type/transaction-type.ctrl.js
+++ b/client/src/modules/transaction-type/transaction-type.ctrl.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('TransactionTypeController', TransactionTypeController);
 
 TransactionTypeController.$inject = [
-  '$translate', '$timeout', 'TransactionTypeService', 'NotifyService',
+  '$translate', 'TransactionTypeService', 'NotifyService',
   'ModalService', 'uiGridConstants', 'bhConstants',
 ];
 
@@ -12,7 +12,7 @@ TransactionTypeController.$inject = [
  * @description
  * This controller powers the transaction type grid.
  */
-function TransactionTypeController($translate, $timeout, TransactionType, Notify, Modal, uiGridConstants, bhConstants) {
+function TransactionTypeController($translate, TransactionType, Notify, Modal, uiGridConstants, bhConstants) {
   const vm = this;
 
   // global variables
@@ -88,22 +88,13 @@ function TransactionTypeController($translate, $timeout, TransactionType, Notify
       .catch(Notify.handleError);
   }
 
-  async function loadTransactionTypes() {
-    try {
-      const types = await TransactionType.read();
-
-      // ensure ALL transaction types have translated keys before displaying data
-      const parsedTypes = await Promise.all(types.map(assignDescriptionTranslation));
-
-      // this promise returns outside of Angular's digest loop for some reason, this
-      // ensures the data change is propegated
-      $timeout(() => {
+  function loadTransactionTypes() {
+    return TransactionType.read()
+      .then(types => {
+        const parsedTypes = types.map(assignDescriptionTranslation);
         vm.gridOptions.data = parsedTypes.map(assignTransactionTypeLabels);
-      });
-
-    } catch (e) {
-      Notify.handleError(e);
-    }
+      })
+      .catch(Notify.handleError);
   }
 
   // Assign translatable labels to each transaction type based on the hardcoded
@@ -118,24 +109,13 @@ function TransactionTypeController($translate, $timeout, TransactionType, Notify
   }
 
 
-  async function assignDescriptionTranslation(type) {
-    try {
-      const translatedDescription = await $translate(type.text);
-      type.descriptionLabel = translatedDescription;
-    } catch (e) {
-      // there was an issue with the translation, this is most commonly caused
-      // by no value found for this key, throwing an exception
-      // - default to the translate key as the directive does
-      type.descriptionLabel = type.text;
-    }
+  function assignDescriptionTranslation(type) {
+    type.descriptionLabel = $translate.instant(type.text);
     return type;
   }
 
   function startup() {
-    // startup executes load only once Angular is initalised and has set the default
-    // language setting correctly, executing this earlier will use the default language
-    // @TODO(sfount) an abstract, clear way of guaranteeing language files are downloaded should be considerd
-    $timeout(() => loadTransactionTypes());
+    loadTransactionTypes();
   }
 
   // startup the module

--- a/server/models/bhima.sql
+++ b/server/models/bhima.sql
@@ -1,6 +1,5 @@
 -- core tables that drive system configuration - these configurations could
 -- be overriden by individual enterprises however these are the defaults
-
 -- set variables
 SET foreign_key_checks = 0;
 
@@ -154,7 +153,6 @@ INSERT INTO `report` (`id`, `report_key`, `title_key`) VALUES
   (25, 'stock_value', 'TREE.STOCK_VALUE'),
   (26, 'ohada_profit_loss', 'TREE.OHADA_RESULT_ACCOUNT'),
   (27, 'income_expense_by_year', 'REPORT.INCOME_EXPENSE_BY_YEAR');
-  
 
 -- Supported Languages
 INSERT INTO `language` VALUES


### PR DESCRIPTION
The async/await is broken in production builds since AngularJS is not aware of it and uglify changes the scope of the compressed JS.  Unfortunately, we missed the transaction types async/await.  This commit removes it.