### PR TITLE
Fix grouping issue

### DIFF
--- a/client/src/js/services/grid/GridGrouping.js
+++ b/client/src/js/services/grid/GridGrouping.js
@@ -176,7 +176,9 @@ function GridGroupingService(GridAggregators, uiGridGroupingConstants, Session,
   }
 
   function changeGrouping (column) {
-    this.gridApi.grouping.groupColumn(column);
+    $timeout(() => {
+      this.gridApi.grouping.groupColumn(column);
+    }, 0);
 
     if (this.expandByDefault) {
       unfoldAllGroups(this.gridApi);
@@ -184,7 +186,9 @@ function GridGroupingService(GridAggregators, uiGridGroupingConstants, Session,
   }
 
   function removeGrouping(column) {
-    this.gridApi.grouping.ungroupColumn(column);
+    $timeout(() => {
+      this.gridApi.grouping.ungroupColumn(column);
+    }, 0);
   }
 
   // return the current grouping


### PR DESCRIPTION
The stock grid cannot group correctly in some server (online) : 
![image](https://user-images.githubusercontent.com/5445251/49221185-ad40f100-f3d8-11e8-80db-3e093ab7f169.png)

To fix that we use a solution of [MatejQ](https://github.com/angular-ui/ui-grid/issues/5495#issuecomment-353027397) by using `$timeout`.