### PR TITLE
feat: add search by description to registries

### DIFF
--- a/client/src/modules/cash/cash.service.js
+++ b/client/src/modules/cash/cash.service.js
@@ -147,6 +147,7 @@ function CashService(
     },
     { key : 'currency_id', label : 'FORM.LABELS.CURRENCY' },
     { key : 'reversed', label : 'CASH.REGISTRY.REVERSED_RECORDS' },
+    { key : 'description', label : 'FORM.LABELS.DESCRIPTION' },
     { key : 'patientReference', label : 'FORM.LABELS.REFERENCE_PATIENT' },
     { key : 'defaultPeriod', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
     { key : 'invoiceReference', label : 'FORM.LABELS.INVOICE' },
@@ -166,8 +167,9 @@ function CashService(
     const assignedKeys = Object.keys(cashFilters.formatHTTP());
 
     // assign default period filter
-    const periodDefined =
-      service.util.arrayIncludes(assignedKeys, ['period', 'custom_period_start', 'custom_period_end']);
+    const periodDefined = service.util.arrayIncludes(assignedKeys, [
+      'period', 'custom_period_start', 'custom_period_end',
+    ]);
 
     if (!periodDefined) {
       cashFilters.assignFilters(Periods.defaultFilters());

--- a/client/src/modules/cash/payments/templates/search.modal.html
+++ b/client/src/modules/cash/payments/templates/search.modal.html
@@ -77,6 +77,12 @@
             <bh-clear on-clear="$ctrl.clear('currency_id')"></bh-clear>
           </bh-currency-select>
 
+          <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.description.$invalid }">
+            <label class="control-label" translate>FORM.LABELS.DESCRIPTION</label>
+            <bh-clear on-clear="$ctrl.clear('description')"></bh-clear>
+            <textarea ng-model="$ctrl.searchQueries.description" class="form-control" rows="2"></textarea>
+          </div>
+
           <div class="form-group">
             <div class="radio">
               <bh-clear on-clear="$ctrl.clear('reversed')"></bh-clear>

--- a/client/src/modules/cash/payments/templates/search.modal.js
+++ b/client/src/modules/cash/payments/templates/search.modal.js
@@ -20,7 +20,7 @@ function SearchCashPaymentModalController(Notify, Instance, filters, Store, Peri
 
   const searchQueryOptions = [
     'is_caution', 'reference', 'cashbox_id', 'user_id', 'reference_patient',
-    'currency_id', 'reversed', 'debtor_group_uuid',
+    'currency_id', 'reversed', 'debtor_group_uuid', 'description',
   ];
 
   vm.searchQueries = {};
@@ -120,9 +120,8 @@ function SearchCashPaymentModalController(Notify, Instance, filters, Store, Peri
         // To avoid overwriting a real display value, we first determine if the value changed in the current view.
         // If so, we do not use the previous display value.  If the values are identical, we can restore the
         // previous display value without fear of data being out of date.
-        const usePreviousDisplayValue =
-          angular.equals(initialSearchQueries[key], value) &&
-          angular.isDefined(lastDisplayValues[key]);
+        const usePreviousDisplayValue = angular.equals(initialSearchQueries[key], value)
+          && angular.isDefined(lastDisplayValues[key]);
 
         // default to the raw value if no display value is defined
         const displayValue = usePreviousDisplayValue ? lastDisplayValues[key] : displayValues[key] || value;

--- a/client/src/modules/invoices/patientInvoice.service.js
+++ b/client/src/modules/invoices/patientInvoice.service.js
@@ -137,6 +137,7 @@ function PatientInvoiceService(
     { key : 'defaultPeriod', label : 'TABLE.COLUMNS.PERIOD', valueFilter : 'translate' },
     { key : 'debtor_group_uuid', label : 'FORM.LABELS.DEBTOR_GROUP' },
     { key : 'project_id', label : 'FORM.LABELS.PROJECT' },
+    { key : 'description', label : 'FORM.LABELS.DESCRIPTION' },
     { key : 'cash_uuid', label : 'FORM.INFO.PAYMENT' },
   ]);
 

--- a/client/src/modules/invoices/registry/registry.js
+++ b/client/src/modules/invoices/registry/registry.js
@@ -76,6 +76,10 @@ function InvoiceRegistryController(
     type : 'number',
     footerCellFilter : 'currency:'.concat(Session.enterprise.currency_id),
   }, {
+    field : 'description',
+    displayName : 'FORM.LABELS.DESCRIPTION',
+    headerCellFilter : 'translate',
+  }, {
     field : 'project_name',
     displayName : 'TABLE.COLUMNS.PROJECT',
     headerCellFilter : 'translate',

--- a/client/src/modules/invoices/registry/search.modal.html
+++ b/client/src/modules/invoices/registry/search.modal.html
@@ -71,6 +71,12 @@
               <bh-clear on-clear="$ctrl.clear('debtor_group_uuid')"></bh-clear>
           </bh-debtor-group-select>
 
+          <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.description.$invalid }">
+            <label class="control-label" translate>FORM.LABELS.DESCRIPTION</label>
+            <bh-clear on-clear="$ctrl.clear('description')"></bh-clear>
+            <textarea ng-model="$ctrl.searchQueries.description" class="form-control" rows="2"></textarea>
+          </div>
+
           <bh-user-select
             user-id="$ctrl.searchQueries.user_id"
             name="user_id"

--- a/client/src/modules/invoices/registry/search.modal.js
+++ b/client/src/modules/invoices/registry/search.modal.js
@@ -32,7 +32,7 @@ function InvoiceRegistrySearchModalController(ModalInstance, filters, Notify, St
   //       these are known when the filter service is defined
   const searchQueryOptions = [
     'is_caution', 'reference', 'cashbox_id', 'user_id', 'reference_patient',
-    'currency_id', 'reversed', 'service_id', 'debtor_group_uuid',
+    'currency_id', 'reversed', 'service_id', 'debtor_group_uuid', 'description',
   ];
 
   // assign already defined custom filters to searchQueries object

--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -157,6 +157,8 @@ function find(options) {
   filters.fullText('description');
   filters.period('period', 'date');
 
+  filters.fullText('description');
+
   // TODO - re-write these use document maps and entity maps
   const referenceStatement = `CONCAT_WS('.', '${CASH_KEY}', project.abbr, cash.reference) = ?`;
   filters.custom('reference', referenceStatement);

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -235,7 +235,7 @@ function find(options) {
   }
   const sql = `
     SELECT BUID(invoice.uuid) as uuid, invoice.project_id, invoice.date,
-      patient.display_name as patientName, invoice.cost,
+      patient.display_name as patientName, invoice.cost, invoice.description,
       BUID(invoice.debtor_uuid) as debtor_uuid, dm.text AS reference,
       em.text AS patientReference, service.name as serviceName, proj.name AS project_name,
       user.display_name, invoice.user_id, invoice.reversed, invoice.edited
@@ -259,6 +259,8 @@ function find(options) {
   filters.equals('service_id');
   filters.equals('user_id');
   filters.equals('uuid');
+
+  filters.fullText('description');
 
   filters.equals('reference', 'text', 'dm');
   filters.equals('patientReference', 'text', 'em');

--- a/test/integration/cash.search.js
+++ b/test/integration/cash.search.js
@@ -38,6 +38,16 @@ function CashPaymentsSearch() {
       .catch(helpers.handler);
   });
 
+  it('GET /cash filters by description and returns one record', () => {
+    return agent.get('/cash')
+      .query({ description : 'cool' })
+      .then((res) => {
+        helpers.api.listed(res, 1);
+      })
+      .catch(helpers.handler);
+  });
+
+
   // test limit functionality alone
   it('GET /cash?limit=1 returns a single record', () => {
     const params = { limit : 1 };

--- a/test/integration/patientInvoice.js
+++ b/test/integration/patientInvoice.js
@@ -85,6 +85,15 @@ describe('(/invoices) Patient Invoices', () => {
         .catch(helpers.handler);
     });
 
+    it('GET /invoices should filter by description and return 3 invoices', () => {
+      return agent.get('/invoices')
+        .query({ description : 'TPA_VENTE/' })
+        .then(res => {
+          helpers.api.listed(res, 3);
+        })
+        .catch(helpers.handler);
+    });
+
     // filter should find exactly one result
     it('GET /invoices?cost=75 should return a single invoice', () => {
       return agent.get('/invoices?cost=75')


### PR DESCRIPTION
This commit adds search by description to the cash and invoice
registries.  Both filters are powered by a `fullText()` search, so any
word or phrase used in the description will match.

Closes #3397.
Closes #3398.