### PR TITLE
fix(tests): remove .only() preventing e2e tests

### DIFF
--- a/test/end-to-end/distributionFeesCenters/distribution_key.spec.js
+++ b/test/end-to-end/distributionFeesCenters/distribution_key.spec.js
@@ -8,7 +8,7 @@ helpers.configure(chai);
 
 const { expect } = chai;
 
-describe.only('Distribution keys Management', () => {
+describe('Distribution keys Management', () => {
   // navigate to the page
   before(() => helpers.navigate('#!/distribution_center/distribution_key'));
 


### PR DESCRIPTION
This commit removes the `.only()` that caused end to end tests not to be run in master.