### PR TITLE
test(weekend): rewrite weekend end to end tests

### DIFF
--- a/client/src/js/components/bhWeekConfigSelect.js
+++ b/client/src/js/components/bhWeekConfigSelect.js
@@ -6,33 +6,25 @@ angular.module('bhima.components')
     bindings    : {
       configWeekId : '<',
       onSelectCallback : '&',
-      required         : '<?',
       label            : '@?',
-      name             : '@?',
-      validationTrigger :  '<?',
+      required         : '<?',
     },
   });
 
 WeekConfigSelectController.$inject = [
-  'ConfigurationWeekEndService', '$timeout', '$scope', 'NotifyService',
+  'ConfigurationWeekendService', 'NotifyService',
 ];
 
 /**
  * Week Configuration Select Controller
  */
-function WeekConfigSelectController(WeekConfigs, $timeout, $scope, Notify) {
+function WeekConfigSelectController(WeekConfigs, Notify) {
   const $ctrl = this;
 
   // fired at the beginning of the weekend configuration select
   $ctrl.$onInit = function $onInit() {
     // translated label for the form input
     $ctrl.label = $ctrl.label || 'FORM.LABELS.WEEKEND_CONFIGURATION';
-
-    // fired when an weekend configuration has been selected
-    $ctrl.onSelectCallback = $ctrl.onSelectCallback || angular.noop;
-
-    // default for form name
-    $ctrl.name = $ctrl.name || 'WeekConfigForm';
 
 
     if (!angular.isDefined($ctrl.required)) {
@@ -44,22 +36,10 @@ function WeekConfigSelectController(WeekConfigs, $timeout, $scope, Notify) {
         $ctrl.weekendConfigs = weekendConfigs;
       })
       .catch(Notify.handleError);
-
-
-    // alias the name as WeekConfigForm
-    $timeout(aliasComponentForm);
   };
 
-  // this makes the HTML much more readable by reference WeekConfigForm instead of the name
-  function aliasComponentForm() {
-    $scope.WeekConfigForm = $scope[$ctrl.name];
-  }
-
   // fires the onSelectCallback bound to the component boundary
-  $ctrl.onSelect = function onSelect($item) {
-    $ctrl.onSelectCallback({ weekendConfig : $item });
-
-    // alias the WeekConfigForm name so that we can find it via filterFormElements
-    $scope[$ctrl.name].$bhValue = $item.id;
+  $ctrl.onSelect = weekendConfig => {
+    $ctrl.onSelectCallback({ weekendConfig });
   };
 }

--- a/client/src/modules/payroll/modals/payroll.modal.html
+++ b/client/src/modules/payroll/modals/payroll.modal.html
@@ -13,7 +13,7 @@
   </div>
 
   <div class="modal-body">
-    <div class="modal-body" ng-class="{ 'has-error' : PayrollModalForm.$submitted && PayrollModalForm.label.$invalid }">
+    <div class="form-group" ng-class="{ 'has-error' : PayrollModalForm.$submitted && PayrollModalForm.label.$invalid }">
       <label class="control-label" translate>FORM.LABELS.DESIGNATION</label>
       <input name="label" ng-model="PayrollConfigModalCtrl.payroll.label" autocomplete="off" class="form-control" required>
       <div class="help-block" ng-messages="PayrollModalForm.label.$error" ng-show="PayrollModalForm.$submitted">
@@ -21,72 +21,58 @@
       </div>
     </div>
 
-    <div class="modal-body">
-      <bh-date-interval
-        label="FORM.LABELS.PERIODES"
-        date-id="periodes-date"
-        date-from="PayrollConfigModalCtrl.payroll.dateFrom"
-        date-to="PayrollConfigModalCtrl.payroll.dateTo"
-        required="true"
-        validation-trigger="PayrollModalForm.$submitted">
-      </bh-date-interval>
-    </div>
+    <bh-date-interval
+      label="FORM.LABELS.PERIODES"
+      date-id="periodes-date"
+      date-from="PayrollConfigModalCtrl.payroll.dateFrom"
+      date-to="PayrollConfigModalCtrl.payroll.dateTo"
+      required="true"
+      validation-trigger="PayrollModalForm.$submitted">
+    </bh-date-interval>
 
-    <div class="modal-body">
-      <bh-employee-config-select
-        id="config_employee_id"
-        config-employee-id="PayrollConfigModalCtrl.payroll.config_employee_id"
-        name="EmployeeConfigForm"
-        on-select-callback="PayrollConfigModalCtrl.onSelectEmployeeConfig(employeeConfig)"
-        required="true"
-        validation-trigger="PayrollModalForm.$submitted">
-      </bh-employee-config-select>
-    </div>
+    <bh-employee-config-select
+      id="config_employee_id"
+      config-employee-id="PayrollConfigModalCtrl.payroll.config_employee_id"
+      name="EmployeeConfigForm"
+      on-select-callback="PayrollConfigModalCtrl.onSelectEmployeeConfig(employeeConfig)"
+      required="true"
+      validation-trigger="PayrollModalForm.$submitted">
+    </bh-employee-config-select>
 
-    <div class="modal-body">
-      <bh-rubric-config-select
-        id="config_rubric_id"
-        config-rubric-id="PayrollConfigModalCtrl.payroll.config_rubric_id"
-        name="RubricConfigForm"
-        on-select-callback="PayrollConfigModalCtrl.onSelectRubricConfig(rubricConfig)"
-        required="true"
-        validation-trigger="PayrollModalForm.$submitted">
-      </bh-rubric-config-select>
-    </div>
+    <bh-rubric-config-select
+      id="config_rubric_id"
+      config-rubric-id="PayrollConfigModalCtrl.payroll.config_rubric_id"
+      name="RubricConfigForm"
+      on-select-callback="PayrollConfigModalCtrl.onSelectRubricConfig(rubricConfig)"
+      required="true"
+      validation-trigger="PayrollModalForm.$submitted">
+    </bh-rubric-config-select>
 
-    <div class="modal-body">
-      <bh-account-config-select
-        id="config_accounting_id"
-        config-accounting-id="PayrollConfigModalCtrl.payroll.config_accounting_id"
-        name="AccountConfigForm"
-        on-select-callback="PayrollConfigModalCtrl.onSelectAccountConfig(accountConfig)"
-        required="true"
-        validation-trigger="PayrollModalForm.$submitted">
-      </bh-account-config-select>
-    </div>
+    <bh-account-config-select
+      id="config_accounting_id"
+      config-accounting-id="PayrollConfigModalCtrl.payroll.config_accounting_id"
+      name="AccountConfigForm"
+      on-select-callback="PayrollConfigModalCtrl.onSelectAccountConfig(accountConfig)"
+      required="true"
+      validation-trigger="PayrollModalForm.$submitted">
+    </bh-account-config-select>
 
-    <div class="modal-body">
-      <bh-weekend-config-select
-        id="config_weekend_id"
-        config-week-id="PayrollConfigModalCtrl.payroll.config_weekend_id"
-        name="WeekendConfigForm"
-        on-select-callback="PayrollConfigModalCtrl.onSelectWeekendConfig(weekendConfig)"
-        required="true"
-        validation-trigger="PayrollModalForm.$submitted">
-      </bh-weekend-config-select>
-    </div>
+    <bh-weekend-config-select
+      id="config_weekend_id"
+      config-week-id="PayrollConfigModalCtrl.payroll.config_weekend_id"
+      on-select-callback="PayrollConfigModalCtrl.onSelectWeekendConfig(weekendConfig)"
+      required="true">
+    </bh-weekend-config-select>
 
-    <div class="modal-body">
-      <bh-ipr-config-select
-        id="config_ipr_id"
-        config-ipr-id="PayrollConfigModalCtrl.payroll.config_ipr_id"
-        name="IprConfigForm"
-        on-select-callback="PayrollConfigModalCtrl.onSelectIprConfig(iprConfig)"
-        required="false"
-        validation-trigger="PayrollModalForm.$submitted">
-          <bh-clear on-clear="PayrollConfigModalCtrl.clear('config_ipr_id')"></bh-clear>
-      </bh-ipr-config-select>
-    </div>
+    <bh-ipr-config-select
+      id="config_ipr_id"
+      config-ipr-id="PayrollConfigModalCtrl.payroll.config_ipr_id"
+      name="IprConfigForm"
+      on-select-callback="PayrollConfigModalCtrl.onSelectIprConfig(iprConfig)"
+      required="false"
+      validation-trigger="PayrollModalForm.$submitted">
+      <bh-clear on-clear="PayrollConfigModalCtrl.clear('config_ipr_id')"></bh-clear>
+    </bh-ipr-config-select>
   </div>
 
   <div class="modal-footer">

--- a/client/src/modules/payroll/modals/payroll.modal.js
+++ b/client/src/modules/payroll/modals/payroll.modal.js
@@ -77,9 +77,9 @@ function PayrollConfigModalController($state, PayrollConfigurations, Notify, App
     vm.payroll.dateFrom = moment(vm.payroll.dateFrom).format('YYYY-MM-DD');
     vm.payroll.dateTo = moment(vm.payroll.dateTo).format('YYYY-MM-DD');
 
-    const promise = (vm.isCreating) ?
-      PayrollConfigurations.create(vm.payroll) :
-      PayrollConfigurations.update(vm.payroll.id, vm.payroll);
+    const promise = (vm.isCreating)
+      ? PayrollConfigurations.create(vm.payroll)
+      : PayrollConfigurations.update(vm.payroll.id, vm.payroll);
 
     return promise
       .then(() => {

--- a/client/src/modules/payroll/weekend_configuration/configuration.html
+++ b/client/src/modules/payroll/weekend_configuration/configuration.html
@@ -1,27 +1,21 @@
 <div class="flex-header">
   <div class="bhima-title">
     <ol class="headercrumb">
-      <li class="static" translate> TREE.ADMIN </li>
-      <li class="title" translate> TREE.WEEKEND_CONFIGURATION </li>
+      <li class="static" translate>TREE.ADMIN</li>
+      <li class="title" translate>TREE.WEEKEND_CONFIGURATION</li>
     </ol>
 
     <div class="toolbar">
       <div class="toolbar-item">
-        <button class="btn btn-default text-capitalize" id="create" ui-sref="configurationWeekEnd.create" data-method="create">
-          <span class="fa fa-plus"></span> <span translate>FORM.BUTTONS.ADD_WEEKEND_CONFIGURATION</span>
+        <button class="btn btn-default text-capitalize" ui-sref="configurationWeekend.create" data-method="create">
+          <span class="fa fa-plus"></span>
+          <span translate class="hidden-xs">FORM.BUTTONS.ADD_WEEKEND_CONFIGURATION</span>
         </button>
       </div>
 
-      <div class="toolbar-item">
-        <button
-          type="button"
-          ng-click="ConfigurationCtrl.toggleFilter()"
-          data-method="filter"
-          class="btn btn-default"
-          ng-class="{ 'btn-info' : ConfigurationCtrl.filterEnabled }">
-          <i class="fa fa-filter"></i>
-        </button>
-      </div>
+      <bh-filter-toggle
+        on-toggle="ConfigurationCtrl.toggleFilter()">
+      </bh-filter-toggle>
     </div>
   </div>
 </div>
@@ -29,9 +23,10 @@
 <!-- main content -->
 <div class="flex-content">
   <div class="container-fluid">
-    <div id="weekEnd-config-grid"
-      ui-grid="ConfigurationCtrl.gridOptions"
+    <div
+      id="weekend-config-grid"
       class="grid-full-height"
+      ui-grid="ConfigurationCtrl.gridOptions"
       ui-grid-auto-resize
       ui-grid-resize-columns>
 

--- a/client/src/modules/payroll/weekend_configuration/configuration.js
+++ b/client/src/modules/payroll/weekend_configuration/configuration.js
@@ -1,42 +1,39 @@
 angular.module('bhima.controllers')
-.controller('ConfigurationWeekEndController', ConfigurationWeekEndController);
+  .controller('ConfigurationWeekendController', ConfigurationWeekendController);
 
-ConfigurationWeekEndController.$inject = [
-  'ConfigurationWeekEndService', 'ModalService',
-  'NotifyService', 'uiGridConstants', '$state', 'SessionService',
+ConfigurationWeekendController.$inject = [
+  'ConfigurationWeekendService', 'ModalService', 'NotifyService', 'uiGridConstants',
 ];
 
 /**
- * WeekEnd Management Controller
+ * Weekend Management Controller
  *
- * This controller is about the WeekEnd management module in the admin zone
- * It's responsible for creating, editing and updating a WeekEnd
+ * @description
+ * This controller is about the Weekend management module in the admin zone
+ * It's responsible for creating, editing and updating a Weekend
  */
-function ConfigurationWeekEndController(Configs, ModalService,
-  Notify, uiGridConstants, $state, Session) {
-  var vm = this;
+function ConfigurationWeekendController(Configs, Modals, Notify, uiGridConstants) {
+  const vm = this;
 
   // bind methods
   vm.deleteConfig = deleteConfig;
-  vm.editConfig = editConfig;
   vm.toggleFilter = toggleFilter;
-  vm.currencySymbol = Session.enterprise.currencySymbol;
 
   // global variables
   vm.gridApi = {};
-  vm.filterEnabled = false;
 
-  var gridColumn =
-    [
-      { field : 'label', displayName : 'FORM.LABELS.DESIGNATION', headerCellFilter : 'translate' },
-      { field : 'action',
-        width : 80,
-        displayName : '',
-        cellTemplate : '/modules/payroll/weekend_configuration/templates/action.tmpl.html',
-        enableSorting : false,
-        enableFiltering : false,
-      },
-    ];
+  const gridColumn = [{
+    field : 'label',
+    displayName : 'FORM.LABELS.DESIGNATION',
+    headerCellFilter : 'translate',
+  }, {
+    field : 'action',
+    width : 80,
+    displayName : '',
+    cellTemplate : '/modules/payroll/weekend_configuration/templates/action.tmpl.html',
+    enableSorting : false,
+    enableFiltering : false,
+  }];
 
   // options for the UI grid
   vm.gridOptions = {
@@ -54,8 +51,7 @@ function ConfigurationWeekEndController(Configs, ModalService,
   }
 
   function toggleFilter() {
-    vm.filterEnabled = !vm.filterEnabled;
-    vm.gridOptions.enableFiltering = vm.filterEnabled;
+    vm.gridOptions.enableFiltering = !vm.gridOptions.enableFiltering;
     vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
   }
 
@@ -63,33 +59,28 @@ function ConfigurationWeekEndController(Configs, ModalService,
     vm.loading = true;
 
     Configs.read()
-    .then(function (data) {
-      vm.gridOptions.data = data;
-    })
-    .catch(Notify.handleError)
-    .finally(function () {
-      vm.loading = false;
-    });
+      .then(data => {
+        vm.gridOptions.data = data;
+      })
+      .catch(Notify.handleError)
+      .finally(() => {
+        vm.loading = false;
+      });
   }
 
   // switch to delete warning mode
   function deleteConfig(title) {
-    ModalService.confirm('FORM.DIALOGS.CONFIRM_DELETE')
-    .then(function (bool) {
-      if (!bool) { return; }
+    Modals.confirm('FORM.DIALOGS.CONFIRM_DELETE')
+      .then(bool => {
+        if (!bool) { return; }
 
-      Configs.delete(title.id)
-      .then(function () {
-        Notify.success('FORM.INFO.DELETE_SUCCESS');
-        loadConfigs();
-      })
-      .catch(Notify.handleError);
-    });
-  }
-
-  // update an existing WeekEnd Configuration
-  function editConfig(title) {
-    $state.go('configurationWeekEnd.edit', { id : title.id });
+        Configs.delete(title.id)
+          .then(() => {
+            Notify.success('FORM.INFO.DELETE_SUCCESS');
+            loadConfigs();
+          })
+          .catch(Notify.handleError);
+      });
   }
 
   loadConfigs();

--- a/client/src/modules/payroll/weekend_configuration/configuration.routes.js
+++ b/client/src/modules/payroll/weekend_configuration/configuration.routes.js
@@ -1,57 +1,53 @@
 angular.module('bhima.routes')
-.config(['$stateProvider', function ($stateProvider) {
-  $stateProvider
-    .state('configurationWeekEnd', {
-      url         : '/payroll/weekend_configuration',
-      controller  : 'ConfigurationWeekEndController as ConfigurationCtrl',
-      templateUrl : 'modules/payroll/weekend_configuration/configuration.html',
-    })
+  .config(['$stateProvider', $stateProvider => {
+    $stateProvider
+      .state('configurationWeekend', {
+        url         : '/payroll/weekend_configuration',
+        controller  : 'ConfigurationWeekendController as ConfigurationCtrl',
+        templateUrl : 'modules/payroll/weekend_configuration/configuration.html',
+      })
 
-    .state('configurationWeekEnd.create', {
-      url : '/create',
-      params : {
-        weekEnd : { value : null },
-        creating : { value : true },
-      },
-      onEnter : ['$uibModal', configurationWeekEndModal],
-      onExit : ['$uibModalStack', closeModal],
-    })
+      .state('configurationWeekend.create', {
+        url : '/create',
+        params : {
+          weekEnd : { value : null },
+          creating : { value : true },
+        },
+        onEnter : ['$uibModal', configurationWeekendModal],
+        onExit : ['$uibModalStack', closeModal],
+      })
 
-    .state('configurationWeekEnd.edit', {
-      url : '/:id/edit',
-      params : {
-        weekEnd : { value : null },
-        creating : { value : false },
-      },
-      onEnter : ['$uibModal', configurationWeekEndModal],
-      onExit : ['$uibModalStack', closeModal],
-    })
+      .state('configurationWeekend.edit', {
+        url : '/:id/edit',
+        params : {
+          weekEnd : { value : null },
+          creating : { value : false },
+        },
+        onEnter : ['$uibModal', configurationWeekendModal],
+        onExit : ['$uibModalStack', closeModal],
+      })
 
-    .state('configurationWeekEnd.config', {
-      url : '/:id/config',
-      params : {
-        weekEnd : { value : null },
-      },
-      onEnter : ['$uibModal', configurationWeekEnd],
-      onExit : ['$uibModalStack', closeModal],
-    });    
-}]);
+      .state('configurationWeekend.config', {
+        url : '/:id/config',
+        params : {
+          weekEnd : { value : null },
+        },
+        onEnter : ['$uibModal', configurationWeekend],
+        onExit : ['$uibModalStack', closeModal],
+      });
+  }]);
 
-function configurationWeekEndModal($modal) {
+function configurationWeekendModal($modal) {
   $modal.open({
-    keyboard : false,
-    backdrop : 'static',
     templateUrl : 'modules/payroll/weekend_configuration/modals/weekEnd.modal.html',
-    controller : 'WeekEndModalController as WeekEndModalCtrl',
+    controller : 'WeekendModalController as WeekendModalCtrl',
   });
 }
 
-function configurationWeekEnd($modal) {
+function configurationWeekend($modal) {
   $modal.open({
-    keyboard : false,
-    backdrop : 'static',
     templateUrl : 'modules/payroll/weekend_configuration/modals/config.modal.html',
-    controller : 'WeekEndConfigModalController as WeekEndConfigModalCtrl',
+    controller : 'WeekendConfigModalController as WeekendConfigModalCtrl',
   });
 }
 

--- a/client/src/modules/payroll/weekend_configuration/configuration.service.js
+++ b/client/src/modules/payroll/weekend_configuration/configuration.service.js
@@ -1,16 +1,16 @@
 angular.module('bhima.services')
-  .service('ConfigurationWeekEndService', ConfigurationWeekEndService);
+  .service('ConfigurationWeekendService', ConfigurationWeekendService);
 
-ConfigurationWeekEndService.$inject = ['PrototypeApiService'];
+ConfigurationWeekendService.$inject = ['PrototypeApiService'];
 
 /**
- * @class ConfigurationWeekEndService
+ * @class ConfigurationWeekendService
  * @extends PrototypeApiService
  *
  * @description
  * Encapsulates common requests to the /weekend_config/ URL.
  */
-function ConfigurationWeekEndService(Api) {
+function ConfigurationWeekendService(Api) {
   const service = new Api('/weekend_config/');
 
   service.getWeekDays = getWeekDays;

--- a/client/src/modules/payroll/weekend_configuration/modals/config.modal.html
+++ b/client/src/modules/payroll/weekend_configuration/modals/config.modal.html
@@ -1,9 +1,9 @@
-<form name="WeekEndForm" bh-submit="WeekEndConfigModalCtrl.submit(WeekEndForm)" novalidate>
+<form name="WeekendForm" bh-submit="WeekendConfigModalCtrl.submit(WeekendForm)" novalidate>
   <div class="modal-header">
     <ol class="headercrumb">
       <li class="title">
         <span translate>TREE.WEEKEND_CONFIGURATION</span>
-        <label class="badge badge-success" translate>{{ WeekEndConfigModalCtrl.weekend.label }}</label>
+        <label class="badge badge-success" translate>{{ WeekendConfigModalCtrl.weekend.label }}</label>
       </li>
     </ol>
   </div>
@@ -12,22 +12,22 @@
     <div class="help-block" translate>
       FORM.SELECT.WEEKEND_DAYS
     </div>
-    <div ng-repeat="days in WeekEndConfigModalCtrl.weekDays" class="form-group">
+    <div ng-repeat="days in WeekendConfigModalCtrl.weekDays" class="form-group">
       <div style="margin:0" class="checkbox">
         <label style="padding-left: 12%">
           <input type="checkbox" name="days" ng-model="days.checked">
           <span translate>{{ days.label }}</span>
-        </label> 
+        </label>
       </div>
     </div>
   </div>
 
   <div class="modal-footer">
-    <button data-method="cancel" type="button" class="btn btn-default" ng-click="WeekEndConfigModalCtrl.closeModal()">
+    <button data-method="cancel" type="button" class="btn btn-default" ng-click="WeekendConfigModalCtrl.closeModal()">
       <span translate>FORM.BUTTONS.CANCEL</span>
     </button>
 
-    <bh-loading-button loading-state="WeekEndForm.$loading">
+    <bh-loading-button loading-state="WeekendForm.$loading">
       <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>
   </div>

--- a/client/src/modules/payroll/weekend_configuration/modals/config.modal.js
+++ b/client/src/modules/payroll/weekend_configuration/modals/config.modal.js
@@ -1,22 +1,24 @@
 angular.module('bhima.controllers')
-  .controller('WeekEndConfigModalController', WeekEndConfigModalController);
+  .controller('WeekendConfigModalController', WeekendConfigModalController);
 
-WeekEndConfigModalController.$inject = [
-  '$state', 'ConfigurationWeekEndService', 'NotifyService', 'appcache', 'bhConstants',
+WeekendConfigModalController.$inject = [
+  '$state', 'ConfigurationWeekendService', 'NotifyService', 'appcache', 'bhConstants',
 ];
 
-function WeekEndConfigModalController($state, Config, Notify, AppCache, bhConstants) {
-  var vm = this;
+function WeekendConfigModalController($state, Config, Notify, AppCache, bhConstants) {
+  const vm = this;
   vm.weekend = {};
 
-  var cache = AppCache('RubricModal');
+  const cache = AppCache('RubricModal');
 
   if ($state.params.creating || $state.params.id) {
-    vm.stateParams = cache.stateParams = $state.params;
+    cache.stateParams = $state.params;
+    vm.stateParams = cache.stateParams;
   } else {
     vm.stateParams = cache.stateParams;
   }
-  vm.isCreating = vm.stateParams.creating;
+
+  vm.isCreateState = vm.stateParams.creating;
 
   vm.weekDays = bhConstants.weekDays;
 
@@ -24,16 +26,16 @@ function WeekEndConfigModalController($state, Config, Notify, AppCache, bhConsta
   vm.submit = submit;
   vm.closeModal = closeModal;
 
-  if (!vm.isCreating) {
+  if (!vm.isCreateState) {
     Config.read(vm.stateParams.id)
-      .then(function (weekend) {
+      .then((weekend) => {
         vm.weekend = weekend;
       })
       .catch(Notify.handleError);
   }
 
   Config.getWeekDays(vm.stateParams.id)
-    .then(function (daysConfig) {
+    .then((daysConfig) => {
       daysConfig.forEach(object => {
         vm.weekDays.forEach(days => {
           if (days.id === object.indice) { days.checked = true; }
@@ -44,23 +46,21 @@ function WeekEndConfigModalController($state, Config, Notify, AppCache, bhConsta
 
   // submit the data to the server for configure week day
   function submit(accountForm) {
-    var promise,
-      daysChecked;
-
     if (accountForm.$invalid || accountForm.$pristine) { return 0; }
 
-    daysChecked = vm.weekDays.filter(days => days.checked )
-      .map(days => days.id );
-   
+    const daysChecked = vm.weekDays
+      .filter(days => days.checked)
+      .map(days => days.id);
+
     return Config.setWeekDays(vm.stateParams.id, daysChecked)
-      .then(function () {
+      .then(() => {
         Notify.success('FORM.INFO.UPDATE_SUCCESS');
-        $state.go('configurationWeekEnd', null, { reload : true });
+        $state.go('configurationWeekend', null, { reload : true });
       })
       .catch(Notify.handleError);
   }
 
   function closeModal() {
-    $state.go('configurationWeekEnd');
+    $state.go('configurationWeekend');
   }
 }

--- a/client/src/modules/payroll/weekend_configuration/modals/weekEnd.modal.html
+++ b/client/src/modules/payroll/weekend_configuration/modals/weekEnd.modal.html
@@ -1,11 +1,11 @@
-<form name="WeekEndForm" bh-submit="WeekEndModalCtrl.submit(WeekEndForm)" novalidate>
+<form name="WeekendForm" bh-submit="WeekendModalCtrl.submit(WeekendForm)" novalidate>
   <div class="modal-header">
     <ol class="headercrumb">
-      <li ng-if="WeekEndModalCtrl.isCreating" class="title">
+      <li ng-if="WeekendModalCtrl.isCreateState" class="title">
         <span translate>TREE.WEEKEND_CONFIGURATION</span>
         <label class="badge badge-success" translate>FORM.LABELS.CREATE</label>
       </li>
-      <li ng-if="!WeekEndModalCtrl.isCreating" class="title">
+      <li ng-if="!WeekendModalCtrl.isCreateState" class="title">
         <span translate>TREE.WEEKEND_CONFIGURATION</span>
         <label class="badge badge-success" translate>FORM.LABELS.UPDATE</label>
       </li>
@@ -13,21 +13,21 @@
   </div>
 
   <div class="modal-body">
-    <div class="form-group" ng-class="{ 'has-error' : WeekEndForm.$submitted && WeekEndForm.label.$invalid }">
+    <div class="form-group" ng-class="{ 'has-error' : WeekendForm.$submitted && WeekendForm.label.$invalid }">
       <label class="control-label" translate>FORM.LABELS.DESIGNATION</label>
-      <input name="label" ng-model="WeekEndModalCtrl.weekend.label" autocomplete="off" class="form-control" required>
-      <div class="help-block" ng-messages="WeekEndForm.label.$error" ng-show="WeekEndForm.$submitted">
+      <input name="label" ng-model="WeekendModalCtrl.weekend.label" autocomplete="off" class="form-control" required>
+      <div class="help-block" ng-messages="WeekendForm.label.$error" ng-show="WeekendForm.$submitted">
         <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
       </div>
     </div>
   </div>
 
   <div class="modal-footer">
-    <button data-method="cancel" type="button" class="btn btn-default" ng-click="WeekEndModalCtrl.closeModal()">
+    <button data-method="cancel" type="button" class="btn btn-default" ng-click="WeekendModalCtrl.closeModal()">
       <span translate>FORM.BUTTONS.CANCEL</span>
     </button>
 
-    <bh-loading-button loading-state="WeekEndForm.$loading">
+    <bh-loading-button loading-state="WeekendForm.$loading">
       <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>
   </div>

--- a/client/src/modules/payroll/weekend_configuration/modals/weekEnd.modal.js
+++ b/client/src/modules/payroll/weekend_configuration/modals/weekEnd.modal.js
@@ -1,55 +1,55 @@
 angular.module('bhima.controllers')
-  .controller('WeekEndModalController', WeekEndModalController);
+  .controller('WeekendModalController', WeekendModalController);
 
-WeekEndModalController.$inject = [
-  '$state', 'ConfigurationWeekEndService', 'NotifyService', 'appcache',
+WeekendModalController.$inject = [
+  '$state', 'ConfigurationWeekendService', 'NotifyService', 'appcache',
 ];
 
-function WeekEndModalController($state, Config, Notify, AppCache) {
-  var vm = this;
+function WeekendModalController($state, Config, Notify, AppCache) {
+  const vm = this;
   vm.weekend = {};
 
-  var cache = AppCache('RubricModal');
+  const cache = AppCache('RubricModal');
 
   if ($state.params.creating || $state.params.id) {
-    vm.stateParams = cache.stateParams = $state.params;
+    cache.stateParams = $state.params;
+    vm.stateParams = cache.stateParams;
   } else {
     vm.stateParams = cache.stateParams;
   }
-  vm.isCreating = vm.stateParams.creating;
+
+  vm.isCreateState = vm.stateParams.creating;
 
   // exposed methods
   vm.submit = submit;
   vm.closeModal = closeModal;
 
-  if (!vm.isCreating) {
+  if (!vm.isCreateState) {
     Config.read(vm.stateParams.id)
-      .then(function (weekConfig) {    
+      .then((weekConfig) => {
         vm.weekend = weekConfig;
       })
       .catch(Notify.handleError);
   }
 
   // submit the data to the server from all two forms (update, create)
-  function submit(WeekEndForm) {
-    var promise;
+  function submit(WeekendForm) {
+    if (WeekendForm.$invalid || WeekendForm.$pristine) { return 0; }
 
-    if (WeekEndForm.$invalid || WeekEndForm.$pristine) { return 0; }
-
-    promise = (vm.isCreating) ?
-      Config.create(vm.weekend) :
-      Config.update(vm.weekend.id, vm.weekend);
+    const promise = (vm.isCreateState)
+      ? Config.create(vm.weekend)
+      : Config.update(vm.weekend.id, vm.weekend);
 
     return promise
-      .then(function () {
-        var translateKey = (vm.isCreating) ? 'FORM.INFO.CREATE_SUCCESS' : 'FORM.INFO.UPDATE_SUCCESS';
+      .then(() => {
+        const translateKey = (vm.isCreateState) ? 'FORM.INFO.CREATE_SUCCESS' : 'FORM.INFO.UPDATE_SUCCESS';
         Notify.success(translateKey);
-        $state.go('configurationWeekEnd', null, { reload : true });
+        $state.go('configurationWeekend', null, { reload : true });
       })
       .catch(Notify.handleError);
   }
 
   function closeModal() {
-    $state.go('configurationWeekEnd');
+    $state.go('configurationWeekend');
   }
 }

--- a/client/src/modules/payroll/weekend_configuration/templates/action.tmpl.html
+++ b/client/src/modules/payroll/weekend_configuration/templates/action.tmpl.html
@@ -1,23 +1,26 @@
-<div class="ui-grid-cell-contents text-center" uib-dropdown dropdown-append-to-body>
-  <a uib-dropdown-toggle href>
-    <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
-    <span class="caret"></span>
+<div class="ui-grid-cell-contents text-center" uib-dropdown dropdown-append-to-body data-row="{{row.entity.label}}">
+  <a uib-dropdown-toggle href data-action="open-dropdown-menu">
+    <span translate>FORM.BUTTONS.ACTIONS</span> <span class="caret"></span>
   </a>
 
-  <ul data-action="{{rowRenderIndex}}"  class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+  <ul data-row-menu="{{row.entity.label}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+    <li class="dropdown-header">{{row.entity.label}}</li>
     <li>
-      <a data-method="edit" ui-sref="configurationWeekEnd.edit({id : row.entity.id})" href>
+      <a data-method="edit-record" ui-sref="configurationWeekend.edit({id : row.entity.id})" href>
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
       </a>
     </li>
+
     <li>
-      <a data-method="config" ui-sref="configurationWeekEnd.config({id : row.entity.id})" href>
+      <a data-method="configure" ui-sref="configurationWeekend.config({id : row.entity.id})" href>
         <i class="fa fa-cog"></i> <span translate>FORM.BUTTONS.CONFIGURE</span>
       </a>
     </li>
+
     <li class="divider"></li>
+
     <li>
-      <a data-method="delete" ng-click="grid.appScope.deleteConfig(row.entity)" href>
+      <a data-method="delete-record" ng-click="grid.appScope.deleteConfig(row.entity)" href>
         <span class="text-danger">
           <i class="fa fa-trash"></i> <span translate>FORM.BUTTONS.DELETE</span>
         </span>

--- a/client/src/modules/templates/bhWeekendConfigSelect.tmpl.html
+++ b/client/src/modules/templates/bhWeekendConfigSelect.tmpl.html
@@ -1,32 +1,34 @@
-<div ng-form="{{ $ctrl.name }}" bh-weekend-config-select ng-model-options="{ updateOn: 'default' }">
+<div ng-form="WeekendConfigSelectForm" bh-weekend-config-select ng-model-options="{ updateOn: 'default' }">
   <div
     class="form-group"
-    ng-class="{ 'has-error' : $ctrl.validationTrigger && WeekendConfigForm.config_weekend_id.$invalid }">
+    ng-class="{ 'has-error' : WeekendConfigSelectForm.$submitted && WeekendConfigForm.config_weekend_id.$invalid }">
 
     <label class="control-label" translate>
-      {{ ::$ctrl.label }}
+      {{ $ctrl.label }}
     </label>
+
     <ng-transclude></ng-transclude>
+
     <div class="text-danger" ng-if="!$ctrl.weekendConfigs.length">
-      <i class="fa fa-exclamation-triangle"></i> <span translate> FORM.WARNINGS.NO_CONFIGURATION_FOUND </span>  
+      <i class="fa fa-exclamation-triangle"></i> <span translate> FORM.WARNINGS.NO_CONFIGURATION_FOUND </span>
     </div>
-        
+
     <ui-select
       name="config_weekend_id"
       ng-model="$ctrl.configWeekId"
-      on-select="$ctrl.onSelect($item, $model)"
+      on-select="$ctrl.onSelect($item)"
       ng-required="$ctrl.required">
       <ui-select-match placeholder="{{ ::'FORM.SELECT.WEEKEND_CONFIGURATION' | translate }}">
         <span>{{$select.selected.label}}</span>
       </ui-select-match>
       <ui-select-choices
         ui-select-focus-patch
-        repeat="weekendConfig.id as weekendConfig in $ctrl.weekendConfigs | filter: { 'label': $select.search }">        
+        repeat="weekendConfig.id as weekendConfig in $ctrl.weekendConfigs | filter: { 'label': $select.search }">
         <span ng-bind-html="weekendConfig.label | highlight:$select.search"></span>
       </ui-select-choices>
     </ui-select>
 
-    <div class="help-block" ng-messages="WeekendConfigForm.config_weekend_id.$error" ng-show="$ctrl.validationTrigger &&  WeekendConfigForm.config_weekend_id.$invalid">
+    <div class="help-block" ng-messages="WeekendConfigForm.config_weekend_id.$error" ng-show="WeekendConfigSelectForm.$submitted &&  WeekendConfigForm.config_weekend_id.$invalid">
       <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
     </div>
   </div>

--- a/test/end-to-end/weekendConfig/weekend_config.page.js
+++ b/test/end-to-end/weekendConfig/weekend_config.page.js
@@ -1,112 +1,73 @@
-/* global element, by */
+/* global $$ */
+/* eslint class-methods-use-this:off */
 
-/**
- * This class is represents a weekEnd Configuration page in term of structure and
- * behaviour so it is a weekEnd configuration page object
- */
-
-const chai = require('chai');
-const helpers = require('../shared/helpers');
-
-helpers.configure(chai);
-
-/* loading grid actions */
-const GA = require('../shared/GridAction');
-const GU = require('../shared/GridUtils');
+const GridRow = require('../shared/GridRow');
 const FU = require('../shared/FormUtils');
-const components = require('../shared/components');
+const { notification } = require('../shared/components');
 
-class WeekEndConfigPage {
-  constructor() {
-    this.gridId = 'weekEnd-config-grid';
-    this.weekEndGrid = element(by.id(this.gridId));
-    this.actionLinkColumn = 1;
-  }
+class WeekendConfigPage {
 
-  /**
-   * simulate the create weekEnd Configuration button click to show the dialog of creation
-   */
-  createWeekEndConfig(weekEnd) {
+  create(label) {
     FU.buttons.create();
-    FU.input('WeekEndModalCtrl.weekend.label', weekEnd.label);
-
-    FU.buttons.submit();
-    components.notification.hasSuccess();
+    FU.input('WeekendModalCtrl.weekend.label', label);
+    FU.modal.submit();
+    notification.hasSuccess();
   }
 
   /**
    * block creation without the function name
    */
-  errorOnCreateWeekEndConfig() {
+  errorOnCreateWeekendConfig() {
     FU.buttons.create();
     FU.buttons.submit();
-    FU.validation.error('WeekEndModalCtrl.weekend.label');
+    FU.validation.error('WeekendModalCtrl.weekend.label');
     FU.buttons.cancel();
   }
 
-  /**
-   * simulate a click on the edit link of a function
-   */
-  editWeekEndConfig(label, updateWeekEndConfig) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'edit', this.gridId);
-        FU.input('WeekEndModalCtrl.weekend.label', updateWeekEndConfig.label);
-
-        FU.buttons.submit();
-        components.notification.hasSuccess();
-      });
+  update(oldLabel, newLabel) {
+    const row = new GridRow(oldLabel);
+    row.dropdown().click();
+    row.edit().click();
+    FU.input('WeekendModalCtrl.weekend.label', newLabel);
+    FU.modal.submit();
+    notification.hasSuccess();
   }
 
-  /**
-   * simulate a click on the Configure link of a function
-   */
-  setWeekEndConfig(label) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'config', this.gridId);
+  setWeekendConfig(label) {
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.method('configure').click();
 
-        element.all(by.css('[name="days"]')).get(0).click();
-        element.all(by.css('[name="days"]')).get(1).click();
-        element.all(by.css('[name="days"]')).get(6).click();
+    // set days
+    const days = $$('[name="days"]');
+    days.get(0).click();
+    days.get(1).click();
+    days.get(6).click();
 
-        FU.buttons.submit();
-        components.notification.hasSuccess();
-      });
+    FU.modal.submit();
+    notification.hasSuccess();
   }
 
-  /**
-   * simulate a click on the Configure link of a function for Inset WeekEnd
-   */
-  inSetWeekEndConfig(label) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'config', this.gridId);
+  unsetWeekendConfig(label) {
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.method('configure').click();
 
-        element.all(by.css('[name="days"]')).get(0).click();
-        element.all(by.css('[name="days"]')).get(1).click();
-        element.all(by.css('[name="days"]')).get(6).click();
+    // set days
+    const days = $$('[name="days"]');
+    days.get(0).click();
+    days.get(1).click();
+    days.get(6).click();
 
-        FU.buttons.submit();
-        components.notification.hasSuccess();
-      });
+    FU.modal.submit();
+    notification.hasSuccess();
   }
 
-  /**
-   * simulate a click on the delete link of a function
-   */
-  deleteWeekEndConfig(label) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'delete', this.gridId);
-        components.modalAction.confirm();
-        components.notification.hasSuccess();
-      });
+  remove(label) {
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.remove().click();
   }
 }
 
-module.exports = WeekEndConfigPage;
+module.exports = WeekendConfigPage;

--- a/test/end-to-end/weekendConfig/weekend_config.spec.js
+++ b/test/end-to-end/weekendConfig/weekend_config.spec.js
@@ -1,46 +1,36 @@
 const helpers = require('../shared/helpers');
-const WeekEndConfigPage = require('./weekend_config.page');
-const chai = require('chai');
+const WeekendConfigPage = require('./weekend_config.page');
 
-/* configuring helpers */
-helpers.configure(chai);
-
-describe('Week End Configuration Management', () => {
+describe('Weekend Configuration Management', () => {
   // navigate to the page
   before(() => helpers.navigate('#!/payroll/weekend_configuration'));
 
-  const Page = new WeekEndConfigPage();
+  const page = new WeekendConfigPage();
 
-  const weekEndConfig = {
-    label : 'Configuration Week End 2013',
-  };
+  const newWeekendConfigLabel = 'Configuration Weekend 2013';
+  const updateWeekendConfigLabel = 'Configuration Weekend 2013 Updated';
 
-  const updateWeekEndConfig = {
-    label : 'Configuration Week End 2013 Updated',
-  };
-
-  it('successfully creates a new WeekEnd Configuration', () => {
-    Page.createWeekEndConfig(weekEndConfig);
+  it('successfully creates a new weekend configuration', () => {
+    page.create(newWeekendConfigLabel);
   });
 
-  it('successfully edits a WeekEnd Configuration', () => {
-    Page.editWeekEndConfig(weekEndConfig.label, updateWeekEndConfig);
+  it('successfully edits a weekend configuration', () => {
+    page.update(newWeekendConfigLabel, updateWeekendConfigLabel);
   });
 
-  it('successfully Set Week days in WeekEnd Configuration', () => {
-    Page.setWeekEndConfig(updateWeekEndConfig.label);
+  it('successfully set week days in weekend configuration', () => {
+    page.setWeekendConfig(updateWeekendConfigLabel);
   });
 
-  it('successfully InSet Week days in WeekEnd Configuration', () => {
-    Page.inSetWeekEndConfig(updateWeekEndConfig.label);
+  it('successfully inset week days in weekend configuration', () => {
+    page.unsetWeekendConfig(updateWeekendConfigLabel);
   });
 
-  it('don\'t create when incorrect WeekEnd', () => {
-    Page.errorOnCreateWeekEndConfig();
+  it('don\'t create an incorrect weekend', () => {
+    page.errorOnCreateWeekendConfig();
   });
 
-  it('successfully delete a WeekEnd', () => {
-    Page.deleteWeekEndConfig(updateWeekEndConfig.label);
+  it('successfully deletes a weekend', () => {
+    page.remove(updateWeekendConfigLabel);
   });
-
 });


### PR DESCRIPTION
The weekend tests have posed us issues in the past, but they have been updated for simplicity and clarity.  The grid uses GridRow to find entries by their labels and renames variables that were spelled in
correctly throughout the weekend configuration.  Additionally, the client-side has been updated to the latest ES2015+ standards.