### PR TITLE
feat(report): global total on multi account stmt

### DIFF
--- a/server/controllers/finance/reports/reportAccountsMultiple/report.handlebars
+++ b/server/controllers/finance/reports/reportAccountsMultiple/report.handlebars
@@ -27,6 +27,9 @@
 
   <section>
     {{#each accounts as |account|}}
+
+      <h4>{{account.meta.number}} - {{account.meta.label}}</h4>
+
       <table class="table table-condensed table-report table-bordered">
         <thead>
           <tr class="text-capitalize text-center" style="background-color: #ddd;">
@@ -124,6 +127,14 @@
           </tr>
         </tfoot>
       </table>
+
+      <br />
     {{/each}}
   </section>
+
+  <footer>
+    <div class="pull-right">
+      <strong>{{translate "FORM.LABELS.TOTAL"}}: {{debcred globalBalance currency.id}}</strong>
+    </div>
+  </footer>
 </body>


### PR DESCRIPTION
This commit adds a global total field to the multiple account statement
that takes into account the account statement total of each of the
accounts selected and produces a grand total at the bottom of the
report.  I also fixed a bug where account names were not being
displayed.

Closes #3520.


