### PR TITLE
docs(stock): expand English stock docs

### DIFF
--- a/docs/en/stock-management/depot.md
+++ b/docs/en/stock-management/depot.md
@@ -1,14 +1,28 @@
-> [Home](../index.md) / [Inventory Management](./index.md) / Deposits
+&raquo; [Home](../index.md) / [Inventory Management](./index.md) / Depots
 
-# deposits
+# Depot Registry
 
-the deposits are used to store products, we can not talk about stock of products without talking about deposit. The concept of deposit allows to allocate the stock to different depots and to make movements between these deposits.
+<div class="bs-callout bs-callout-warning">
+  <p>
+    **Attention!** A user must be assigned to a depot before it will be visible
+    for them to use.
 
-To access the deposit module:
-
-<div class = "bs-callout bs-callout-success">
-  <P> Depot > <strong>Depot Registry</strong>: This module is a registry that lists all the repositories in the system, and allows you to create new ones.
+    To avoid user mistakes and fraud, BHIMA requries that each user be individually
+    assigned to a depot similar to [cashboxes]().
   </p>
 </div>
 
-To create a new repository, click on the **Add Depot** button which will open a modal window to enter repository information.
+
+Depots are used to store products.  We can not talk about stock without talking about depots. The depot forms
+a container for the enterprise's stock, and allows users to import stock through [Stock Entry](), or dispense
+stock through [Stock Exit]().
+
+To create a new repository, click on the **Add Depot** button in the top right corner of the module
+which will open a modal window to enter the depot information.
+
+
+## Depot Capabilities
+Each depot can be customized to allow only certain kinds of entries and exits.  For example, a central
+warehouse might not distribute directly to patients, but may serve as a staging center to distribute to
+other depots.  Similarly, a depot could be a distribution center only and not allow direct entry of
+donated or purchased stock.

--- a/docs/en/stock-management/index.md
+++ b/docs/en/stock-management/index.md
@@ -1,4 +1,4 @@
-> [Home](../index.md) / Inventory Management
+&raquo; [Home](../index.md) / Inventory Management
 
 # Inventory and stock management
 

--- a/docs/en/stock-management/inventory.md
+++ b/docs/en/stock-management/inventory.md
@@ -1,4 +1,4 @@
-> [Home](../index.md) / [Inventory Management](./index.md) / inventories
+&raquo; [Home](../index.md) / [Inventory Management](./index.md) / inventories
 
 # Inventories
 

--- a/docs/en/stock-management/movement.adjustment.md
+++ b/docs/en/stock-management/movement.adjustment.md
@@ -1,3 +1,3 @@
-> [Home](../index.md) / [Inventory Management](./index.md) /  [stocks movements](./movement.md) / Stock Adjustment
+&raquo; [Home](../index.md) / [Inventory Management](./index.md) /  [stocks movements](./movement.md) / Stock Adjustment
 
 # Stock Adjustment

--- a/docs/en/stock-management/movement.entry.md
+++ b/docs/en/stock-management/movement.entry.md
@@ -1,3 +1,3 @@
-> [Home](../index.md) / [Inventory Management](./index.md) /  [stocks movements](./movement.md) / Stock Entry
+&raquo; [Home](../index.md) / [Inventory Management](./index.md) /  [stocks movements](./movement.md) / Stock Entry
 
 # Stock Entry

--- a/docs/en/stock-management/movement.exit.md
+++ b/docs/en/stock-management/movement.exit.md
@@ -1,3 +1,3 @@
-> [Home](../index.md) / [Inventory Management](./index.md) /  [stocks movements](./movement.md) / Stock Exit
+&raquo; [Home](../index.md) / [Inventory Management](./index.md) /  [stocks movements](./movement.md) / Stock Exit
 
 # Stock Exit

--- a/docs/en/stock-management/movement.md
+++ b/docs/en/stock-management/movement.md
@@ -1,4 +1,4 @@
-> [Home](../index.md) / [Inventory Management](./index.md) / stock movements
+&raquo; [Home](../index.md) / [Inventory Management](./index.md) / stock movements
 
 # Stocks movements
 

--- a/docs/en/stock-management/overview.md
+++ b/docs/en/stock-management/overview.md
@@ -1,4 +1,4 @@
-> [Home](../index.md) / [Inventory Management](./index.md) / Overview of Inventory Management
+&raquo; [Home](../index.md) / [Inventory Management](./index.md) / Overview of Inventory Management
 
 # Overview of inventory management
 


### PR DESCRIPTION
This commit rewords and expands the English stock documentation to be
more comprehensive.  In particular, the depot documentation has been
reworked with paragraphs about depot capabilities and a warning about
requiring an assignment before a user may access a depot.