### PR TITLE
fix(vouchers): complete i18n translations

### DIFF
--- a/client/src/i18n/en/vouchers.json
+++ b/client/src/i18n/en/vouchers.json
@@ -86,10 +86,10 @@
         "NO_INPUT_PROVIDED": "Invalid data supplied to voucher tools."
       },
       "REVERSE": {
-        "ACTION": "Reverse",
         "ACTION_1": "Transaction {{trans_id}} was marked as <code>reversed</code>",
         "ACTION_2_1": "Voucher document",
         "ACTION_2_2": "was created with equal and opposite values to reverse transaction {{trans_id}}",
+        "ACTION": "Reverse",
         "AUTHORISED_BY": "Reversal document was authorised by user:",
         "CONFIGURED_FOR": "Please confirm that you authorise reversing transaction:",
         "DESCRIPTION": "Transaction reversed using Administrative Voucher Tools",
@@ -98,14 +98,15 @@
         "TITLE": "Reverse Transaction"
       },
       "CORRECT": {
-        "ACTION": "Correct",
-        "DETAILS": "This transaction can now be updated with corrections. Submitting this process will create two voucher documents, one reversing the effects of this transaction with equal and opposite values, the second with rows reflected corrections made here.",
-        "CONFIGURED_FOR": "The transaction {{trans_id}} will <b>not be edited</b> as it has already been posted. This will create a reversal voucher followed by a second voucher with the corrections made here. Please confirm that you authorise the above corrections to {{trans_id}}.",
         "ACTION_1": "Transaction {{trans_id}} was marked as <code>reversed</code>",
         "ACTION_2_1": "Voucher document",
         "ACTION_2_2": "was created with equal and opposite values to reverse transaction {{trans_id}}",
         "ACTION_3_2": "was created with corrections provided by this tool",
+        "ACTION": "Correct",
         "AUTHORISED_BY": "Voucher documents were authorised by user:",
+        "CONFIGURED_FOR": "The transaction {{trans_id}} will <b>not be edited</b> as it has already been posted. This will create a reversal voucher followed by a second voucher with the corrections made here. Please confirm that you authorise the above corrections to {{trans_id}}.",
+        "DESCRIPTION": "Transaction corrected using Administrative Voucher Tools",
+        "DETAILS": "This transaction can now be updated with corrections. Submitting this process will create two voucher documents, one reversing the effects of this transaction with equal and opposite values, the second with rows reflected corrections made here.",
         "SUCCESS": "Transaction reversal and correction documents were written successfully",
         "TITLE": "Correct Transaction"
       }

--- a/client/src/i18n/fr/vouchers.json
+++ b/client/src/i18n/fr/vouchers.json
@@ -86,10 +86,10 @@
         "NO_INPUT_PROVIDED": "Données non valides fournies aux outils de transaction."
       },
       "REVERSE": {
-        "ACTION": "Inverser",
         "ACTION_1": "La transaction {{trans_id}} a été marquée comme <code> inversé </code>",
         "ACTION_2_1": "Document",
         "ACTION_2_2": "a été créé avec des valeurs égales et opposées pour inverser la transaction {{trans_id}}",
+        "ACTION": "Inverser",
         "AUTHORISED_BY": "Le document d'inversion a été autorisé par l'utilisateur:",
         "CONFIGURED_FOR": "S'il vous plaît confirmer que vous autorisez l'inversion de transaction:",
         "DESCRIPTION": "Transaction inversée à l'aide des outils administratifs",
@@ -98,14 +98,15 @@
         "TITLE": "Inverser la transaction"
       },
       "CORRECT": {
-        "ACTION": "Corriger",
-        "DETAILS": "Cette transaction peut maintenant être mise à jour avec des corrections. La soumission de ce processus créera deux documents justificatifs, l'un renversant les effets de cette transaction avec des valeurs égales et opposées, le second avec des lignes reflétant les corrections apportées ici.",
-        "CONFIGURED_FOR": "La transaction {{trans_id}} ne sera pas modifiée </b> car elle a déjà été postée. Cela créera un bon de renversement suivi d'un second bon avec les corrections apportées ici. Veuillez confirmer que vous autorisez les corrections ci-dessus à {{trans_id}}.",
-        "AUTHORISED_BY": "Le document d'inversion a été autorisé par l'utilisateur:",
         "ACTION_1": "La transaction {{trans_id}} a été marquée comme <code> inversé </code>",
         "ACTION_2_1": "Document",
         "ACTION_2_2": "a été créé avec des valeurs égales et opposées pour inverser la transaction {{trans_id}}",
         "ACTION_3_2": "a été créé avec les corrections fournies par cet outil",
+        "ACTION": "Corriger",
+        "AUTHORISED_BY": "Le document d'inversion a été autorisé par l'utilisateur:",
+        "CONFIGURED_FOR": "La transaction {{trans_id}} ne sera pas modifiée </b> car elle a déjà été postée. Cela créera un bon de renversement suivi d'un second bon avec les corrections apportées ici. Veuillez confirmer que vous autorisez les corrections ci-dessus à {{trans_id}}.",
+        "DESCRIPTION": "Transaction corrigée à l'aide des outils administratifs",
+        "DETAILS": "Cette transaction peut maintenant être mise à jour avec des corrections. La soumission de ce processus créera deux documents justificatifs, l'un renversant les effets de cette transaction avec des valeurs égales et opposées, le second avec des lignes reflétant les corrections apportées ici.",
         "SUCCESS": "L'inversion de transaction et les documents de correction ont été écrits avec succès",
         "TITLE": "Corriger transaction"
       }


### PR DESCRIPTION
This commit fixes a missing translation for the correction voucher tool.

Closes #3393.