### PR TITLE
refactor(bhStockEntryExitType): rewrite component

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -91,6 +91,8 @@
     "MOVEMENTS"       : "Movements",
     "NO_ORDER"        : "No Orders",
     "NO_DATA"         : "No Data",
+    "NO_ENTRY_TYPES"  : "There are no entry types defined for {{text}}.  Add at least one entry type in the Depot Management module.",
+    "NO_EXIT_TYPES"  : "There are no exit types defined for {{text}}.  Add at least one exit type in the Depot Management module.",
     "OUTPUT"          : "Output",
     "ORDERS"          : "Orders",
     "ORIGIN"          : "Origin",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -36,7 +36,7 @@
       "EXCESSIVE_QUANTITY": "Quantité excessive",
       "LOT_QUANTITY_OVER_GLOBAL": "La quantité totale des lots dépasse la quantity globale fournie",
       "PLEASE_CHECK_EXPIRY_DATE": "Veuillez vérifier la date d'expiration"
-    },    
+    },
     "EXPIRATION_DATE" : "Date d'expiration",
     "EXPIRATION_RISK" : "Risque d'expiration",
     "EXPIRATION"      : "Expiration",
@@ -91,6 +91,8 @@
     "MOVEMENTS"       : "Mouvements",
     "NO_ORDER"        : "Pas de commandes",
     "NO_DATA"         : "Aucune données",
+    "NO_ENTRY_TYPES"  : "Aucun type d'entre n'est défini pour {{text}}. Ajoutez au moins un type d'entre dans le module de gestion des dépôts.",
+    "NO_EXIT_TYPES"  : "Aucun type de sortie n'est défini pour {{text}}. Ajoutez au moins un type de sortie dans le module de gestion des dépôts.",
     "OUTPUT"          : "Sortie",
     "ORDERS"          : "Commandes",
     "ORIGIN"          : "Origine",

--- a/client/src/modules/stock/StockEntryExitType.service.js
+++ b/client/src/modules/stock/StockEntryExitType.service.js
@@ -1,116 +1,50 @@
 angular.module('bhima.services')
   .service('StockEntryExitTypeService', StockEntryExitTypeService);
 
-StockEntryExitTypeService.$inject = [];
-
 function StockEntryExitTypeService() {
   const service = this;
 
-  const entryExitTypeList = [
-    {
-      label : 'patient',
-      labelKey : 'PATIENT_REG.ENTITY',
-      descriptionKey : 'STOCK.PATIENT_DISTRIBUTION',
-      isEntry : false,
-      allowedKey : 'allow_exit_debtor',
-    },
+  service.exitTypes = [{
+    label : 'patient',
+    labelKey : 'PATIENT_REG.ENTITY',
+    descriptionKey : 'STOCK.PATIENT_DISTRIBUTION',
+    allowedKey : 'allow_exit_debtor',
+  }, {
+    label : 'service',
+    labelKey : 'SERVICE.ENTITY',
+    descriptionKey : 'STOCK.SERVICE_DISTRIBUTION',
+    allowedKey : 'allow_exit_service',
+  }, {
+    label : 'depot',
+    labelKey : 'DEPOT.ENTITY',
+    descriptionKey : 'STOCK.DEPOT_DISTRIBUTION',
+    allowedKey : 'allow_exit_transfer',
+  }, {
+    label : 'loss',
+    labelKey : 'STOCK.EXIT_LOSS',
+    descriptionKey : 'STOCK.LOSS_DISTRIBUTION',
+    allowedKey : 'allow_exit_loss',
+  }];
 
-    {
-      label : 'service',
-      labelKey : 'SERVICE.ENTITY',
-      descriptionKey : 'STOCK.SERVICE_DISTRIBUTION',
-      isEntry : false,
-      allowedKey : 'allow_exit_service',
-    },
-
-    {
-      label : 'depot',
-      labelKey : 'DEPOT.ENTITY',
-      descriptionKey : 'STOCK.DEPOT_DISTRIBUTION',
-      isEntry : false,
-      allowedKey : 'allow_exit_transfer',
-    },
-
-    {
-      label : 'loss',
-      labelKey : 'STOCK.EXIT_LOSS',
-      descriptionKey : 'STOCK.LOSS_DISTRIBUTION',
-      isEntry : false,
-      allowedKey : 'allow_exit_loss',
-    },
-
-    {
-      label : 'purchase',
-      labelKey : 'STOCK.ENTRY_PURCHASE',
-      descriptionKey : 'STOCK_FLUX.FROM_PURCHASE',
-      isEntry : true,
-      allowedKey : 'allow_entry_purchase',
-    },
-
-    {
-      label : 'integration',
-      labelKey : 'STOCK.INTEGRATION',
-      descriptionKey : 'STOCK_FLUX.FROM_INTEGRATION',
-      isEntry : true,
-      allowedKey : 'allow_entry_integration',
-    },
-
-    {
-      label : 'donation',
-      labelKey : 'STOCK.DONATION',
-      descriptionKey : 'STOCK_FLUX.FROM_DONATION',
-      isEntry : true,
-      allowedKey : 'allow_entry_donation',
-    },
-
-    {
-      label : 'transfer_reception',
-      labelKey : 'STOCK.RECEPTION_TRANSFER',
-      descriptionKey : 'STOCK_FLUX.FROM_TRANSFER',
-      isEntry : true,
-      allowedKey : 'allow_entry_transfer',
-    },
-  ];
-
-  service.getAllowedTypes = getAllowedTypes;
-
-  service.getEntryTypeList = function getEntryTypeList() {
-    return filterByEntry(true);
-  };
-
-  service.getExitTypeList = function getExitTypeList() {
-    return filterByEntry(false);
-  };
-
-  /**
-   * @function getAllowedTypes
-   *
-   * @description
-   * return allowed entry/exit feature for a given depot
-   *
-   * @param {object} depot
-   */
-  function getAllowedTypes(depot) {
-    if (!depot || !depot.uuid) { return []; }
-
-    return entryExitTypeList.map((item) => {
-      item.isAllowed = depot[item.allowedKey];
-      return item;
-    });
-  }
-
-  /**
-   * @function filterByEntry
-   *
-   * @description
-   * filter the Entry/Exit types list according the isEntry attribute
-   * is true or false
-   *
-   * @param {boolean} isEntry
-   */
-  function filterByEntry(isEntry) {
-    return entryExitTypeList.filter((item) => {
-      return item.isEntry === isEntry;
-    });
-  }
+  service.entryTypes = [{
+    label : 'purchase',
+    labelKey : 'STOCK.ENTRY_PURCHASE',
+    descriptionKey : 'STOCK_FLUX.FROM_PURCHASE',
+    allowedKey : 'allow_entry_purchase',
+  }, {
+    label : 'integration',
+    labelKey : 'STOCK.INTEGRATION',
+    descriptionKey : 'STOCK_FLUX.FROM_INTEGRATION',
+    allowedKey : 'allow_entry_integration',
+  }, {
+    label : 'donation',
+    labelKey : 'STOCK.DONATION',
+    descriptionKey : 'STOCK_FLUX.FROM_DONATION',
+    allowedKey : 'allow_entry_donation',
+  }, {
+    label : 'transfer_reception',
+    labelKey : 'STOCK.RECEPTION_TRANSFER',
+    descriptionKey : 'STOCK_FLUX.FROM_TRANSFER',
+    allowedKey : 'allow_entry_transfer',
+  }];
 }

--- a/client/src/modules/templates/bhStockEntryExitType.tmpl.html
+++ b/client/src/modules/templates/bhStockEntryExitType.tmpl.html
@@ -1,24 +1,23 @@
-<div ng-if="type.isAllowed" class="col-md-3 col-xs-6" ng-repeat="type in $ctrl.entryExitTypeList | filter:{isEntry : $ctrl.isEntry}">
-    <button 
-        id="entry-exit-type-{{type.label}}" 
-        class="btn-block panel panel-default segment ima-stat-card" 
-        type="button" 
-        ng-class="{'ima-stat-card-reversed': type.label === $ctrl.selectedEntryExitType.label}"
-        ng-click="$ctrl.selectEntryExitType(type)">
-            <div class="panel-body text-center text-ellipsis">
-                <div class="ui lg statistic">
-                    <div class="value" translate>
-                        {{type.labelKey}}
-                    </div>
-                    <div class="ui-hidable-label">
-                        <span ng-hide="($ctrl.reference || $ctrl.displayName) && type.label === $ctrl.selectedEntryExitType.label" translate>
-                            {{type.descriptionKey}}
-                        </span>
-                        <span ng-show="($ctrl.reference || $ctrl.displayName) && type.label === $ctrl.selectedEntryExitType.label">
-                            {{$ctrl.display()}}
-                        </span>
-                    </div>
-                </div>
-            </div>
-    </button>
+<div class="col-md-3 col-xs-6" ng-repeat="type in $ctrl.types track by type.label">
+  <button
+    type="button"
+    id="entry-exit-type-{{type.label}}"
+    class="btn-block panel panel-default segment ima-stat-card"
+    ng-class="{ 'ima-stat-card-reversed' : $ctrl.isTypeSelected(type) }"
+    ng-click="$ctrl.selectEntryExitType(type)">
+      <div class="panel-body text-center text-ellipsis">
+        <div class="ui lg statistic">
+          <div class="value" translate>{{type.labelKey}}</div>
+          <div class="ui-hidable-label" translate>{{$ctrl.getLabel(type)}}</div>
+        </div>
+      </div>
+  </button>
+</div>
+
+<div class="col-xs-12" ng-if="$ctrl.hasNoTypesDefined">
+  <p class="alert alert-danger">
+    <i class="fa fa-warning"></i>
+    <span ng-show="$ctrl.isEntry === 'true'" translate translate-values="$ctrl.depot">STOCK.NO_ENTRY_TYPES</span>
+    <span ng-hide="$ctrl.isEntry === 'true'" translate translate-values="$ctrl.depot">STOCK.NO_EXIT_TYPES</span>
+  </p>
 </div>


### PR DESCRIPTION
This commit rewrites the `bhStockEntryExitType` component to make it simpler and more performant.  It also adds a special warning message if the user forgot to add entry/exit types for the depot - instead of appearing blank, it will now inform the user of the error.

![2018-12-12_16-11-25](https://user-images.githubusercontent.com/896472/49879074-7253aa00-fe29-11e8-9711-e3bad0882dba.gif)
_GIF 1:  Here's how it looks_