### PR TITLE
fix(vouchers): don't make 300 rows on import

### DIFF
--- a/client/src/js/components/bhAccountTypeaheadInline.js
+++ b/client/src/js/components/bhAccountTypeaheadInline.js
@@ -26,9 +26,6 @@ function AccountTypeaheadInlineController(Accounts, $timeout, $scope, Store) {
 
   // fired at the beginning of the account select
   $ctrl.$onInit = function $onInit() {
-    // fired when an account has been selected
-    $ctrl.onSelectCallback = $ctrl.onSelectCallback || angular.noop;
-
     // default for form name
     $ctrl.name = $ctrl.name || 'AccountForm';
 
@@ -50,21 +47,29 @@ function AccountTypeaheadInlineController(Accounts, $timeout, $scope, Store) {
     const params = { hidden : 0 };
 
     Accounts.read(null, params)
-      .then((elements) => {
+      .then(elements => {
         // bind the accounts to the controller
         const accounts = Accounts.order(elements);
         $ctrl.accounts = Accounts.filterTitleAccounts(accounts);
 
         store.setData($ctrl.accounts);
+
+        if ($ctrl.accountId) {
+          setAccount($ctrl.accountId);
+        }
       });
   }
 
   $ctrl.$onChanges = function $onChanges(changes) {
     const accountId = changes.accountId && changes.accountId.currentValue;
     if (accountId) {
-      $ctrl.account = store.get(accountId);
+      setAccount(accountId);
     }
   };
+
+  function setAccount(id) {
+    $ctrl.account = store.get(id);
+  }
 
   // fires the onSelectCallback bound to the component boundary
   $ctrl.onSelect = function onSelect($item) {

--- a/client/src/modules/vouchers/complex-voucher.ctrl.js
+++ b/client/src/modules/vouchers/complex-voucher.ctrl.js
@@ -98,17 +98,20 @@ function ComplexJournalVoucherController(
   // @TODO fixed me to display correctly selected items(invoices, ..) accounts
   // without adding empty items before
   function gridManager(modal) {
-    vm.Voucher.addItems(300);
-    modal().then(result => {
-      if (!result) {
-        removeNullRows();
-        if (vm.Voucher.store.data.length === 0) {
-          vm.Voucher.addItems(2);
+    modal()
+      .then(result => {
+        if (!result) {
+          removeNullRows();
+
+          if (vm.Voucher.store.data.length === 0) {
+            vm.Voucher.addItems(2);
+          }
+
+          return;
         }
-        return;
-      }
-      processVoucherToolRows(result);
-    });
+
+        processVoucherToolRows(result);
+      });
   }
   /**
    * @function processVoucherToolRows
@@ -156,7 +159,7 @@ function ComplexJournalVoucherController(
    */
   function removeNullRows() {
     const gridData = JSON.parse(JSON.stringify(vm.gridOptions.data));
-    gridData.forEach((item) => {
+    gridData.forEach(item => {
       if (!item.account_id) {
         vm.Voucher.store.remove(item.uuid);
       }
@@ -174,7 +177,7 @@ function ComplexJournalVoucherController(
   /** Entity modal */
   function openEntityModal(row) {
     FindEntity.openModal()
-      .then((entity) => {
+      .then(entity => {
         row.entity = entity;
       });
   }
@@ -182,7 +185,7 @@ function ComplexJournalVoucherController(
   /** Reference modal */
   function openReferenceModal(row) {
     FindReference.openModal(row.entity)
-      .then((doc) => {
+      .then(doc => {
         row.configure({ document : doc });
       });
   }


### PR DESCRIPTION
This commit tells the bhAccountInline component to load accounts when the account id is given to the component controller.  This allows us to remove the mad hack that created hundreds of voucher rows and
significantly impacted performance.