### PR TITLE
refactor(Account References): rewrite tests

### DIFF
--- a/client/src/modules/account_reference/account_reference.modal.html
+++ b/client/src/modules/account_reference/account_reference.modal.html
@@ -53,8 +53,8 @@
       <label class="control-label" translate>FORM.SELECT.ACCOUNTS</label>
 
       <ui-select
-        multiple="true" 
-        name="accounts" 
+        multiple="true"
+        name="accounts"
         ng-model="AccountReferenceModalCtrl.accountReference.accounts"
         close-on-select="false"
         append-to-body="true">
@@ -79,8 +79,8 @@
       <label class="control-label" translate>ACCOUNT.REFERENCE.EXCEPTION</label>
 
       <ui-select
-        multiple="true" 
-        name="accountsException" 
+        multiple="true"
+        name="accountsException"
         ng-model="AccountReferenceModalCtrl.accountReference.accountsException"
         close-on-select="false"
         append-to-body="true">
@@ -102,21 +102,21 @@
     <!-- parent reference -->
     <div class="form-group" ng-class="{ 'has-error' : AccountReferenceForm.$submitted && AccountReferenceForm.parent.$invalid }">
         <label class="control-label" translate>ACCOUNT.REFERENCE.PARENT_REFERENCE</label>
-  
+
         <ui-select
-          name="parent" 
+          name="parent"
           ng-model="AccountReferenceModalCtrl.accountReference.parent"
           append-to-body="true">
-  
+
           <ui-select-match placeholder="{{ 'ACCOUNT.REFERENCE.PARENT_REFERENCE' | translate }}">
             <span>{{$select.selected.abbr}}</span>
           </ui-select-match>
-  
+
           <ui-select-choices repeat="reference.id as reference in AccountReferenceModalCtrl.references | filter:{abbr: $select.search}">
             <strong ng-bind-html="reference.abbr | highlight:$select.search"></strong>
           </ui-select-choices>
         </ui-select>
-  
+
         <div class="help-block" ng-messages="AccountReferenceForm.parent.$error" ng-show="AccountReferenceForm.$submitted">
           <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
         </div>
@@ -128,8 +128,8 @@
       <label class="control-label text-danger" translate>FORM.LABELS.CREDIT_BALANCE</label>
 
       <ui-select
-        multiple="true" 
-        name="accountsCreditBalance" 
+        multiple="true"
+        name="accountsCreditBalance"
         ng-model="AccountReferenceModalCtrl.accountReference.accountsCreditBalance"
         close-on-select="false"
         append-to-body="true">
@@ -150,8 +150,8 @@
       <label class="control-label text-danger" translate>FORM.LABELS.DEBIT_BALANCE</label>
 
       <ui-select
-        multiple="true" 
-        name="accountsDebitBalance" 
+        multiple="true"
+        name="accountsDebitBalance"
         ng-model="AccountReferenceModalCtrl.accountReference.accountsDebitBalance"
         close-on-select="false"
         append-to-body="true">
@@ -167,8 +167,6 @@
       </ui-select>
     </div>
     <hr>
-
-
   </div>
 
   <div class="modal-footer">
@@ -180,7 +178,7 @@
       <i class="fa fa-exclamation-triangle"></i> <span translate>ACCOUNT.REFERENCE.RECORD_ERROR</span>
     </p>
 
-    <button id="account-reference-cancel" type="button" class="btn btn-default" ng-click="AccountReferenceModalCtrl.closeModal()" translate>
+    <button data-method="cancel" type="button" class="btn btn-default" ng-click="AccountReferenceModalCtrl.closeModal()" translate>
       FORM.BUTTONS.CANCEL
     </button>
 

--- a/client/src/modules/account_reference/templates/action.cell.html
+++ b/client/src/modules/account_reference/templates/action.cell.html
@@ -1,20 +1,19 @@
-<div class="ui-grid-cell-contents text-right"
-  uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
+<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body  data-row="{{row.entity.abbr}}">
 
-  <a href>
+  <a href uib-dropdown-toggle data-action="open-dropdown-menu">
     <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
 
-  <ul data-action="{{ rowRenderIndex}}"  class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
-    <li class="dropdown-header">
-      <a href><span>{{row.entity.abbr}}</span></a>
+  <ul data-row-menu="{{row.entity.abbr}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+    <li class="dropdown-header text-ellipsis"  style="max-width:250px;">
+      <a>{{row.entity.abbr}}</a>
     </li>
 
     <li class="divider"></li>
 
     <li>
-      <a data-method="edit" ng-click="grid.appScope.edit(row.entity)" href>
+      <a data-method="edit-record" ng-click="grid.appScope.edit(row.entity)" href>
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
       </a>
     </li>
@@ -22,7 +21,7 @@
     <li class="divider"></li>
 
     <li>
-      <a data-method="delete" ng-click="grid.appScope.remove(row.entity.id)" href>
+      <a data-method="delete-record" ng-click="grid.appScope.remove(row.entity.id)" href>
         <span class="text-danger">
           <i class="fa fa-trash"></i> <span translate>FORM.BUTTONS.DELETE</span>
         </span>

--- a/test/end-to-end/account-reference/account-reference.cu.page.js
+++ b/test/end-to-end/account-reference/account-reference.cu.page.js
@@ -1,5 +1,4 @@
-
-/* global element, by */
+/* global element, by, $$ */
 
 /**
  * This class is represents a accountReference creation page in terms of structure and
@@ -7,94 +6,85 @@
  */
 const FU = require('../shared/FormUtils');
 
-function CreateUpdateAccountReferencePage() {
-  const page = this;
+class CreateUpdateAccountReferencePage {
+  constructor() {
+    this.abbr = element(by.model('AccountReferenceModalCtrl.accountReference.abbr'));
+    this.description = element(by.model('AccountReferenceModalCtrl.accountReference.description'));
+    this.isAmoDep = element(by.model('AccountReferenceModalCtrl.accountReference.is_amo_dep'));
+    this.accounts = element(by.model('AccountReferenceModalCtrl.accountReference.accounts'));
+    this.accountsException = element(by.model('AccountReferenceModalCtrl.accountReference.accountsException'));
+    this.parent = element(by.model('AccountReferenceModalCtrl.accountReference.parent'));
 
-  const abbr = element(by.model('AccountReferenceModalCtrl.accountReference.abbr'));
-  const description = element(by.model('AccountReferenceModalCtrl.accountReference.description'));
-  const isAmoDep = element(by.model('AccountReferenceModalCtrl.accountReference.is_amo_dep'));
-  const accounts = element(by.model('AccountReferenceModalCtrl.accountReference.accounts'));
-  const accountsException = element(by.model('AccountReferenceModalCtrl.accountReference.accountsException'));
-  const parent = element(by.model('AccountReferenceModalCtrl.accountReference.parent'));
+    this.sameAccountReferencePanel = element(by.id('account-reference-same'));
 
-  const submitButton = $('[uib-modal-window] [data-method="submit"]');
-  const cancelButton = element(by.id('account-reference-cancel'));
+    this.buttons = {
+      submit : $('[uib-modal-window] [data-method="submit"]'),
+      cancel : $('[uib-modal-window] [data-method="cancel"]'),
+    };
 
-  const sameAccountReferencePanel = element(by.id('account-reference-same'));
+    this.uiSelectCloseButtons = element.all(by.css('[class="close ui-select-match-close"]'));
+  }
 
   /* set an accountReference abbr value */
-  function setAbbr(abbrValue) {
-    return abbr.clear().sendKeys(abbrValue);
+  setAbbr(abbrValue) {
+    return this.abbr.clear().sendKeys(abbrValue);
   }
 
   /* set an accountReference description value */
-  function setDescription(descriptionValue) {
-    return description.clear().sendKeys(descriptionValue);
+  setDescription(descriptionValue) {
+    return this.description.clear().sendKeys(descriptionValue);
   }
 
   /* set an accountReference is amortissement/depreciation value */
-  function clickIsAmoDep() {
-    return isAmoDep.click();
+  clickIsAmoDep() {
+    return this.isAmoDep.click();
   }
 
-  function clearSelectedItems() {
-    const removeItemButtons = element.all(by.css('[class="close ui-select-match-close"]'));
-    removeItemButtons.each(closeItem => closeItem.click());
+  clearSelectedItems() {
+    return this.uiSelectCloseButtons.map(closeItem => closeItem.click());
   }
 
   /* set accounts */
-  function setAccountValues(values) {
-    accounts.click();
+  setAccountValues(values) {
+    this.accounts.click();
     values.forEach(v => {
       FU.uiSelectAppended('AccountReferenceModalCtrl.accountReference.accounts', v);
     });
   }
 
   /* set accounts exceptions */
-  function setAccountExceptionValues(values) {
-    accountsException.click();
+  setAccountExceptionValues(values) {
+    this.accountsException.click();
     values.forEach(v => {
       FU.uiSelectAppended('AccountReferenceModalCtrl.accountReference.accountsException', v);
     });
   }
 
   /* set the parent of the reference */
-  function setParentValue(value) {
-    parent.click();
-    FU.uiSelectAppended('AccountReferenceModalCtrl.accountReference.parent', value);
+  setParentValue(value) {
+    this.parent.click();
+    return FU.uiSelectAppended('AccountReferenceModalCtrl.accountReference.parent', value);
   }
 
   /* submit */
-  function submit() {
-    return FU.modal.submit();
+  submit() {
+    return this.buttons.submit.click();
   }
 
   /* cancel creation */
-  function close() {
-    return cancelButton.click();
+  close() {
+    return this.buttons.cancel.click();
   }
 
   /* check if the page is displayed */
-  function isDisplayed() {
-    return submitButton.isPresent();
+  isDisplayed() {
+    return this.buttons.submit.isPresent();
   }
 
   /* check if the accountReference tried to edited the same accountReference */
-  function isSameAccountReference() {
-    return sameAccountReferencePanel.isPresent();
+  isSameAccountReference() {
+    return this.sameAccountReferencePanel.isPresent();
   }
-
-  page.setAbbr = setAbbr;
-  page.setDescription = setDescription;
-  page.clickIsAmoDep = clickIsAmoDep;
-  page.setAccountValues = setAccountValues;
-  page.setAccountExceptionValues = setAccountExceptionValues;
-  page.setParentValue = setParentValue;
-  page.close = close;
-  page.isDisplayed = isDisplayed;
-  page.isSameAccountReference = isSameAccountReference;
-  page.submit = submit;
-  page.clearSelectedItems = clearSelectedItems;
 }
 
 module.exports = CreateUpdateAccountReferencePage;

--- a/test/end-to-end/account-reference/account-reference.page.js
+++ b/test/end-to-end/account-reference/account-reference.page.js
@@ -1,55 +1,42 @@
 /* global element, by */
+/* eslint class-methods-use-this:off */
 
 /**
- * This class is represents a accountReference page in term of structure and
+ * This class is represents an accountReference page in term of structure and
  * behaviour so it is a accountReference page object
  */
 
-/* loading grid actions */
-const GA = require('../shared/GridAction');
+const GridRow = require('../shared/GridRow');
 
-function AccountReferencePage() {
-  const page = this;
+class AccountReferencePage {
 
-  const accountReferenceGrid = element(by.id('account-reference-grid'));
-  const addAccountReferenceButton = element(by.css('[data-method="create"]'));
-  const actionLinkColumn = 7;
+  constructor() {
+    this.grid = element(by.id('account-reference-grid'));
+    this.createBtn = element(by.css('[data-method="create"]'));
+  }
 
-  /* send back the number of accountReference in the grid */
-  function getAccountReferenceCount() {
-    return accountReferenceGrid
-      .element(by.css('.ui-grid-render-container-body'))
+  count() {
+    return this.grid
+      .$('.ui-grid-render-container-body')
       .all(by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index'))
       .count();
   }
 
-  /**
-   * simulate the add accountReference button click to show the dialog of creation
-   */
-  function createAccountReference() {
-    return addAccountReferenceButton.click();
+  create() {
+    return this.createBtn.click();
   }
 
-  /**
-   * simulate a click to a link tailed to the accountReference
-   *  listed in the grid to show the dialog for an editing
-   */
-  function editAccountReference(n) {
-    GA.clickOnMethod(n, actionLinkColumn, 'edit', 'account-reference-grid');
+  update(reference) {
+    const row = new GridRow(reference);
+    row.dropdown().click();
+    row.edit().click();
   }
 
-  /**
-   * simulate a click to a link tailed to the accountReference
-   *  listed in the grid to show the dialog for a deletion
-   */
-  function deleteAccountReference(n) {
-    GA.clickOnMethod(n, actionLinkColumn, 'delete', 'account-reference-grid');
+  remove(reference) {
+    const row = new GridRow(reference);
+    row.dropdown().click();
+    row.remove().click();
   }
-
-  page.getAccountReferenceCount = getAccountReferenceCount;
-  page.createAccountReference = createAccountReference;
-  page.editAccountReference = editAccountReference;
-  page.deleteAccountReference = deleteAccountReference;
 }
 
 module.exports = AccountReferencePage;

--- a/test/end-to-end/account-reference/account-reference.spec.js
+++ b/test/end-to-end/account-reference/account-reference.spec.js
@@ -1,5 +1,4 @@
-/* loading chai and helpers */
-const chai = require('chai');
+const { expect } = require('chai');
 const helpers = require('../shared/helpers');
 const components = require('../shared/components');
 
@@ -7,15 +6,8 @@ const components = require('../shared/components');
 const AccountReferencePage = require('./account-reference.page.js');
 const AccountReferenceCreateUpdatePage = require('./account-reference.cu.page.js');
 
-/* configuring helpers */
-helpers.configure(chai);
-
-const { expect } = chai;
-
 describe('AccountReference Management Page', () => {
   const path = '#/account_reference';
-  const accountReferencePage = new AccountReferencePage();
-  const accountReferenceCreateUpdatePage = new AccountReferenceCreateUpdatePage();
   const mockCreate = {
     abbr : 'AO',
     description : 'Test Accounts Reference',
@@ -23,6 +15,7 @@ describe('AccountReference Management Page', () => {
     accounts : ['31110010', '31110011', '57110010', '57110011'],
     accountsException : ['31110011', '57110011'],
   };
+
   const mockCreate2 = {
     abbr : 'AA',
     description : 'Test Accounts Reference',
@@ -31,6 +24,7 @@ describe('AccountReference Management Page', () => {
     accountsException : ['31110011', '57110011'],
     parent : 'AO',
   };
+
   const mockEdit = {
     abbr : 'AO',
     description : 'Updated Test Accounts Reference',
@@ -38,56 +32,70 @@ describe('AccountReference Management Page', () => {
     accounts : ['31110010', '31110011'],
     accountsException : ['31110011'],
   };
-  let accountReferenceCount = 0;
+
+  const numReferences = 0;
 
   before(() => helpers.navigate(path));
 
-  it('creates an accounts reference successfully', () => {
-    accountReferencePage.createAccountReference();
-    accountReferenceCreateUpdatePage.setAbbr(mockCreate.abbr);
-    accountReferenceCreateUpdatePage.setDescription(mockCreate.description);
-    accountReferenceCreateUpdatePage.setAccountValues(mockCreate.accounts);
-    accountReferenceCreateUpdatePage.setAccountExceptionValues(mockCreate.accountsException);
-    accountReferenceCreateUpdatePage.submit();
+  let page;
+  beforeEach(() => {
+    page = new AccountReferencePage();
+  });
 
-    accountReferenceCount++;
+  it(`should begin with ${numReferences + 1} account references`, () => {
+    expect(page.count()).to.eventually.equal(numReferences);
+  });
+
+  it('creates an accounts reference successfully', () => {
+    page.create();
+
+    const modal = new AccountReferenceCreateUpdatePage();
+
+    modal.setAbbr(mockCreate.abbr);
+    modal.setDescription(mockCreate.description);
+    modal.setAccountValues(mockCreate.accounts);
+    modal.setAccountExceptionValues(mockCreate.accountsException);
+    modal.submit();
+
     components.notification.hasSuccess();
-    expect(accountReferencePage.getAccountReferenceCount()).to.eventually.equal(accountReferenceCount);
+    expect(page.count()).to.eventually.equal(numReferences + 1);
   });
 
   it('edits an accounts reference successfully', () => {
-    accountReferencePage.editAccountReference(0);
-    accountReferenceCreateUpdatePage.clearSelectedItems();
-    accountReferenceCreateUpdatePage.setAbbr(mockEdit.abbr);
-    accountReferenceCreateUpdatePage.setDescription(mockEdit.description);
-    accountReferenceCreateUpdatePage.setAccountValues(mockEdit.accounts, true);
-    accountReferenceCreateUpdatePage.setAccountExceptionValues(mockEdit.accountsException, true);
-    accountReferenceCreateUpdatePage.submit();
+    page.update(mockCreate.abbr);
+    const modal = new AccountReferenceCreateUpdatePage();
+    modal.clearSelectedItems();
+    modal.setAbbr(mockEdit.abbr);
+    modal.setDescription(mockEdit.description);
+    modal.setAccountValues(mockEdit.accounts, true);
+    modal.setAccountExceptionValues(mockEdit.accountsException, true);
+    modal.submit();
 
     components.notification.hasSuccess();
   });
 
   it('creates an accounts reference with a parent', () => {
-    accountReferencePage.createAccountReference();
-    accountReferenceCreateUpdatePage.setAbbr(mockCreate2.abbr);
-    accountReferenceCreateUpdatePage.setDescription(mockCreate2.description);
-    accountReferenceCreateUpdatePage.setAccountValues(mockCreate2.accounts);
-    accountReferenceCreateUpdatePage.setAccountExceptionValues(mockCreate2.accountsException);
-    accountReferenceCreateUpdatePage.setParentValue(mockCreate2.parent);
-    accountReferenceCreateUpdatePage.submit();
+    page.create();
+    const modal = new AccountReferenceCreateUpdatePage();
 
-    accountReferenceCount++;
+    modal.setAbbr(mockCreate2.abbr);
+    modal.setDescription(mockCreate2.description);
+    modal.setAccountValues(mockCreate2.accounts);
+    modal.setAccountExceptionValues(mockCreate2.accountsException);
+    modal.setParentValue(mockCreate2.parent);
+    modal.submit();
+
     components.notification.hasSuccess();
-    expect(accountReferencePage.getAccountReferenceCount()).to.eventually.equal(accountReferenceCount);
+    expect(page.count()).to.eventually.equal(numReferences + 2);
   });
 
   it('delete an accounts reference successfully', () => {
-    accountReferencePage.deleteAccountReference(1);
+    page.remove(mockCreate2.abbr);
     components.notification.hasSuccess();
-    accountReferenceCount--;
+    expect(page.count()).to.eventually.equal(numReferences + 1);
   });
 
-  it('displays all accountReferences loaded from the database', () => {
-    expect(accountReferencePage.getAccountReferenceCount()).to.eventually.equal(accountReferenceCount);
+  it(`should end with ${numReferences + 1} account references`, () => {
+    expect(page.count()).to.eventually.equal(numReferences + 1);
   });
 });


### PR DESCRIPTION
This commit rewrites the account reference tests to better support the page object syntax.  It also makes it clear which account references is being clicked by using the GridRow syntax to select rows in the uiGrid.