### PR TITLE
feat(report): add unposted records option

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -202,6 +202,8 @@
       "REMOVE_ZERO_ROWS_HELP" : "This option will remove rows that do not have any data in them.  Produces a more compact output.",
       "INCLUDE_CLOSING_BALANCES" : "Include Closing Balances",
       "INCLUDE_CLOSING_BALANCES_HELP" : "This option will force the balance sheet to show the entire year's balances, including the closing balances.  Any operations made to close income and expense accounts will be reflected in the balance sheet.",
+      "INCLUDE_UNPOSTED_RECORDS" : "Include Unposted Values",
+      "INCLUDE_UNPOSTED_RECORDS_HELP" : "This option will force the report to include unposted values in the dataset.  Unposted values should never be included in a final report as they have not been validated by an accountant.",
       "REMOVE_UNUSED_ACCOUNT": "Remove Unused Accounts"
     },
     "OHADA": {
@@ -337,6 +339,7 @@
         "RQ" : "Participation des travailleurs"
       }
     },
+    "PROVISIONARY" : "Provisionary",
     "FOOTER": {
       "RESPONSIBLE" : "Responsible",
       "RECEIVED_BY" : "Received By",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -202,6 +202,8 @@
       "REMOVE_ZERO_ROWS_HELP" : "Cette option supprime les lignes qui ne contiennent aucune donnée. Produit un rapport plus compacte.",
       "INCLUDE_CLOSING_BALANCES" : "Inclure les soldes de clôture",
       "INCLUDE_CLOSING_BALANCES_HELP" : "Cette option force la balance à afficher les soldes de l’année entière, y compris les soldes de clôture. Toute opération effectuée pour clôturer les comptes de produits et de charges sera reflétée dans la balance.",
+      "INCLUDE_UNPOSTED_RECORDS" : "Inclure les valeurs non-postée",
+      "INCLUDE_UNPOSTED_RECORDS_HELP" : "",
       "REMOVE_UNUSED_ACCOUNT" : "Enlèver les comptes non utilisés"
     },
     "OHADA": {
@@ -337,6 +339,7 @@
         "RQ" : "Participation des travailleurs"
       }
     },
+    "PROVISIONARY" : "Provisoir",
     "FOOTER": {
       "RESPONSIBLE" : "Responsable",
       "RECEIVED_BY" : "Receptionné par",

--- a/client/src/js/components/bhDateInterval.js
+++ b/client/src/js/components/bhDateInterval.js
@@ -68,9 +68,9 @@ function bhDateInterval(moment, bhConstants, Fiscal, Session) {
         });
     }
 
-    startup();
-
     $ctrl.pickerToOptions = { showWeeks : false, minDate : $ctrl.dateFrom };
+
+    startup();
   };
 
   function search(selection) {

--- a/client/src/modules/reports/generate/account_report/account_report.config.js
+++ b/client/src/modules/reports/generate/account_report/account_report.config.js
@@ -18,6 +18,7 @@ function AccountReportConfigController(
 
   vm.reportDetails = {
     currency_id : Session.enterprise.currency_id,
+    includeUnpostedValues : 0,
   };
 
   vm.dateInterval = 1;
@@ -31,6 +32,10 @@ function AccountReportConfigController(
   vm.clearPreview = function clearPreview() {
     vm.previewGenerated = false;
     vm.previewResult = null;
+  };
+
+  vm.onChangeUnpostedValues = (bool) => {
+    vm.reportDetails.includeUnpostedValues = bool;
   };
 
   vm.setCurrency = function setCurrency(currencyId) {

--- a/client/src/modules/reports/generate/account_report/account_report.html
+++ b/client/src/modules/reports/generate/account_report/account_report.html
@@ -48,6 +48,14 @@
               on-change="ReportConfigCtrl.setCurrency(currency)">
             </bh-currency-select>
 
+            <bh-yes-no-radios
+              value="ReportConfigCtrl.reportDetails.includeUnpostedValues"
+              on-change-callback="ReportConfigCtrl.onChangeUnpostedValues(value)"
+              name="includeUnpostedValues"
+              label="REPORT.OPTIONS.INCLUDE_UNPOSTED_RECORDS"
+              help-text="REPORT.OPTIONS.INCLUDE_UNPOSTED_RECORDS_HELP">
+            </bh-yes-no-radios>
+
             <bh-loading-button loading-state="ConfigForm.$loading">
               <span translate>REPORT.UTIL.PREVIEW</span>
             </bh-loading-button>

--- a/client/src/modules/templates/bhDateInterval.tmpl.html
+++ b/client/src/modules/templates/bhDateInterval.tmpl.html
@@ -71,8 +71,7 @@
           show-button-bar="false"
           ng-model="$ctrl.dateTo"
           ng-change="$ctrl.onChange"
-          ng-required="$ctrl.required"
-          >
+          ng-required="$ctrl.required">
         <span class="input-group-btn">
           <button class="btn btn-default" type="button" ng-click="$ctrl.dateToIsOpen =! $ctrl.dateToIsOpen">
             <i class="fa fa-calendar-plus-o"></i>

--- a/server/controllers/finance/reports/reportAccounts/report.handlebars
+++ b/server/controllers/finance/reports/reportAccounts/report.handlebars
@@ -3,7 +3,11 @@
 <body>
   {{> header }}
 
-  <h3 class="text-center text-uppercase"><strong>{{translate "REPORT.ACCOUNT"}}</strong></h3>
+  <h3 class="text-center text-uppercase">
+    <strong>
+      {{#if hasUnpostedRecords}}({{translate "REPORT.PROVISIONARY"}}) {{/if}}
+      {{translate "REPORT.ACCOUNT"}}</strong>
+  </h3>
 
   <h4 class="text-center"><strong>{{ account.number }} | {{ account.label}}</strong></h4>
 
@@ -68,7 +72,7 @@
 
         {{! All transactions within the query range }}
         {{#each transactions}}
-          <tr>
+          <tr {{#if this.isUnposted}}style="font-style:italic;"{{/if}}>
             <td>{{date this.trans_date}}</td>
             <td title="{{this.trans_id}}">{{this.trans_id}}</td>
             <td title="{{this.document_reference}}">{{this.document_reference}}</td>
@@ -100,7 +104,7 @@
 
       {{!  This contains the grid totals }}
       <tfoot>
-        <tr>
+        <tr {{#if hasUnpostedRecords}}style="font-style:italic"{{/if}}>
           <th>{{date footer.date}}</th>
           <th colspan="3">{{translate "FORM.LABELS.TOTAL"}}</th>
           <th class="text-right">{{footer.invertedRate}}</th>


### PR DESCRIPTION
This commit adds a "show unposted records" option to the account statement report so that we can see changes made in real time and how that affects the balances.

We can make this more performant by moving the WHERE queries into the subquery.  It is low hanging fruit, and should be done later.