### PR TITLE
chore(roles): remove project_id from roles

### DIFF
--- a/client/src/modules/roles/modal/userRole.js
+++ b/client/src/modules/roles/modal/userRole.js
@@ -16,7 +16,7 @@ function UsersRolesController(data, $uibModal, $uibModalInstance, RolesService, 
 
   // load all roles
   function loadRoles() {
-    RolesService.userRoles(vm.user.id, Session.project.id)
+    RolesService.userRoles(vm.user.id)
       .then(response => {
         delete vm.gridOptions.data;
         vm.roles = response.data;

--- a/client/src/modules/roles/roles.ctrl.js
+++ b/client/src/modules/roles/roles.ctrl.js
@@ -11,14 +11,11 @@ function RolesController($uibModal, Roles, Session, Modal, Notify, bhConstants, 
 
   vm.canEditRoles = false;
 
-  vm.createUpdateRoleModal = function createUpdateRoleModal(selectedRole) {
-    // if no selected role was passed this means we are creating a new role
-    // set the default role parameters to pass the modal (set project ID)
-    const role = selectedRole || { project_id : Session.project.id };
+  vm.createUpdateRoleModal = function createUpdateRoleModal(selectedRole = {}) {
     $uibModal.open({
       templateUrl : 'modules/roles/create.html',
       controller : 'RolesAddController as RolesAddCtrl',
-      resolve : { data : () => role },
+      resolve : { data : () => selectedRole },
     });
   };
 

--- a/client/src/modules/roles/roles.service.js
+++ b/client/src/modules/roles/roles.service.js
@@ -25,8 +25,8 @@ function RolesService(Api) {
     return service.$http.post(url, data);
   };
 
-  service.userRoles = function userRoles(userId, projectId) {
-    const url = `/roles/user/${userId}/${projectId}`;
+  service.userRoles = function userRoles(userId) {
+    const url = `/roles/user/${userId}`;
     return service.$http.get(url);
   };
 

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -744,13 +744,13 @@ exports.configure = function configure(app) {
 
   app.get('/roles/actions/:roleUuid', rolesCtrl.rolesAction);
   app.get('/roles/actions/user/:action_id', rolesCtrl.hasAction);
-  app.get('/roles/user/:user_id/:project_id', rolesCtrl.listForUser);
+  app.get('/roles/user/:id', rolesCtrl.listForUser);
   app.post('/roles', rolesCtrl.create);
   app.put('/roles/:uuid', rolesCtrl.update);
   app.delete('/roles/:uuid', rolesCtrl.remove);
 
-  app.post('/roles/affectUnits', rolesCtrl.affectPages);
-  app.post('/roles/assignTouser', rolesCtrl.affectToUser);
+  app.post('/roles/affectUnits', rolesCtrl.assignUnitsToRole);
+  app.post('/roles/assignTouser', rolesCtrl.assignRolesToUser);
   app.post('/roles/actions', rolesCtrl.assignActionToRole);
 
   // unit

--- a/server/models/migrations/v0.8.0-v0.9.0/migrate.sql
+++ b/server/models/migrations/v0.8.0-v0.9.0/migrate.sql
@@ -847,3 +847,8 @@ CREATE TABLE `tags`(
 
 INSERT INTO unit VALUES
 (217, 'Tags','TREE.TAGS','', 1,'/modules/tags/tags','/tags');
+
+-- @jniles: remove project from role
+ALTER TABLE role DROP INDEX project_role_label;
+ALTER TABLE role DROP FOREIGN KEY `role_ibfk_1`;
+ALTER TABLE role DROP column project_id;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1777,11 +1777,7 @@ DROP TABLE IF EXISTS `role`;
 CREATE TABLE `role` (
   `uuid` binary(16) NOT NULL,
   `label` varchar(50) NOT NULL,
-  `project_id` SMALLINT(5) UNSIGNED NOT NULL,
-  KEY `project_id` (`project_id`),
-  PRIMARY kEY(`uuid`),
-  UNIQUE `project_role_label` (`project_id`,`label`),
-  FOREIGN KEY (`project_id`) REFERENCES `project` (`id`) ON UPDATE CASCADE
+  PRIMARY kEY(`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
 

--- a/test/data.sql
+++ b/test/data.sql
@@ -938,8 +938,8 @@ SET @regularRoleUUID = HUID('5f7dd0c6-9273-4955-a703-126fbd504b61');
 
 DELETE FROM role;
 
-INSERT INTO `role`(uuid, label, project_id)
-  VALUES(@roleUUID, 'Admin', 1), (@regularRoleUUID, 'Regular', 1);
+INSERT INTO `role`(uuid, label)
+  VALUES (@roleUUID, 'Admin'), (@regularRoleUUID, 'Regular');
 
 -- superuser
 INSERT INTO role_unit

--- a/test/integration/role.js
+++ b/test/integration/role.js
@@ -13,11 +13,9 @@ describe('(/roles) The roles API endpoint', () => {
   // role we will add during this test suite.
   const newRole = {
     label : 'Receptionniste',
-    project_id : 1,
   };
 
   const adminUuid = '5B7DD0D692734955A703126FBD504B61';
-
   const regularUserRoleUuid = '5F7DD0C692734955A703126FBD504B61';
   const regularUserRoleUnits = [
     { id : 0, key : 'TREE.ROOT', parent : null },
@@ -110,8 +108,8 @@ describe('(/roles) The roles API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /roles/user/:user_id/:project_id Should test if a action is assigned to the connected user', () => {
-    return agent.get('/roles/user/1/1')
+  it('GET /roles/user/:user_id/ should test if a action is assigned to the connected user', () => {
+    return agent.get('/roles/user/1')
       .then(res => {
         expect(res).to.have.status(200);
         expect(res.body).to.not.be.empty;


### PR DESCRIPTION
This commit removes the `project_id` from the roles.  We don't have good error handling to inform the user what went wrong if they don't have the write project permissions, and we don't have the client-side interface
to give user roles permissions to projects.

Finalizes #2856.