### PR TITLE
chore: update links from 2.x -> bhima

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -7,8 +7,7 @@
  of this license document, but changing it is not allowed.
 
                             Preamble
-
-  The licenses for most software are designed to take away your
+The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
 License is intended to guarantee your freedom to share and change free
 software--to make sure the software is free for all its users.  This

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 BHIMA
 =================
 
-[![Build Status](https://travis-ci.org/IMA-WorldHealth/bhima-2.X.svg)](https://travis-ci.org/IMA-WorldHealth/bhima-2.X)
-[![API Doc](https://doclets.io/IMA-WorldHealth/bhima-2.X/master.svg)](https://doclets.io/IMA-WorldHealth/bhima-2.X/master)
+[![Build Status](https://travis-ci.org/IMA-WorldHealth/bhima.svg)](https://travis-ci.org/IMA-WorldHealth/bhima)
 
 Bhima is a free, open source accounting and hospital information management system
 (HIMS) tailored for rural hospitals in Africa.  We are an international team
@@ -13,12 +12,12 @@ BHIMA is an acronym for _basic hospital information management application_.
 Project Goals
 --------------------
 
-Bhima aims to provide a flexible and robust accounting and managerial solution
+BHIMA aims to provide a flexible and robust accounting and managerial solution
 for rural hospitals.  This includes, but is not limited to, basic income/expense
 reporting, budgeting, patient and organisational billing, depreciation,
 inventory and pricing, and purchasing.
 
-Additionally, bhima bundles reports and optional reporting plugins to aid
+Additionally, BHIMA bundles reports and optional reporting plugins to aid
 hospital administrators, aid organisations, and governmental/non-governmental
 agencies access up to date utilization data.
 
@@ -29,16 +28,16 @@ accessing the server simultaneously.
 Contributing
 ---------------
 All contributions are welcome!  If you want to get started hacking on BHIMA, the
-[developer wiki](https://github.com/IMA-WorldHealth/bhima-2.X/wiki) contains notes
+[developer wiki](https://github.com/IMA-WorldHealth/bhima/wiki) contains notes
 on our designs and testing infrastructure.  If you have any questions or need help
-getting started, please [open an issue](https://github.com/IMA-WorldHealth/bhima-2.X/issues/new) - 
+getting started, please [open an issue](https://github.com/IMA-WorldHealth/bhima/issues/new) -
 chances are you are not the only one!
 
-If you just want to jump into to messing with the software, check out [Getting Up And Running](https://github.com/IMA-WorldHealth/bhima-2.X/wiki/Getting-Up-and-Running).
+If you just want to jump into to messing with the software, check out [Getting Up And Running](https://github.com/IMA-WorldHealth/bhima/wiki/Getting-Up-and-Running).
 
-If you are new to git/Github check out our [Getting Started Guide](https://github.com/IMA-WorldHealth/bhima-2.X/wiki/Getting-Started:-Contributing-on-Github).
+If you are new to git/Github check out our [Getting Started Guide](https://github.com/IMA-WorldHealth/bhima/wiki/Getting-Started:-Contributing-on-Github).
 
-Want to jump straight into code?  The [First Time Contributor](https://github.com/IMA-WorldHealth/bhima-2.X/issues?q=is%3Aissue+is%3Aopen+label%3A%22first+time+contributor%22)
+Want to jump straight into code?  The [First Time Contributor](https://github.com/IMA-WorldHealth/bhima/issues?q=is%3Aissue+is%3Aopen+label%3A%22first+time+contributor%22)
 issues are a decent place to start.
 
 
@@ -48,4 +47,4 @@ See the [installation guide](./docs/INSTALL.md).
 
 License
 ---------------
-Bhima is licensed under GPL-2.0.  [Read the License](./LICENSE).
+BHIMA is licensed under GPL-2.0.  [Read the License](./LICENSE).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,12 +1,10 @@
-Bhima Installation Guide
+BHIMA Installation Guide
 ===========================
 
-*NOTE* This guide is built for bhima version 2.X.  If you are attempting to build version 1.X, see [this repository](https://github.com/IMA-WorldHealth/bhima-1.X).
-
-This guide will get you up and running with bhima locally.  Please note that bhima is under active development and tends to move fast and break things.  If you are interested in development progress, shoot us a line at <developers@imaworldhealth.org>.
+This guide will get you up and running with BHIMA locally.  Please note that BHIMA is under active development and tends to move fast and break things.  If you are interested in development progress, shoot us a line at <developers@imaworldhealth.org>.
 
 ###### Dependencies
-Before you begin the installation process, please make sure you have all the bhima dependencies installed locally.  We only test on Linux, so your best bet is to use a Linux flavor you are familiar with.  Please make sure you have recent version of:
+Before you begin the installation process, please make sure you have all the BHIMA dependencies installed locally.  We only test on Linux, so your best bet is to use a Linux flavor you are familiar with.  Please make sure you have recent version of:
  1. [MySQL](http://dev.mysql.com/downloads/) (5.6 or newer)
  2. [Redis](redis.io)
  3. curl
@@ -14,7 +12,7 @@ Before you begin the installation process, please make sure you have all the bhi
  5. [WKHTMLtoPDF](http://wkhtmltopdf.org/downloads.html) (use the compiled binaries, even if it is distributed with your package manager.  The binaries come with patched Qt).
  6.	yarn
  7.	git
- 
+
 ###### Detailed dependency installation instructions for Ubuntu (verified / installed specifically using VirtualBox)
 
 ```bash
@@ -40,11 +38,11 @@ export NVM_DIR="$HOME/.nvm"
 #Download NodeJS version 8
 nvm install 8
 
-#Run the following commands to install WKHTMLtoPDF (note that version 0.12.4 should be installed, 0.12.5 does not currently work with bhima):
+#Run the following commands to install WKHTMLtoPDF (note that version 0.12.4 should be installed, 0.12.5 does not currently work with BHIMA):
 sudo apt-get install xvfb
 wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
 tar xvf wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
-sudo mv wkhtmltox/bin/wkhtmltopdf /usr/bin 
+sudo mv wkhtmltox/bin/wkhtmltopdf /usr/bin
 sudo rm wkhtmltox-0.12.4_linux-generic-amd64.tar.xz  && rm -rf wkhtmltox
 
 #Installs yarn without re-installing NodeJS
@@ -57,11 +55,11 @@ sudo apt-get install git
 ```
 
 ###### Getting the source
-Clone the source using git from the [github repository](https://github.com/IMA-WorldHealth/bhima-2.x) using the following commands:
+Clone the source using git from the [github repository](https://github.com/IMA-WorldHealth/bhima) using the following commands:
 
 ```bash
-git clone https://github.com/IMA-WorldHealth/bhima-2.X.git bhima-2.X
-cd bhima-2.X
+git clone https://github.com/IMA-WorldHealth/bhima.git bhima
+cd bhima
 ```
 
 ###### Building from source
@@ -73,7 +71,7 @@ To execute the build scripts, you can use either `yarn` or `npm`.  We'll use
 use `npm run` where it says `yarn` below.
 
 ```bash
-# Inside the bhima-2.X/ directory
+# Inside the bhima/ directory
 
 # install all node modules
 yarn install
@@ -93,20 +91,20 @@ the default node instance, `NODE_ENV="development"`.  Please set this globally,
 if it is not set by default on your machine.
 
 Before building, edit your `.env.development` to set up your MySQL database
-connection parameters.  Their variables should be self-explanatory. 
+connection parameters.  Their variables should be self-explanatory.
 
 Use the following command to edit the .env.development file if desired (make your changes and then type ctrl + x to exit and save):
 ```bash
 nano .env.development
 ```
 
-###### Configure the bhima user in MySQL and build the app
+###### Configure the BHIMA user in MySQL and build the app
 
 ```bash
-#Run the following commands to create the bhima user in MySQL, so that it can build the database (make sure the user and #password both match what you set in the .env.development file):
+#Run the following commands to create the BHIMA user in MySQL, so that it can build the database (make sure the user and #password both match what you set in the .env.development file):
 sudo mysql -u root -p
-CREATE USER ‘bhima’@‘localhost' IDENTIFIED BY 'password';
-GRANT ALL PRIVILEGES ON * . * TO ‘bhima’@‘localhost';
+CREATE USER 'bhima'@'localhost' IDENTIFIED BY 'password';
+GRANT ALL PRIVILEGES ON * . * TO 'bhima'@'localhost';
 #Use ctrl + z to get back to the main terminal prompt
 ```
 
@@ -168,7 +166,7 @@ Navigate to [https://localhost:8080](https://localhost:8080) in the browser to
 verify the installation.  You should be greeted with a login page.
 
 ###### Testing the Application
-Our tests are broken into unit tests, end to end tests, and integration tests.  There is more information on testing in the [wiki](https://github.com/IMA-WorldHealth/bhima-2.X/wiki).
+Our tests are broken into unit tests, end to end tests, and integration tests.  There is more information on testing in the [wiki](https://github.com/IMA-WorldHealth/bhima/wiki).
  1. **Integration Tests** - These test the server + database integration and generally our APIs.  All reachable API endpoints should generally have an integration test associated with them.  To run them, type `yarn test:integration`.
  2. **Server Unit Tests** - Server libraries are unit tested with mocha and chai, similar to the integration tests.  To run them, type `yarn test:server-unit`.
  2. **Client Unit Tests** - Client components are unit tested with karma which you should have installed if you installed all dependencies.  Karma launches a chrome browser to execute the tests.  To run them, type `yarn test:client-unit`.
@@ -176,4 +174,4 @@ Our tests are broken into unit tests, end to end tests, and integration tests.  
 
 You can run all tests by simply typing `yarn test`.
 
-Enjoy using bhima!
+Enjoy using BHIMA!

--- a/server/controllers/inventory/index.js
+++ b/server/controllers/inventory/index.js
@@ -9,7 +9,7 @@
 * JSON instance or 404 NOT FOUND.  The others return an array of
 * results.
 *
-* TODO: We should migrate the inventory to using the regular bhima 2.x guidelines.
+* TODO: We should migrate the inventory to using the regular bhima guidelines.
 */
 
 const core = require('./inventory/core');


### PR DESCRIPTION
This commit updates the links from bhima-2.x to BHIMA and removes references to 1.x.  This should ease user on-boarding by only having a single BHIMA without needing to know the historical reasons behind
BHIMA's evolution.