### PR TITLE
fix(install): do not use project_id for role

### DIFF
--- a/server/controllers/install.js
+++ b/server/controllers/install.js
@@ -111,7 +111,7 @@ exports.proceedInstall = (req, res, next) => {
     const sqlUser = `
       INSERT INTO user (username, password, display_name) VALUES (?, PASSWORD(?), ?);`;
 
-    const sqlRole = `CALL superUserRole(${USER_ID}, ${PROJECT_ID})`;
+    const sqlRole = `CALL superUserRole(${USER_ID})`;
 
     const sqlProjectPermission = 'INSERT INTO project_permission SET ? ';
 

--- a/server/models/procedures/roles.sql
+++ b/server/models/procedures/roles.sql
@@ -1,19 +1,19 @@
 
 DELIMITER $$
-CREATE PROCEDURE superUserRole(IN user_id INT, IN project_id INT)
+CREATE PROCEDURE superUserRole(IN user_id INT)
 BEGIN
 
     DECLARE roleUUID BINARY(16);
-    
+
     SET roleUUID = HUID(UUID());
-    
-    INSERT INTO role(uuid, label, project_id)
-    VALUES(roleUUID, 'Administrateur', project_id);
+
+    INSERT INTO role(uuid, label)
+    VALUES(roleUUID, 'Administrateur');
 
     INSERT INTO role_unit
     SELECT HUID(uuid()) as uuid,roleUUID, id FROM unit;
 
-    INSERT INTO user_role(uuid, user_id, role_uuid) 
+    INSERT INTO user_role(uuid, user_id, role_uuid)
     VALUES(HUID(uuid()), user_id, roleUUID);
 
     INSERT INTO role_actions(uuid, role_uuid, actions_id)


### PR DESCRIPTION
This commit fixes a bug in the install procedures which still referred to the project_id column for the roles table.  This bug blocks all new creations of enterprises/users.  The link to project_id was removed in https://github.com/IMA-WorldHealth/bhima-2.X/pull/3345.