### PR TITLE
Improve Cashbox Report

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -286,7 +286,7 @@
             "CASHIER": "Cashier",
             "CASH_ACCOUNT": "Cash Account",
             "CASH_JOURNAL": "Cash Journal",
-            "CASH_SPLITED": "Separate Income Expenditure",
+            "CASH_SPLIT": "Separate Receipts and Expenses",
             "CASH_PAYMENTS": "Cash Payments",
             "CHECK_ALL":"Check all",
             "CAUTION": "Caution",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -283,7 +283,7 @@
             "CANCEL": "Annuler",
             "CANCELED": "Annulée",
             "CASH_JOURNAL": "Journal Caisse",
-            "CASH_SPLITED": "Revenu depense separés",
+            "CASH_SPLIT": "Revenu et depense separés",
             "CHARACTERISTICS": "Caractéristiques",
             "CASHBOX": "Caisse",
             "CASHIER": "Caissier",

--- a/client/src/modules/reports/generate/cash_report/cash_report.config.js
+++ b/client/src/modules/reports/generate/cash_report/cash_report.config.js
@@ -32,8 +32,7 @@ function CashReportConfigController($sce, Notify, SavedReports, AppCache, report
 
   vm.preview = function preview(form) {
     if (form.$invalid) {
-      Notify.danger('FORM.ERRORS.RECORD_ERROR');
-      return;
+      return Notify.danger('FORM.ERRORS.RECORD_ERROR');
     }
 
     // update cached configuration
@@ -69,10 +68,12 @@ function CashReportConfigController($sce, Notify, SavedReports, AppCache, report
     if (cache.reportDetails) {
       vm.reportDetails = angular.copy(cache.reportDetails);
     }
+
     // Set the defaults for the format and type
     if (!angular.isDefined(vm.reportDetails.format)) {
       vm.reportDetails.format = 1;
     }
+
     if (!angular.isDefined(vm.reportDetails.type)) {
       vm.reportDetails.type = 1;
     }

--- a/client/src/modules/reports/generate/cash_report/cash_report.config.js
+++ b/client/src/modules/reports/generate/cash_report/cash_report.config.js
@@ -12,15 +12,16 @@ function CashReportConfigController($sce, Notify, SavedReports, AppCache, report
 
   vm.previewGenerated = false;
   vm.reportDetails = {};
+
   vm.reportTypes = [
-    { id : 1, label : 'FORM.LABELS.ENTRY_EXIT' },
-    { id : 2, label : 'FORM.LABELS.ENTRY' },
-    { id : 3, label : 'FORM.LABELS.EXIT' },
+    { id : 'ENTRY_AND_EXIT', label : 'FORM.LABELS.ENTRY_EXIT' },
+    { id : 'ENTRY', label : 'FORM.LABELS.ENTRY' },
+    { id : 'EXIT', label : 'FORM.LABELS.EXIT' },
   ];
 
   vm.reportFormats = [
-    { id : 1, label : 'FORM.LABELS.CASH_JOURNAL' },
-    { id : 2, label : 'FORM.LABELS.CASH_SPLITED' },
+    { id : 'NORMAL', label : 'FORM.LABELS.CASH_JOURNAL' },
+    { id : 'SPLIT', label : 'FORM.LABELS.CASH_SPLIT' },
   ];
 
   checkCachedConfiguration();
@@ -71,11 +72,11 @@ function CashReportConfigController($sce, Notify, SavedReports, AppCache, report
 
     // Set the defaults for the format and type
     if (!angular.isDefined(vm.reportDetails.format)) {
-      vm.reportDetails.format = 1;
+      vm.reportDetails.format = vm.reportFormats[0].id;
     }
 
     if (!angular.isDefined(vm.reportDetails.type)) {
-      vm.reportDetails.type = 1;
+      vm.reportDetails.type = vm.reportTypes[0].id;
     }
   }
 }

--- a/client/src/modules/reports/generate/cash_report/cash_report.html
+++ b/client/src/modules/reports/generate/cash_report/cash_report.html
@@ -51,7 +51,7 @@
                 name="type"
                 ng-model="ReportConfigCtrl.reportDetails.type"
                 ng-options="type.id as (type.label | translate) for type in ReportConfigCtrl.reportTypes"
-                ng-disabled="ReportConfigCtrl.reportDetails.format === 1"
+                ng-disabled="ReportConfigCtrl.reportDetails.format === 'NORMAL'"
                 required>
                 <option value="" disabled>{{ "FORM.SELECT.REPORT_TYPE" | translate }}<option>
               </select>

--- a/client/src/modules/reports/generate/cash_report/cash_report.html
+++ b/client/src/modules/reports/generate/cash_report/cash_report.html
@@ -23,49 +23,46 @@
         <div class="panel-body">
           <form name="ConfigForm" bh-submit="ReportConfigCtrl.preview(ConfigForm)" novalidate>
             <!-- report format seletion -->
-            <div class="form-group"
-                ng-class="{ 'has-error' : ConfigForm.$submitted && ConfigForm.reportFormat.$invalid }">
-                <label
-                  ng-repeat="reportFormat in ReportConfigCtrl.reportFormats"
-                  class="radio-inline">
-                  <input
-                    name="reportFormat"
-                    type="radio"
-                    ng-model="ReportConfigCtrl.reportDetails.format"
-                    ng-value="reportFormat.id"
-                    data-report-format-option="{{ reportFormat.id }}"
-                    required>
-                  <span translate>{{reportFormat.label}}</span>
-                </label>
-                <div class="help-block" ng-messages="ConfigForm.reportFormat.$error" ng-show="ConfigForm.$submitted">
-                    <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-                </div>
+            <div class="form-group" ng-class="{ 'has-error' : ConfigForm.$submitted && ConfigForm.reportFormat.$invalid }">
+              <label
+                ng-repeat="reportFormat in ReportConfigCtrl.reportFormats"
+                class="radio-inline">
+                <input
+                  name="reportFormat"
+                  type="radio"
+                  ng-model="ReportConfigCtrl.reportDetails.format"
+                  ng-value="reportFormat.id"
+                  data-report-format-option="{{ reportFormat.id }}"
+                  required>
+                <span translate>{{reportFormat.label}}</span>
+              </label>
+              <div class="help-block" ng-messages="ConfigForm.reportFormat.$error" ng-show="ConfigForm.$submitted">
+                <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <!-- report type selection  -->
-            <div class="form-group"
-                ng-class="{ 'has-error' : ConfigForm.$submitted && ConfigForm.type.$invalid }">
-                <label class="control-label">
-                    <i class="fa fa-briefcase"></i> <span translate> FORM.SELECT.REPORT_TYPE</span>
-                </label>
-                <select
-                    class="form-control"
-                    name="type"
-                    ng-model="ReportConfigCtrl.reportDetails.type"
-                    ng-options="type.id as (type.label | translate) for type in ReportConfigCtrl.reportTypes"
-                    ng-disabled="ReportConfigCtrl.reportDetails.format === 1"
-                    required>
-                    <option value="" disabled>{{ "FORM.SELECT.REPORT_TYPE" | translate }}<option>
-                </select>
-                <div class="help-block" ng-messages="ConfigForm.type.$error" ng-show="ConfigForm.$submitted">
-                    <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-                </div>
+            <div class="form-group" ng-class="{ 'has-error' : ConfigForm.$submitted && ConfigForm.type.$invalid }">
+              <label class="control-label">
+                <i class="fa fa-briefcase"></i> <span translate> FORM.SELECT.REPORT_TYPE</span>
+              </label>
+              <select
+                class="form-control"
+                name="type"
+                ng-model="ReportConfigCtrl.reportDetails.type"
+                ng-options="type.id as (type.label | translate) for type in ReportConfigCtrl.reportTypes"
+                ng-disabled="ReportConfigCtrl.reportDetails.format === 1"
+                required>
+                <option value="" disabled>{{ "FORM.SELECT.REPORT_TYPE" | translate }}<option>
+              </select>
+              <div class="help-block" ng-messages="ConfigForm.type.$error" ng-show="ConfigForm.$submitted">
+                <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+              </div>
             </div>
 
             <!-- cashbox selection  -->
             <bh-cashbox-select
               cashboxId="ReportConfigCtrl.reportDetails.account_id"
-              name="cashbox"
               on-select-callback="ReportConfigCtrl.onSelectCashbox(cashbox)">
             </bh-cashbox-select>
 

--- a/client/src/modules/reports/generate/cash_report/cash_report.html
+++ b/client/src/modules/reports/generate/cash_report/cash_report.html
@@ -63,7 +63,8 @@
             <!-- cashbox selection  -->
             <bh-cashbox-select
               cashboxId="ReportConfigCtrl.reportDetails.account_id"
-              on-select-callback="ReportConfigCtrl.onSelectCashbox(cashbox)">
+              on-select-callback="ReportConfigCtrl.onSelectCashbox(cashbox)"
+              restrict-to-user="false">
             </bh-cashbox-select>
 
             <!-- Date interval  -->

--- a/server/controllers/finance/accounts/index.js
+++ b/server/controllers/finance/accounts/index.js
@@ -247,12 +247,12 @@ function getAnnualBalance(req, res, next) {
   const { id, fiscalYearId } = req.params;
 
   const query = `
-    SELECT 
+    SELECT
       pt.account_id,
-      IFNULL(SUM(pt.debit), 0) AS debit, 
+      IFNULL(SUM(pt.debit), 0) AS debit,
       IFNULL(SUM(pt.credit), 0) AS credit,
-      IFNULL(SUM(pt.debit - pt.credit), 0) AS balance 
-    FROM period_total pt 
+      IFNULL(SUM(pt.debit - pt.credit), 0) AS balance
+    FROM period_total pt
     WHERE pt.account_id = ? AND pt.fiscal_year_id = ?
     GROUP BY pt.account_id;
   `;

--- a/server/controllers/finance/accounts/transactions.js
+++ b/server/controllers/finance/accounts/transactions.js
@@ -1,0 +1,207 @@
+/**
+ * @overview AccountTransactions
+ *
+ * @description
+ * This file provides a common tool for reading the transations associated with an account.
+ * It provides a re-usable interface to access this information, and supports:
+ *  1. Inclusion of non-posted records
+ *  2. Exchange Rate Calculation
+ *  3. Running Balance Calculation
+ *
+ */
+
+const _ = require('lodash');
+const db = require('../../../lib/db');
+const FilterParser = require('../../../lib/filter');
+const Exchange = require('../exchange');
+const Accounts = require('.');
+
+/**
+ * @function getGeneralLedgerSQL
+ *
+ * @description
+ * Used by the getAccountTransactions() function internally.  The internal SQL
+ * just pulls out the values tied to a particular account.
+ *
+ * The exchange rate logic is complicated.  Here is the basic idea:
+ *  1. If you are in the enterprise currency, you want the calculation to
+ *    use ${amount} / rate to calculate the values.
+ *  2. If the you not in the enterprise currency, you want to use ${amount} * rate
+ *    to convert "back" to the enterprise currency.
+ *
+ */
+function getGeneralLedgerSQL(options) {
+  const filters = new FilterParser(options);
+
+  // return the proper way to convert the values depending on if we are in the
+  // exchange rate currency or not.
+  const enterpriseCurrencyColumns = `
+    (debit / rate) AS exchangedDebit, (credit / rate) AS exchangedCredit,
+    (balance / rate) AS exchangedBalance, @cumsum := (balance / rate) + @cumsum AS cumsum
+  `;
+
+  const nonEnterpriseCurrencyColumns = `
+    (debit * rate) AS exchangedDebit, (credit * rate) AS exchangedCredit,
+    (balance * rate) AS exchangedBalance, @cumsum := (balance * rate) + @cumsum AS cumsum
+  `;
+
+  const columns = options.isEnterpriseCurrency ? enterpriseCurrencyColumns : nonEnterpriseCurrencyColumns;
+
+  // get the underlying table for posted/unposted
+  const table = getBaseTable(options);
+
+  const sql = `
+    SELECT trans_id, description, trans_date, document_reference, debit, credit, posted,
+      debit_equiv, credit_equiv, currency_id, rate, IF(rate < 1, (1 / rate), rate) AS invertedRate,
+      ${columns}
+      FROM (
+      SELECT trans_id, description, trans_date, document_map.text AS document_reference,
+        IF(${options.isEnterpriseCurrency},
+          IFNULL(GetExchangeRate(${options.enterprise_id}, currency_id, trans_date), 1),
+          IF(${options.currency_id} = currency_id, 1,
+            IFNULL(GetExchangeRate(${options.enterprise_id}, ${options.currency_id}, trans_date), 1)
+        )) AS rate,
+        SUM(debit_equiv) as debit_equiv, SUM(credit_equiv) AS credit_equiv,
+        (SUM(debit) - SUM(credit)) AS balance, SUM(debit) AS debit,
+        SUM(credit) AS credit, MAX(currency_id) AS currency_id,
+        ${options.includeUnpostedValues ? 'posted' : '1 as posted'}
+      FROM ${table}
+      LEFT JOIN document_map ON record_uuid = document_map.uuid
+  `;
+
+  filters.equals('account_id');
+  filters.dateFrom('dateFrom', 'trans_date');
+  filters.dateTo('dateTo', 'trans_date');
+  filters.period('period', 'date');
+
+  filters.setGroup('GROUP BY record_uuid');
+  filters.setOrder('ORDER BY trans_date ASC');
+
+  const query = filters.applyQuery(sql);
+  const parameters = filters.parameters();
+
+  return { query, parameters };
+}
+
+/**
+ * @function getBaseTable
+ *
+ * @description
+ * This function constructs the underlying base tables for posted/unposted values from the general_ledger or
+ * a UNION of the posting_journal and general_ledger.
+ *
+ * TODO(@jniles) - move the WHERE queries into the subquery for performance reasons
+ */
+function getBaseTable(options) {
+  const includeUnpostedValuesTables = `(
+    SELECT trans_id, description, trans_date, debit_equiv, credit_equiv, currency_id, debit, credit,
+    account_id, record_uuid, reference_uuid, 1 as posted
+    FROM general_ledger
+    UNION ALL
+    SELECT trans_id, description, trans_date, debit_equiv, credit_equiv, currency_id, debit, credit,
+    account_id, record_uuid, reference_uuid, 0 as posted
+    FROM posting_journal
+  ) AS ledger`;
+
+  const table = options.includeUnpostedValues ? includeUnpostedValuesTables : `general_ledger as ledger`;
+  return table;
+}
+
+// @TODO define standards for displaying and rounding totals, unless numbers are rounded
+//       uniformly they may be displayed differently from what is recorded
+function getTotalsSQL(options) {
+  const currencyId = options.currency_id || options.enterprise_currency_id;
+
+  // get the underlying dataset based on the posted/unposted flag
+  const table = getBaseTable(options);
+
+  const sqlTotals = `
+    SELECT
+      IFNULL(GetExchangeRate(${options.enterprise_id}, ${currencyId}, NOW()), 1) AS rate,
+      ${currencyId} AS currency_id,
+      SUM(ROUND(debit, 2)) AS debit, SUM(ROUND(credit, 2)) AS credit,
+      SUM(ROUND(debit_equiv, 2)) AS debit_equiv, SUM(ROUND(credit_equiv, 2)) AS credit_equiv,
+      (SUM(ROUND(debit_equiv, 2)) - SUM(ROUND(credit_equiv, 2))) AS balance
+    FROM ${table}
+  `;
+
+  const filters = new FilterParser(options);
+
+  filters.equals('account_id');
+  filters.dateFrom('dateFrom', 'trans_date');
+  filters.dateTo('dateTo', 'trans_date');
+  filters.period('period', 'date');
+
+  const totalsQuery = filters.applyQuery(sqlTotals);
+  const totalsParameters = filters.parameters();
+
+  return { totalsQuery, totalsParameters };
+}
+
+
+/**
+ * @function getAccountTransactions
+ *
+ * @description
+ * This function returns all the transactions for an account,
+ */
+async function getAccountTransactions(options, openingBalance = 0) {
+  const { query, parameters } = getGeneralLedgerSQL(options);
+
+  // the running balance can only be in the enterprise currency.  It doesn't
+  // make sense to have the running balance in any other currency.
+  const sql = `
+    SELECT groups.trans_id, groups.debit, groups.credit, groups.debit_equiv,
+      groups.credit_equiv, groups.trans_date, groups.document_reference,
+      groups.exchangedCredit, groups.exchangedDebit, groups.exchangedBalance,
+      groups.rate, ROUND(groups.invertedRate, 2) AS invertedRate, groups.cumsum,
+      groups.description, groups.currency_id, groups.posted
+    FROM (${query})c, (SELECT @cumsum := ${openingBalance || 0})z) AS groups
+  `;
+
+  const { totalsQuery, totalsParameters } = getTotalsSQL(options);
+
+  // fire all requests in parallel for performance reasons
+  const [account, transactions, totals] = await Promise.all([
+    Accounts.lookupAccount(options.account_id),
+    db.exec(sql, parameters),
+    db.one(totalsQuery, totalsParameters),
+  ]);
+
+  // alias the unposted record flag for styling with italics
+  let hasUnpostedRecords = false;
+  transactions.forEach(txn => {
+    txn.isUnposted = txn.posted === 0;
+    if (txn.isUnposted) { hasUnpostedRecords = true; }
+  });
+
+  // if there is data in the transaction array, use the date of the last transaction
+  const lastTransaction = transactions[transactions.length - 1];
+  const lastDate = (lastTransaction && lastTransaction.trans_date) || options.dateTo;
+
+  const hasLastCumSum = !_.isUndefined(lastTransaction && lastTransaction.cumsum);
+  const lastCumSum = hasLastCumSum ? lastTransaction.cumsum : (totals.balance * totals.rate);
+
+  const lastCurrencyId = (lastTransaction && lastTransaction.currency_id) || totals.currency_id;
+  const shouldDisplayDebitCredit = transactions.every(txn => txn.currency_id === lastCurrencyId);
+
+  // contains the grid totals for the footer
+  const footer = {
+    date : lastDate,
+    exchangedBalance : totals.balance * totals.rate,
+    exchangedCumSum : lastCumSum,
+    exchangedDate : new Date(),
+    invertedRate : Exchange.formatExchangeRateForDisplay(totals.rate),
+    shouldDisplayDebitCredit,
+    transactionCurrencyId : lastCurrencyId,
+
+    // add totals into the footer
+    totals,
+  };
+
+  return {
+    account, transactions, hasUnpostedRecords, footer,
+  };
+}
+
+exports.getAccountTransactions = getAccountTransactions;

--- a/server/controllers/finance/reports/cashReport/index.js
+++ b/server/controllers/finance/reports/cashReport/index.js
@@ -1,15 +1,18 @@
 /**
- * cashReport Controller
+ * @module finance/reports/cashReport
  *
- *
- * This controller is responsible for processing cash report.
- *
- * @module finance/cashReport
+ * @description
+ * The Cash Report presents a colloquial view of receipts and expenses from
+ * a cashbox.  A user is able to view the report in two templates:
+ *   1. a combined view where all transactions are ordered by date
+ *   2. a separated view that puts income and expense in two separate tables
  *
  * @requires lodash
  * @requires lib/db
  * @requires lib/ReportManager
  * @requires lib/errors/BadRequest
+ * @requires finance/accounts/extra
+ * @requires finance/accounts/transactions
  */
 
 const _ = require('lodash');

--- a/server/controllers/finance/reports/cashReport/index.js
+++ b/server/controllers/finance/reports/cashReport/index.js
@@ -16,7 +16,9 @@ const _ = require('lodash');
 const db = require('../../../../lib/db');
 const ReportManager = require('../../../../lib/ReportManager');
 const BadRequest = require('../../../../lib/errors/BadRequest');
-const accountExtrat = require('../../accounts/extra');
+
+const AccountExtras = require('../../accounts/extra');
+const AccountTransactions = require('../../accounts/transactions');
 
 const TEMPLATE_COMBINED = './server/controllers/finance/reports/cashReport/report_combined.handlebars';
 const TEMPLATE_SEPARATED = './server/controllers/finance/reports/cashReport/report_separated.handlebars';
@@ -24,228 +26,23 @@ const TEMPLATE_SEPARATED = './server/controllers/finance/reports/cashReport/repo
 // expose to the API
 exports.document = document;
 
-function getRecordQuery(token, format, openingBalance) {
-  let query;
+/**
+ * @function getCashboxByAccountId
+ *
+ * @description
+ * Locates a cashbox infomration by
+ *
+ */
+function getCashboxByAccountId(accountId) {
+  const sql = `
+    SELECT c.id, c.label, cu.symbol, c.is_auxiliary, cac.currency_id, cac.account_id
+    FROM cash_box AS c
+    JOIN cash_box_account_currency AS cac ON c.id = cac.cash_box_id
+    JOIN currency AS cu ON cac.currency_id = cu.id
+    WHERE cac.account_id = ?;
+  `;
 
-  if (format === 1) {
-    query = `
-      SELECT
-        t.trans_id, t.trans_date, t.debit, t.credit, t.description, t.account_id, 
-        a.number, a.label, t.balance, t.cbalance, c.reference AS cashReference, 
-        v.reference AS voucherReference, t.record_uuid
-      FROM
-        (
-          SELECT
-              trans_id, trans_date, debit_equiv AS debit, credit_equiv AS credit, account_id, 
-              description, balance, (@cbal := @cbal + balance) AS cbalance, record_uuid
-          FROM
-          
-            (
-              (
-                    SELECT
-                      p.trans_date, p.debit_equiv, p.credit_equiv, p.trans_id, p.record_uuid,
-                      p.description, p.account_id, (p.debit_equiv - p.credit_equiv) AS balance
-                    FROM
-                      posting_journal AS p
-                    WHERE 
-                      p.account_id= ? AND 
-                      (DATE(p.trans_date) >= DATE(?) AND DATE(p.trans_date) <= DATE(?))
-                  )
-                  UNION ALL
-                  (
-                    SELECT
-                      g.trans_date, g.debit_equiv, g.credit_equiv, g.trans_id, g.record_uuid,
-                      g.description, g.account_id, (g.debit_equiv - g.credit_equiv) AS balance
-                    FROM
-                      general_ledger AS g 
-                    WHERE 
-                      g.account_id= ? AND 
-                      (DATE(g.trans_date) >= DATE(?) AND DATE(g.trans_date) <= DATE(?))
-                  )
-              ) AS u, (SELECT @cbal := ${openingBalance}) AS z 
-          ORDER BY 
-            trans_date
-        ) AS t
-      JOIN 
-        account a ON a.id = t.account_id
-      LEFT JOIN 
-        cash c ON c.uuid = t.record_uuid
-      LEFT JOIN
-        voucher v ON v.uuid = t.record_uuid;`;
-  } else {
-    query = `
-      SELECT
-        t.trans_id, t.trans_date, t.debit_equiv AS debit, t.credit_equiv AS credit, t.description, 
-        t.transaction_type_id, t.user_id, u.username, a.number, 
-        tr.text AS transactionType, a.label
-      FROM
-        (
-          (
-            SELECT
-              p.trans_date, p.debit_equiv, p.credit_equiv,
-              p.trans_id, p.description, p.transaction_type_id, p.user_id, p.account_id
-            FROM
-              posting_journal AS p
-            WHERE 
-              p.account_id= ? AND (DATE(p.trans_date) >= DATE(?) AND DATE(p.trans_date) <= DATE(?))
-          )
-          UNION ALL
-          (
-            SELECT
-              g.trans_date, g.debit_equiv, g.credit_equiv,
-              g.trans_id, g.description, g.transaction_type_id, g.user_id, g.account_id
-            FROM
-              general_ledger AS g
-            WHERE 
-              g.account_id= ? AND (DATE(g.trans_date) >= DATE(?) AND DATE(g.trans_date) <= DATE(?))
-          )
-        ) AS t
-      JOIN 
-        user u ON t.user_id = u.id
-      JOIN 
-        account a ON a.id = t.account_id
-      LEFT JOIN 
-        transaction_type tr ON tr.id = t.transaction_type_id
-      WHERE 
-        ${token} 
-      GROUP BY 
-        t.trans_id;`;
-  }
-
-  return query;
-}
-
-function getCashRecord(accountId, dateFrom, dateTo, format, type) {
-  const reportContext = {};
-  let promise;
-
-  if (format === 1) {
-    promise = accountExtrat.getOpeningBalanceForDate(accountId, dateFrom, false)
-      .then((openingBalance) => {
-        _.merge(reportContext, { openingBalance : openingBalance.balance });
-        return db.exec(getRecordQuery(null, format, openingBalance.balance), [
-          accountId,
-          dateFrom,
-          dateTo,
-          accountId,
-          dateFrom,
-          dateTo,
-        ]);
-      })
-      .then((records) => {
-        return { records, isEmpty : records.length === 0 };
-      });
-  } else {
-    promise = accountExtrat.getOpeningBalanceForDate(accountId, dateFrom, false)
-      .then((openingBalance) => {
-        _.merge(reportContext, { openingBalance : openingBalance.balance });
-        return db.exec(getRecordQuery('t.debit_equiv > 0', format), [
-          accountId,
-          dateFrom,
-          dateTo,
-          accountId,
-          dateFrom,
-          dateTo,
-        ]);
-      })
-      .then((entries) => {
-        reportContext.entries = entries;
-        // Getting expenses records
-        return db.exec(getRecordQuery('t.credit_equiv > 0', format), [
-          accountId,
-          dateFrom,
-          dateTo,
-          accountId,
-          dateFrom,
-          dateTo,
-        ]);
-      })
-      .then((expenses) => {
-        reportContext.expenses = expenses;
-        _.merge(reportContext, {
-          type_id : Number(type),
-          isEmpty : reportContext.entries.length === 0 && reportContext.expenses.length === 0,
-        });
-        // Getting sum entries
-        return db.one(aggregateRecordQuery('t.debit > 0'), [accountId, dateFrom, dateTo, accountId, dateFrom, dateTo]);
-      })
-      .then((totalEntry) => {
-        reportContext.totalEntry = totalEntry.arithmeticBalance;
-        // Getting sum expenses
-        return db.one(aggregateRecordQuery('t.credit > 0'), [accountId, dateFrom, dateTo, accountId, dateFrom, dateTo]);
-      })
-      .then((totalExpense) => {
-        reportContext.totalExpense = totalExpense.arithmeticBalance;
-        // Getting intermediate balance of cash account
-        return db.one(aggregateRecordQuery(), [accountId, dateFrom, dateTo, accountId, dateFrom, dateTo]);
-      })
-      .then((intermediateTotal) => {
-        reportContext.intermediateTotal = intermediateTotal.algebricBalance;
-        // getting final balance of cash account
-        return db.one(aggregateRecordQuery(1, reportContext.openingBalance), [
-          accountId,
-          dateFrom,
-          dateTo,
-          accountId,
-          dateFrom,
-          dateTo,
-        ]);
-      });
-  }
-
-  return promise
-    .then((data) => {
-      _.merge(reportContext, data);
-      const sql = `
-      SELECT
-        c.label AS cashName, cu.symbol AS cashCurrency
-      FROM
-        cash_box AS c
-      JOIN 
-        cash_box_account_currency AS cac ON c.id = cac.cash_box_id
-      JOIN 
-        currency AS cu ON cac.currency_id = cu.id
-      WHERE cac.account_id = ?;`;
-      return db.one(sql, [accountId]);
-    })
-    .then((cashDetail) => {
-      _.merge(reportContext, cashDetail);
-      return reportContext;
-    });
-}
-
-function aggregateRecordQuery(token = 1, openingBalance) {
-  const query = `
-  SELECT
-    ABS(SUM(t.debit - t.credit)) AS arithmeticBalance, SUM(t.debit - t.credit) AS algebricBalance
-  FROM
-    (
-      (
-      SELECT
-        IFNULL(p.debit_equiv, 0) AS debit, IFNULL(p.credit_equiv, 0) AS credit
-      FROM
-        posting_journal AS p
-      WHERE 
-        p.account_id= ? AND 
-        (DATE(p.trans_date) >= DATE(?) AND DATE(p.trans_date) <= DATE(?))
-      )
-      UNION ALL
-      (
-      SELECT
-        IFNULL(g.debit_equiv, 0) AS debit, IFNULL(g.credit_equiv, 0) AS credit
-      FROM
-        general_ledger AS g
-      WHERE
-        g.account_id= ? AND 
-        (DATE(g.trans_date) >= DATE(?) AND DATE(g.trans_date) <= DATE(?))
-      )
-    ) AS t WHERE ${token}`;
-
-  if (openingBalance) {
-    return `SELECT (${openingBalance} + tt.algebricBalance) AS finalTotal FROM (${query}) AS tt`;
-  }
-
-  return query;
+  return db.one(sql, [accountId]);
 }
 
 
@@ -255,7 +52,7 @@ function aggregateRecordQuery(token = 1, openingBalance) {
  */
 function document(req, res, next) {
   const params = req.query;
-  let documentReport;
+  let report;
 
   if (!params.dateFrom || !params.dateTo) {
     throw new BadRequest('Date range should be specified', 'ERRORS.BAD_REQUEST');
@@ -275,23 +72,44 @@ function document(req, res, next) {
 
   try {
     const TEMPLATE = params.format === 1 ? TEMPLATE_COMBINED : TEMPLATE_SEPARATED;
-    documentReport = new ReportManager(TEMPLATE, req.session, params);
+    report = new ReportManager(TEMPLATE, req.session, params);
   } catch (e) {
     next(e);
     return;
   }
 
-  getCashRecord(params.account_id, params.dateFrom, params.dateTo, params.format, params.type)
-    .then((reportContext) => {
-      _.merge(reportContext, {
+  // set parameters so that they provide
+  params.enterprise_id = req.session.enterprise.id;
+  params.includeUnpostedValues = true;
+
+  const context = {};
+
+  getCashboxByAccountId(params.account_id)
+    .then(cashbox => {
+      _.merge(context, { cashbox });
+
+      // determine the currency rendering
+      params.currency_id = cashbox.currency_id;
+      params.isEnterpriseCurrency = params.currency_id === req.session.enterprise.currency_id;
+
+      // get the opening balance for the acount
+      return AccountExtras.getOpeningBalanceForDate(cashbox.account_id, params.dateFrom);
+    })
+    .then(header => {
+      _.merge(context, { header });
+      // get the account's transactions
+      return AccountTransactions.getAccountTransactions(params, header.balance);
+    })
+    .then((txns) => {
+      _.merge(context, txns, {
         dateFrom : params.dateFrom,
         dateTo : params.dateTo,
       });
-      return documentReport.render(reportContext);
+
+      return report.render(context);
     })
     .then(result => {
       res.set(result.headers).send(result.report);
     })
-    .catch(next)
-    .done();
+    .catch(next);
 }

--- a/server/controllers/finance/reports/cashReport/report_combined.handlebars
+++ b/server/controllers/finance/reports/cashReport/report_combined.handlebars
@@ -1,6 +1,5 @@
 {{> head title="TREE.CASH_REPORT" }}
 
-
 <div class="container">
   {{> header}}
 
@@ -10,57 +9,58 @@
         <strong>{{translate 'TREE.CASH_REPORT'}}</strong>
       </h3>
       <h5 class="text-center text-uppercase">
-        {{ this.cashName}} ({{ this.cashCurrency}})
+        {{ cashbox.label }} ({{ cashbox.symbol}})
       </h5>
       <h6 class="text-center text-uppercase">
-        {{date this.dateFrom }} - {{date this.dateTo }}
+        {{date dateFrom }} - {{date dateTo }}
       </h6>
 
-      {{#if this.isEmpty}}
-      <div class="text-center">
-        {{translate 'FORM.INFO.NO_RECORDS_DATABASE'}}
-      </div>
-      {{else}}
       <div class="text-right">
-        <strong>{{ translate 'FORM.LABELS.OPENING_BALANCE' }} : {{currency this.openingBalance metadata.enterprise.curency_id}}</strong>
+        <strong>{{ translate 'FORM.LABELS.OPENING_BALANCE' }} : {{debcred header.balance metadata.enterprise.currency_id}}</strong>
       </div>
+
       <table class="table table-condensed table-report">
-        <thead>          
+        <thead>
           <tr style="background-color:#ddd;">
-            <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }} </th>
-            <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.DATE' }} </th>
-            <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.NUM_PIECE' }} </th>
-            <th style="width: 40%"> {{ translate 'TABLE.COLUMNS.DESCRIPTION'}} </th>
-            <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.ENTRY' }} </th>
-            <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.EXIT' }} </th>
-            <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.BALANCE' }} </th>
+            <th style="width: 10%">{{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }}</th>
+            <th style="width: 10%">{{ translate 'TABLE.COLUMNS.DATE' }}</th>
+            <th style="width: 10%">{{ translate 'TABLE.COLUMNS.NUM_PIECE' }}</th>
+            <th style="width: 40%">{{ translate 'TABLE.COLUMNS.DESCRIPTION'}}</th>
+            <th style="width: 10%">{{ translate 'TABLE.COLUMNS.ENTRY' }}</th>
+            <th style="width: 10%">{{ translate 'TABLE.COLUMNS.EXIT' }}</th>
+            <th style="width: 10%">{{ translate 'TABLE.COLUMNS.BALANCE' }}</th>
           </tr>
         </thead>
         <tbody>
-          {{#each this.records}}
-          <tr>
-            <td class="text-left">{{ trans_id }}</td>
-            <td class="text-left">{{ date trans_date }}</td>
-            <td class="text-left">
-              {{#if cashReference}} {{ cashReference}} {{else}} {{voucherReference}} {{/if}}
-            </td>
-            <td class="text-left" style="white-space : nowrap;  text-overflow : ellipsis; overflow : hidden; max-width : 400px;">
-              {{ description }}
-            </td>
-            <td class="text-right">
-              {{ currency debit ../metadata.enterprise.currency_id}}
-            </td>
-            <td class="text-right">
-              {{ currency credit ../metadata.enterprise.currency_id}}
-            </td>
-            <td class="text-right">
-              {{ currency cbalance ../metadata.enterprise.currency_id}}
-            </td>
-          </tr>
+          {{#each transactions as |txn| }}
+            <tr {{#unless txn.posted}}style="font-style: italic !important;"{{/unless}}>
+              <td>{{ txn.trans_id }}</td>
+              <td>{{ date txn.trans_date }}</td>
+              <td>{{ txn.document_reference }}</td>
+              <td style="white-space : nowrap;  text-overflow : ellipsis; overflow : hidden; max-width : 400px;" title="{{ txn.description }}">
+                {{ txn.description }}
+              </td>
+              <td class="text-right">
+                {{ currency txn.debit txn.currency_id}}
+              </td>
+              <td class="text-right">
+                {{ currency txn.credit txn.currency_id}}
+              </td>
+              <td class="text-right">
+                {{ currency txn.cumsum ../metadata.enterprise.currency_id}}
+              </td>
+            </tr>
+          {{else}}
+            {{>emptyTable columns=7}}
           {{/each}}
         </tbody>
+        <tfoot>
+          <tr>
+            <th colspan="6">{{ date footer.date }}</th>
+            <th class="text-right">{{ debcred footer.exchangedCumSum metadata.enterprise.currency_id}}</th>
+          </tr>
+        </tfoot>
       </table>
-      {{/if}}
     </div>
   </div>
 </div>

--- a/server/controllers/finance/reports/cashReport/report_combined.handlebars
+++ b/server/controllers/finance/reports/cashReport/report_combined.handlebars
@@ -22,13 +22,13 @@
       <table class="table table-condensed table-report">
         <thead>
           <tr style="background-color:#ddd;">
-            <th style="width: 10%">{{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }}</th>
-            <th style="width: 10%">{{ translate 'TABLE.COLUMNS.DATE' }}</th>
-            <th style="width: 10%">{{ translate 'TABLE.COLUMNS.NUM_PIECE' }}</th>
-            <th style="width: 40%">{{ translate 'TABLE.COLUMNS.DESCRIPTION'}}</th>
-            <th style="width: 10%">{{ translate 'TABLE.COLUMNS.ENTRY' }}</th>
-            <th style="width: 10%">{{ translate 'TABLE.COLUMNS.EXIT' }}</th>
-            <th style="width: 10%">{{ translate 'TABLE.COLUMNS.BALANCE' }}</th>
+            <th>{{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }}</th>
+            <th>{{ translate 'TABLE.COLUMNS.DATE' }}</th>
+            <th>{{ translate 'TABLE.COLUMNS.NUM_PIECE' }}</th>
+            <th style="width: 45%">{{ translate 'TABLE.COLUMNS.DESCRIPTION'}}</th>
+            <th>{{ translate 'TABLE.COLUMNS.ENTRY' }}</th>
+            <th>{{ translate 'TABLE.COLUMNS.EXIT' }}</th>
+            <th>{{ translate 'TABLE.COLUMNS.BALANCE' }}</th>
           </tr>
         </thead>
         <tbody>

--- a/server/controllers/finance/reports/cashReport/report_combined.handlebars
+++ b/server/controllers/finance/reports/cashReport/report_combined.handlebars
@@ -22,8 +22,8 @@
       <table class="table table-condensed table-report">
         <thead>
           <tr style="background-color:#ddd;">
-            <th>{{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }}</th>
             <th>{{ translate 'TABLE.COLUMNS.DATE' }}</th>
+            <th>{{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }}</th>
             <th>{{ translate 'TABLE.COLUMNS.NUM_PIECE' }}</th>
             <th style="width: 45%">{{ translate 'TABLE.COLUMNS.DESCRIPTION'}}</th>
             <th>{{ translate 'TABLE.COLUMNS.ENTRY' }}</th>

--- a/server/controllers/finance/reports/cashReport/report_separated.handlebars
+++ b/server/controllers/finance/reports/cashReport/report_separated.handlebars
@@ -1,7 +1,6 @@
 {{> head title="TREE.CASH_REPORT" }}
 
-
-<div class="container">
+4div class="container">
   {{> header}}
 
   <div class="row">
@@ -10,123 +9,101 @@
         <strong>{{translate 'TREE.CASH_REPORT'}}</strong>
       </h3>
       <h5 class="text-center text-uppercase">
-        {{ this.cashName}} ({{ this.cashCurrency}})
+        {{ cashbox.label }} ({{ cashbox.symbol}})
       </h5>
       <h6 class="text-center text-uppercase">
-        {{date this.dateFrom }} - {{date this.dateTo }}
+        {{date dateFrom }} - {{date dateTo }}
       </h6>
 
-      {{#if this.isEmpty}}
-        <div class="text-center">
-          {{translate 'FORM.INFO.NO_RECORDS_DATABASE'}}
-        </div>
-      {{else}}
-        <div class="text-right">
-          <strong>{{ translate 'FORM.LABELS.OPENING_BALANCE' }} : {{currency this.openingBalance metadata.enterprise.curency_id}}</strong>
-        </div>
-        {{#if (isIncomeViewable this.type_id)}}
-          <h6 class="text-center text-uppercase">
-            {{ translate 'REPORT.CASH_INCOME' }}
-          </h6>
-          <table class="table table-condensed table-report">
-            <thead>
-              <tr style="background-color:#ddd;">
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }} </th>
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.DATE'  }} </th>
-                <th style="width: 50%"> {{ translate 'TABLE.COLUMNS.DESCRIPTION'}} </th>
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.SOURCE'  }} </th>
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.BY' }} </th>
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.AMOUNT' }} </th>
-              </tr>
-            </thead>
-            <tbody>
-              {{#each this.entries}}
-                <tr>
-                  <td class="text-left">{{ trans_id }}</td>
-                  <td class="text-left">{{ date trans_date }}</td>
-                  <td class="text-left" style="white-space : nowrap;  text-overflow : ellipsis; overflow : hidden; max-width : 500px;">
-                    {{ description }}
-                  </td>
-                  <td class="text-left" style="white-space : nowrap;  text-overflow : ellipsis; overflow : hidden;">
-                    {{ translate transactionType }}
-                  </td>
-                  <td class="text-left">{{ username }}</td>
-                  <td class="text-right">
-                    {{#if debit}}
-                      {{ currency debit ../metadata.enterprise.currency_id}}
-                    {{/if}}
-                  </td>
-                </tr>
-              {{/each}}
-            </tbody>
-            <tfoot>
-              <tr style="background-color:#ddd;">
-                <th class="text-right" colspan="6">
-                  {{ translate 'TABLE.COLUMNS.TOTAL' }} : {{ currency this.totalEntry metadata.enterprise.currency_id}}
-                </th>
-              </tr>
-            </tfoot>
-          </table>
-        {{/if}}
-        {{#if (isExpenseViewable this.type_id)}}
-          <h6 class="text-center text-uppercase">
-            {{ translate 'REPORT.CASH_EXPENSE' }}
-          </h6>
-          <table class="table table-condensed table-report">
-            <thead>
-              <tr style="background-color:#ddd;">
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }} </th>
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.DATE'  }} </th>
-                <th style="width: 50%"> {{ translate 'TABLE.COLUMNS.DESCRIPTION'}} </th>
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.SOURCE'  }} </th>
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.BY' }} </th>
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.AMOUNT' }} </th>
-              </tr>
-            </thead>
-            <tbody>
-              {{#each this.expenses}}
-                <tr>
-                  <td class="text-left">{{ trans_id }}</td>
-                  <td class="text-left">{{ date trans_date }}</td>
-                  <td class="text-left" style="white-space : nowrap;  text-overflow : ellipsis; overflow : hidden; max-width : 500px;">
-                    {{ description }}
-                  </td>
-                  <td class="text-left" style="white-space : nowrap;  text-overflow : ellipsis; overflow : hidden;">
-                    {{ translate transactionType }}
-                  </td>
-                  <td class="text-left">{{ username }}</td>
-                  <td class="text-right">
-                    {{#if credit}}
-                      {{ currency credit ../metadata.enterprise.currency_id}}
-                    {{/if}}
-                  </td>
-                </tr>
-              {{/each}}
-            </tbody>
-            <tfoot>
-              <tr style="background-color:#ddd;">
-                <th class="text-right" colspan="6">
-                  {{ translate 'TABLE.COLUMNS.TOTAL' }} :{{ currency this.totalExpense metadata.enterprise.currency_id}}
-                </th>
-              </tr>
-              <tr>
-                <th colspan="4"><br/></th>
-              </tr>
-              {{#if (isResultViewable this.type_id)}}
-                <tr style="background-color:#ddd;">
-                  <th class="text-right" colspan="6">{{translate 'FORM.LABELS.INTERMEDIATE_BALANCE'}} : {{ currency this.intermediateTotal metadata.enterprise.currency_id}}</th>
-                </tr>
+      <div class="text-right">
+        <strong>{{ translate 'FORM.LABELS.OPENING_BALANCE' }} : {{debcred header.balance metadata.enterprise.currency_id}}</strong>
+      </div>
 
-                <tr>
-                  <th colspan="4"><br/></th>
-                </tr>
-                <tr style="background-color:#ddd;">
-                  <th class="text-right" colspan="6">{{translate 'FORM.LABELS.FINAL_BALANCE'}} : {{ currency this.finalTotal metadata.enterprise.currency_id}}</th>
-                </tr>
-              {{/if}}
-            </tfoot>
-          </table>
-         {{/if}}
+      {{#if hasIncome }}
+        <h4>{{translate "FORM.LABELS.INCOME"}}</h4>
+        <table class="table table-condensed table-report">
+          <thead>
+            <tr style="background-color:#ddd;">
+              <th>{{ translate 'TABLE.COLUMNS.DATE' }}</th>
+              <th>{{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }}</th>
+              <th>{{ translate 'TABLE.COLUMNS.RECORD' }}</th>
+              <th style="min-width: 50%">{{ translate 'TABLE.COLUMNS.DESCRIPTION'}}</th>
+              <th>{{ translate 'TABLE.COLUMNS.SOURCE' }}</th>
+              <th>{{ translate 'TABLE.COLUMNS.AMOUNT' }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each income as |txn|}}
+              <tr {{#unless txn.posted}}style="font-style: italic !important;"{{/unless}}>
+                <td>{{ date txn.trans_date }}</td>
+                <td>{{ txn.trans_id }}</td>
+                <td>{{ txn.document_reference }}</td>
+                <td style="white-space : nowrap;  text-overflow : ellipsis; overflow : hidden; max-width : 400px;" title="{{ txn.description }}">
+                  {{ txn.description }}
+                </td>
+                <td>{{translate txn.transactionType}}</td>
+                <td class="text-right">{{ currency txn.debit txn.currency_id}}</td>
+              </tr>
+            {{else}}
+              {{>emptyTable columns=6}}
+            {{/each}}
+          </tbody>
+          <tfoot>
+            <tr style="background-color:#ddd;">
+              <th colspan="5">{{ translate 'TABLE.COLUMNS.TOTAL' }}</th>
+              <th class="text-right">
+                {{ currency footer.totals.debit cashbox.currency_id}}
+              </th>
+            </tr>
+          </tfoot>
+        </table>
+      {{/if}}
+
+      <br />
+      <br />
+
+      {{#if hasExpense}}
+        <h4>{{translate "FORM.LABELS.EXPENSE"}}</h4>
+        <table class="table table-condensed table-report">
+          <thead>
+            <tr style="background-color:#ddd;">
+              <th>{{ translate 'TABLE.COLUMNS.DATE' }}</th>
+              <th>{{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }}</th>
+              <th>{{ translate 'TABLE.COLUMNS.RECORD' }}</th>
+              <th style="min-width: 50%">{{ translate 'TABLE.COLUMNS.DESCRIPTION'}}</th>
+              <th>{{ translate 'TABLE.COLUMNS.SOURCE' }}</th>
+              <th>{{ translate 'TABLE.COLUMNS.AMOUNT' }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each expense as |txn|}}
+              <tr {{#unless txn.posted}}style="font-style: italic !important;"{{/unless}}>
+                <td>{{ date txn.trans_date }}</td>
+                <td>{{ txn.trans_id }}</td>
+                <td>{{ txn.document_reference }}</td>
+                <td style="white-space : nowrap;  text-overflow : ellipsis; overflow : hidden; max-width : 400px;" title="{{ txn.description }}">
+                  {{ txn.description }}
+                </td>
+                <td>{{translate txn.transactionType}}</td>
+                <td class="text-right">{{ currency txn.credit txn.currency_id}}</td>
+              </tr>
+            {{else}}
+              {{>emptyTable columns=6}}
+            {{/each}}
+          </tbody>
+          <tfoot>
+            <tr style="background-color:#ddd;">
+              <th colspan="5">{{ translate 'TABLE.COLUMNS.TOTAL' }}</th>
+              <th class="text-right">
+                {{ currency footer.totals.credit cashbox.currency_id}}
+              </th>
+            </tr>
+          </tfoot>
+        </table>
+      {{/if}}
+
+      {{#if hasBoth}}
+
       {{/if}}
     </div>
   </div>

--- a/server/controllers/finance/reports/cashReport/report_separated.handlebars
+++ b/server/controllers/finance/reports/cashReport/report_separated.handlebars
@@ -19,7 +19,7 @@
       {{#if this.isEmpty}}
         <div class="text-center">
           {{translate 'FORM.INFO.NO_RECORDS_DATABASE'}}
-        </div>        
+        </div>
       {{else}}
         <div class="text-right">
           <strong>{{ translate 'FORM.LABELS.OPENING_BALANCE' }} : {{currency this.openingBalance metadata.enterprise.curency_id}}</strong>
@@ -32,18 +32,18 @@
             <thead>
               <tr style="background-color:#ddd;">
                 <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }} </th>
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.DATE'  }} </th>              
+                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.DATE'  }} </th>
                 <th style="width: 50%"> {{ translate 'TABLE.COLUMNS.DESCRIPTION'}} </th>
                 <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.SOURCE'  }} </th>
                 <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.BY' }} </th>
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.AMOUNT' }} </th>              
-              </tr>            
+                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.AMOUNT' }} </th>
+              </tr>
             </thead>
             <tbody>
               {{#each this.entries}}
                 <tr>
                   <td class="text-left">{{ trans_id }}</td>
-                  <td class="text-left">{{ date trans_date }}</td>              
+                  <td class="text-left">{{ date trans_date }}</td>
                   <td class="text-left" style="white-space : nowrap;  text-overflow : ellipsis; overflow : hidden; max-width : 500px;">
                     {{ description }}
                   </td>
@@ -54,14 +54,14 @@
                   <td class="text-right">
                     {{#if debit}}
                       {{ currency debit ../metadata.enterprise.currency_id}}
-                    {{/if}}  
+                    {{/if}}
                   </td>
-                </tr> 
+                </tr>
               {{/each}}
             </tbody>
             <tfoot>
               <tr style="background-color:#ddd;">
-                <th class="text-right" colspan="6"> 
+                <th class="text-right" colspan="6">
                   {{ translate 'TABLE.COLUMNS.TOTAL' }} : {{ currency this.totalEntry metadata.enterprise.currency_id}}
                 </th>
               </tr>
@@ -76,31 +76,31 @@
             <thead>
               <tr style="background-color:#ddd;">
                 <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }} </th>
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.DATE'  }} </th>              
+                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.DATE'  }} </th>
                 <th style="width: 50%"> {{ translate 'TABLE.COLUMNS.DESCRIPTION'}} </th>
                 <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.SOURCE'  }} </th>
-                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.BY' }} </th>                            
+                <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.BY' }} </th>
                 <th style="width: 10%"> {{ translate 'TABLE.COLUMNS.AMOUNT' }} </th>
-              </tr>            
+              </tr>
             </thead>
             <tbody>
               {{#each this.expenses}}
                 <tr>
                   <td class="text-left">{{ trans_id }}</td>
-                  <td class="text-left">{{ date trans_date }}</td>              
+                  <td class="text-left">{{ date trans_date }}</td>
                   <td class="text-left" style="white-space : nowrap;  text-overflow : ellipsis; overflow : hidden; max-width : 500px;">
                     {{ description }}
                   </td>
                   <td class="text-left" style="white-space : nowrap;  text-overflow : ellipsis; overflow : hidden;">
                     {{ translate transactionType }}
                   </td>
-                  <td class="text-left">{{ username }}</td>                                            
+                  <td class="text-left">{{ username }}</td>
                   <td class="text-right">
                     {{#if credit}}
                       {{ currency credit ../metadata.enterprise.currency_id}}
                     {{/if}}
                   </td>
-                </tr> 
+                </tr>
               {{/each}}
             </tbody>
             <tfoot>
@@ -127,7 +127,7 @@
             </tfoot>
           </table>
          {{/if}}
-      {{/if}}        
+      {{/if}}
     </div>
   </div>
 </div>

--- a/server/controllers/finance/reports/cashReport/report_separated.handlebars
+++ b/server/controllers/finance/reports/cashReport/report_separated.handlebars
@@ -1,12 +1,12 @@
 {{> head title="TREE.CASH_REPORT" }}
 
-4div class="container">
+<div class="container">
   {{> header}}
 
   <div class="row">
     <div class="col-xs-12">
       <h3 class="text-center text-uppercase">
-        <strong>{{translate 'TREE.CASH_REPORT'}}</strong>
+        <strong>{{translate "TREE.CASH_REPORT"}}</strong>
       </h3>
       <h5 class="text-center text-uppercase">
         {{ cashbox.label }} ({{ cashbox.symbol}})
@@ -16,7 +16,7 @@
       </h6>
 
       <div class="text-right">
-        <strong>{{ translate 'FORM.LABELS.OPENING_BALANCE' }} : {{debcred header.balance metadata.enterprise.currency_id}}</strong>
+        <strong>{{ translate "FORM.LABELS.OPENING_BALANCE" }} : {{debcred header.balance metadata.enterprise.currency_id}}</strong>
       </div>
 
       {{#if hasIncome }}
@@ -24,12 +24,12 @@
         <table class="table table-condensed table-report">
           <thead>
             <tr style="background-color:#ddd;">
-              <th>{{ translate 'TABLE.COLUMNS.DATE' }}</th>
-              <th>{{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }}</th>
-              <th>{{ translate 'TABLE.COLUMNS.RECORD' }}</th>
-              <th style="min-width: 50%">{{ translate 'TABLE.COLUMNS.DESCRIPTION'}}</th>
-              <th>{{ translate 'TABLE.COLUMNS.SOURCE' }}</th>
-              <th>{{ translate 'TABLE.COLUMNS.AMOUNT' }}</th>
+              <th>{{ translate "TABLE.COLUMNS.DATE" }}</th>
+              <th>{{ translate "TABLE.COLUMNS.TRANSACTION_ID" }}</th>
+              <th>{{ translate "TABLE.COLUMNS.RECORD" }}</th>
+              <th style="min-width: 50%">{{ translate "TABLE.COLUMNS.DESCRIPTION"}}</th>
+              <th>{{ translate "TABLE.COLUMNS.SOURCE" }}</th>
+              <th>{{ translate "TABLE.COLUMNS.AMOUNT" }}</th>
             </tr>
           </thead>
           <tbody>
@@ -50,7 +50,7 @@
           </tbody>
           <tfoot>
             <tr style="background-color:#ddd;">
-              <th colspan="5">{{ translate 'TABLE.COLUMNS.TOTAL' }}</th>
+              <th colspan="5">{{ translate "TABLE.COLUMNS.TOTAL" }}</th>
               <th class="text-right">
                 {{ currency footer.totals.debit cashbox.currency_id}}
               </th>
@@ -60,19 +60,18 @@
       {{/if}}
 
       <br />
-      <br />
 
       {{#if hasExpense}}
         <h4>{{translate "FORM.LABELS.EXPENSE"}}</h4>
         <table class="table table-condensed table-report">
           <thead>
             <tr style="background-color:#ddd;">
-              <th>{{ translate 'TABLE.COLUMNS.DATE' }}</th>
-              <th>{{ translate 'TABLE.COLUMNS.TRANSACTION_ID' }}</th>
-              <th>{{ translate 'TABLE.COLUMNS.RECORD' }}</th>
-              <th style="min-width: 50%">{{ translate 'TABLE.COLUMNS.DESCRIPTION'}}</th>
-              <th>{{ translate 'TABLE.COLUMNS.SOURCE' }}</th>
-              <th>{{ translate 'TABLE.COLUMNS.AMOUNT' }}</th>
+              <th>{{ translate "TABLE.COLUMNS.DATE" }}</th>
+              <th>{{ translate "TABLE.COLUMNS.TRANSACTION_ID" }}</th>
+              <th>{{ translate "TABLE.COLUMNS.RECORD" }}</th>
+              <th style="min-width: 50%">{{ translate "TABLE.COLUMNS.DESCRIPTION"}}</th>
+              <th>{{ translate "TABLE.COLUMNS.SOURCE" }}</th>
+              <th>{{ translate "TABLE.COLUMNS.AMOUNT" }}</th>
             </tr>
           </thead>
           <tbody>
@@ -93,7 +92,7 @@
           </tbody>
           <tfoot>
             <tr style="background-color:#ddd;">
-              <th colspan="5">{{ translate 'TABLE.COLUMNS.TOTAL' }}</th>
+              <th colspan="5">{{ translate "TABLE.COLUMNS.TOTAL" }}</th>
               <th class="text-right">
                 {{ currency footer.totals.credit cashbox.currency_id}}
               </th>
@@ -102,9 +101,16 @@
         </table>
       {{/if}}
 
-      {{#if hasBoth}}
+      <br />
 
+      {{#if hasBoth}}
+        <p class="text-right">
+          <strong>{{translate "TABLE.COLUMNS.BALANCE"}}:</strong>
+          <span>{{debcred footer.totals.balance cashbox.currency_id}}</span>
+        </p>
       {{/if}}
+
+      <br />
     </div>
   </div>
 </div>

--- a/server/controllers/finance/reports/cashflow/report.handlebars
+++ b/server/controllers/finance/reports/cashflow/report.handlebars
@@ -12,7 +12,7 @@
   {{/if}}
 
   <h4 class="text-center">
-    <span>{{cashLabels}}</span> <em>({{cashLabelSymbol}})</em> 
+    <span>{{cashLabels}}</span> <em>({{cashLabelSymbol}})</em>
     <span class="text-lowercase">{{translate 'REPORT.CASHFLOW.IN'}}</span> {{metadata.enterprise.currencySymbol}}
   </h4>
 
@@ -28,7 +28,7 @@
               {{/each}}
             </tr>
           </thead>
-          
+
           <tbody>
             {{!-- INCOMES --}}
             <tr style="background-color: #efefef;font-size:1.3rem;">
@@ -102,7 +102,7 @@
             {{/each}}
             <tr>
               <td colspan="{{colspan}}">&nbsp;</td>
-            </tr>            
+            </tr>
           </tbody>
 
           <tbody>

--- a/server/controllers/finance/reports/reportAccounts/index.js
+++ b/server/controllers/finance/reports/reportAccounts/index.js
@@ -1,13 +1,11 @@
 const _ = require('lodash');
-const db = require('../../../../lib/db');
 const ReportManager = require('../../../../lib/ReportManager');
 
-const Accounts = require('../../accounts');
 const AccountsExtra = require('../../accounts/extra');
+const AccountTransactions = require('../../accounts/transactions');
 const Exchange = require('../../exchange');
 const Currency = require('../../currencies');
 const Fiscal = require('../../fiscal');
-const FilterParser = require('../../../../lib/filter');
 
 const TEMPLATE = './server/controllers/finance/reports/reportAccounts/report.handlebars';
 
@@ -71,7 +69,7 @@ function document(req, res, next) {
       };
 
       _.extend(bundle, { header });
-      return getAccountTransactions(params, bundle.header.exchangedBalance);
+      return AccountTransactions.getAccountTransactions(params, bundle.header.exchangedBalance);
     })
     .then(result => {
       _.extend(bundle, result, { params });
@@ -102,205 +100,4 @@ function document(req, res, next) {
     .done();
 }
 
-/**
- * @function getGeneralLedgerSQL
- *
- * @description
- * Used by the getAccountTransactions() function internally.  The internal SQL
- * just pulls out the values tied to a particular account.
- *
- * The exchange rate logic is complicated.  Here is the basic idea:
- *  1. If you are in the enterprise currency, you want the calculation to
- *    use ${amount} / rate to calculate the values.
- *  2. If the you not in the enterprise currency, you want to use ${amount} * rate
- *    to convert "back" to the enterprise currency.
- *
- */
-function getGeneralLedgerSQL(options) {
-  const filters = new FilterParser(options);
-
-  // return the proper way to convert the values depending on if we are in the
-  // exchange rate currency or not.
-  const enterpriseCurrencyColumns = `
-    (debit / rate) AS exchangedDebit, (credit / rate) AS exchangedCredit,
-    (balance / rate) AS exchangedBalance, @cumsum := (balance / rate) + @cumsum AS cumsum
-  `;
-
-  const nonEnterpriseCurrencyColumns = `
-    (debit * rate) AS exchangedDebit, (credit * rate) AS exchangedCredit,
-    (balance * rate) AS exchangedBalance, @cumsum := (balance * rate) + @cumsum AS cumsum
-  `;
-
-  const columns = options.isEnterpriseCurrency ? enterpriseCurrencyColumns : nonEnterpriseCurrencyColumns;
-
-  // get the underlying table for posted/unposted
-  const table = getBaseTable(options);
-
-  const sql = `
-    SELECT trans_id, description, trans_date, document_reference, debit, credit, posted,
-      debit_equiv, credit_equiv, currency_id, rate, IF(rate < 1, (1 / rate), rate) AS invertedRate,
-      ${columns}
-      FROM (
-      SELECT trans_id, description, trans_date, document_map.text AS document_reference,
-        IF(${options.isEnterpriseCurrency},
-          IFNULL(GetExchangeRate(${options.enterprise_id}, currency_id, trans_date), 1),
-          IF(${options.currency_id} = currency_id, 1,
-            IFNULL(GetExchangeRate(${options.enterprise_id}, ${options.currency_id}, trans_date), 1)
-        )) AS rate,
-        SUM(debit_equiv) as debit_equiv, SUM(credit_equiv) AS credit_equiv,
-        (SUM(debit) - SUM(credit)) AS balance, SUM(debit) AS debit,
-        SUM(credit) AS credit, MAX(currency_id) AS currency_id,
-        ${options.includeUnpostedValues ? 'posted' : '1 as posted'}
-      FROM ${table}
-      LEFT JOIN document_map ON record_uuid = document_map.uuid
-  `;
-
-  filters.equals('account_id');
-  filters.dateFrom('dateFrom', 'trans_date');
-  filters.dateTo('dateTo', 'trans_date');
-  filters.period('period', 'date');
-
-  filters.setGroup('GROUP BY record_uuid');
-  filters.setOrder('ORDER BY trans_date ASC');
-
-  const query = filters.applyQuery(sql);
-  const parameters = filters.parameters();
-
-  return { query, parameters };
-}
-
-/**
- * @function getBaseTable
- *
- * @description
- * This function constructs the underlying base tables for posted/unposted values from the general_ledger or
- * a UNION of the posting_journal and general_ledger.
- *
- * TODO(@jniles) - move the WHERE queries into the subquery for performance reasons
- */
-function getBaseTable(options) {
-  const includeUnpostedValuesTables = `(
-    SELECT trans_id, description, trans_date, debit_equiv, credit_equiv, currency_id, debit, credit,
-    account_id, record_uuid, reference_uuid, 1 as posted
-    FROM general_ledger
-    UNION ALL
-    SELECT trans_id, description, trans_date, debit_equiv, credit_equiv, currency_id, debit, credit,
-    account_id, record_uuid, reference_uuid, 0 as posted
-    FROM posting_journal
-  ) AS ledger`;
-
-  const table = options.includeUnpostedValues ? includeUnpostedValuesTables : `general_ledger as ledger`;
-  return table;
-}
-
-// @TODO define standards for displaying and rounding totals, unless numbers are rounded
-//       uniformly they may be displayed differently from what is recorded
-function getTotalsSQL(options) {
-  const currencyId = options.currency_id || options.enterprise_currency_id;
-
-  // get the underlying dataset based on the posted/unposted flag
-  const table = getBaseTable(options);
-
-  const sqlTotals = `
-    SELECT
-      IFNULL(GetExchangeRate(${options.enterprise_id}, ${currencyId}, NOW()), 1) AS rate,
-      ${currencyId} AS currency_id,
-      SUM(ROUND(debit, 2)) AS debit, SUM(ROUND(credit, 2)) AS credit,
-      SUM(ROUND(debit_equiv, 2)) AS debit_equiv, SUM(ROUND(credit_equiv, 2)) AS credit_equiv,
-      (SUM(ROUND(debit_equiv, 2)) - SUM(ROUND(credit_equiv, 2))) AS balance
-    FROM ${table}
-  `;
-
-  const filters = new FilterParser(options);
-
-  filters.equals('account_id');
-  filters.dateFrom('dateFrom', 'trans_date');
-  filters.dateTo('dateTo', 'trans_date');
-  filters.period('period', 'date');
-
-  const totalsQuery = filters.applyQuery(sqlTotals);
-  const totalsParameters = filters.parameters();
-
-  return { totalsQuery, totalsParameters };
-}
-
-
-/**
- * @function getAccountTransactions
- *
- * @description
- * This function returns all the transactions for an account,
- */
-function getAccountTransactions(options, openingBalance = 0) {
-  const { query, parameters } = getGeneralLedgerSQL(options);
-
-  // the running balance can only be in the enterprise currency.  It doesn't
-  // make sense to have the running balance in any other currency.
-  const sql = `
-    SELECT groups.trans_id, groups.debit, groups.credit, groups.debit_equiv,
-      groups.credit_equiv, groups.trans_date, groups.document_reference,
-      groups.exchangedCredit, groups.exchangedDebit, groups.exchangedBalance,
-      groups.rate, ROUND(groups.invertedRate, 2) AS invertedRate, groups.cumsum,
-      groups.description, groups.currency_id, groups.posted
-    FROM (${query})c, (SELECT @cumsum := ${openingBalance || 0})z) AS groups
-  `;
-
-  const { totalsQuery, totalsParameters } = getTotalsSQL(options);
-
-  const bundle = {};
-
-  return Accounts.lookupAccount(options.account_id)
-    .then(account => {
-      _.extend(bundle, { account });
-      return db.exec(sql, parameters);
-    })
-    .then(transactions => {
-      _.extend(bundle, { transactions });
-
-      // alias the unposted record flag for styling with italics
-      let hasUnpostedRecords = false;
-      transactions.forEach(txn => {
-        txn.isUnposted = txn.posted === 0;
-        if (txn.isUnposted) { hasUnpostedRecords = true; }
-      });
-
-      _.extend(bundle, { hasUnpostedRecords });
-
-      // get totals for this period
-      return db.one(totalsQuery, totalsParameters);
-    })
-    .then(totals => {
-
-      // if there is data in the transaction array, use the date of the last transaction
-      const lastTransaction = bundle.transactions[bundle.transactions.length - 1];
-      const lastDate = (lastTransaction && lastTransaction.trans_date) || options.dateTo;
-
-      const hasLastCumSum = !_.isUndefined(lastTransaction && lastTransaction.cumsum);
-      const lastCumSum = hasLastCumSum ? lastTransaction.cumsum : (totals.balance * totals.rate);
-
-      const lastCurrencyId = (lastTransaction && lastTransaction.currency_id) || totals.currency_id;
-      const shouldDisplayDebitCredit = bundle.transactions.every(txn => txn.currency_id === lastCurrencyId);
-
-      // contains the grid totals for the footer
-      const footer = {
-        date : lastDate,
-        exchangedBalance : totals.balance * totals.rate,
-        exchangedCumSum : lastCumSum,
-        exchangedDate : new Date(),
-        invertedRate : Exchange.formatExchangeRateForDisplay(totals.rate),
-        shouldDisplayDebitCredit,
-        transactionCurrencyId : lastCurrencyId,
-      };
-
-      // combine shared properties
-      _.merge(footer, totals);
-      _.merge(bundle, { footer });
-
-      return bundle;
-    });
-}
-
 exports.document = document;
-exports.getGeneralLedgerSQL = getGeneralLedgerSQL;
-exports.getTotalsSQL = getTotalsSQL;
-exports.getAccountTransactions = getAccountTransactions;

--- a/server/controllers/finance/reports/reportAccountsMultiple/index.js
+++ b/server/controllers/finance/reports/reportAccountsMultiple/index.js
@@ -8,7 +8,7 @@ const Currency = require('../../currencies');
 
 const TEMPLATE = './server/controllers/finance/reports/reportAccountsMultiple/report.handlebars';
 
-const { getAccountTransactions } = require('../reportAccounts/index');
+const { getAccountTransactions } = require('../../accounts/transactions');
 
 /**
  * @method document

--- a/server/lib/template/helpers/presentation.js
+++ b/server/lib/template/helpers/presentation.js
@@ -10,24 +10,9 @@ function getTitle(reportType) {
   return map[reportType];
 }
 
-function isIncomeViewable(reportType) {
-  return reportType === 1 || reportType === 2;
-}
-
-function isExpenseViewable(reportType) {
-  return reportType === 1 || reportType === 3;
-}
-
-function isResultViewable(reportType) {
-  return reportType === 1;
-}
-
 function slashed(text) {
   return text.replace(/\\/g, '/');
 }
 
 exports.getTitle = getTitle;
-exports.isIncomeViewable = isIncomeViewable;
-exports.isExpenseViewable = isExpenseViewable;
-exports.isResultViewable = isResultViewable;
 exports.slashed = slashed;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -2231,13 +2231,13 @@ CREATE TABLE `distribution_key` (
   FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
-DROP TABLE IF EXISTS `account_reference_type`;  
+DROP TABLE IF EXISTS `account_reference_type`;
 CREATE TABLE `account_reference_type` (
-  `id` MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT, 
-  `label` VARCHAR(100) NOT NULL, 
-  `fixed` tinyint(1) DEFAULT 0, 
-  PRIMARY KEY (`id`), 
-  UNIQUE KEY `account_reference_type_1` (`label`) 
+  `id` MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `label` VARCHAR(100) NOT NULL,
+  `fixed` tinyint(1) DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `account_reference_type_1` (`label`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
 SET foreign_key_checks = 1;

--- a/test/integration/reports/finance/cash_report.js
+++ b/test/integration/reports/finance/cash_report.js
@@ -7,9 +7,8 @@ const helpers = require('../../helpers');
 
 describe(`(${target}) cash Reports`, () => {
   const keys = [
-    'cashCurrency', 'cashName', 'entries', 'finalTotal', 'expenses', 'isEmpty',
-    'metadata', 'totalEntry', 'totalExpense', 'type_id', 'dateFrom', 'dateTo',
-    'intermediateTotal', 'openingBalance',
+    'account', 'cashbox', 'footer', 'dateFrom', 'dateTo', 'hasUnpostedRecords', 'header',
+    'metadata', 'transactions',
   ];
 
   const parameters = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,20 +128,20 @@
   version "3.1.2"
   resolved "https://codeload.github.com/jonashartmann/webcam-directive/tar.gz/9e13c9ef06b7f0e162ac20f9e1fafb4b60c3c451"
 
-"@snyk/dep-graph@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@snyk/dep-graph/-/dep-graph-1.1.2.tgz#a0377fbb29dd42bc12d1c2493b51a7b7fe0d334a"
-  integrity sha512-mCoAFKtmezBL61JOzLMzqqd/sXXxp0iektEwf4zw+sM3zuG4Tnmhf8OqNO6Wscn84bMIfLlI/nvECdxvSS7MTw==
+"@snyk/dep-graph@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@snyk/dep-graph/-/dep-graph-1.4.0.tgz#0d0971c3ef3238a74112ed5d81c782a6a292575a"
+  integrity sha512-dz4Fo4L9sN0Rt8hMe+zMYZ4mAiljtyIeWvujLyCxhIT5iHSlceUYlba5TDsOFuKyuZKkuhVjORWY1oFEuRzCcA==
   dependencies:
     graphlib "^2.1.5"
     lodash "^4"
     source-map-support "^0.5.9"
     tslib "^1.9.3"
 
-"@snyk/gemfile@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@snyk/gemfile/-/gemfile-1.1.0.tgz#8c254dfc7739b2e8513c44c976fc41872d5f6af0"
-  integrity sha512-mLwF+ccuvRZMS0SxUAxA3dAp8mB3m2FxIsBIUWFTYvzxl+E4XTZb8uFrUqXHbcxhZH1Z8taHohNTbzXZn3M8ag==
+"@snyk/gemfile@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@snyk/gemfile/-/gemfile-1.2.0.tgz#919857944973cce74c650e5428aaf11bcd5c0457"
+  integrity sha512-nI7ELxukf7pT4/VraL4iabtNNMz8mUo7EXlqCFld8O5z6mIMLX9llps24iPpaIZOwArkY3FWA+4t+ixyvtTSIA==
 
 "@types/angular@^1.6.25", "@types/angular@^1.6.41":
   version "1.6.54"
@@ -149,9 +149,9 @@
   integrity sha512-xA1FuozWXeRQ7FClUbvk8ePL+dydBeDoCWRPFTHU5+8uvVtIIfLGiHA8CMkwsbddFCYnTDVbLxG85a/HBx7LtA==
 
 "@types/node@^8.0.7":
-  version "8.10.39"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.39.tgz#e7e87ad00364dd7bc485c940926345b8ec1a26ca"
-  integrity sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA==
+  version "8.10.40"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.40.tgz#4314888d5cd537945d73e9ce165c04cc550144a4"
+  integrity sha512-RRSjdwz63kS4u7edIwJUn8NqKLLQ6LyqF/X4+4jp38MBT3Vwetewi2N4dgJEshLbDwNgOJXNYoOwzVZUSSLhkQ==
 
 "@types/q@^0.0.32":
   version "0.0.32"
@@ -159,9 +159,9 @@
   integrity sha1-vShOV8hPEyXacCur/IKlMoGQwMU=
 
 "@types/selenium-webdriver@^3.0.0":
-  version "3.0.14"
-  resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.14.tgz#0b20a2370e6b1b8322c9c3dfcaa409e6c7c0c0a9"
-  integrity sha512-4GbNCDs98uHCT/OMv40qQC/OpoPbYn9XdXeTiFwHBBFO6eJhYEPUu2zDKirXSbHlvDV8oZ9l8EQ+HrEx/YS9DQ==
+  version "3.0.15"
+  resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.15.tgz#024c24051c3798e9a0cf5cceb1c893140df1bc31"
+  integrity sha512-5nh8/K2u9p4bk95GGCJB7KBvewaB0TUziZ9DTr+mR2I6RoO4OJVqx7rxK83hs2J1tomwtCGkhiW+Dy8EUnfB+Q==
 
 "@yarnpkg/lockfile@^1.0.2":
   version "1.1.0"
@@ -231,7 +231,7 @@ acorn@^5.5.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^6.0.2:
+acorn@^6.0.7:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.0.tgz#b0a3be31752c97a0f7013c5f4903b71a05db6818"
   integrity sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==
@@ -268,10 +268,10 @@ ajv@^5.2.3, ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.5.3, ajv@^6.5.5, ajv@^6.6.1:
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.8.1.tgz#0890b93742985ebf8973cd365c5b23920ce3cb20"
-  integrity sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==
+ajv@^6.5.5, ajv@^6.9.1:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.1.tgz#a4d3683d74abc5670e75f0b16520f70a20ea8dc1"
+  integrity sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -581,11 +581,11 @@ async@^1.4.0:
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
 async@^2.1.2, async@^2.5.0, async@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
-  integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
+  integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
   dependencies:
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
 async@~0.9.0:
   version "0.9.2"
@@ -950,9 +950,9 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000935"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000935.tgz#0b4210ae207013c76bc1a2e0e903b15bec742a08"
-  integrity sha512-HFqvW9MZZcWD02F3J2GV2ggQyIXiDr7DRPlOWSKVIihu8J1dtsYFqtMjmFqiYamfOmY4NHyn7xFaWAHBtFWgjQ==
+  version "1.0.30000938"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000938.tgz#dc37923823ddf88e6bb0a82a7fb913a11e5cf681"
+  integrity sha512-1lbcoAGPQFUYOdY7sxpsl8ZDBfn5cyn80XuYnZwk7N4Qp7Behw7uxZCH5jjH2qWTV2WM6hgjvDVpP/uV3M/l9g==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -1081,9 +1081,9 @@ cheerio@^0.22.0:
     lodash.some "^4.4.0"
 
 chokidar@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.0.tgz#5fcb70d0b28ebe0867eb0f09d5f6a08f29a1efa0"
-  integrity sha512-5t6G2SH8eO6lCvYOoUpaRnF5Qfd//gd7qJAkwRUw9qlGVkiQ13uwQngqbWWaurOsaAm9+kUGbITADxt6H0XFNQ==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.2.tgz#9c23ea40b01638439e0513864d362aeacc5ad058"
+  integrity sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==
   dependencies:
     anymatch "^2.0.0"
     async-each "^1.0.1"
@@ -1530,9 +1530,9 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js@^2.2.0, core-js@^2.4.0:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.4.tgz#b8897c062c4d769dd30a0ac5c73976c47f92ea0d"
-  integrity sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
+  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
 core-js@~2.3.0:
   version "2.3.0"
@@ -1605,9 +1605,9 @@ css-select@~1.2.0:
     nth-check "~1.0.1"
 
 css-what@2.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
-  integrity sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
+  integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
 cssnano@^3.0.0:
   version "3.10.0"
@@ -1734,14 +1734,14 @@ debug@2, debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, de
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
+debug@3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3, debug@^3.1.0, debug@^3.2.5:
+debug@3.2.6, debug@^3, debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -1901,6 +1901,11 @@ denque@^1.1.0:
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.0.tgz#79e2f0490195502107f24d9553f374837dabc916"
   integrity sha512-gh513ac7aiKrAgjiIBWZG0EASyDF9p4JMWwKA8YU5s9figrL5SRNEMT6FDynsegakuhWd1wVqTvqvqAoDxw7wQ==
 
+depd@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 depd@~1.1.1, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -2007,6 +2012,13 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
+
 dom-serialize@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/dom-serialize/-/dom-serialize-2.2.1.tgz#562ae8999f44be5ea3076f5419dcd59eb43ac95b"
@@ -2018,22 +2030,17 @@ dom-serialize@^2.2.0:
     void-elements "^2.0.0"
 
 dom-serializer@0, dom-serializer@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
-  integrity sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
+  integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
   dependencies:
-    domelementtype "~1.1.1"
-    entities "~1.1.1"
+    domelementtype "^1.3.0"
+    entities "^1.1.1"
 
-domelementtype@1, domelementtype@^1.3.0:
+domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
-
-domelementtype@~1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
-  integrity sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=
 
 domhandler@^2.3.0:
   version "2.4.2"
@@ -2129,6 +2136,11 @@ email-validator@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/email-validator/-/email-validator-2.0.4.tgz#b8dfaa5d0dae28f1b03c95881d904d4e40bfe7ed"
   integrity sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==
+
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 enabled@1.0.x:
   version "1.0.2"
@@ -2254,9 +2266,9 @@ es-to-primitive@^1.2.0:
     is-symbol "^1.0.2"
 
 es6-promise@^4.0.3:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
-  integrity sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.6.tgz#b685edd8258886365ea62b57d30de28fadcd974f"
+  integrity sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==
 
 es6-promise@~3.0.2:
   version "3.0.2"
@@ -2409,34 +2421,34 @@ eslint@^4.19.1:
     text-table "~0.2.0"
 
 eslint@^5.0.0:
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.13.0.tgz#ce71cc529c450eed9504530939aa97527861ede9"
-  integrity sha512-nqD5WQMisciZC5EHZowejLKQjWGuFS5c70fxqSKlnDME+oz9zmE8KTlX+lHSg+/5wsC/kf9Q9eMkC8qS3oM2fg==
+  version "5.14.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.14.1.tgz#490a28906be313685c55ccd43a39e8d22efc04ba"
+  integrity sha512-CyUMbmsjxedx8B0mr79mNOqetvkbij/zrXnFeK2zc3pGRn3/tibjiNAv/3UxFEyfMDjh+ZqTrJrEGBFiGfD5Og==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    ajv "^6.5.3"
+    ajv "^6.9.1"
     chalk "^2.1.0"
     cross-spawn "^6.0.5"
     debug "^4.0.1"
-    doctrine "^2.1.0"
+    doctrine "^3.0.0"
     eslint-scope "^4.0.0"
     eslint-utils "^1.3.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^5.0.0"
+    espree "^5.0.1"
     esquery "^1.0.1"
     esutils "^2.0.2"
-    file-entry-cache "^2.0.0"
+    file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
     glob "^7.1.2"
     globals "^11.7.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^6.1.0"
+    inquirer "^6.2.2"
     js-yaml "^3.12.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.17.5"
+    lodash "^4.17.11"
     minimatch "^3.0.4"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
@@ -2447,7 +2459,7 @@ eslint@^5.0.0:
     semver "^5.5.1"
     strip-ansi "^4.0.0"
     strip-json-comments "^2.0.1"
-    table "^5.0.2"
+    table "^5.2.3"
     text-table "^0.2.0"
 
 espree@^3.5.4:
@@ -2458,12 +2470,12 @@ espree@^3.5.4:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
-espree@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.0.tgz#fc7f984b62b36a0f543b13fb9cd7b9f4a7f5b65c"
-  integrity sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==
+espree@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
+  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
   dependencies:
-    acorn "^6.0.2"
+    acorn "^6.0.7"
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
 
@@ -2532,6 +2544,19 @@ excel4node@^1.3.5:
     mime "2.3.1"
     uuid "3.3.2"
     xmlbuilder "10.0.0"
+
+execa@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
+  integrity sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 execa@^0.7.0:
   version "0.7.0"
@@ -2830,6 +2855,13 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
+
 file-uri-to-path@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -2977,6 +3009,15 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
 flat@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.0.tgz#090bec8b05e39cba309747f1d588f04dbaf98db2"
@@ -3008,11 +3049,11 @@ flush-write-stream@^1.0.2:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.0.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.6.1.tgz#514973c44b5757368bad8bddfe52f81f015c94cb"
-  integrity sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
+  integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
   dependencies:
-    debug "=3.1.0"
+    debug "^3.2.6"
 
 for-in@^0.1.3:
   version "0.1.8"
@@ -3406,9 +3447,9 @@ global-prefix@^1.0.1:
     which "^1.2.14"
 
 globals@^11.0.1, globals@^11.7.0:
-  version "11.10.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.10.0.tgz#1e09776dffda5e01816b3bb4077c8b59c24eaa50"
-  integrity sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
+  integrity sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
 
 globby@^5.0.0:
   version "5.0.0"
@@ -3804,10 +3845,11 @@ helmet-csp@2.7.1:
     platform "1.3.5"
 
 helmet@^3.15.0:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/helmet/-/helmet-3.15.0.tgz#fe0bb80e05d9eec589e3cbecaf5384409a3a64c9"
-  integrity sha512-j9JjtAnWJj09lqe/PEICrhuDaX30TeokXJ9tW6ZPhVH0+LMoihDeJ58CdWeTGzM66p6EiIODmgAaWfdeIWI4Gg==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-3.15.1.tgz#2c80d1a59138b6f23929605afca4b1c88b3298ec"
+  integrity sha512-hgoNe/sjKlKNvJ3g9Gz149H14BjMMWOCmW/DTXl7IfyKGtIK37GePwZrHNfr4aPXdKVyXcTj26RgRFbPKDy9lw==
   dependencies:
+    depd "2.0.0"
     dns-prefetch-control "0.1.0"
     dont-sniff-mimetype "1.0.0"
     expect-ct "0.1.1"
@@ -3856,16 +3898,16 @@ html-comment-regex@^1.1.0:
   integrity sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==
 
 htmlparser2@^3.9.1, htmlparser2@^3.9.2:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.0.tgz#5f5e422dcf6119c0d983ed36260ce9ded0bee464"
-  integrity sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
+  integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
   dependencies:
-    domelementtype "^1.3.0"
+    domelementtype "^1.3.1"
     domhandler "^2.3.0"
     domutils "^1.5.1"
     entities "^1.1.1"
     inherits "^2.0.1"
-    readable-stream "^3.0.6"
+    readable-stream "^3.1.1"
 
 http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
   version "1.6.3"
@@ -4067,7 +4109,7 @@ inquirer@^3.0.0, inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inquirer@^6.1.0:
+inquirer@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
   integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
@@ -4588,9 +4630,9 @@ jsbn@~0.1.0:
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
 json-2-csv@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/json-2-csv/-/json-2-csv-3.2.0.tgz#4d964078b382cda79776d1970acd8007ed6ffabe"
-  integrity sha512-KaFf8dUS2/2YtT9Onn3cjWF2wCWljpFDyNxjh44IqyCPOw2+cESDzJ8lvJtsD4mow4aZS3Rl2h7JesjTEfDv/A==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/json-2-csv/-/json-2-csv-3.4.1.tgz#48c0d33ed2e4f31ab3d7e2baa8eebaf65bed8c0b"
+  integrity sha512-zOcKtk2FGPOV/vRli67e/XyGNvDiYhmaUkKkJe8H0wH9J2YQ7qCK/88tyIplX21HvsgpfsXrsb6sLNc93t+/wg==
   dependencies:
     deeks "2.2.0"
     doc-path "2.0.0"
@@ -5177,7 +5219,7 @@ longest@^1.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
   integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
-loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5212,10 +5254,10 @@ lzma-native@^4.0.1:
     readable-stream "^2.3.5"
     rimraf "^2.6.1"
 
-macos-release@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-1.1.0.tgz#831945e29365b470aa8724b0ab36c8f8959d10fb"
-  integrity sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==
+macos-release@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.0.0.tgz#7dddf4caf79001a851eb4fba7fb6034f251276ab"
+  integrity sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A==
 
 mailgun-js@^0.22.0:
   version "0.22.0"
@@ -5383,17 +5425,17 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-mime-db@~1.37.0:
-  version "1.37.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
-  integrity sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==
+mime-db@~1.38.0:
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
+  integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
 
 mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
-  version "2.1.21"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96"
-  integrity sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==
+  version "2.1.22"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd"
+  integrity sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==
   dependencies:
-    mime-db "~1.37.0"
+    mime-db "~1.38.0"
 
 mime@1.2.11, mime@~1.2.11:
   version "1.2.11"
@@ -5887,9 +5929,9 @@ object-copy@^0.1.0:
     kind-of "^3.0.3"
 
 object-keys@^1.0.11, object-keys@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
-  integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
+  integrity sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -6002,7 +6044,7 @@ opener@^1.4.2:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
   integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
-opn@^5.2.0:
+opn@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"
   integrity sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==
@@ -6080,13 +6122,13 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-name@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/os-name/-/os-name-2.0.1.tgz#b9a386361c17ae3a21736ef0599405c9a8c5dc5e"
-  integrity sha1-uaOGNhwXrjohc27wWZQFyajF3F4=
+os-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.0.0.tgz#e1434dbfddb8e74b44c98b56797d951b7648a5d9"
+  integrity sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==
   dependencies:
-    macos-release "^1.0.0"
-    win-release "^1.0.0"
+    macos-release "^2.0.0"
+    windows-release "^3.1.0"
 
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -6705,12 +6747,13 @@ promisify-call@^2.0.2:
     with-callback "^1.0.2"
 
 prop-types@^15.5.8, prop-types@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
-  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
   dependencies:
-    loose-envify "^1.3.1"
+    loose-envify "^1.4.0"
     object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 protractor@^5.0.0:
   version "5.4.2"
@@ -6902,24 +6945,29 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     strip-json-comments "~2.0.1"
 
 react-dom@^16.0.0:
-  version "16.8.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.1.tgz#ec860f98853d09d39bafd3a6f1e12389d283dbb4"
-  integrity sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==
+  version "16.8.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.2.tgz#7c8a69545dd554d45d66442230ba04a6a0a3c3d3"
+  integrity sha512-cPGfgFfwi+VCZjk73buu14pYkYBR1b/SRMSYqkLDdhSEHnSwcuYTPu6/Bh6ZphJFIk80XLvbSe2azfcRzNF+Xg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.1"
+    scheduler "^0.13.2"
+
+react-is@^16.8.1:
+  version "16.8.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.2.tgz#09891d324cad1cb0c1f2d91f70a71a4bee34df0f"
+  integrity sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q==
 
 react@^16.0.0:
-  version "16.8.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.1.tgz#ae11831f6cb2a05d58603a976afc8a558e852c4a"
-  integrity sha512-wLw5CFGPdo7p/AgteFz7GblI2JPOos0+biSoxf1FPsGxWQZdN/pj6oToJs1crn61DL3Ln7mN86uZ4j74p31ELQ==
+  version "16.8.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.2.tgz#83064596feaa98d9c2857c4deae1848b542c9c0c"
+  integrity sha512-aB2ctx9uQ9vo09HVknqv3DGRpI7OIGJhCx3Bt0QqoRluEjHSaObJl+nG12GDdYH6sTgE7YiPJ6ZUyMx9kICdXw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.1"
+    scheduler "^0.13.2"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -6971,7 +7019,7 @@ readable-stream@2, readable-stream@2.3.6, readable-stream@^2.0.0, readable-strea
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.0.6, readable-stream@^3.1.1:
+"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.1.1.tgz#ed6bbc6c5ba58b090039ff18ce670515795aeb06"
   integrity sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==
@@ -7317,7 +7365,7 @@ right-pad@^1.0.1:
   resolved "https://registry.yarnpkg.com/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
   integrity sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=
 
-rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1, rimraf@~2.6.2:
+rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -7379,10 +7427,10 @@ sax@>=0.6.0, sax@^1.2.4, sax@~1.2.1:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.1.tgz#1a217df1bfaabaf4f1b92a9127d5d732d85a9591"
-  integrity sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==
+scheduler@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.2.tgz#969eaee2764a51d2e97b20a60963b2546beff8fa"
+  integrity sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -7409,7 +7457,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
@@ -7543,7 +7591,7 @@ slice-ansi@1.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
 
-slice-ansi@^2.0.0:
+slice-ansi@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
   integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
@@ -7597,19 +7645,19 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-snyk-config@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/snyk-config/-/snyk-config-2.2.0.tgz#d400ce50e293ce5c3ade4cf46a53bea8205771e6"
-  integrity sha512-mq0wbP/AgjcmRq5i5jg2akVVV3iSYUPTowZwKn7DChRLDL8ySOzWAwan+ImXiyNbrWo87FNI/15O6MpOnTxOIg==
+snyk-config@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/snyk-config/-/snyk-config-2.2.1.tgz#bdacf79193158ec659bdcc4194140fd8d3772f9d"
+  integrity sha512-eCsFKHHE4J2DpD/1NzAtCmkmVDK310OXRtmoW0RlLnld1ESprJ5A/QRJ5Zxx1JbA8gjuwERY5vfUFA8lEJeopA==
   dependencies:
     debug "^3.1.0"
-    lodash "^4.17.5"
+    lodash "^4.17.11"
     nconf "^0.10.0"
 
-snyk-docker-plugin@1.21.3:
-  version "1.21.3"
-  resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-1.21.3.tgz#ec6baec00ccd29ca32975d2ed4b0c4571a08bc8b"
-  integrity sha512-XarMwYuBRcbMlldAJRtYSU2Vy3Y8OnQq7MIKZ1VHwkdW3vi/F/rpQK6TFTRUTsf5BIl0qH3TTOBaegNjCKQdTQ==
+snyk-docker-plugin@1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-1.22.0.tgz#4eb5887934860a60e150d9ebb417ebb071f5cddb"
+  integrity sha512-bykxNtfeWQNFjF6gv8u8w+TOa4fdr+teLm+DkvYlWkdlvaw5m4yywRI5USve4X6S9p4G+Fw4/wfjXx7LgCcxrQ==
   dependencies:
     debug "^3"
     dockerfile-ast "0.0.12"
@@ -7657,21 +7705,21 @@ snyk-nodejs-lockfile-parser@1.11.0:
     tslib "^1.9.3"
     uuid "^3.3.2"
 
-snyk-nuget-plugin@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/snyk-nuget-plugin/-/snyk-nuget-plugin-1.7.1.tgz#61f0fd0e9c88e2330385a6142cc3713581ddff40"
-  integrity sha512-j4VavJ9HtDDnLZgqJRFzXfBLErC3YtIwAwvECL2xs3q2mVQlw3GpWH+6gQJVfzRm8CWZpbDNdr1DD5lkXxTXXg==
+snyk-nuget-plugin@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/snyk-nuget-plugin/-/snyk-nuget-plugin-1.7.2.tgz#35ae0a0c68bfc68c6c52710bebd037ff765d1f9a"
+  integrity sha512-zmYD9veH7OeIqGnZHiGv8c8mKtmYrxo2o7P4lNUkpHdCMMsar7moRJxGgO9WlcIrwAGjIhMdP9fUvJ+jVDEteQ==
   dependencies:
     debug "^3.1.0"
     jszip "^3.1.5"
     lodash "^4.17.10"
-    snyk-paket-parser "1.4.1"
+    snyk-paket-parser "1.4.3"
     xml2js "^0.4.17"
 
-snyk-paket-parser@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/snyk-paket-parser/-/snyk-paket-parser-1.4.1.tgz#7e70d42f74dae04560055b9fb80150893a3b3c39"
-  integrity sha512-JabIAWwbjfSOkR0os6/KkdkLt7MN6ILFbyP5KgPxGP26V+1bJyXP24/h1blq/0dQY8UOiCQ62eP6Ycv+lfzCBg==
+snyk-paket-parser@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/snyk-paket-parser/-/snyk-paket-parser-1.4.3.tgz#380ae8c5fb598f81c110f6b645c728c9cc50b7a5"
+  integrity sha512-6m736zGVoeT/zS9KEtlmqTSPEPjAfLe8iYoQ3AwbyxDhzuLY49lTaV67MyZtGwjhi1x4KBe+XOgeWwyf6Avf/A==
   dependencies:
     tslib "^1.9.3"
 
@@ -7757,12 +7805,12 @@ snyk-try-require@1.3.1, snyk-try-require@^1.1.1, snyk-try-require@^1.3.1:
     then-fs "^2.0.0"
 
 snyk@^1.132.2:
-  version "1.132.2"
-  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.132.2.tgz#bc13daeb7cb5ceb486e7657baa511608c8cbe69d"
-  integrity sha512-p/TzTyhpsLSQQiZAPcds2XdYyEZP965k2cUa4A6wGrHs+K3XwVGNU9kiVkJYEfdseMPzvCVJpPvwIBm6OOujXg==
+  version "1.134.2"
+  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.134.2.tgz#c94e055b59e3bc3a2995f575457fba33ac2c8520"
+  integrity sha512-WGR3TTZxXOdALEEcQtADFEOHaanhbzwLvS6gyg5vF6Akj7qRAwIIXYBUycbNdAax1mylAsXCzR352dkTwKD9lg==
   dependencies:
-    "@snyk/dep-graph" "1.1.2"
-    "@snyk/gemfile" "1.1.0"
+    "@snyk/dep-graph" "1.4.0"
+    "@snyk/gemfile" "1.2.0"
     abbrev "^1.1.1"
     ansi-escapes "^3.1.0"
     chalk "^2.4.1"
@@ -7771,22 +7819,22 @@ snyk@^1.132.2:
     diff "^4.0.1"
     get-uri "2.0.2"
     inquirer "^3.0.0"
-    lodash "^4.17.5"
+    lodash "^4.17.11"
     needle "^2.2.4"
-    opn "^5.2.0"
-    os-name "^2.0.1"
+    opn "^5.4.0"
+    os-name "^3.0.0"
     proxy-agent "2.3.1"
     proxy-from-env "^1.0.0"
     recursive-readdir "^2.2.2"
-    semver "^5.5.0"
-    snyk-config "2.2.0"
-    snyk-docker-plugin "1.21.3"
+    semver "^5.6.0"
+    snyk-config "2.2.1"
+    snyk-docker-plugin "1.22.0"
     snyk-go-plugin "1.6.1"
     snyk-gradle-plugin "2.1.3"
     snyk-module "1.9.1"
     snyk-mvn-plugin "2.0.1"
     snyk-nodejs-lockfile-parser "1.11.0"
-    snyk-nuget-plugin "1.7.1"
+    snyk-nuget-plugin "1.7.2"
     snyk-php-plugin "1.5.2"
     snyk-policy "1.13.3"
     snyk-python-plugin "1.9.1"
@@ -7795,11 +7843,11 @@ snyk@^1.132.2:
     snyk-sbt-plugin "2.0.1"
     snyk-tree "^1.0.0"
     snyk-try-require "1.3.1"
-    source-map-support "^0.5.9"
+    source-map-support "^0.5.10"
     tempfile "^2.0.0"
     then-fs "^2.0.0"
     update-notifier "^2.5.0"
-    uuid "^3.2.1"
+    uuid "^3.3.2"
 
 socket.io-adapter@~1.1.0:
   version "1.1.1"
@@ -7904,7 +7952,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.7, source-map-support@^0.5.9:
+source-map-support@^0.5.10, source-map-support@^0.5.7, source-map-support@^0.5.9:
   version "0.5.10"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.10.tgz#2214080bc9d51832511ee2bab96e3c2f9353120c"
   integrity sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==
@@ -8098,6 +8146,15 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.0.0.tgz#5a1690a57cc78211fffd9bf24bbe24d090604eb1"
+  integrity sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.0.0"
+
 string_decoder@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
@@ -8251,15 +8308,15 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
-table@^5.0.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.2.2.tgz#61d474c9e4d8f4f7062c98c7504acb3c08aa738f"
-  integrity sha512-f8mJmuu9beQEDkKHLzOv4VxVYlU68NpdzjbGPl69i4Hx0sTopJuNxuzJd17iV2h24dAfa93u794OnDA5jqXvfQ==
+table@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.2.3.tgz#cde0cc6eb06751c009efab27e8c820ca5b67b7f2"
+  integrity sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==
   dependencies:
-    ajv "^6.6.1"
+    ajv "^6.9.1"
     lodash "^4.17.11"
-    slice-ansi "^2.0.0"
-    string-width "^2.1.1"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
 
 tar@^4:
   version "4.4.8"
@@ -8734,7 +8791,7 @@ uuid-parse@^1.0.0:
   resolved "https://registry.yarnpkg.com/uuid-parse/-/uuid-parse-1.0.0.tgz#f4657717624b0e4b88af36f98d89589a5bbee569"
   integrity sha1-9GV3F2JLDkuIrzb5jYlYmlu+5Wk=
 
-uuid@3.3.2, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
+uuid@3.3.2, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -8970,13 +9027,6 @@ widest-line@^2.0.0:
   dependencies:
     string-width "^2.1.1"
 
-win-release@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/win-release/-/win-release-1.1.1.tgz#5fa55e02be7ca934edfc12665632e849b72e5209"
-  integrity sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=
-  dependencies:
-    semver "^5.0.1"
-
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
@@ -8986,6 +9036,13 @@ window-size@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
   integrity sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=
+
+windows-release@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.1.0.tgz#8d4a7e266cbf5a233f6c717dac19ce00af36e12e"
+  integrity sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==
+  dependencies:
+    execa "^0.10.0"
 
 winston-transport@^4.3.0:
   version "4.3.0"
@@ -9064,6 +9121,13 @@ write-file-atomic@^2.0.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
 
 write@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
This PR improves the cashbox report in the following ways:
 1. The dates (from - to) are now respected in the search query.
 2. The currencies are rendered in the correct cashbox currency.
 3. We include a real opening balance and closing balance.
 4. The user can identify the difference between posted and unposted records via italics applied to unposted records.

We've also centralized the `getAccountTransactions()` call used between multiple reports into a single shared file `accounts/transactions`.  We've also rewritten the query for the combined posting_journal and general_ledger such that the WHERE statement is executed in subqueries, greatly improving the performance of the combined query.

Finally, the `getAccountTransactions()` function now sorts first based on `created_at` date, then on `trans_date`.  This makes back-dated transactions show up later in the rendering.  For example, users frequently back-date the transfer from the cashbox into the main coffre, and it makes sense to show these at the bottom of the report.

Closes #3595.