### PR TITLE
fix(ci): make hound fail on violations

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -2,3 +2,5 @@ eslint:
   enabled: true
   config_file: .eslintrc.json
   version: 5.7.0
+
+fail_on_violations: true


### PR DESCRIPTION
This commit makes Hound's CI fail on violations so that it blocks bors.