### PR TITLE
fix: update tests for the new year

### DIFF
--- a/test/data.sql
+++ b/test/data.sql
@@ -348,6 +348,9 @@ CALL CreateFiscalYear(1, @fiscalYear2016, @superUser, 'Test Fiscal Year 2017', 1
 SET @fiscalYear2018 = 0;
 CALL CreateFiscalYear(1, @fiscalYear2017, @superUser, 'Fiscal Year 2018', 12, DATE('2018-01-01'), DATE('2018-12-31'), 'Notes for 2018', @fiscalYear2018);
 
+SET @fiscalYear2019 = 0;
+CALL CreateFiscalYear(1, @fiscalYear2018, @superUser, 'Fiscal Year 2019', 12, DATE('2019-01-01'), DATE('2019-12-31'), 'Notes for 2019', @fiscalYear2019);
+
 -- give test permission to all projects
 INSERT INTO `project_permission` VALUES (1, 1, 1),(2, 1, 2),(3, 2, 1),(4, 4, 1);
 

--- a/test/end-to-end/fiscalYears/fiscalYears.spec.js
+++ b/test/end-to-end/fiscalYears/fiscalYears.spec.js
@@ -42,7 +42,7 @@ describe('Fiscal Year', () => {
     FU.input('FiscalManageCtrl.fiscal.label', fiscalYear.label);
 
     // select the proper date
-    components.dateInterval.range('01/01/2019', '31/12/2019');
+    components.dateInterval.range('01/01/2020', '31/12/2020');
     FU.select('FiscalManageCtrl.fiscal.previous_fiscal_year_id', fiscalYear.previous);
     FU.input('FiscalManageCtrl.fiscal.note', fiscalYear.note);
     FU.buttons.submit();

--- a/test/end-to-end/patient/registry.search.js
+++ b/test/end-to-end/patient/registry.search.js
@@ -110,8 +110,8 @@ function PatientRegistrySearch() {
   });
 
   // demonstrates that sex + time-delimited filtering works
-  it('should find no female patients registered in the last year.', () => {
-    const NUM_MATCHING = 0;
+  it('should find one female patients registered in the last year.', () => {
+    const NUM_MATCHING = 1;
     element(by.id('female')).click();
     modal.switchToDefaultFilterTab();
     modal.setPeriod('lastYear');

--- a/test/integration/fiscalYear.js
+++ b/test/integration/fiscalYear.js
@@ -4,9 +4,9 @@ const helpers = require('./helpers');
 
 describe('(/fiscal) Fiscal Year', () => {
   const newFiscalYear = {
-    label : 'A New Fiscal Year 2019',
-    start_date : new Date('2019-01-01 01:00'),
-    end_date : new Date('2019-12-31 01:00'),
+    label : 'A New Fiscal Year 2020',
+    start_date : new Date('2020-01-01 01:00'),
+    end_date : new Date('2020-12-31 01:00'),
     number_of_months : 12,
     note : 'Fiscal Year for Integration Test',
     closing_account : 111, // 1311 - Résusltat net : Bénéfice *
@@ -46,7 +46,7 @@ describe('(/fiscal) Fiscal Year', () => {
   it('GET /fiscal returns a list of fiscal_years', () => {
     return agent.get('/fiscal')
       .then(res => {
-        helpers.api.listed(res, 5);
+        helpers.api.listed(res, 6);
         const firstYearPeriods = res.body[0].periods;
         expect(firstYearPeriods).to.be.equal(undefined);
       })
@@ -57,7 +57,7 @@ describe('(/fiscal) Fiscal Year', () => {
   it('GET /fiscal returns a list of fiscal_years width their periods', () => {
     return agent.get('/fiscal?includePeriods=1')
       .then(res => {
-        helpers.api.listed(res, 5);
+        helpers.api.listed(res, 6);
         const firstYearPeriods = res.body[0].periods;
         expect(firstYearPeriods).to.not.be.empty;
       })

--- a/test/integration/trialBalance.js
+++ b/test/integration/trialBalance.js
@@ -64,8 +64,8 @@ describe('(/journal/trialbalance) API endpoint', () => {
         expect(summary).to.have.length(2);
 
         // all accounts have 0 balance before
-        expect(summary[0].balance_before).to.equal(-100);
-        expect(summary[1].balance_before).to.equal(100);
+        expect(summary[0].balance_before).to.equal(0);
+        expect(summary[1].balance_before).to.equal(0);
 
         expect(summary[0].debit_equiv).to.equal(0);
         expect(summary[1].debit_equiv).to.equal(100);
@@ -73,8 +73,8 @@ describe('(/journal/trialbalance) API endpoint', () => {
         expect(summary[0].credit_equiv).to.equal(100);
         expect(summary[1].credit_equiv).to.equal(0);
 
-        expect(summary[0].balance_final).to.equal(-200);
-        expect(summary[1].balance_final).to.equal(200);
+        expect(summary[0].balance_final).to.equal(-100);
+        expect(summary[1].balance_final).to.equal(100);
       })
       .catch(helpers.handler);
   });


### PR DESCRIPTION
Our tests are based on the year totals, so we need to update them every year.  Eventually, we should figure out a better way to test using a single time period, but this seems easiest for now.