### PR TITLE
fix(journal): preserve trans_id_reference_number

### DIFF
--- a/client/src/modules/journal/modals/editTransaction.modal.js
+++ b/client/src/modules/journal/modals/editTransaction.modal.js
@@ -399,6 +399,7 @@ function JournalEditTransactionController(
     const columns = [
       'hrRecord', 'record_uuid', 'project_name', 'trans_id', 'transaction_type_id', 'display_name', 'trans_date',
       'project_id', 'fiscal_year_id', 'currency_id', 'user_id', 'posted', 'period_id', 'description',
+      'trans_id_reference_number',
     ];
 
     // for some reason no data has been passed in, no shared attributes are possible

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -129,7 +129,7 @@ function buildTransactionQuery(options, posted) {
       BUID(p.reference_uuid) AS reference_uuid, dm2.text AS hrReference,
       p.comment, p.transaction_type_id, p.user_id, p.cc_id, p.pc_id, pro.abbr,
       pro.name AS project_name, tp.text AS transaction_type_text,
-     a.number AS account_number, a.label AS account_label,
+      a.number AS account_number, a.label AS account_label, p.trans_id_reference_number,
       u.display_name ${includeExchangeRate}
     FROM ${table} p
       JOIN project pro ON pro.id = p.project_id


### PR DESCRIPTION
We now remember the trans_id_reference_number when we create new lines in a transaction.  This means we no longer error when trying to add new lines to a transaction.

Note that we still need to add a test.

Partially addresses #3536.