### PR TITLE
feat(Trial Balance): group by account type

### DIFF
--- a/client/src/i18n/en/posting_journal.json
+++ b/client/src/i18n/en/posting_journal.json
@@ -69,7 +69,8 @@
       "SHOW_ERRORS" : "Switch to Error View",
       "RETURN_TO_OVERVIEW" : "Return to Summary View",
       "IS_BALANCED" : "Balanced",
-      "POSTED_TRANSACTIONS" : "Success!  Posted {{ numRecords }} Transactions to the General Ledger."
+      "POSTED_TRANSACTIONS" : "Success!  Posted {{ numRecords }} Transactions to the General Ledger.",
+      "SUMMARY_BY_TYPE" : "Changes by Account Type"
     },
     "TITLE" : "Journal"
   }

--- a/client/src/i18n/fr/posting_journal.json
+++ b/client/src/i18n/fr/posting_journal.json
@@ -70,7 +70,8 @@
       "SHOW_ERRORS" : "Passer à la vue d'erreur",
       "RETURN_TO_OVERVIEW" : "Retourner à la vue sommaire",
       "IS_BALANCED" : "Balancé",
-      "POSTED_TRANSACTIONS" : "Succès! Posté {{numRecords}} Transactions au Grand Livre."
+      "POSTED_TRANSACTIONS" : "Succès! Posté {{numRecords}} Transactions au Grand Livre.",
+      "SUMMARY_BY_TYPE" : "Changements par type de compte"
     }
   }
 }

--- a/client/src/modules/journal/trial-balance/overview.html
+++ b/client/src/modules/journal/trial-balance/overview.html
@@ -20,3 +20,16 @@
     error-state="OverviewCtrl.hasError">
   </bh-grid-loading-indicator>
 </div>
+
+<div class="row" ng-if="OverviewCtrl.summaryByAccountType">
+  <ul style="margin-left: 0; padding-left:0;">
+    <li  style="display: inline-block; padding: 2.5px;">
+      <i class="fa fa-balance-scale"></i>
+      <span translate>POSTING_JOURNAL.TRIAL_BALANCE.SUMMARY_BY_TYPE</span> &vert;
+    </li>
+    <li ng-repeat="(type, balance) in OverviewCtrl.summaryByAccountType" style="display: inline-block; padding: 2.5px;">
+      <strong translate>{{ type }}</strong>: &nbsp;
+      <span>{{ balance | currency:OverviewCtrl.currencyId }}</span>
+    </li>
+  </ul>
+</div>

--- a/client/src/modules/journal/trial-balance/overview.js
+++ b/client/src/modules/journal/trial-balance/overview.js
@@ -14,6 +14,7 @@ TrialBalanceOverviewController.$inject = [
 function TrialBalanceOverviewController(Session, TrialBalance, Notify, uiGridConstants, GridExport, $state) {
   const vm = this;
   const currencyId = Session.enterprise.currency_id;
+  vm.currencyId = currencyId;
 
   const GRID_HEADER_ERROR_CLASS = 'ui-grid-header-cell-error';
   const GRID_HEADER_DEFAULT_CLASS = 'ui-grid-header-cell-primary';
@@ -119,6 +120,7 @@ function TrialBalanceOverviewController(Session, TrialBalance, Notify, uiGridCon
     TrialBalance.summary()
       .then(summary => {
         vm.gridOptions.data = summary;
+        vm.summaryByAccountType = TrialBalance.groupByAccountType(summary);
       })
       .catch(errorHandler)
       .finally(toggleLoadingIndicator);

--- a/client/src/modules/journal/trial-balance/overview.subgrid.html
+++ b/client/src/modules/journal/trial-balance/overview.subgrid.html
@@ -1,9 +1,0 @@
-<div
-  id="details-grid"
-  ui-grid="grid.appScope.subGridOptions">
-  <bh-grid-loading-indicator
-    loading-state="grid.appScope.loadingSubGrid"
-    empty-state="grid.appScope.subGridOptions.data.length === 0"
-    error-state="grid.appScope.hasSubGridError">
-  </bh-grid-loading-indicator>
-</div>

--- a/server/models/procedures/trial_balance.sql
+++ b/server/models/procedures/trial_balance.sql
@@ -210,6 +210,7 @@ Running this a table with the following type:
 USAGE: CALL TrialBalanceSummary()
 */
 --
+DROP PROCEDURE IF EXISTS TrialBalanceSummary$$
 CREATE PROCEDURE TrialBalanceSummary()
 BEGIN
   -- this assumes lines have been staged using CALL StageTrialBalanceTransaction()
@@ -239,7 +240,7 @@ BEGIN
     ) totals ON u.account_id = totals.account_id
     GROUP BY u.account_id;
 
-  SELECT account_id, account.number AS number, account.label AS label,
+  SELECT account_id, account.number AS number, account.label AS label, account.type_id,
     balance_before, debit_equiv, credit_equiv,
     balance_before + debit_equiv - credit_equiv AS balance_final
   FROM (

--- a/test/client-unit/services/TrialBalance.spec.js
+++ b/test/client-unit/services/TrialBalance.spec.js
@@ -1,0 +1,42 @@
+/* global inject expect */
+describe('TrialBalanceService', () => {
+  let TrialBalance;
+
+  beforeEach(module('bhima.services', 'bhima.mocks', 'angularMoment', 'bhima.constants'));
+
+  beforeEach(inject(TrialBalanceService => {
+    TrialBalance = TrialBalanceService;
+  }));
+
+  it('#groupByAccountType() returns 0 when types are the same', () => {
+    const rows = [
+      { debit_equiv : 10, credit_equiv : 0, type_id : 1 },
+      { debit_equiv : 0, credit_equiv : 10, type_id : 1 },
+    ];
+
+    const grouping = TrialBalance.groupByAccountType(rows);
+    expect(grouping).to.deep.equal({ 'ACCOUNT.TYPES.ASSET' : 0 });
+  });
+
+  it('#groupByAccountType() returns the correct sums for diverse account types', () => {
+    const rows = [
+      { debit_equiv : 10, credit_equiv : 0, type_id : 1 },
+      { debit_equiv : 0, credit_equiv : 10, type_id : 4 },
+      { debit_equiv : 30, credit_equiv : 0, type_id : 2 },
+      { debit_equiv : 0, credit_equiv : 15, type_id : 5 },
+      { debit_equiv : 0, credit_equiv : 15, type_id : 1 },
+      { debit_equiv : 100, credit_equiv : 0, type_id : 5 },
+      { debit_equiv : 0, credit_equiv : 100, type_id : 4 },
+    ];
+
+    const result = {
+      'ACCOUNT.TYPES.ASSET' : -5,
+      'ACCOUNT.TYPES.INCOME' : -110,
+      'ACCOUNT.TYPES.LIABILITY' : 30,
+      'ACCOUNT.TYPES.EXPENSE' : 85,
+    };
+
+    const grouping = TrialBalance.groupByAccountType(rows);
+    expect(grouping).to.deep.equal(result);
+  });
+});


### PR DESCRIPTION
This commit adds a feature to the Trial Balance to group by the account type id.  This gives a brief overview at a glance of the movements of funds in lesser detail than the global overview.

Closes #3411.

Here it is in action:
![2018-11-30_13-10-38](https://user-images.githubusercontent.com/896472/49288591-77b40a80-f4a1-11e8-8ffc-2857d0f71dc7.gif)
