### PR TITLE
fix(accounts): do not rebind account data

### DIFF
--- a/client/src/i18n/en/account.json
+++ b/client/src/i18n/en/account.json
@@ -24,7 +24,7 @@
     "CREATE_ANOTHER":"Create another account",
     "CREATED":"Account record written",
     "DELETED":"Deleted",
-    "DISPLAY_HIDDEN": "Displayed hidden accounts",
+    "DISPLAY_HIDDEN": "Display hidden accounts",
     "UPDATED":"Account record updated",
     "GENERATE":"Generate Account Report",
     "HELP_TXT_1":"Chart of accounts for",

--- a/client/src/modules/accounts/AccountGrid.js
+++ b/client/src/modules/accounts/AccountGrid.js
@@ -144,5 +144,23 @@ function AccountGridService(AccountStore, Accounts, Store, Languages, $httpParam
     return this._store.get(id);
   };
 
+  AccountGrid.prototype.filterHiddenAccounts = function filterHiddenAccounts(showHiddenAccounts) {
+    const arr = this._store.data;
+
+    // either filter out hidden accounts or passthrough
+    const passthrough = () => true;
+    const filterFn = showHiddenAccounts
+      ? passthrough
+      : account => account.hidden === 0;
+
+    // we want to replace the whole array, so choose the max
+    // if we use a length that is too short, we will leave some behind
+    // if we pick a length that is greater, JS just expands the array
+    const len = Math.max(arr.length, this.data.length);
+
+    // cheekily filters the data in place - thanks stack overflow
+    this.data.splice(0, len, ...arr.filter(filterFn));
+  };
+
   return AccountGrid;
 }

--- a/client/src/modules/accounts/accounts.html
+++ b/client/src/modules/accounts/accounts.html
@@ -44,17 +44,17 @@
         </a>
       </div>
 
-      <div class="toolbar-item" ng-if="AccountsCtrl.showHiddenAccounts">
-        <a class="btn btn-default text-capitalize" ng-click="AccountsCtrl.hiddenAccount(1)">
+      <div class="toolbar-item" ng-if="!AccountsCtrl.showHiddenAccounts">
+        <a class="btn btn-default text-capitalize" ng-click="AccountsCtrl.setShowHiddenAccounts(true)">
           <i class="fa fa-eye"></i>
-          <span class="hidden-xs" translate> ACCOUNT.DISPLAY_HIDDEN </span>
+          <span class="hidden-xs" translate>ACCOUNT.DISPLAY_HIDDEN</span>
         </a>
       </div>
 
-      <div class="toolbar-item" ng-if="!AccountsCtrl.showHiddenAccounts">
-        <a class="btn btn-default text-capitalize" ng-click="AccountsCtrl.hiddenAccount(0)">
+      <div class="toolbar-item" ng-if="AccountsCtrl.showHiddenAccounts">
+        <a class="btn btn-default text-capitalize" ng-click="AccountsCtrl.setShowHiddenAccounts(false)">
           <i class="fa fa-eye-slash"></i>
-          <span class="hidden-xs" translate> ACCOUNT.HIDE_HIDDEN </span>
+          <span class="hidden-xs" translate>ACCOUNT.HIDE_HIDDEN</span>
         </a>
       </div>
 

--- a/client/src/modules/accounts/accounts.js
+++ b/client/src/modules/accounts/accounts.js
@@ -25,7 +25,8 @@ function AccountsController(
 
   vm.Constants = Constants;
   vm.loading = true;
-  vm.showHiddenAccounts = true;
+
+  vm.showHiddenAccounts = false;
 
   // account title indent value in pixels
   vm.indentTitleSpace = 20;
@@ -39,7 +40,7 @@ function AccountsController(
   vm.remove = remove;
   vm.toggleHideAccount = toggleHideAccount;
   vm.toggleLockAccount = toggleLockAccount;
-  vm.hiddenAccount = hiddenAccount;
+  vm.setShowHiddenAccounts = setShowHiddenAccounts;
 
   vm.Accounts = new AccountGrid();
   function init(initialLoad) {
@@ -104,15 +105,9 @@ function AccountsController(
     ];
   }
 
-  function hiddenAccount(value) {
-    if (value === 1) {
-      vm.showHiddenAccounts = false;
-      vm.gridOptions.data = vm.Accounts.data;
-
-    } else {
-      vm.showHiddenAccounts = true;
-      vm.gridOptions.data = vm.unHiddenAccount;
-    }
+  function setShowHiddenAccounts(showHiddenAccounts) {
+    vm.showHiddenAccounts = showHiddenAccounts;
+    vm.Accounts.filterHiddenAccounts(showHiddenAccounts);
   }
 
   function handleUpdatedAccount(event, account) {
@@ -181,9 +176,11 @@ function AccountsController(
   }
 
   function bindGridData() {
-    // Filter unhidden account
-    vm.unHiddenAccount = vm.Accounts.data.filter(item => (item.hidden === 0));
-    vm.gridOptions.data = vm.unHiddenAccount;
+    // format view, filtering if necessary
+    vm.setShowHiddenAccounts(vm.showHiddenAccounts);
+
+    // bind grid data
+    vm.gridOptions.data = vm.Accounts.data;
   }
 
   /**
@@ -229,6 +226,9 @@ function AccountsController(
             .then(() => {
               account.hidden = !account.hidden;
               vm.Accounts.updateViewEdit(null, account);
+
+              // re-filter view
+              setShowHiddenAccounts(vm.showHiddenAccounts);
             });
         }
       });


### PR DESCRIPTION
This commit fixes the bindings with the AccountGrid store that was broken with the filter to hide accounts.

The problem came from rebinding the `vm.gridOptions.data` to a new array via the `Array.prototype.filter()` function.  By using `this.data.splice()` we perform the filtering in-place and do not break any bindings.