### PR TITLE
fix sort order in the lot registry

### DIFF
--- a/client/src/modules/stock/lots/registry.js
+++ b/client/src/modules/stock/lots/registry.js
@@ -37,10 +37,18 @@ function StockLotsController(
     field : 'code',
     displayName : 'STOCK.CODE',
     headerCellFilter : 'translate',
+    sort : {
+      direction : uiGridConstants.ASC,
+      priority : 0,
+    },
   }, {
     field : 'text',
     displayName : 'STOCK.INVENTORY',
     headerCellFilter : 'translate',
+    sort : {
+      direction : uiGridConstants.ASC,
+      priority : 1,
+    },
   }, {
     field : 'group_name',
     displayName : 'TABLE.COLUMNS.INVENTORY_GROUP',
@@ -95,6 +103,10 @@ function StockLotsController(
     headerCellFilter : 'translate',
     cellTemplate     : 'modules/stock/lots/templates/lifetime.cell.html',
     type : 'number',
+    sort : {
+      direction : uiGridConstants.ASC,
+      priority : 2,
+    },
   }, {
     field : 'S_LOT_LIFETIME',
     displayName : 'STOCK.LOT_LIFETIME',
@@ -107,6 +119,10 @@ function StockLotsController(
     headerCellFilter : 'translate',
     cellTemplate     : 'modules/stock/lots/templates/risk.cell.html',
     type : 'number',
+    sort : {
+      direction : uiGridConstants.DESC,
+      priority : 3,
+    },
   }, {
     field : 'S_RISK_QUANTITY',
     displayName : 'STOCK.RISK_QUANTITY',

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -493,7 +493,10 @@ function processMultipleLots(inventories) {
 
   _.map(inventoryLots, (lots) => {
     // order lots by ascending lifetime
-    const orderedInventoryLots = _.orderBy(lots, 'lifetime', 'asc');
+    let orderedInventoryLots = _.orderBy(lots, 'lifetime', 'asc');
+    // order lots also by ascending quantity
+    // assuming the lot with lowest quantity is consumed first
+    orderedInventoryLots = _.orderBy(orderedInventoryLots, 'quantity', 'asc');
 
     // compute the lot coefficient
     let lotLifetime = 0;


### PR DESCRIPTION
This PR fix the sorting order in the lot registry for correct lifetime risk calculation.

Before : 
The second row must appear at the top so that we can easily interpret columns : duree lot, risk, ...
![image](https://user-images.githubusercontent.com/5445251/49304996-37b74c80-f4ce-11e8-9d59-1681b6860ed6.png)

After : 
![image](https://user-images.githubusercontent.com/5445251/49305090-8e248b00-f4ce-11e8-973b-496e6dd7c6f6.png)

