### PR TITLE
Rewrite End to End tests for Rubrics, Holidays, Rubric Configuration, and IPR Tax

### DIFF
--- a/client/src/modules/holidays/holidays.html
+++ b/client/src/modules/holidays/holidays.html
@@ -7,21 +7,15 @@
 
     <div class="toolbar">
       <div class="toolbar-item">
-        <button class="btn btn-default text-capitalize" id="create" ui-sref="holidays.create" data-method="create">
+        <button class="btn btn-default text-capitalize" ui-sref="holidays.create" data-method="create">
           <span class="fa fa-plus"></span> <span translate>HOLIDAY.ADD_HOLIDAY</span>
         </button>
       </div>
 
-      <div class="toolbar-item">
-        <button
-          type="button"
-          ng-click="HolidayCtrl.toggleFilter()"
-          data-method="filter"
-          class="btn btn-default"
-          ng-class="{ 'btn-info' : HolidayCtrl.filterEnabled }">
-          <i class="fa fa-filter"></i>
-        </button>
-      </div>
+      <bh-filter-toggle
+        on-toggle="HolidayCtrl.toggleFilter()">
+      </bh-filter-toggle>
+
     </div>
   </div>
 </div>
@@ -29,9 +23,10 @@
 <!-- main content -->
 <div class="flex-content">
   <div class="container-fluid">
-    <div id="holiday-grid"
-      ui-grid="HolidayCtrl.gridOptions"
+    <div
+      id="holiday-grid"
       class="grid-full-height"
+      ui-grid="HolidayCtrl.gridOptions"
       ui-grid-auto-resize>
 
       <bh-grid-loading-indicator

--- a/client/src/modules/holidays/modals/holiday.modal.html
+++ b/client/src/modules/holidays/modals/holiday.modal.html
@@ -1,11 +1,12 @@
 <form name="HolidayForm" bh-submit="HolidayModalCtrl.submit(HolidayForm)" novalidate>
   <div class="modal-header">
     <ol class="headercrumb">
-      <li ng-if="HolidayModalCtrl.isCreating" class="title">
+      <li class="static" translate>HOLIDAY.TITLE</li>
+      <li ng-if="HolidayModalCtrl.isCreateState" class="title">
         <span translate>HOLIDAY.ADD_HOLIDAY</span>
         <label class="badge badge-success" translate>FORM.LABELS.CREATE</label>
       </li>
-      <li ng-if="!HolidayModalCtrl.isCreating" class="title">
+      <li ng-if="!HolidayModalCtrl.isCreateState" class="title">
         <span translate>HOLIDAY.EDIT_HOLIDAY</span>
         <label class="badge badge-success" translate>FORM.LABELS.UPDATE</label>
       </li>
@@ -13,15 +14,13 @@
   </div>
 
   <div class="modal-body">
-    <div class="form-group">
-      <bh-employee-select
-        employee-uuid="HolidayModalCtrl.holiday.employee_uuid"
-        on-select-callback="HolidayModalCtrl.onSelectEmployee(employee)"
-        required="true">
-      </bh-employee-select>
-    </div>
+    <bh-employee-select
+      employee-uuid="HolidayModalCtrl.holiday.employee_uuid"
+      on-select-callback="HolidayModalCtrl.onSelectEmployee(employee)"
+      required="true">
+    </bh-employee-select>
 
-    <div class="modal-body" ng-class="{ 'has-error' : HolidayForm.$submitted && HolidayForm.label.$invalid }">
+    <div class="form-group" ng-class="{ 'has-error' : HolidayForm.$submitted && HolidayForm.label.$invalid }">
       <label class="control-label" translate>FORM.LABELS.DESIGNATION</label>
       <input name="label" ng-model="HolidayModalCtrl.holiday.label" autocomplete="off" class="form-control" required>
       <div class="help-block" ng-messages="HolidayForm.label.$error" ng-show="HolidayForm.$submitted">
@@ -29,16 +28,14 @@
       </div>
     </div>
 
-    <div class="modal-body">
-      <bh-date-interval
-        label="FORM.LABELS.PERIODES"
-        date-id="holiday-date"
-        date-from="HolidayModalCtrl.holiday.dateFrom"
-        date-to="HolidayModalCtrl.holiday.dateTo">
-      </bh-date-interval>
-    </div>
+    <bh-date-interval
+      label="FORM.LABELS.PERIODES"
+      date-id="holiday-date"
+      date-from="HolidayModalCtrl.holiday.dateFrom"
+      date-to="HolidayModalCtrl.holiday.dateTo">
+    </bh-date-interval>
 
-    <div class="modal-body" ng-class="{ 'has-error' : HolidayForm.$submitted && HolidayForm.percentage.$invalid }">
+    <div class="form-group" ng-class="{ 'has-error' : HolidayForm.$submitted && HolidayForm.percentage.$invalid }">
       <label class="control-label" translate>FORM.LABELS.PERCENTAGE</label>
       <input name="percentage" type="number" max="100" min="0" ng-model="HolidayModalCtrl.holiday.percentage" autocomplete="off" class="form-control" required>
       <div class="help-block" ng-messages="HolidayForm.percentage.$error" ng-show="HolidayForm.$submitted">
@@ -53,7 +50,6 @@
     </button>
 
     <bh-loading-button loading-state="HolidayForm.$loading">
-      <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>
   </div>
 </form>

--- a/client/src/modules/holidays/modals/holiday.modal.js
+++ b/client/src/modules/holidays/modals/holiday.modal.js
@@ -12,17 +12,19 @@ function HolidayModalController($state, Holidays, ModalService, Notify, AppCache
   const cache = AppCache('HolidayModal');
 
   if ($state.params.creating || $state.params.id) {
-    vm.stateParams = cache.stateParams = $state.params;
+    cache.stateParams = $state.params;
+    vm.stateParams = cache.stateParams;
   } else {
     vm.stateParams = cache.stateParams;
   }
-  vm.isCreating = vm.stateParams.creating;
+
+  vm.isCreateState = vm.stateParams.creating;
 
   // exposed methods
   vm.submit = submit;
   vm.closeModal = closeModal;
 
-  if (!vm.isCreating) {
+  if (!vm.isCreateState) {
     Holidays.read(vm.stateParams.id)
       .then((holiday) => {
         holiday.dateFrom = new Date(holiday.dateFrom);
@@ -46,13 +48,13 @@ function HolidayModalController($state, Holidays, ModalService, Notify, AppCache
     vm.holiday.dateFrom = moment(vm.holiday.dateFrom).format('YYYY-MM-DD');
     vm.holiday.dateTo = moment(vm.holiday.dateTo).format('YYYY-MM-DD');
 
-    const promise = (vm.isCreating) ?
-      Holidays.create(vm.holiday) :
-      Holidays.update(vm.holiday.id, vm.holiday);
+    const promise = (vm.isCreateState)
+      ? Holidays.create(vm.holiday)
+      : Holidays.update(vm.holiday.id, vm.holiday);
 
     return promise
       .then(() => {
-        const translateKey = (vm.isCreating) ? 'FORM.INFO.CREATE_SUCCESS' : 'FORM.INFO.UPDATE_SUCCESS';
+        const translateKey = (vm.isCreateState) ? 'FORM.INFO.CREATE_SUCCESS' : 'FORM.INFO.UPDATE_SUCCESS';
         Notify.success(translateKey);
         $state.go('holidays', null, { reload : true });
       })

--- a/client/src/modules/holidays/templates/action.tmpl.html
+++ b/client/src/modules/holidays/templates/action.tmpl.html
@@ -1,18 +1,19 @@
-<div class="ui-grid-cell-contents text-center" uib-dropdown dropdown-append-to-body>
-  <a uib-dropdown-toggle href>
-    <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
+<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body data-row="{{row.entity.label}}">
+  <a uib-dropdown-toggle href data-action="open-dropdown-menu">
+    <span translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
 
-  <ul data-action="{{rowRenderIndex}}"  class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+  <ul data-row-menu="{{row.entity.label}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+    <li class="dropdown-header">{{row.entity.label}}</li>
     <li>
-      <a data-method="edit" ng-click="grid.appScope.editHoliday(row.entity)" href>
+      <a data-method="edit-record" ng-click="grid.appScope.editHoliday(row.entity)" href>
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
       </a>
     </li>
     <li class="divider"></li>
     <li>
-      <a data-method="delete" ng-click="grid.appScope.deleteHoliday(row.entity)" href>
+      <a data-method="delete-record" ng-click="grid.appScope.deleteHoliday(row.entity)" href>
         <span class="text-danger">
           <i class="fa fa-trash"></i> <span translate>FORM.BUTTONS.DELETE</span>
         </span>

--- a/client/src/modules/ipr_tax/ipr_tax.html
+++ b/client/src/modules/ipr_tax/ipr_tax.html
@@ -1,27 +1,20 @@
 <div class="flex-header">
   <div class="bhima-title">
     <ol class="headercrumb">
-      <li class="static" translate> TREE.ADMIN </li>
-      <li class="title" translate> IPRTAX.TITLE </li>
+      <li class="static" translate>TREE.ADMIN</li>
+      <li class="title" translate>IPRTAX.TITLE</li>
     </ol>
 
     <div class="toolbar">
       <div class="toolbar-item">
         <button class="btn btn-default text-capitalize" ui-sref="ipr_tax.create" data-method="create">
-          <span class="fa fa-plus"></span> <span translate>IPRTAX.ADD_IPRTAX</span>
+          <span class="fa fa-plus"></span> <span class="hidden-xs" translate>IPRTAX.ADD_IPRTAX</span>
         </button>
       </div>
 
-      <div class="toolbar-item">
-        <button
-          type="button"
-          ng-click="IprTaxCtrl.toggleFilter()"
-          data-method="filter"
-          class="btn btn-default"
-          ng-class="{ 'btn-info' : IprTaxCtrl.filterEnabled }">
-          <i class="fa fa-filter"></i>
-        </button>
-      </div>
+      <bh-filter-toggle
+        on-toggle="IprTaxCtrl.toggleFilter()">
+      </bh-filter-toggle>
     </div>
   </div>
 </div>
@@ -29,9 +22,10 @@
 <!-- main content -->
 <div class="flex-content">
   <div class="container-fluid">
-    <div id="ipr-grid"
-      ui-grid="IprTaxCtrl.gridOptions"
+    <div
+      id="ipr-grid"
       class="grid-full-height"
+      ui-grid="IprTaxCtrl.gridOptions"
       ui-grid-auto-resize>
 
       <bh-grid-loading-indicator

--- a/client/src/modules/ipr_tax/ipr_tax.js
+++ b/client/src/modules/ipr_tax/ipr_tax.js
@@ -1,9 +1,8 @@
 angular.module('bhima.controllers')
-.controller('IprTaxManagementController', IprTaxManagementController);
+  .controller('IprTaxManagementController', IprTaxManagementController);
 
 IprTaxManagementController.$inject = [
-  'IprTaxService', 'ModalService',
-  'NotifyService', 'uiGridConstants', '$state', 'SessionService',
+  'IprTaxService', 'ModalService', 'NotifyService', 'uiGridConstants',
 ];
 
 /**
@@ -12,33 +11,30 @@ IprTaxManagementController.$inject = [
  * This controller is about the IprTax management module in the admin zone
  * It's responsible for creating, editing and updating a IprTax
  */
-function IprTaxManagementController(IprTaxes, ModalService,
-  Notify, uiGridConstants, $state, Session) {
-  var vm = this;
+function IprTaxManagementController(IprTaxes, ModalService, Notify, uiGridConstants) {
+  const vm = this;
 
   // bind methods
   vm.deleteIprTax = deleteIprTax;
-  vm.editIprTax = editIprTax;
   vm.toggleFilter = toggleFilter;
 
   // global variables
   vm.gridApi = {};
   vm.filterEnabled = false;
 
-  var gridColumn =
-    [
-    
-      { field : 'label', displayName : 'FORM.LABELS.DESIGNATION', headerCellFilter : 'translate' },
-      { field : 'description', displayName : 'FORM.LABELS.DESCRIPTION', headerCellFilter : 'translate' },
-      { field : 'currency_name', displayName : 'FORM.LABELS.CURRENCY', headerCellFilter : 'translate' },
-      { field : 'action',
-        width : 80,
-        displayName : '',
-        cellTemplate : '/modules/ipr_tax/templates/action.tmpl.html',
-        enableSorting : false,
-        enableFiltering : false,
-      },
-    ];
+  const gridColumn = [
+    { field : 'label', displayName : 'FORM.LABELS.DESIGNATION', headerCellFilter : 'translate' },
+    { field : 'description', displayName : 'FORM.LABELS.DESCRIPTION', headerCellFilter : 'translate' },
+    { field : 'currency_name', displayName : 'FORM.LABELS.CURRENCY', headerCellFilter : 'translate' },
+    {
+      field : 'action',
+      width : 80,
+      displayName : '',
+      cellTemplate : '/modules/ipr_tax/templates/action.tmpl.html',
+      enableSorting : false,
+      enableFiltering : false,
+    },
+  ];
 
   // options for the UI grid
   vm.gridOptions = {
@@ -56,8 +52,7 @@ function IprTaxManagementController(IprTaxes, ModalService,
   }
 
   function toggleFilter() {
-    vm.filterEnabled = !vm.filterEnabled;
-    vm.gridOptions.enableFiltering = vm.filterEnabled;
+    vm.gridOptions.enableFiltering = !vm.gridOptions.enableFiltering;
     vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
   }
 
@@ -65,33 +60,28 @@ function IprTaxManagementController(IprTaxes, ModalService,
     vm.loading = true;
 
     IprTaxes.read()
-    .then(function (data) {
-      vm.gridOptions.data = data;
-    })
-    .catch(Notify.handleError)
-    .finally(function () {
-      vm.loading = false;
-    });
+      .then(data => {
+        vm.gridOptions.data = data;
+      })
+      .catch(Notify.handleError)
+      .finally(() => {
+        vm.loading = false;
+      });
   }
 
   // switch to delete warning mode
   function deleteIprTax(title) {
     ModalService.confirm('FORM.DIALOGS.CONFIRM_DELETE')
-    .then(function (bool) {
-      if (!bool) { return; }
+      .then(bool => {
+        if (!bool) { return; }
 
-      IprTaxes.delete(title.id)
-      .then(function () {
-        Notify.success('FORM.INFO.DELETE_SUCCESS');
-        loadIprTaxes();
-      })
-      .catch(Notify.handleError);
-    });
-  }
-
-  // update an existing IprTax
-  function editIprTax(title) {
-    $state.go('ipr_tax.edit', { id : title.id });
+        IprTaxes.delete(title.id)
+          .then(() => {
+            Notify.success('FORM.INFO.DELETE_SUCCESS');
+            loadIprTaxes();
+          })
+          .catch(Notify.handleError);
+      });
   }
 
   loadIprTaxes();

--- a/client/src/modules/ipr_tax/ipr_tax.routes.js
+++ b/client/src/modules/ipr_tax/ipr_tax.routes.js
@@ -1,5 +1,5 @@
 angular.module('bhima.routes')
-  .config(['$stateProvider', function ($stateProvider) {
+  .config(['$stateProvider', $stateProvider => {
     $stateProvider
       .state('ipr_tax', {
         url         : '/ipr_tax',

--- a/client/src/modules/ipr_tax/modals/ipr_tax.modal.html
+++ b/client/src/modules/ipr_tax/modals/ipr_tax.modal.html
@@ -1,6 +1,7 @@
 <form name="IprTaxForm" bh-submit="IprTaxModalCtrl.submit(IprTaxForm)" novalidate>
   <div class="modal-header">
     <ol class="headercrumb">
+      <li class="static" translate>IPRTAX.TITLE</li>
       <li ng-if="IprTaxModalCtrl.isCreating" class="title">
         <span translate>IPRTAX.ADD_IPRTAX</span>
         <label class="badge badge-success" translate>FORM.LABELS.CREATE</label>
@@ -13,7 +14,7 @@
   </div>
 
   <div class="modal-body">
-    <div class="modal-body" ng-class="{ 'has-error' : IprTaxForm.$submitted && IprTaxForm.label.$invalid }">
+    <div class="form-group" ng-class="{ 'has-error' : IprTaxForm.$submitted && IprTaxForm.label.$invalid }">
       <label class="control-label" translate>FORM.LABELS.DESIGNATION</label>
       <input name="label" ng-model="IprTaxModalCtrl.iprTax.label" autocomplete="off" class="form-control" required>
       <div class="help-block" ng-messages="IprTaxForm.label.$error" ng-show="IprTaxForm.$submitted">
@@ -21,7 +22,7 @@
       </div>
     </div>
 
-    <div class="modal-body" ng-class="{ 'has-error' : IprTaxForm.$submitted && IprTaxForm.description.$invalid }">
+    <div class="form-group" ng-class="{ 'has-error' : IprTaxForm.$submitted && IprTaxForm.description.$invalid }">
       <label class="control-label" translate>FORM.LABELS.DESCRIPTION</label>
       <textarea
         ng-model="IprTaxModalCtrl.iprTax.description"
@@ -35,12 +36,10 @@
       </div>
     </div>
 
-    <div class="modal-body">
-      <bh-currency-select
-        currency-id="IprTaxModalCtrl.iprTax.currency_id"
-        validation-trigger="IprTaxForm.$submitted">
-      </bh-currency-select>
-    </div>      
+    <bh-currency-select
+      currency-id="IprTaxModalCtrl.iprTax.currency_id"
+      validation-trigger="IprTaxForm.$submitted">
+    </bh-currency-select>
   </div>
 
   <div class="modal-footer">

--- a/client/src/modules/ipr_tax/templates/action.tmpl.html
+++ b/client/src/modules/ipr_tax/templates/action.tmpl.html
@@ -1,18 +1,19 @@
-<div class="ui-grid-cell-contents text-center" uib-dropdown dropdown-append-to-body>
-  <a uib-dropdown-toggle href>
-    <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
+<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body data-row="{{row.entity.label}}">
+  <a uib-dropdown-toggle href data-action="open-dropdown-menu">
+    <span translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
 
-  <ul data-action="{{rowRenderIndex}}"  class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+  <ul data-row-menu="{{row.entity.label}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+    <li class="dropdown-header">{{row.entity.label}}</li>
     <li>
-      <a data-method="edit" ng-click="grid.appScope.editIprTax(row.entity)" href>
+      <a data-method="edit-record" ui-sref="ipr_tax.edit({ id : row.entity.id })" href>
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
       </a>
     </li>
     <li class="divider"></li>
     <li>
-      <a data-method="delete" ng-click="grid.appScope.deleteIprTax(row.entity)" href>
+      <a data-method="delete-record" ng-click="grid.appScope.deleteIprTax(row.entity)" href>
         <span class="text-danger">
           <i class="fa fa-trash"></i> <span translate>FORM.BUTTONS.DELETE</span>
         </span>

--- a/client/src/modules/payroll/rubric_configuration/configuration.html
+++ b/client/src/modules/payroll/rubric_configuration/configuration.html
@@ -7,21 +7,14 @@
 
     <div class="toolbar">
       <div class="toolbar-item">
-        <button class="btn btn-default text-capitalize" id="create" ui-sref="configurationRubric.create" data-method="create">
-          <span class="fa fa-plus"></span> <span translate>FORM.BUTTONS.ADD_RUBRIC_CONFIGURATION</span>
+        <button class="btn btn-default text-capitalize" ui-sref="configurationRubric.create" data-method="create">
+          <span class="fa fa-plus"></span> <span class="hidden-xs" translate>FORM.BUTTONS.ADD_RUBRIC_CONFIGURATION</span>
         </button>
       </div>
 
-      <div class="toolbar-item">
-        <button
-          type="button"
-          ng-click="ConfigurationCtrl.toggleFilter()"
-          data-method="filter"
-          class="btn btn-default"
-          ng-class="{ 'btn-info' : ConfigurationCtrl.filterEnabled }">
-          <i class="fa fa-filter"></i>
-        </button>
-      </div>
+      <bh-filter-toggle
+        on-toggle="ConfigurationCtrl.toggleFilter()">
+      </bh-filter-toggle>
     </div>
   </div>
 </div>
@@ -29,9 +22,10 @@
 <!-- main content -->
 <div class="flex-content">
   <div class="container-fluid">
-    <div id="rubric-grid"
-      ui-grid="ConfigurationCtrl.gridOptions"
+    <div
+      id="rubric-grid"
       class="grid-full-height"
+      ui-grid="ConfigurationCtrl.gridOptions"
       ui-grid-auto-resize
       ui-grid-resize-columns>
 

--- a/client/src/modules/payroll/rubric_configuration/modals/config.modal.html
+++ b/client/src/modules/payroll/rubric_configuration/modals/config.modal.html
@@ -10,8 +10,8 @@
 
   <div class="modal-body">
     <ul class="list-group" style="max-height: 70vh; overflow:auto;">
-      <li ng-if="!RubricConfigModalCtrl.rubrics.length" class="list-group-item">      
-        <span translate>TABLE.COLUMNS.EMPTY</span>        
+      <li ng-if="!RubricConfigModalCtrl.rubrics.length" class="list-group-item">
+        <span translate>TABLE.COLUMNS.EMPTY</span>
       </li>
 
       <li ng-if="RubricConfigModalCtrl.rubrics.length" class="list-group-item">
@@ -22,21 +22,21 @@
           </label>
         </div>
       </li>
-      
+
       <li ng-if="RubricConfigModalCtrl.socialCares.length" class="list-group-item">
         <div style="margin:0" class="checkbox">
           <label style="padding-left: 8%">
             <input type="checkbox" ng-model="RubricConfigModalCtrl.headSocial" id="social" ng-change="RubricConfigModalCtrl.toggleSocialCares(RubricConfigModalCtrl.socialCheck)">
-            <span translate> FORM.LABELS.SOCIAL_CARE </span> 
-          </label> 
+            <span translate> FORM.LABELS.SOCIAL_CARE </span>
+          </label>
         </div>
-      </li>      
+      </li>
       <li ng-repeat="rubric in RubricConfigModalCtrl.socialCares" class="list-group-item">
         <div style="margin:0" class="checkbox">
           <label style="padding-left: 12%">
             <input type="checkbox" ng-model="rubric.checked">
             <span>{{ rubric.label }}</span>
-          </label> 
+          </label>
         </div>
       </li>
 
@@ -44,16 +44,16 @@
         <div style="margin:0" class="checkbox">
           <label style="padding-left: 8%">
             <input type="checkbox" ng-model="RubricConfigModalCtrl.headMembershipFee" ng-change="RubricConfigModalCtrl.toggleMembershipFee(RubricConfigModalCtrl.membershipFeeCheck)">
-            <span translate> FORM.LABELS.MEMBERSHIP_FEE </span> 
-          </label> 
+            <span translate> FORM.LABELS.MEMBERSHIP_FEE </span>
+          </label>
         </div>
-      </li>      
+      </li>
       <li ng-repeat="rubric in RubricConfigModalCtrl.membershipFee" class="list-group-item">
         <div style="margin:0" class="checkbox">
           <label style="padding-left: 12%">
             <input type="checkbox" ng-model="rubric.checked">
             <span>{{ rubric.label }}</span>
-          </label> 
+          </label>
         </div>
       </li>
 
@@ -61,16 +61,16 @@
         <div style="margin:0" class="checkbox">
           <label style="padding-left: 8%">
             <input type="checkbox" ng-model="RubricConfigModalCtrl.headTax" id="tax" ng-change="RubricConfigModalCtrl.toggleTaxes(RubricConfigModalCtrl.taxCheck)">
-            <span translate> FORM.LABELS.TAXES </span> 
-          </label> 
+            <span translate> FORM.LABELS.TAXES </span>
+          </label>
         </div>
-      </li>      
+      </li>
       <li ng-repeat="rubric in RubricConfigModalCtrl.taxes" class="list-group-item">
         <div style="margin:0" class="checkbox">
           <label style="padding-left: 12%">
             <input type="checkbox" ng-model="rubric.checked">
             <span>{{ rubric.label }}</span>
-          </label> 
+          </label>
         </div>
       </li>
 
@@ -78,8 +78,8 @@
         <div style="margin:0" class="checkbox">
           <label style="padding-left: 8%">
             <input type="checkbox" ng-model="RubricConfigModalCtrl.headOther" ng-change="RubricConfigModalCtrl.toggleOthers(RubricConfigModalCtrl.otherCheck)">
-            <span translate> FORM.LABELS.OTHERS </span> 
-          </label> 
+            <span translate> FORM.LABELS.OTHERS </span>
+          </label>
         </div>
       </li>
       <li ng-repeat="unit in RubricConfigModalCtrl.others" class="list-group-item">
@@ -87,16 +87,11 @@
           <label style="padding-left: 12%">
             <input type="checkbox" ng-model="unit.checked">
             <span>{{ unit.label }}</span>
-          </label> 
+          </label>
         </div>
       </li>
-
-
     </ul>
   </div>
-
-
-
 
   <div class="modal-footer">
     <button data-method="cancel" type="button" class="btn btn-default" ng-click="RubricConfigModalCtrl.closeModal()">

--- a/client/src/modules/payroll/rubric_configuration/templates/action.tmpl.html
+++ b/client/src/modules/payroll/rubric_configuration/templates/action.tmpl.html
@@ -1,23 +1,24 @@
-<div class="ui-grid-cell-contents text-center" uib-dropdown dropdown-append-to-body>
-  <a uib-dropdown-toggle href>
-    <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
+<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body data-row="{{row.entity.label}}">
+  <a uib-dropdown-toggle href data-action="open-dropdown-menu">
+    <span translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
 
-  <ul data-action="{{rowRenderIndex}}"  class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+  <ul data-row-menu="{{row.entity.label}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+    <li class="dropdown-header">{{row.entity.label}}</li>
     <li>
-      <a data-method="edit" ui-sref="configurationRubric.edit({id : row.entity.id})" href>
+      <a data-method="edit-record" ui-sref="configurationRubric.edit({id : row.entity.id})" href>
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
       </a>
     </li>
     <li>
-      <a data-method="config" ui-sref="configurationRubric.config({id : row.entity.id})" href>
+      <a data-method="configure" ui-sref="configurationRubric.config({id : row.entity.id})" href>
         <i class="fa fa-cog"></i> <span translate>FORM.BUTTONS.CONFIGURE</span>
       </a>
     </li>
     <li class="divider"></li>
     <li>
-      <a data-method="delete" ng-click="grid.appScope.deleteConfig(row.entity)" href>
+      <a data-method="delete-record" ng-click="grid.appScope.deleteConfig(row.entity)" href>
         <span class="text-danger">
           <i class="fa fa-trash"></i> <span translate>FORM.BUTTONS.DELETE</span>
         </span>

--- a/client/src/modules/payroll/rubrics/rubrics.html
+++ b/client/src/modules/payroll/rubrics/rubrics.html
@@ -36,8 +36,8 @@
       </div>
 
       <div class="toolbar-item">
-        <button class="btn btn-default text-capitalize" id="create" ui-sref="rubrics.create" data-method="create">
-          <span class="fa fa-plus"></span> <span translate>PAYROLL_RUBRIC.ADD_PAYROLL_RUBRIC</span>
+        <button class="btn btn-default text-capitalize" ui-sref="rubrics.create" data-method="create">
+          <span class="fa fa-plus"></span> <span class="hidden-xs" translate>PAYROLL_RUBRIC.ADD_PAYROLL_RUBRIC</span>
         </button>
       </div>
 

--- a/client/src/modules/payroll/rubrics/templates/action.tmpl.html
+++ b/client/src/modules/payroll/rubrics/templates/action.tmpl.html
@@ -1,18 +1,19 @@
-<div class="ui-grid-cell-contents text-center" uib-dropdown dropdown-append-to-body>
-  <a uib-dropdown-toggle href>
-    <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
+<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body data-row="{{row.entity.label}}">
+  <a uib-dropdown-toggle href data-action="open-dropdown-menu">
+    <span translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
 
-  <ul data-action="{{rowRenderIndex}}"  class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+  <ul data-row-menu="{{row.entity.label}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+    <li class="dropdown-header">{{row.entity.label}}</li>
     <li>
-      <a data-method="edit" ng-click="grid.appScope.editRubric(row.entity)" href>
+      <a data-method="edit-record" ng-click="grid.appScope.editRubric(row.entity)" href>
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
       </a>
     </li>
     <li class="divider"></li>
     <li>
-      <a data-method="delete" ng-click="grid.appScope.deleteRubric(row.entity)" href>
+      <a data-method="delete-record" ng-click="grid.appScope.deleteRubric(row.entity)" href>
         <span class="text-danger">
           <i class="fa fa-trash"></i> <span translate>FORM.BUTTONS.DELETE</span>
         </span>

--- a/client/src/modules/users/templates/grid/action.cell.html
+++ b/client/src/modules/users/templates/grid/action.cell.html
@@ -4,7 +4,7 @@
   uib-dropdown-toggle
   data-row="{{row.entity.display_name}}">
   <a href data-action="open-dropdown-menu">
-    <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
+    <span translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
 

--- a/test/end-to-end/employees/registration.page.js
+++ b/test/end-to-end/employees/registration.page.js
@@ -1,4 +1,5 @@
 /* global element, by */
+/* eslint class-methods-use-this:off */
 
 /**
  * This class is represents an employee registration page
@@ -124,10 +125,10 @@ class RegistrationPage {
 
   // Set RubricPayroll defined value By Employee
   setRubricPayroll(rubrics) {
-    for (let key in rubrics) {
-      let rubricPayroll = element( by.id(key));
-      rubricPayroll.sendKeys(rubrics[key]);    
-    }
+    Object.keys(rubrics).forEach(key => {
+      const rubricPayroll = element(by.id(key));
+      rubricPayroll.sendKeys(rubrics[key]);
+    });
   }
 
   // set origin location
@@ -140,11 +141,11 @@ class RegistrationPage {
     components.locationSelect.set(locations, 'current-location-id');
   }
 
-  isEmpoyeeCreated(resp) {
+  isEmployeeCreated(resp) {
     return FU.exists(by.id('receipt-confirm-created'), resp);
   }
 
-  expectNotificationSuccess(resp) {
+  expectNotificationSuccess() {
     components.notification.hasSuccess();
   }
 
@@ -158,7 +159,7 @@ class RegistrationPage {
     FU.validation.error('EmployeeCtrl.employee.hospital_no');
   }
 
-  noRequiredFieldOk() {
+  notRequiredFieldOk() {
     FU.validation.ok('EmployeeCtrl.employee.nb_enfant');
     FU.validation.ok('EmployeeCtrl.employee.phone');
     FU.validation.ok('EmployeeCtrl.employee.email');

--- a/test/end-to-end/employees/registration.spec.js
+++ b/test/end-to-end/employees/registration.spec.js
@@ -38,7 +38,7 @@ describe('Employees', () => {
     creditor_group : 'Employees',
   };
 
-  const pathPatient = '#!/employees/81af634f-321a-40de-bc6f-ceb1167a9f65/patientAsEmployee';
+  const pathPatient = '#!/employees/81AF634F321A40DEBC6FCEB1167A9F65/patientAsEmployee';
 
   before(() => helpers.navigate(path));
 
@@ -48,7 +48,7 @@ describe('Employees', () => {
 
     registrationPage.createEmployee();
     registrationPage.requiredFieldErrored();
-    registrationPage.noRequiredFieldOk();
+    registrationPage.notRequiredFieldOk();
   });
 
   it('creates a new employee', () => {
@@ -81,7 +81,7 @@ describe('Employees', () => {
     registrationPage.setBankAccount(employee.bank_account);
 
     registrationPage.createEmployee();
-    registrationPage.isEmpoyeeCreated(true);
+    registrationPage.isEmployeeCreated(true);
     browser.refresh();
   });
 

--- a/test/end-to-end/employees/registry.spec.js
+++ b/test/end-to-end/employees/registry.spec.js
@@ -1,10 +1,7 @@
-const chai = require('chai');
 const helpers = require('../shared/helpers');
 
 const EmployeeRegistryPage = require('./registry.page.js');
 const SearchModalPage = require('./searchModal.page.js');
-
-helpers.configure(chai);
 
 describe('Employees Registry', () => {
   const path = '#!/employees';
@@ -63,7 +60,7 @@ describe('Employees Registry', () => {
     searchModalPage.setReference(parameters.reference);
     searchModalPage.submit();
     employeeRegistryPage.employeeCount(ONE_EMPLOYEE, `The number of filtered employee should be ${ONE_EMPLOYEE}`);
-    employeeRegistryPage.clearFilter();  
+    employeeRegistryPage.clearFilter();
   });
 
   it('clearing filters restores default number of rows to the grid', () => {

--- a/test/end-to-end/holidays/holidays.page.js
+++ b/test/end-to-end/holidays/holidays.page.js
@@ -1,36 +1,28 @@
-/* global element, by */
-
-/**
- * This class is represents a holiday page in term of structure and
- * behaviour so it is a holiday page object
- */
+/* eslint class-methods-use-this:off */
 
 /* loading grid actions */
-const GA = require('../shared/GridAction');
-const GU = require('../shared/GridUtils');
+const GridRow = require('../shared/GridRow');
 const FU = require('../shared/FormUtils');
 const components = require('../shared/components');
 
 class HolidayPage {
   constructor() {
-    this.gridId = 'holiday-grid';
-    this.holidayGrid = element(by.id(this.gridId));
-    this.actionLinkColumn = 5;
+    this.modal = $('[uib-modal-window]');
   }
 
   /**
    * simulate the create holiday button click to show the dialog of creation
    */
-  createHoliday(holiday) {
+  create(holiday) {
     FU.buttons.create();
-    components.employeeSelect.set('Test');
+    components.employeeSelect.set('Employee');
 
     FU.input('HolidayModalCtrl.holiday.label', holiday.label);
     FU.input('HolidayModalCtrl.holiday.percentage', holiday.percentage);
 
     components.dateInterval.range(holiday.dateFrom, holiday.dateTo);
 
-    FU.buttons.submit();
+    FU.modal.submit();
     components.notification.hasSuccess();
   }
 
@@ -39,17 +31,16 @@ class HolidayPage {
    */
   preventHoliday(holiday) {
     FU.buttons.create();
-    components.employeeSelect.set('Test');
+    components.employeeSelect.set('Employee');
 
-    FU.input('HolidayModalCtrl.holiday.label', holiday.label);
-    FU.input('HolidayModalCtrl.holiday.percentage', holiday.percentage);
+    FU.input('HolidayModalCtrl.holiday.label', holiday.label, this.modal);
+    FU.input('HolidayModalCtrl.holiday.percentage', holiday.percentage, this.modal);
 
     components.dateInterval.range(holiday.dateFrom, holiday.dateTo);
 
-    FU.buttons.submit();
+    FU.modal.submit();
     FU.buttons.cancel();
 
-    // FIX ME TO CHECK ERROR UNDER THE MODAL
     components.notification.hasError();
   }
 
@@ -66,29 +57,23 @@ class HolidayPage {
   /**
    * simulate a click on the edit link of a function
    */
-  editHoliday(label, updateHoliday) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'edit', this.gridId);
-        FU.input('HolidayModalCtrl.holiday.label', updateHoliday.label);
+  update(label, updateHoliday) {
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.edit().click();
 
-        FU.buttons.submit();
-        components.notification.hasSuccess();
-      });
+    FU.input('HolidayModalCtrl.holiday.label', updateHoliday.label, this.modal);
+
+    FU.buttons.submit();
+    components.notification.hasSuccess();
   }
 
-  /**
-   * simulate a click on the delete link of a function
-   */
-  deleteHoliday(label) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'delete', this.gridId);
-        components.modalAction.confirm();
-        components.notification.hasSuccess();
-      });
+  remove(label) {
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.remove().click();
+    FU.modal.submit();
+    components.notification.hasSuccess();
   }
 }
 

--- a/test/end-to-end/holidays/holidays.spec.js
+++ b/test/end-to-end/holidays/holidays.spec.js
@@ -2,10 +2,9 @@ const helpers = require('../shared/helpers');
 const HolidayPage = require('./holidays.page');
 
 describe('Holidays Management', () => {
-  // navigate to the page
   before(() => helpers.navigate('#!/holidays'));
 
-  const Page = new HolidayPage();
+  const page = new HolidayPage();
 
   const holiday = {
     percentage  : 100,
@@ -26,24 +25,23 @@ describe('Holidays Management', () => {
     percentage : 75,
   };
 
-  it('successfully creates a new Holiday', () => {
-    Page.createHoliday(holiday);
+  it('successfully creates a new holiday', () => {
+    page.create(holiday);
   });
 
-  it('successfully edits a Holiday', () => {
-    Page.editHoliday(holiday.label, updateHoliday);
+  it('successfully edits a holiday', () => {
+    page.update(holiday.label, updateHoliday);
   });
 
-  it('Prevent the definition of a nested vacation period', () => {
-    Page.preventHoliday(nestedHoliday);
+  it('prevent the definition of a nested vacation period', () => {
+    page.preventHoliday(nestedHoliday);
   });
 
   it('don\'t create when incorrect Holiday', () => {
-    Page.errorOnCreateHoliday();
+    page.errorOnCreateHoliday();
   });
 
-  it('successfully delete a Holiday', () => {
-    Page.deleteHoliday(updateHoliday.label);
+  it('successfully delete a holiday', () => {
+    page.remove(updateHoliday.label);
   });
-
 });

--- a/test/end-to-end/iprTaxes/iprTaxes.page.js
+++ b/test/end-to-end/iprTaxes/iprTaxes.page.js
@@ -1,89 +1,60 @@
 /* global element, by */
+/* eslint class-methods-use-this:off */
 
-/**
- * This class is represents a Ipr Tax page in term of structure and
- * behaviour so it is a Ipr Tax page object
- */
-
-const chai = require('chai');
-const helpers = require('../shared/helpers');
-
-helpers.configure(chai);
-
-/* loading grid actions */
-const GU = require('../shared/GridUtils');
-const GA = require('../shared/GridAction');
+const GridRow = require('../shared/GridRow');
 const FU = require('../shared/FormUtils');
 const components = require('../shared/components');
 
 class IprTaxPage {
   constructor() {
     this.gridId = 'ipr-grid';
-    this.iprTaxGrid = element(by.id(this.gridId));
-    this.actionLinkColumn = 3;
   }
 
-  /**
-   * send back the number of iprTaxes in the grid
-   */
-  getIprTaxCount() {
-    return this.iprTaxGrid
+  count() {
+    return element(by.id(this.gridId))
       .element(by.css('.ui-grid-render-container-body'))
       .all(by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index'))
       .count();
   }
 
-  /**
-   * simulate the create Ipr Scale button click to show the dialog of creation
-   */
-  createIprTax(iprTax) {
+  create(iprTax) {
     FU.buttons.create();
+
     FU.input('IprTaxModalCtrl.iprTax.label', iprTax.label);
     FU.input('IprTaxModalCtrl.iprTax.description', iprTax.description);
     components.currencySelect.set(iprTax.currency_id);
-    
-    FU.buttons.submit();
+
+    FU.modal.submit();
     components.notification.hasSuccess();
   }
 
-  /**
-   * block creation without the function name
-   */
   errorOnCreateIprTax() {
     FU.buttons.create();
-    FU.buttons.submit();
+    FU.modal.submit();
     FU.validation.error('IprTaxModalCtrl.iprTax.label');
     FU.buttons.cancel();
   }
 
-  /**
-   * simulate a click on the edit link of a function
-   */
-  editIprTax(label, updateIprTax) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'edit', this.gridId);
-        FU.input('IprTaxModalCtrl.iprTax.label', updateIprTax.label);
-        FU.input('IprTaxModalCtrl.iprTax.description', updateIprTax.description);
-        components.currencySelect.set(updateIprTax.currency_id);
+  update(label, updateIprTax) {
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.edit().click();
 
-        FU.buttons.submit();
-        components.notification.hasSuccess();
-      });
+    FU.input('IprTaxModalCtrl.iprTax.label', updateIprTax.label);
+    FU.input('IprTaxModalCtrl.iprTax.description', updateIprTax.description);
+    components.currencySelect.set(updateIprTax.currency_id);
+
+    FU.modal.submit();
+    components.notification.hasSuccess();
   }
 
-  /**
-   * simulate a click on the delete link of a function
-   */
-  deleteIprTax(label) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'delete', this.gridId);
-        components.modalAction.confirm();
-        components.notification.hasSuccess();
-      });
+  remove(label) {
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.remove().click();
+
+    components.modalAction.confirm();
+    components.notification.hasSuccess();
   }
 }
 

--- a/test/end-to-end/iprTaxes/iprTaxes.spec.js
+++ b/test/end-to-end/iprTaxes/iprTaxes.spec.js
@@ -1,30 +1,25 @@
+const { expect } = require('chai');
 const helpers = require('../shared/helpers');
 const IprTaxPage = require('./iprTaxes.page');
-const chai = require('chai');
-
-
-/** configuring helpers**/
-helpers.configure(chai);
 
 describe('Ipr Tax Management', () => {
-  // navigate to the page
   before(() => helpers.navigate('#!/ipr_tax'));
 
-  const Page = new IprTaxPage();
+  const page = new IprTaxPage();
 
-  const iprTax1 = {    
+  const iprTax1 = {
     label         : 'IPR 1995',
     description   : 'Impot Professionnel sur le revenu 1995',
     currency_id   : 2,
   };
 
-  const iprTax2 = {    
+  const iprTax2 = {
     label         : 'IPR 2000',
     description   : 'Impot Professionnel sur le revenu 2000',
     currency_id   : 2,
   };
 
-  const iprTax3 = {    
+  const iprTax3 = {
     label         : 'IPR 2013',
     description   : 'Impot Professionnel sur le revenu 2013',
     currency_id   : 1,
@@ -36,27 +31,35 @@ describe('Ipr Tax Management', () => {
     currency_id   : 2,
   };
 
+  it('should start with one IPR taxes', () => {
+    expect(page.count()).to.eventually.equal(1);
+  });
+
   it('successfully creates a new IPR Scale 1995', () => {
-    Page.createIprTax(iprTax1);
+    page.create(iprTax1);
   });
 
   it('successfully creates a new IPR Scale 2000', () => {
-    Page.createIprTax(iprTax2);
+    page.create(iprTax2);
   });
 
   it('successfully creates a new IPR Scale 2013', () => {
-    Page.createIprTax(iprTax3);
+    page.create(iprTax3);
   });
 
   it('successfully edits an IPR Tax', () => {
-    Page.editIprTax(iprTax1.label, updateIPR);
+    page.update(iprTax1.label, updateIPR);
   });
 
   it('successfully delete a Ipr tax Scale', () => {
-    Page.deleteIprTax(updateIPR.label);
+    page.remove(updateIPR.label);
   });
 
   it('don\'t create when incorrect Ipr Tax', () => {
-    Page.errorOnCreateIprTax();
+    page.errorOnCreateIprTax();
+  });
+
+  it('should end with three IPR taxes', () => {
+    expect(page.count()).to.eventually.equal(3);
   });
 });

--- a/test/end-to-end/rubrics/rubrics.page.js
+++ b/test/end-to-end/rubrics/rubrics.page.js
@@ -1,48 +1,29 @@
 /* global element, by */
+/* eslint class-methods-use-this:off */
 
-/**
- * This class is represents a rubric page in term of structure and
- * behaviour so it is a rubric page object
- */
-
-const chai = require('chai');
-const helpers = require('../shared/helpers');
-
-helpers.configure(chai);
-
-/* loading grid actions */
-const GA = require('../shared/GridAction');
-const GU = require('../shared/GridUtils');
+const GridRow = require('../shared/GridRow');
 const FU = require('../shared/FormUtils');
-const components = require('../shared/components');
+const { notification, accountSelect } = require('../shared/components');
 
 class RubricPage {
   constructor() {
     this.gridId = 'rubric-grid';
-    this.rubricGrid = element(by.id(this.gridId));
-    this.actionLinkColumn = 14;
   }
 
-  /**
-   * send back the number of rubrics in the grid
-   */
-  getRubricCount() {
-    return this.rubricGrid
+  count() {
+    return element(by.id(this.gridId))
       .element(by.css('.ui-grid-render-container-body'))
       .all(by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index'))
       .count();
   }
 
-  /**
-   * simulate the create rubric button click to show the dialog of creation
-   */
-  createRubric(rubric) {
+  create(rubric) {
     FU.buttons.create();
     FU.input('RubricModalCtrl.rubric.label', rubric.label);
     FU.input('RubricModalCtrl.rubric.abbr', rubric.abbr);
 
-    components.accountSelect.set(rubric.debtor_account_id, 'debtor_account_id');
-    components.accountSelect.set(rubric.expense_account_id, 'expense_account_id');
+    accountSelect.set(rubric.debtor_account_id, 'debtor_account_id');
+    accountSelect.set(rubric.expense_account_id, 'expense_account_id');
 
     FU.input('RubricModalCtrl.rubric.value', rubric.value);
 
@@ -62,13 +43,10 @@ class RubricPage {
     const isEmployee = (rubric.is_employee === 1) ? 'is_employee_yes' : 'is_employee_no';
     element(by.id(isEmployee)).click();
 
-    FU.buttons.submit();
-    components.notification.hasSuccess();
+    FU.modal.submit();
+    notification.hasSuccess();
   }
 
-  /**
-   * block creation without the function name
-   */
   errorOnCreateRubric() {
     FU.buttons.create();
     FU.buttons.submit();
@@ -76,32 +54,22 @@ class RubricPage {
     FU.buttons.cancel();
   }
 
-  /**
-   * simulate a click on the edit link of a function
-   */
-  editRubric(label, updateRubric) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'edit', this.gridId);
-        FU.input('RubricModalCtrl.rubric.label', updateRubric.label);
+  update(label, updateRubric) {
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.edit().click();
+    FU.input('RubricModalCtrl.rubric.label', updateRubric.label);
 
-        FU.buttons.submit();
-        components.notification.hasSuccess();
-      });
+    FU.modal.submit();
+    notification.hasSuccess();
   }
 
-  /**
-   * simulate a click on the delete link of a function
-   */
-  deleteRubric(label) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'delete', this.gridId);
-        components.modalAction.confirm();
-        components.notification.hasSuccess();
-      });
+  remove(label) {
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.remove().click();
+    FU.modal.submit();
+    notification.hasSuccess();
   }
 }
 

--- a/test/end-to-end/rubrics/rubrics.spec.js
+++ b/test/end-to-end/rubrics/rubrics.spec.js
@@ -1,16 +1,10 @@
 const helpers = require('../shared/helpers');
 const RubricPage = require('./rubrics.page');
-const chai = require('chai');
-
-
-/** configuring helpers**/
-helpers.configure(chai);
 
 describe('Rubrics Management', () => {
-  // navigate to the page
   before(() => helpers.navigate('#!/payroll/rubrics'));
 
-  const Page = new RubricPage();
+  const page = new RubricPage();
 
   const rubric = {
     label : 'RUBRIC SYNDICAL',
@@ -30,20 +24,20 @@ describe('Rubrics Management', () => {
     is_percent : 0
   };
 
-  it('successfully creates a new Rubric', () => {
-    Page.createRubric(rubric);
+  it('successfully creates a new rubric', () => {
+    page.create(rubric);
   });
 
-  it('successfully edits a Rubric', () => {
-    Page.editRubric(rubric.label, updateRubric);
+  it('successfully edits a rubric', () => {
+    page.update(rubric.label, updateRubric);
   });
 
-  it('don\'t create when incorrect Rubric', () => {
-    Page.errorOnCreateRubric();
+  it('don\'t create when incorrect rubric', () => {
+    page.errorOnCreateRubric();
   });
 
-  it('successfully delete a Rubric', () => {
-    Page.deleteRubric(updateRubric.label);
+  it('successfully deletes a rubric', () => {
+    page.remove(updateRubric.label);
   });
 
 });

--- a/test/end-to-end/rubrics/rubrics.spec.js
+++ b/test/end-to-end/rubrics/rubrics.spec.js
@@ -10,7 +10,7 @@ describe('Rubrics Management', () => {
     label : 'RUBRIC SYNDICAL',
     abbr  : 'CoSynd',
     is_percent : 1,
-    debtor_account_id : '40111002', //SUPPLIER'S ACCOUNT 1
+    debtor_account_id : '40111002', // SUPPLIER'S ACCOUNT 1
     expense_account_id : '60310015', // Achat Produit  de Perfusion
     value : 6.5,
     is_discount : 1,
@@ -21,7 +21,7 @@ describe('Rubrics Management', () => {
 
   const updateRubric = {
     label : 'CHEF COMPTABLE',
-    is_percent : 0
+    is_percent : 0,
   };
 
   it('successfully creates a new rubric', () => {

--- a/test/end-to-end/rubricsConfig/rubrics_config.page.js
+++ b/test/end-to-end/rubricsConfig/rubrics_config.page.js
@@ -1,118 +1,79 @@
 /* global element, by */
+/* eslint class-methods-use-this:off */
 
-/**
- * This class is represents a rubric Configuration page in term of structure and
- * behaviour so it is a rubric configuration page object
- */
-
-const chai = require('chai');
-const helpers = require('../shared/helpers');
-
-helpers.configure(chai);
-
-/* loading grid actions */
-const GA = require('../shared/GridAction');
-const GU = require('../shared/GridUtils');
+const GridRow = require('../shared/GridRow');
 const FU = require('../shared/FormUtils');
-const components = require('../shared/components');
+const { notification } = require('../shared/components');
 
 class RubricConfigPage {
   constructor() {
     this.gridId = 'rubric-grid';
-    this.rubricGrid = element(by.id(this.gridId));
-    this.actionLinkColumn = 1;
   }
 
-  /**
-   * send back the number of rubrics in the grid
-   */
-  getRubricConfigCount() {
-    return this.rubricGrid
+  count() {
+    return element(by.id(this.gridId))
       .element(by.css('.ui-grid-render-container-body'))
       .all(by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index'))
       .count();
   }
 
-  /**
-   * simulate the create rubric Configuration button click to show the dialog of creation
-   */
-  createRubricConfig(rubric) {
+  create(rubric) {
     FU.buttons.create();
     FU.input('ConfigModalCtrl.rubric.label', rubric.label);
 
-    FU.buttons.submit();
-    components.notification.hasSuccess();
+    FU.modal.submit();
+    notification.hasSuccess();
   }
 
-  /**
-   * block creation without the function name
-   */
   errorOnCreateRubricConfig() {
     FU.buttons.create();
-    FU.buttons.submit();
+    FU.modal.submit();
     FU.validation.error('ConfigModalCtrl.rubric.label');
-    FU.buttons.cancel();
+    FU.modal.cancel();
   }
 
-  /**
-   * simulate a click on the edit link of a function
-   */
-  editRubricConfig(label, updateRubricConfig) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'edit', this.gridId);
-        FU.input('ConfigModalCtrl.rubric.label', updateRubricConfig.label);
+  update(label, updateRubricConfig) {
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.edit().click();
 
-        FU.buttons.submit();
-        components.notification.hasSuccess();
-      });
+    FU.input('ConfigModalCtrl.rubric.label', updateRubricConfig.label);
+
+    FU.modal.submit();
+    notification.hasSuccess();
   }
 
-  /**
-   * simulate a click on the Configure link of a function
-   */
   setRubricConfig(label) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'config', this.gridId);
-        element(by.id('social')).click();        
-        element(by.id('tax')).click();
-        FU.buttons.submit();
-        components.notification.hasSuccess();
-      });
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.method('configure').click();
+
+    element(by.id('social')).click();
+    element(by.id('tax')).click();
+
+    FU.modal.submit();
+    notification.hasSuccess();
   }
 
-  /**
-   * simulate a click on the Configure link of a function for Inset Rubric
-   */
-  inSetRubricConfig(label) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'config', this.gridId);
-        // First click for select all
-        element(by.id('all')).click();
+  unsetRubricConfig(label) {
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.method('configure').click();
 
-        // Second click for unselect all        
-        element(by.id('all')).click();
-        FU.buttons.submit();
-        components.notification.hasSuccess();
-      });
+    // double click to set all, then unset
+    element(by.id('all')).click();
+    element(by.id('all')).click();
+
+    FU.modal.submit();
+    notification.hasSuccess();
   }
 
-  /**
-   * simulate a click on the delete link of a function
-   */
-  deleteRubricConfig(label) {
-    GU.getGridIndexesMatchingText(this.gridId, label)
-      .then(indices => {
-        const { rowIndex } = indices;
-        GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'delete', this.gridId);
-        components.modalAction.confirm();
-        components.notification.hasSuccess();
-      });
+  remove(label) {
+    const row = new GridRow(label);
+    row.dropdown().click();
+    row.remove().click();
+    FU.modal.submit();
+    notification.hasSuccess();
   }
 }
 

--- a/test/end-to-end/rubricsConfig/rubrics_config.spec.js
+++ b/test/end-to-end/rubricsConfig/rubrics_config.spec.js
@@ -1,16 +1,11 @@
+const { expect } = require('chai');
 const helpers = require('../shared/helpers');
 const RubricConfigPage = require('./rubrics_config.page');
-const chai = require('chai');
-
-
-/** configuring helpers**/
-helpers.configure(chai);
 
 describe('Rubrics Configuration Management', () => {
-  // navigate to the page
   before(() => helpers.navigate('#!/payroll/rubric_configuration'));
 
-  const Page = new RubricConfigPage();
+  const page = new RubricConfigPage();
 
   const rubricConfig = {
     label : 'Configuration 2013',
@@ -20,28 +15,31 @@ describe('Rubrics Configuration Management', () => {
     label : 'Configuration 2013 Updated',
   };
 
-  it('successfully creates a new Rubric Configuration', () => {
-    Page.createRubricConfig(rubricConfig);
+  it('successfully creates a new rubric configuration', () => {
+    page.create(rubricConfig);
   });
 
-  it('successfully edits a Rubric Configuration', () => {
-    Page.editRubricConfig(rubricConfig.label, updateRubricConfig);
+  it('successfully edits a rubric configuration', () => {
+    page.update(rubricConfig.label, updateRubricConfig);
   });
 
-  it('successfully Set Rubrics in Rubric Configuration', () => {
-    Page.setRubricConfig(updateRubricConfig.label);
+  it('successfully set rubrics in rubric configuration', () => {
+    page.setRubricConfig(updateRubricConfig.label);
   });
 
-  it('successfully InSet Rubrics in Rubric Configuration', () => {
-    Page.inSetRubricConfig(updateRubricConfig.label);
+  it('successfully unset rubrics in rubric configuration', () => {
+    page.unsetRubricConfig(updateRubricConfig.label);
   });
 
-  it('don\'t create when incorrect Rubric', () => {
-    Page.errorOnCreateRubricConfig();
+  it('don\'t create when incorrect rubric', () => {
+    page.errorOnCreateRubricConfig();
   });
 
-  it('successfully delete a Rubric', () => {
-    Page.deleteRubricConfig(updateRubricConfig.label);
+  it('successfully delete a rubric', () => {
+    page.remove(updateRubricConfig.label);
   });
 
+  it('should have 1 rubric to end with', () => {
+    expect(page.count()).to.eventually.equal(1);
+  });
 });

--- a/test/end-to-end/user/user.page.js
+++ b/test/end-to-end/user/user.page.js
@@ -1,10 +1,5 @@
 /* global element, by */
 
-/**
- * This class is represents a user page in term of structure and
- * behaviour so it is a user page object
- */
-
 /* loading grid actions */
 const GridRow = require('../shared/GridRow');
 const FU = require('../shared/FormUtils');


### PR DESCRIPTION
This PR rewrites the tests for holiday management, rubric configuration, rubrics, and IPR taxes.  They all now use `GridRow()` to identify which row to click, instead of the GridAction/GridUtil, which was both inefficient and imprecise.  The goal is to reduce the number of flakey tests in `master`, or at least provide more information when they crash to debug.

All of these use page objects, with standard `create()`, `update()` and `remove()` methods.  A few use `count()` to check the number of rows in the grid.  We probably should do `count()` for all registries to check the number of rows in their grids.

Finally, a few modules have seen HTML improvements, including:
 1. Code lint fixes
 2. Better use of `headercrumb`.
 3. Migrating to `bhFilterToggle`
 4. Transforming `class='modal-body"` repeats into `class="form-group".
 5. Pruning unused ids/data-* tags.

This is following the current trend of refactoring our tests to be more standard, simpler, and more predictable.