### PR TITLE
fix(report): complete unpaid invoices report

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -144,8 +144,8 @@
       "TITLE": "Cash Report",
       "DESCRIPTION": "This report shows all cash entries and exits inside the enterprise"
     },
-    "UNBALANCED_INVOICE_PAYMENTS_REPORT": {
-      "TITLE": "Unbalanced Invoices Report",
+    "UNPAID_INVOICE_PAYMENTS_REPORT": {
+      "TITLE": "Unpaid Invoices Report",
       "DESCRIPTION": "This report shows the balance of invoices which are not completely paid or overpaid during a period."
     },
     "STOCK": {

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -144,7 +144,7 @@
       "TITLE" : "Rapport Annuel des Clients",
       "DESCRIPTION" : "Ce rapport affiche tous les groupes de débiteurs, leurs soldes de compte au début de l'exercice, les soldes actuels et leurs soldes de clôture."
     },
-    "UNBALANCED_INVOICE_PAYMENTS_REPORT": {
+    "UNPAID_INVOICE_PAYMENTS_REPORT": {
       "TITLE": "Rapport de la balance des paiements non finalisés des factures",
       "DESCRIPTION": "Ce rapport affiche la balance des factures qui ne pas totalement payées ou surpayées pour une période donnée"
     },

--- a/client/src/js/components/bhDebtorGroupSelect.js
+++ b/client/src/js/components/bhDebtorGroupSelect.js
@@ -29,6 +29,8 @@ function DebtorGroupSelectController(DebtorGroup) {
     // translated label for the form input
     $ctrl.label = $ctrl.label || 'FORM.LABELS.DEBTOR_GROUP';
 
+    $ctrl.required = angular.isDefined($ctrl.required) ? $ctrl.required : true;
+
     // load all Debtor Group
     DebtorGroup.read(null, filters)
       .then(handleDebtorGroups);

--- a/client/src/modules/reports/generate/unpaid-invoice-payments/unpaid-invoice-payments.config.js
+++ b/client/src/modules/reports/generate/unpaid-invoice-payments/unpaid-invoice-payments.config.js
@@ -15,6 +15,16 @@ function UnbalancedInvoicePaymentsConfigController($sce, Notify, SavedReports, A
 
   checkCachedConfiguration();
 
+  vm.onSelectDebtorGroup = (debtorGroup) => {
+    vm.reportDetails.debtorGroupName = debtorGroup.name;
+    vm.reportDetails.debtorGroupUuid = debtorGroup.uuid;
+  };
+
+  vm.onClear = () => {
+    delete vm.reportDetails.debtorGroupName;
+    delete vm.reportDetails.debtorGroupUuid;
+  };
+
   vm.clearPreview = function clearPreview() {
     vm.previewGenerated = false;
     vm.previewResult = null;

--- a/client/src/modules/reports/generate/unpaid-invoice-payments/unpaid-invoice-payments.html
+++ b/client/src/modules/reports/generate/unpaid-invoice-payments/unpaid-invoice-payments.html
@@ -8,8 +8,8 @@
 <div ng-show="!ReportConfigCtrl.previewGenerated">
   <div class="row">
     <div class="col-md-12">
-      <h3 class="text-capitalize" translate>REPORT.UNBALANCED_INVOICE_PAYMENTS_REPORT.TITLE</h3>
-      <p class="text-info" translate>REPORT.UNBALANCED_INVOICE_PAYMENTS_REPORT.DESCRIPTION</p>
+      <h3 class="text-capitalize" translate>REPORT.UNPAID_INVOICE_PAYMENTS_REPORT.TITLE</h3>
+      <p class="text-info" translate>REPORT.UNPAID_INVOICE_PAYMENTS_REPORT.DESCRIPTION</p>
     </div>
   </div>
 
@@ -25,11 +25,19 @@
 
             <!-- Date interval  -->
             <bh-date-interval
-              ng-if="!ReportConfigCtrl.reportDetails.simplePreview"
               date-from="ReportConfigCtrl.reportDetails.dateFrom"
               date-to="ReportConfigCtrl.reportDetails.dateTo"
               limit-min-fiscal>
             </bh-date-interval>
+
+
+            <!-- Optional Debtor Select -->
+            <bh-debtor-group-select
+              debtor-group-uuid = "ReportConfigCtrl.reportDetails.debtorGroupUuid"
+              on-select-callback = "ReportConfigCtrl.onSelectDebtorGroup(debtorGroup)"
+              required="false">
+              <bh-clear on-clear="ReportConfigCtrl.onClear()"></bh-clear>
+            </bh-debtor-group-select>
 
             <bh-loading-button loading-state="ConfigForm.$loading">
               <span translate>REPORT.UTIL.PREVIEW</span>

--- a/client/src/modules/templates/bhDebtorGroupSelect.tmpl.html
+++ b/client/src/modules/templates/bhDebtorGroupSelect.tmpl.html
@@ -6,9 +6,11 @@
       {{ $ctrl.label }}
     </label>
     <ng-transclude></ng-transclude>
-    <ui-select name="debtor_group_uuid"
+    <ui-select
+      name="debtor_group_uuid"
       ng-model="$ctrl.debtorGroupUuid"
-      on-select="$ctrl.onSelect($item)" required>
+      on-select="$ctrl.onSelect($item)"
+      ng-required="$ctrl.required">
       <ui-select-match placeholder="{{ 'FORM.SELECT.DEBTOR_GROUP' | translate }}"><span>{{$select.selected.name}}</span></ui-select-match>
       <ui-select-choices ui-select-focus-patch repeat="group.uuid as group in ($ctrl.debtorGroups | filter:$select.search | orderBy:'name') track by group.uuid">
         <span ng-bind-html="group.name | highlight:$select.search"></span>

--- a/server/controllers/finance/debtors/groups/index.js
+++ b/server/controllers/finance/debtors/groups/index.js
@@ -40,6 +40,8 @@ exports.list = list;
 /** [HTTP API ENDPOINT] get debtor groups invoices list */
 exports.invoices = invoices;
 
+exports.lookupDebtorGroup = lookupDebtorGroup;
+
 /**
  * Looks up a debtor group in the database by uuid.
  *

--- a/server/controllers/finance/reports/unpaid-invoice-payments/report.handlebars
+++ b/server/controllers/finance/reports/unpaid-invoice-payments/report.handlebars
@@ -1,4 +1,4 @@
-{{> head title="REPORT.UNBALANCED_INVOICE_PAYMENTS_REPORT" }}
+{{> head title="REPORT.UNPAID_INVOICE_PAYMENTS_REPORT" }}
 
 <div class="container">
   {{> header}}
@@ -8,7 +8,7 @@
     <div class="col-xs-12">
       <!-- page title  -->
       <h3 class="text-center">
-        <strong>{{translate "REPORT.UNBALANCED_INVOICE_PAYMENTS_REPORT.TITLE"}}</strong>
+        <strong>{{translate "REPORT.UNPAID_INVOICE_PAYMENTS_REPORT.TITLE"}}</strong>
       </h3>
 
       <h5 style="margin:15px;" class="text-center">
@@ -18,7 +18,6 @@
       <table class="table table-condensed table-report">
         <thead>
           <tr style="background-color:#ddd;">
-            <th style="width: 45%;">{{translate 'FORM.LABELS.PROJECT'}}</th>
             <th class="text-center">{{translate 'FORM.LABELS.DEBTOR_GROUP'}}</th>
             <th class="text-center">{{translate 'FORM.LABELS.PATIENT'}}</th>
             {{#each services as |service|}}
@@ -33,7 +32,6 @@
               {{#if row.isTotalRow}}class="table-subtotal-row"{{/if}}
               {{#if row.isGroupTotalRow}}style="font-style:italic"{{/if}}
               >
-              <td>{{ row.projectName }}</td>
               <td>{{ row.debtorGroupName }}</td>
               <td>{{ row.debtorReference }}</td>
               {{#each ../services as |service|}}

--- a/server/models/bhima.sql
+++ b/server/models/bhima.sql
@@ -97,7 +97,7 @@ INSERT INTO unit VALUES
   (207, 'Account Reference Report','TREE.ACCOUNT_REFERENCE_REPORT','',144,'/modules/reports/account_reference','/reports/account_reference'),
   (208, 'Import Stock From File','TREE.IMPORT_STOCK_FROM_FILE','',160,'/modules/stock/import','/stock/import'),
   (209, 'Accounts Report Multiple','TREE.REPORTS_MULTIPLE_ACCOUNTS','',144,'/modules/reports/account_report_multiple','/reports/account_report_multiple'),
-  (210, 'Unbalanced Invoice Payments','REPORT.UNBALANCED_INVOICE_PAYMENTS_REPORT.TITLE','',144,'/modules/reports/unpaid-invoice-payments','/reports/unpaid-invoice-payments'),
+  (210, 'Unbalanced Invoice Payments','REPORT.UNPAID_INVOICE_PAYMENTS_REPORT.TITLE','',144,'/modules/reports/unpaid-invoice-payments','/reports/unpaid-invoice-payments'),
   (211, 'Income Expenses by Month', 'TREE.PROFIT_AND_LOSS_BY_MONTH', 'The Report of income and expenses', 144, '/modules/finance/income_expense_by_month', '/reports/income_expense_by_month'),
   (212, 'Entity Management','ENTITY.MANAGEMENT','',1,'/modules/entities','/entities'),
   (213, 'Stock value Report','TREE.STOCK_VALUE','',144,'/modules/reports/stock_value','/reports/stock_value'),

--- a/server/models/migrations/v0.8.0-v0.9.0/migrate.sql
+++ b/server/models/migrations/v0.8.0-v0.9.0/migrate.sql
@@ -1013,5 +1013,11 @@ UPDATE report SET title_key = 'REPORT.PROFIT_AND_LOSS' WHERE id = 3;
 UPDATE report SET title_key = 'REPORT.PROFIT_AND_LOSS_BY_MONTH' WHERE id = 24;
 UPDATE report SET title_key = 'REPORT.PROFIT_AND_LOSS_BY_YEAR' WHERE id = 27;
 
-
 ALTER TABLE `patient_group` MODIFY COLUMN `note` TEXT NULL;
+
+DELETE FROM report WHERE id = 23;
+INSERT INTO report VALUES  (23, 'unpaid-invoice-payments', 'REPORT.UNPAID_INVOICE_PAYMENTS_REPORT.TITLE');
+
+UPDATE unit SET
+  `name`='Unpaid Invoice Payments', `key`='REPORT.UNPAID_INVOICE_PAYMENTS_REPORT.TITLE', `url`='/modules/reports/unpaid-invoice-payments', `path`='/reports/unpaid-invoice-payments'
+WHERE id = 213;


### PR DESCRIPTION
This commit is completes the unpaid invoice report by adding in a selection on debtor group.  This allows for smaller selections, as well as better totaling.

![unpaidinvoicesoptions](https://user-images.githubusercontent.com/896472/50764402-c3ad5880-1272-11e9-8a9f-b3e0cd952cf7.PNG)
_Fig 1: New Options to Select Debtor Group_

![unpaidinvoicesrendered](https://user-images.githubusercontent.com/896472/50764413-c90aa300-1272-11e9-9797-2ff3ec08654f.PNG)
_Fig 2: New Presentation after Filtering_
