### PR TITLE
fix: parse project abbr to get transaction length

### DIFF
--- a/server/models/functions.sql
+++ b/server/models/functions.sql
@@ -103,6 +103,24 @@ BEGIN
   );
 END $$
 
+/**
+ GetTransactionNumberPart(transId, projectId)
+
+ Returns the number part of a transaction ID.
+*/
+CREATE FUNCTION GetTransactionNumberPart(
+  trans_id TEXT,
+  project_id SMALLINT(5)
+)
+RETURNS INT DETERMINISTIC
+BEGIN
+  RETURN (
+    SELECT SUBSTRING(trans_id, LENGTH(project.abbr) + 1)
+    FROM project
+    WHERE id = project_id
+  );
+END $$
+
 /*
   PredictAccountTypeId(accountNumber)
 

--- a/server/models/procedures.sql
+++ b/server/models/procedures.sql
@@ -11,18 +11,18 @@ SET CHARACTER SET utf8mb4, CHARACTER_SET_CONNECTION = utf8mb4;
 DELIMITER $$
 
 /*
-  Invoicing procedures include: StageInvoice, StageInvoiceItem,
-  StageInvoiceFee, VerifySubsidyStageTable, PostInvoice, PostingSetupUtil,
-  PostingJournalErrorHandler, CopyInvoiceToPostingJournal and PostToGeneralLedger
-*/
-SOURCE server/models/procedures/invoicing.sql
-
-/*
   Cash procedures include: HandleCashRounding, PostCash, StageCash,
   StageCashItem, VerifyCashTemporaryTables, CalculateCashInvoiceBalances,
   WriteCashItems and WriteCash
 */
 SOURCE server/models/procedures/cash.sql
+
+/*
+  Invoicing procedures include: StageInvoice, StageInvoiceItem,
+  StageInvoiceFee, VerifySubsidyStageTable, PostInvoice, PostingSetupUtil,
+  PostingJournalErrorHandler, CopyInvoiceToPostingJournal and PostToGeneralLedger
+*/
+SOURCE server/models/procedures/invoicing.sql
 
 /*
   Time period procedures include: CreateFiscalYear, GetPeriodRange and

--- a/server/models/procedures/voucher.sql
+++ b/server/models/procedures/voucher.sql
@@ -54,6 +54,8 @@ BEGIN
   DECLARE gain_account_id INT UNSIGNED;
   DECLARE loss_account_id INT UNSIGNED;
 
+
+  DECLARE transIdNumberPart INT;
   --
   SELECT p.enterprise_id, p.id, v.currency_id, v.date
     INTO enterprise_id, project_id, currency_id, date
@@ -67,6 +69,8 @@ BEGIN
   SET current_exchange_rate = GetExchangeRate(enterprise_id, currency_id, date);
   SET current_exchange_rate = (SELECT IF(currency_id = enterprise_currency_id, 1, current_exchange_rate));
 
+  SET transIdNumberPart = GetTransactionNumberPart(transaction_id, project_id);
+
   -- POST to the posting journal
   -- @TODO(sfount) transaction ID number reference should be fetched seperately from full transaction ID to model this relationship better
   INSERT INTO posting_journal (uuid, project_id, fiscal_year_id, period_id,
@@ -74,7 +78,7 @@ BEGIN
     credit, debit_equiv, credit_equiv, currency_id, entity_uuid,
     reference_uuid, comment, transaction_type_id, user_id)
   SELECT
-    HUID(UUID()), v.project_id, fiscal_year_id, period_id, transaction_id, SUBSTRING(transaction_id, 4), v.date,
+    HUID(UUID()), v.project_id, fiscal_year_id, period_id, transaction_id, transIdNumberPart, v.date,
     v.uuid, v.description, vi.account_id, vi.debit, vi.credit,
     vi.debit * (1 / current_exchange_rate), vi.credit * (1 / current_exchange_rate), v.currency_id,
     vi.entity_uuid, vi.document_uuid, NULL, v.type_id, v.user_id


### PR DESCRIPTION
This commit adds a new function to the SQL to parse the project
abbreviation and come up with the correct transaction identifier length.

Closes #3450.