### PR TITLE
fix(cash): only show positive balance invoices

### DIFF
--- a/client/src/modules/cash/modals/invoice-modal.html
+++ b/client/src/modules/cash/modals/invoice-modal.html
@@ -13,14 +13,13 @@
 <div class="modal-body" data-debtor-invoice-modal>
 
   <!-- warn the client if not debtor id has been passed in -->
-  <p ng-show="CashInvoiceModalCtrl.missingId" class="text-danger text-center">
+  <p ng-show="CashInvoiceModalCtrl.hasMissingDebtorUuid" class="text-danger text-center">
     <i class="fa fa-warning"></i> <span translate>FORM.ERRORS.MISSING_DEBTOR_ID</span>
   </p>
 
   <!-- ui-grid to select debtor invoices -->
-  <div ng-if="!CashInvoiceModalCtrl.missingId">
+  <div ng-if="!CashInvoiceModalCtrl.hasMissingDebtorUuid">
     <div ui-grid="CashInvoiceModalCtrl.gridOptions" ui-grid-selection class="modal-grid" id="debtorInvoicesGrid">
-
       <bh-grid-loading-indicator
         loading-state="CashInvoiceModalCtrl.loading"
         empty-state="CashInvoiceModalCtrl.gridOptions.data.length === 0"
@@ -47,7 +46,7 @@
     type="submit"
     class="btn btn-primary"
     ng-click="CashInvoiceModalCtrl.submit()"
-    ng-disabled="(CashInvoiceModalCtrl.missingId || CashInvoiceModalCtrl.hasError)"
+    ng-disabled="(CashInvoiceModalCtrl.hasMissingDebtorUuid || CashInvoiceModalCtrl.hasError)"
     data-method="submit"
     translate>
     FORM.BUTTONS.SUBMIT

--- a/client/src/modules/templates/bhFindInvoice.tmpl.html
+++ b/client/src/modules/templates/bhFindInvoice.tmpl.html
@@ -11,26 +11,26 @@
         ng-keypress="$ctrl.onKeyPress($event, FindInvoiceForm)"
         ng-disabled="$ctrl.disabled">
       <span class="input-group-btn">
-        <button 
-          id="search-button" 
-          class="btn btn-default" 
-          type="button" 
-          ng-click="$ctrl.search(FindInvoiceForm)" 
+        <button
+          id="search-button"
+          class="btn btn-default"
+          type="button"
+          ng-click="$ctrl.search(FindInvoiceForm)"
           ng-disabled="$ctrl.disabled"
           translate>
           FORM.BUTTONS.SEARCH
         </button>
       </span>
     </div>
-    <p 
-      ng-if="!$ctrl.invoiceFound && FindInvoiceForm.$submitted" 
-      class="help-block" 
-      translate="FORM.INFO.PATIENT_INVOICE_NOT_FOUND" 
+    <p
+      ng-if="!$ctrl.invoiceFound && FindInvoiceForm.$submitted"
+      class="help-block"
+      translate="FORM.INFO.PATIENT_INVOICE_NOT_FOUND"
       translate-values="{{ $ctrl.translate }}">
     </p>
-    <p 
-      ng-if="$ctrl.invoiceFound && FindInvoiceForm.$submitted" 
-      class="help-block" 
+    <p
+      ng-if="$ctrl.invoiceFound && FindInvoiceForm.$submitted"
+      class="help-block"
       translate="FORM.INFO.PATIENT_INVOICE_FOUND">
     </p>
   </div>


### PR DESCRIPTION
This commit limits the cash window to only showing positively balanced invoices by filtering out negatively balanced invoices on the client.   I've also included a few lint fixes.