### PR TITLE
lifetime has a high priority than quantity

### DIFF
--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -492,11 +492,12 @@ function processMultipleLots(inventories) {
   const inventoryLots = _.groupBy(inventories, 'inventory_uuid');
 
   _.map(inventoryLots, (lots) => {
-    // order lots by ascending lifetime
-    let orderedInventoryLots = _.orderBy(lots, 'lifetime', 'asc');
     // order lots also by ascending quantity
     // assuming the lot with lowest quantity is consumed first
-    orderedInventoryLots = _.orderBy(orderedInventoryLots, 'quantity', 'asc');
+    let orderedInventoryLots = _.orderBy(lots, 'quantity', 'asc');
+
+    // order lots by ascending lifetime has a hight priority than quantity
+    orderedInventoryLots = _.orderBy(orderedInventoryLots, 'lifetime', 'asc');
 
     // compute the lot coefficient
     let lotLifetime = 0;


### PR DESCRIPTION
This PR fix priority issue in stock lots between lifetime and quantity : The lifetime has a higher priority than the quantity

**Before :** 
![image](https://user-images.githubusercontent.com/5445251/49380432-f8793d80-f711-11e8-88b7-1b70234cca5e.png)

**After :** 
![image](https://user-images.githubusercontent.com/5445251/49380540-40986000-f712-11e8-8730-6ca9d5aac2d6.png)
