### PR TITLE
fix(stock): respect stock lots registry groups

### DIFF
--- a/client/src/modules/stock/inventories/registry.js
+++ b/client/src/modules/stock/inventories/registry.js
@@ -19,111 +19,85 @@ function StockInventoriesController(
   const cacheKey = 'stock-inventory-grid';
   const stockInventoryFilters = Stock.filter.inventory;
 
-  const columns = [
-    {
-      field            : 'depot_text',
-      displayName      : 'STOCK.DEPOT',
-      headerCellFilter : 'translate',
-    },
-
-    {
-      field            : 'code',
-      displayName      : 'STOCK.CODE',
-      headerCellFilter : 'translate',
-    },
-
-    {
-      field            : 'text',
-      displayName      : 'STOCK.INVENTORY',
-      headerCellFilter : 'translate',
-      width            : '20%',
-    },
-
-    {
-      field            : 'group_name',
-      displayName      : 'STOCK.INVENTORY_GROUP',
-      headerCellFilter : 'translate',
-    },
-
-    {
-      field            : 'quantity',
-      displayName      : 'STOCK.QUANTITY',
-      headerCellFilter : 'translate',
-      cellClass        : 'text-right',
-    },
-
-    {
-      field            : 'unit_type',
-      width            : 75,
-      displayName      : 'TABLE.COLUMNS.UNIT',
-      headerCellFilter : 'translate',
-      cellTemplate     : 'modules/stock/inventories/templates/unit.tmpl.html',
-    },
-
-    {
-      field            : 'status',
-      displayName      : 'STOCK.STATUS.LABEL',
-      headerCellFilter : 'translate',
-      enableFiltering  : false,
-      enableSorting    : false,
-      cellTemplate     : 'modules/stock/inventories/templates/status.cell.html',
-    },
-
-    {
-      field           : 'avg_consumption',
-      displayName     : 'CMM',
-      enableFiltering : false,
-      enableSorting   : false,
-      cellClass       : 'text-right',
-      cellTemplate    : '',
-    },
-
-    {
-      field            : 'S_MONTH',
-      displayName      : 'MS',
-      enableFiltering  : false,
-      enableSorting    : false,
-      cellClass        : 'text-right',
-      cellTemplate     : '',
-    },
-
-    {
-      field           : 'S_SEC',
-      displayName     : 'SS',
-      enableFiltering : false,
-      enableSorting   : false,
-      cellClass       : 'text-right',
-      cellTemplate    : '',
-    },
-
-    {
-      field           : 'S_MIN',
-      displayName     : 'MIN',
-      enableFiltering : false,
-      enableSorting   : false,
-      cellClass       : 'text-right',
-      cellTemplate    : '',
-    },
-
-    {
-      field           : 'S_MAX',
-      displayName     : 'MAX',
-      enableFiltering : false,
-      enableSorting   : false,
-      cellClass       : 'text-right',
-      cellTemplate    : '',
-    },
-
-    {
-      field            : 'S_Q',
-      displayName      : 'STOCK.ORDERS',
-      headerCellFilter : 'translate',
-      enableFiltering  : false,
-      enableSorting    : false,
-      cellClass        : 'text-right',
-      cellTemplate     : 'modules/stock/inventories/templates/appro.cell.html',
-    },
-  ];
+  const columns = [{
+    field            : 'depot_text',
+    displayName      : 'STOCK.DEPOT',
+    headerCellFilter : 'translate',
+  }, {
+    field            : 'code',
+    displayName      : 'STOCK.CODE',
+    headerCellFilter : 'translate',
+  }, {
+    field            : 'text',
+    displayName      : 'STOCK.INVENTORY',
+    headerCellFilter : 'translate',
+    width            : '20%',
+  }, {
+    field            : 'group_name',
+    displayName      : 'STOCK.INVENTORY_GROUP',
+    headerCellFilter : 'translate',
+  }, {
+    field            : 'quantity',
+    displayName      : 'STOCK.QUANTITY',
+    headerCellFilter : 'translate',
+    cellClass        : 'text-right',
+  }, {
+    field            : 'unit_type',
+    width            : 75,
+    displayName      : 'TABLE.COLUMNS.UNIT',
+    headerCellFilter : 'translate',
+    cellTemplate     : 'modules/stock/inventories/templates/unit.tmpl.html',
+  }, {
+    field            : 'status',
+    displayName      : 'STOCK.STATUS.LABEL',
+    headerCellFilter : 'translate',
+    enableFiltering  : false,
+    enableSorting    : false,
+    cellTemplate     : 'modules/stock/inventories/templates/status.cell.html',
+  }, {
+    field           : 'avg_consumption',
+    displayName     : 'CMM',
+    enableFiltering : false,
+    enableSorting   : false,
+    cellClass       : 'text-right',
+    cellTemplate    : '',
+  }, {
+    field            : 'S_MONTH',
+    displayName      : 'MS',
+    enableFiltering  : false,
+    enableSorting    : false,
+    cellClass        : 'text-right',
+    cellTemplate     : '',
+  }, {
+    field           : 'S_SEC',
+    displayName     : 'SS',
+    enableFiltering : false,
+    enableSorting   : false,
+    cellClass       : 'text-right',
+    cellTemplate    : '',
+  }, {
+    field           : 'S_MIN',
+    displayName     : 'MIN',
+    enableFiltering : false,
+    enableSorting   : false,
+    cellClass       : 'text-right',
+    cellTemplate    : '',
+  }, {
+    field           : 'S_MAX',
+    displayName     : 'MAX',
+    enableFiltering : false,
+    enableSorting   : false,
+    cellClass       : 'text-right',
+    cellTemplate    : '',
+  }, {
+    field            : 'S_Q',
+    displayName      : 'STOCK.ORDERS',
+    headerCellFilter : 'translate',
+    enableFiltering  : false,
+    enableSorting    : false,
+    cellClass        : 'text-right',
+    cellTemplate     : 'modules/stock/inventories/templates/appro.cell.html',
+  }];
 
   // grouping box
   vm.groupingBox = [
@@ -206,6 +180,10 @@ function StockInventoriesController(
     return load(stockInventoryFilters.formatHTTP(true));
   }
 
+  function orderByDepot(rowA, rowB) {
+    return rowA.depot_text > rowB.depot_text ? 1 : -1;
+  }
+
   // load stock lots in the grid
   function load(filters) {
     vm.hasError = false;
@@ -216,10 +194,12 @@ function StockInventoriesController(
 
     Stock.inventories.read(null, filters)
       .then((rows) => {
+
+        // FIXME(@jniles): we should do this ordering on the server via an ORDER BY
+        rows.sort(orderByDepot);
+
         // set status flags
-        rows.forEach((item) => {
-          setStatusFlag(item);
-        });
+        rows.forEach(setStatusFlag);
 
         vm.gridOptions.data = rows;
 

--- a/client/src/modules/stock/lots/registry.html
+++ b/client/src/modules/stock/lots/registry.html
@@ -92,7 +92,7 @@
       </div>
 
       <!-- inline filter -->
-      <bh-filter-toggle 
+      <bh-filter-toggle
         on-toggle="StockLotsCtrl.toggleInlineFilter()">
       </bh-filter-toggle>
     </div>

--- a/client/src/modules/stock/lots/registry.js
+++ b/client/src/modules/stock/lots/registry.js
@@ -29,122 +29,95 @@ function StockLotsController(
   ];
 
   // grid columns
-  const columns = [
-    {
-      field : 'depot_text',
-      displayName : 'STOCK.DEPOT',
-      headerCellFilter : 'translate',
-    },
-
-    {
-      field : 'code',
-      displayName : 'STOCK.CODE',
-      headerCellFilter : 'translate',
-    },
-
-    {
-      field : 'text',
-      displayName : 'STOCK.INVENTORY',
-      headerCellFilter : 'translate',
-    },
-
-    {
-      field : 'group_name',
-      displayName : 'TABLE.COLUMNS.INVENTORY_GROUP',
-      headerCellFilter : 'translate',
-    },
-
-    {
-      field : 'label',
-      displayName : 'STOCK.LOT',
-      headerCellFilter : 'translate',
-    },
-
-    {
-      field : 'quantity',
-      displayName : 'STOCK.QUANTITY',
-      headerCellFilter : 'translate',
-    },
-
-    {
-      field : 'unit_cost',
-      displayName : 'STOCK.UNIT_COST',
-      headerCellFilter : 'translate',
-      type : 'number',
-      cellFilter : 'currency: '.concat(Session.enterprise.currency_id),
-    },
-
-    {
-      field : 'unit_type',
-      width : 75,
-      displayName : 'TABLE.COLUMNS.UNIT',
-      headerCellFilter : 'translate',
-      cellTemplate : 'modules/stock/inventories/templates/unit.tmpl.html',
-    },
-
-    {
-      field : 'entry_date',
-      displayName : 'STOCK.ENTRY_DATE',
-      headerCellFilter : 'translate',
-      cellFilter : 'date',
-    },
-
-    {
-      field : 'expiration_date',
-      displayName : 'STOCK.EXPIRATION_DATE',
-      headerCellFilter : 'translate',
-      cellFilter : 'date',
-    },
-    {
-      field : 'delay_expiration',
-      displayName : 'STOCK.EXPIRATION',
-      headerCellFilter : 'translate',
-    },
-    {
-      field : 'avg_consumption',
-      displayName : 'STOCK.CMM',
-      headerCellFilter : 'translate',
-      type : 'number',
-    },
-    {
-      field : 'S_MONTH',
-      displayName : 'STOCK.MSD',
-      headerCellFilter : 'translate',
-      type : 'number',
-    },
-    {
-      field : 'lifetime',
-      displayName : 'STOCK.LIFETIME',
-      headerCellFilter : 'translate',
-      cellTemplate     : 'modules/stock/lots/templates/lifetime.cell.html',
-      type : 'number',
-    },
-    {
-      field : 'S_LOT_LIFETIME',
-      displayName : 'STOCK.LOT_LIFETIME',
-      headerCellFilter : 'translate',
-      cellTemplate     : 'modules/stock/lots/templates/lot_lifetime.cell.html',
-      type : 'number',
-    },
-    {
-      field : 'S_RISK',
-      displayName : 'STOCK.RISK',
-      headerCellFilter : 'translate',
-      cellTemplate     : 'modules/stock/lots/templates/risk.cell.html',
-      type : 'number',
-    },
-    {
-      field : 'S_RISK_QUANTITY',
-      displayName : 'STOCK.RISK_QUANTITY',
-      headerCellFilter : 'translate',
-      cellTemplate     : 'modules/stock/lots/templates/risk_quantity.cell.html',
-      type : 'number',
-    },
-  ];
+  const columns = [{
+    field : 'depot_text',
+    displayName : 'STOCK.DEPOT',
+    headerCellFilter : 'translate',
+  }, {
+    field : 'code',
+    displayName : 'STOCK.CODE',
+    headerCellFilter : 'translate',
+  }, {
+    field : 'text',
+    displayName : 'STOCK.INVENTORY',
+    headerCellFilter : 'translate',
+  }, {
+    field : 'group_name',
+    displayName : 'TABLE.COLUMNS.INVENTORY_GROUP',
+    headerCellFilter : 'translate',
+  }, {
+    field : 'label',
+    displayName : 'STOCK.LOT',
+    headerCellFilter : 'translate',
+  }, {
+    field : 'quantity',
+    displayName : 'STOCK.QUANTITY',
+    headerCellFilter : 'translate',
+  }, {
+    field : 'unit_cost',
+    displayName : 'STOCK.UNIT_COST',
+    headerCellFilter : 'translate',
+    type : 'number',
+    cellFilter : 'currency: '.concat(Session.enterprise.currency_id),
+  }, {
+    field : 'unit_type',
+    width : 75,
+    displayName : 'TABLE.COLUMNS.UNIT',
+    headerCellFilter : 'translate',
+    cellTemplate : 'modules/stock/inventories/templates/unit.tmpl.html',
+  }, {
+    field : 'entry_date',
+    displayName : 'STOCK.ENTRY_DATE',
+    headerCellFilter : 'translate',
+    cellFilter : 'date',
+  }, {
+    field : 'expiration_date',
+    displayName : 'STOCK.EXPIRATION_DATE',
+    headerCellFilter : 'translate',
+    cellFilter : 'date',
+  }, {
+    field : 'delay_expiration',
+    displayName : 'STOCK.EXPIRATION',
+    headerCellFilter : 'translate',
+  }, {
+    field : 'avg_consumption',
+    displayName : 'STOCK.CMM',
+    headerCellFilter : 'translate',
+    type : 'number',
+  }, {
+    field : 'S_MONTH',
+    displayName : 'STOCK.MSD',
+    headerCellFilter : 'translate',
+    type : 'number',
+  }, {
+    field : 'lifetime',
+    displayName : 'STOCK.LIFETIME',
+    headerCellFilter : 'translate',
+    cellTemplate     : 'modules/stock/lots/templates/lifetime.cell.html',
+    type : 'number',
+  }, {
+    field : 'S_LOT_LIFETIME',
+    displayName : 'STOCK.LOT_LIFETIME',
+    headerCellFilter : 'translate',
+    cellTemplate     : 'modules/stock/lots/templates/lot_lifetime.cell.html',
+    type : 'number',
+  }, {
+    field : 'S_RISK',
+    displayName : 'STOCK.RISK',
+    headerCellFilter : 'translate',
+    cellTemplate     : 'modules/stock/lots/templates/risk.cell.html',
+    type : 'number',
+  }, {
+    field : 'S_RISK_QUANTITY',
+    displayName : 'STOCK.RISK_QUANTITY',
+    headerCellFilter : 'translate',
+    cellTemplate     : 'modules/stock/lots/templates/risk_quantity.cell.html',
+    type : 'number',
+  }];
 
   const gridFooterTemplate = `
     <div>
-      <b>{{ grid.appScope.countGridRows() }}</b> 
+      <b>{{ grid.appScope.countGridRows() }}</b>
       <span translate>TABLE.AGGREGATES.ROWS</span>
     </div>
   `;
@@ -167,7 +140,8 @@ function StockLotsController(
   const state = new GridState(vm.gridOptions, cacheKey);
 
   // expose to the view model
-  vm.grouping = new Grouping(vm.gridOptions, true, 'depot_text', vm.grouped, true);
+  vm.grouping = new Grouping(vm.gridOptions, false, 'depot_text', true, true);
+
   vm.getQueryString = Stock.getQueryString;
   vm.clearGridState = clearGridState;
   vm.search = search;
@@ -180,9 +154,7 @@ function StockLotsController(
   }
 
   // count data rows
-  vm.countGridRows = () => {
-    return vm.gridOptions.data.length;
-  };
+  vm.countGridRows = () => vm.gridOptions.data.length;
 
   // select group
   vm.selectGroup = (group) => {
@@ -235,6 +207,10 @@ function StockLotsController(
     vm.loading = !vm.loading;
   }
 
+  function orderByDepot(rowA, rowB) {
+    return rowA.depot_text > rowB.depot_text ? 1 : -1;
+  }
+
   // load stock lots in the grid
   function load(filters) {
     vm.hasError = false;
@@ -245,8 +221,15 @@ function StockLotsController(
 
     Stock.lots.read(null, filters)
       .then((lots) => {
+
+        // FIXME(@jniles): we should do this ordering on the server via an ORDER BY
+        lots
+          .sort(orderByDepot);
+
         vm.gridOptions.data = lots;
+
         vm.grouping.unfoldAllGroups();
+        vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
       })
       .catch(errorHandler)
       .finally(toggleLoadingIndicator);
@@ -287,7 +270,6 @@ function StockLotsController(
   }
 
   vm.downloadExcel = () => {
-
     const filterOpts = stockLotFilters.formatHTTP();
     const defaultOpts = {
       renderer : 'xlsx',

--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -227,7 +227,14 @@ function StockMovementsController(
       .finally(toggleLoading);
   }
 
+  function orderByDepot(rowA, rowB) {
+    return rowA.depot_text > rowB.depot_text ? 1 : -1;
+  }
+
   function handleMovementRows(rows) {
+    // FIXME(@jniles): we should do this ordering on the server via an ORDER BY
+    rows.sort(orderByDepot);
+
     // preprocess data
     rows.forEach(handleMovementRow);
 


### PR DESCRIPTION
This commit fixes the stock lots registry grouping by ordering the inventory items by depot first.

Closes #3409.

The problem fixed here is that ui-grid wasn't grouping values properly unless they were sorted first.  It's not clear to me why this happens - the documentation doesn't mention it.

In the long run, we should probably deprecate GridGrouping service, and use only TreeBase for our grouping.  This will give us a more uniform way to interact with ui-grid.

Finally, we also need to rewrite the client sort to be done in the server.  The Stock Lots API is overloaded and can be done more efficiently in SQL.

**Before**
![stocklotsoriginal](https://user-images.githubusercontent.com/896472/49230479-1a13b580-f3f0-11e8-892a-05296455c816.jpg)

**After**
![stocklotsafter](https://user-images.githubusercontent.com/896472/49230478-1a13b580-f3f0-11e8-89af-23d8fad650de.jpg)

It also makes these changes for the stock inventories and stock movements registries.