### PR TITLE
feat(reports): filter locked clients

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -44,7 +44,9 @@
     "CHART_OF_ACCOUNTS": "Chart of Accounts",
     "CLIENTS": {
       "TITLE" : "Annual Clients Report",
-      "DESCRIPTION": "This report displays all the debtor groups, their account balances at the beginning of the fiscal year, the debits and credits to their accounts, and their ending balances."
+      "DESCRIPTION": "This report displays all the debtor groups, their account balances at the beginning of the fiscal year, the debits and credits to their accounts, and their ending balances.",
+      "HIDE_LOCKED_CLIENTS" : "Hide Locked Clients",
+      "HIDE_LOCKED_CLIENTS_HELP_TEXT" : "Selecting yes will filter out all locked clients from the report.  By default, the value is no."
     },
     "CLOSING_BALANCE": "Closing Balance",
     "CONFIGURATION": "Report Configuration",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -142,7 +142,9 @@
     },
     "CLIENTS" : {
       "TITLE" : "Rapport Annuel des Clients",
-      "DESCRIPTION" : "Ce rapport affiche tous les groupes de débiteurs, leurs soldes de compte au début de l'exercice, les soldes actuels et leurs soldes de clôture."
+      "DESCRIPTION" : "Ce rapport affiche tous les groupes de débiteurs, leurs soldes de compte au début de l'exercice, les soldes actuels et leurs soldes de clôture.",
+      "HIDE_LOCKED_CLIENTS" : "Masquer les clients verrouillés",
+      "HIDE_LOCKED_CLIENTS_HELP_TEXT" : "Si vous sélectionnez oui, tous les clients verrouillés seront filtrés dans le rapport. Par défaut, la valeur est non."
     },
     "UNPAID_INVOICE_PAYMENTS_REPORT": {
       "TITLE": "Rapport de Factures Non-Payées",

--- a/client/src/js/components/bhCurrencySelect.js
+++ b/client/src/js/components/bhCurrencySelect.js
@@ -74,9 +74,6 @@ function bhCurrencySelect(Currencies) {
     $ctrl.valid = true;
 
     $ctrl.label = $ctrl.label || 'FORM.LABELS.CURRENCY';
-
-    // default to noop() if an onChange() method was not passed in
-    $ctrl.onChange = $ctrl.onChange || angular.noop;
   };
 
   $ctrl.valueChange = () => {

--- a/client/src/modules/enterprises/enterprises.html
+++ b/client/src/modules/enterprises/enterprises.html
@@ -40,18 +40,18 @@
               <div class="form-group">
                 <div class="enterprise-logo-editing">
                   <div class="logo" ng-if="!EnterpriseCtrl.enterprise.logo">
-                    <span ng-if="!EnterpriseCtrl.hasThumbnail"> 
+                    <span ng-if="!EnterpriseCtrl.hasThumbnail">
                       <i class="fa fa-3x fa-file-image-o"></i>
                     </span>
-                    <span ng-if="EnterpriseCtrl.hasThumbnail"> 
+                    <span ng-if="EnterpriseCtrl.hasThumbnail">
                       <img ngf-thumbnail="{{ 'EnterpriseCtrl.thumbnail' }}" style="width: 100px !important; height: 100px !important;">
                     </span>
                   </div>
                   <div class="logo" ng-if="EnterpriseCtrl.enterprise.logo">
-                    <span ng-if="!EnterpriseCtrl.hasThumbnail"> 
+                    <span ng-if="!EnterpriseCtrl.hasThumbnail">
                       <img ng-src="{{ EnterpriseCtrl.enterprise.logo }}" style="width: 100px !important; height: 100px !important;" onError="this.src='assets/empty.png';" >
                     </span>
-                    <span ng-if="EnterpriseCtrl.hasThumbnail"> 
+                    <span ng-if="EnterpriseCtrl.hasThumbnail">
                       <img ngf-thumbnail="{{ 'EnterpriseCtrl.thumbnail' }}" style="width: 100px !important; height: 100px !important;">
                     </span>
                   </div>
@@ -61,11 +61,11 @@
                   <label data-method="upload-logo" class="btn btn-default">
                     <i class="fa fa-edit"></i> <span translate>ENTERPRISE.UPDATE_LOGO</span>
                     <input
-                      type="file" 
-                      accept="image/*" 
+                      type="file"
+                      accept="image/*"
                       ng-model="EnterpriseCtrl.file"
-                      ngf-max-size="2MB" 
-                      ngf-select="EnterpriseCtrl.setThumbnail($file)" 
+                      ngf-max-size="2MB"
+                      ngf-select="EnterpriseCtrl.setThumbnail($file)"
                       style="display: none;">
                   </label>
                 </div>

--- a/client/src/modules/reports/generate/annual-clients-report/annual-clients-report.html
+++ b/client/src/modules/reports/generate/annual-clients-report/annual-clients-report.html
@@ -34,6 +34,13 @@
             on-change="ReportConfigCtrl.onSelectCurrency(currencyId)">
           </bh-currency-select>
 
+          <bh-yes-no-radios
+            label="REPORT.CLIENTS.HIDE_LOCKED_CLIENTS"
+            value="ReportConfigCtrl.reportDetails.hideLockedClients"
+            help-text="REPORT.CLIENTS.HIDE_LOCKED_CLIENTS_HELP_TEXT"
+            on-change-callback="ReportConfigCtrl.onHideLockedClientsToggle(value)">
+          </bh-yes-no-radios>
+
           <!--preview-->
           <bh-loading-button loading-state="ConfigForm.$loading">
             <span translate>REPORT.UTIL.PREVIEW</span>

--- a/client/src/modules/reports/generate/annual-clients-report/annual-clients-report.js
+++ b/client/src/modules/reports/generate/annual-clients-report/annual-clients-report.js
@@ -21,6 +21,7 @@ function AnnualClientsReportController($state, $sce, Notify, AppCache, SavedRepo
 
   vm.reportDetails = {
     currencyId : Session.enterprise.currency_id,
+    hideLockedClients : 0,
   };
 
   checkCachedConfiguration();
@@ -30,8 +31,12 @@ function AnnualClientsReportController($state, $sce, Notify, AppCache, SavedRepo
     vm.reportDetails.fiscalId = fiscal.id;
   };
 
-  vm.onSelectCurrency = currency => {
-    vm.reportDetails.currencyId = currency.id;
+  vm.onSelectCurrency = currencyId => {
+    vm.reportDetails.currencyId = currencyId;
+  };
+
+  vm.onHideLockedClientsToggle = hideLockedClients => {
+    vm.reportDetails.hideLockedClients = hideLockedClients;
   };
 
   vm.requestSaveAs = function requestSaveAs() {
@@ -69,7 +74,7 @@ function AnnualClientsReportController($state, $sce, Notify, AppCache, SavedRepo
 
   function checkCachedConfiguration() {
     if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
+      angular.merge(vm.reportDetails, cache.reportDetails);
     }
   }
 }


### PR DESCRIPTION
This commit adds a filter for locked clients to the Annual Clients
Report, allowing administrators to prevent the display of debtor groups
in the report.

A bug was also discovered with the currency select and is now fixed.

Closes #3386.

![filterlockedclients](https://user-images.githubusercontent.com/896472/53697987-33eddb80-3dd7-11e9-9cf5-f0dcf1edaaa2.PNG)
