### PR TITLE
fix: remove legends from search modals

### DIFF
--- a/client/src/modules/patients/registry/search.modal.html
+++ b/client/src/modules/patients/registry/search.modal.html
@@ -100,15 +100,13 @@
           </bh-user-select>
 
           <!-- patient date interval components -->
-          <fieldset>
-            <legend translate>FORM.LABELS.DOB</legend>
-            <bh-date-interval
-              date-id="dob-date"
-              date-from="$ctrl.searchQueries.dateBirthFrom"
-              date-to="$ctrl.searchQueries.dateBirthTo"
-              mode="clean">
-            </bh-date-interval>
-          </fieldset>
+          <bh-date-interval
+            label="FORM.LABELS.DOB"
+            date-id="dob-date"
+            date-from="$ctrl.searchQueries.dateBirthFrom"
+            date-to="$ctrl.searchQueries.dateBirthTo"
+            mode="clean">
+          </bh-date-interval>
 
           <!-- location -->
 

--- a/client/src/modules/stock/lots/modals/search.modal.html
+++ b/client/src/modules/stock/lots/modals/search.modal.html
@@ -51,28 +51,25 @@
           </div>
 
           <!--entry date -->
-          <fieldset>
-            <legend translate>STOCK.ENTRY_DATE</legend>
-            <bh-date-interval
-              date-id="entry-date"
-              date-from="$ctrl.searchQueries.entry_date_from"
-              date-to="$ctrl.searchQueries.entry_date_to"
-              mode="clean">
-            </bh-date-interval>
-          </fieldset>
+          <bh-date-interval
+            label="STOCK.ENTRY_DATE"
+            date-id="entry-date"
+            date-from="$ctrl.searchQueries.entry_date_from"
+            date-to="$ctrl.searchQueries.entry_date_to"
+            mode="clean">
+          </bh-date-interval>
 
           <!-- expiration date -->
-          <fieldset>
-            <legend translate>STOCK.EXPIRATION_DATE</legend>
-            <bh-date-interval
-              date-id="expiration-date"
-              date-from="$ctrl.searchQueries.expiration_date_from"
-              date-to="$ctrl.searchQueries.expiration_date_to"
-              mode="clean">
-            </bh-date-interval>
-          </fieldset>
+          <bh-date-interval
+            label="STOCK.EXPIRATION_DATE"
+            date-id="expiration-date"
+            date-from="$ctrl.searchQueries.expiration_date_from"
+            date-to="$ctrl.searchQueries.expiration_date_to"
+            mode="clean">
+          </bh-date-interval>
         </div>
       </uib-tab>
+
       <uib-tab index="1" heading="{{ 'FORM.LABELS.DEFAULTS' | translate }}" data-default-filter-tab>
         <div class="tab-body">
           <bh-period-select
@@ -104,6 +101,7 @@
     <button type="button" class="btn btn-default" ng-click="$ctrl.cancel()" data-method="cancel" translate>
       FORM.BUTTONS.CLOSE
     </button>
+
     <bh-loading-button loading-state="ModalForm.$loading">
       <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>


### PR DESCRIPTION
The `<legend>` element takes up way too much space to be used in a search modal.  It has been removed.

Before
![before](https://user-images.githubusercontent.com/896472/50608639-84c37f80-0ecd-11e9-94d8-950b66e774e7.PNG)

After
![after](https://user-images.githubusercontent.com/896472/50608673-9ad14000-0ecd-11e9-92e2-9847cb06579e.PNG)
