### PR TITLE
fix(i18n): add correct PATIENTS key

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -149,7 +149,7 @@
             "DISABLED_CURRENCY": "This currency is unusable since there is no account set for it.  Use the Cashbox Management module to set an account for this currency and cashbox.",
             "DISPLAY_NAME": "The user's full name. This is displayed on any formal documents or receipts processed by the system.",
             "DISTRIBUTION_INVALID": "The distribution is invalid. The sum of distributed values must be equal to the amount of the transaction.",
-            "DISTRIBUTION_PERCENT_INVALID": "The distribution is invalid. The sum of percentage values must be equal to 100%",            
+            "DISTRIBUTION_PERCENT_INVALID": "The distribution is invalid. The sum of percentage values must be equal to 100%",
             "DISTRIBUTION_SUCCESSFULLY": "Distributed successfully",
             "EDITED" : "Edited",
             "EMPLOYEE_NOT_FOUND" : "Employee Not Found",

--- a/client/src/modules/patients/groups/groups.html
+++ b/client/src/modules/patients/groups/groups.html
@@ -31,7 +31,7 @@
               <tr>
                 <th translate> TABLE.COLUMNS.NAME </th>
                 <th translate> TABLE.COLUMNS.PRICE_LIST </th>
-                <th translate> FORM.LABELS.PATIENTS</th>
+                <th translate> FORM.INFO.PATIENTS</th>
                 <th translate> TABLE.COLUMNS.ACTION </th>
               </tr>
             </thead>
@@ -180,7 +180,7 @@
                 <div class="form-group">
                   <label class="control-label">
                     <span translate> FORM.LABELS.PRICE_LIST</span>&nbsp;&nbsp;&nbsp;
-                     
+
                   </label>
                   <select
                     class="form-control"


### PR DESCRIPTION
This commit fixes a translation bug on the patient groups page and updates it to use the correct i18n key.