### PR TITLE
chore(tests): clean up lint of integration tests

### DIFF
--- a/test/client-unit/services/rubricsConfigurationService.spec.js
+++ b/test/client-unit/services/rubricsConfigurationService.spec.js
@@ -1,4 +1,4 @@
-/* global expect inject chai */
+/* global expect inject */
 describe('RubricsConfigurationService', () => {
   let RubricsConfigs;
   let $httpBackend;

--- a/test/integration/accountCategories.js
+++ b/test/integration/accountCategories.js
@@ -1,4 +1,5 @@
-/* global expect, chai, agent */
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 
@@ -10,7 +11,6 @@ describe('(/accounts/categories) Account Categories', () => {
   const DELETABLE_ACCOUNT_TYPE_ID = 5;
   const FETCHABLE_ACCOUNT_TYPE_ID = 1;
   const numAccountCategory = 4;
-
 
   it('GET /accounts/categories returns a list of account category', () => {
     return agent.get('/accounts/categories/')

--- a/test/integration/accountTypes.js
+++ b/test/integration/accountTypes.js
@@ -1,4 +1,5 @@
-/* global expect, chai, agent */
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/barcodes.js
+++ b/test/integration/barcodes.js
@@ -1,8 +1,6 @@
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
-
-/* global expect, chai, agent */
-
-const _ = require('lodash');
 const helpers = require('./helpers');
 
 describe('(/barcode) Barcode Reverse Lookup', () => {
@@ -36,6 +34,4 @@ describe('(/barcode) Barcode Reverse Lookup', () => {
         helpers.api.errored(res, 400);
       });
   });
-
-
 });

--- a/test/integration/cash.cautions.js
+++ b/test/integration/cash.cautions.js
@@ -1,5 +1,5 @@
-/* global expect, chai, agent */
-
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 /**
  * @overview CautionPayments
@@ -8,15 +8,12 @@
  * This contains the test cases for creating cautions via the /cash API.
  *
  */
-
 module.exports = CautionPayments;
 
-const _ = require('lodash');
 const helpers = require('./helpers');
 
 function CautionPayments() {
-  const DEBTOR_UUID = // Test Patient
-    '3be232f9-a4b9-4af6-984c-5d3f87d5c107';
+  const DEBTOR_UUID = '3be232f9-a4b9-4af6-984c-5d3f87d5c107';
 
   const CAUTION_PAYMENT = {
     amount :      15000,

--- a/test/integration/cash.invoices.js
+++ b/test/integration/cash.invoices.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 /**
  * @overview CashInvoicePayments

--- a/test/integration/cashboxes.js
+++ b/test/integration/cashboxes.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 
@@ -157,8 +158,8 @@ describe('(/cashboxes) The Cashboxes API endpoint', () => {
   it('GET /cashboxes/:id/users should return users subscribed to a cashbox', () => {
     // details on the test cashbox as found in the dataset built before integration tests
     const testDataCashbox = {
-      id: 1,
-      numberOfUsers: 2
+      id : 1,
+      numberOfUsers : 2,
     };
     return agent.get(`/cashboxes/${testDataCashbox.id}/users`)
       .then(result => {

--- a/test/integration/creditorGroups.js
+++ b/test/integration/creditorGroups.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/currencies.js
+++ b/test/integration/currencies.js
@@ -1,10 +1,9 @@
-/* global expect, chai, agent */
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 
 describe('(/currencies) currencies API routes', () => {
-
-
   const currencyId = 1;
   const keys = [
     'id', 'name', 'note', 'format_key', 'symbol', 'min_monentary_unit',

--- a/test/integration/debtorGroups.js
+++ b/test/integration/debtorGroups.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/department.js
+++ b/test/integration/department.js
@@ -1,4 +1,5 @@
-/* global expect, chai, agent */
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 
@@ -8,7 +9,6 @@ const helpers = require('./helpers');
  * This test suite implements full CRUD on the /projects HTTP API endpoint.
  */
 describe('(/departments) The department API endpoint', () => {
-  // project we will add during this test suite.
   const uuid = '5b7dd0d6-9273-4955-a703-126fbd504b61';
   const uuid2 = '7b7dd0d6-9273-4955-a703-126fbd504b61';
   const department = {

--- a/test/integration/discounts.js
+++ b/test/integration/discounts.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/distributionFeesCenters.js
+++ b/test/integration/distributionFeesCenters.js
@@ -163,7 +163,7 @@ describe('(/fee_center_distribution) The /fee_center  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('POST /distribution_fee_center/distributionKey a new Distribution Fee Center Key: 2', () => {
+  it('POST /distribution_fee_center/distributionKey a new distribution fee center key: 2', () => {
     return agent.post('/distribution_fee_center/distributionKey')
       .send(distributionKey2)
       .then((res) => {
@@ -172,7 +172,7 @@ describe('(/fee_center_distribution) The /fee_center  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('POST /distribution_fee_center/proceed : Distribution of Ancillary Cost Centers to Main Centers by Monetary Values', () => {
+  it('POST /distribution_fee_center/proceed distribution of aux cost centers to main centers by currency', () => {
     return agent.post('/distribution_fee_center/proceed')
       .send(proceed)
       .then((res) => {
@@ -181,7 +181,7 @@ describe('(/fee_center_distribution) The /fee_center  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('POST /distribution_fee_center/proceed : Throwing BadRequest If dataToDistribute.length is 0', () => {
+  it('POST /distribution_fee_center/proceed throws BadRequest if dataToDistribute.length is 0', () => {
     return agent.post('/distribution_fee_center/proceed')
       .send(proceedInternalServerError)
       .then((res) => {
@@ -190,7 +190,8 @@ describe('(/fee_center_distribution) The /fee_center  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('/distribution_fee_center/automatic Automatic distribution of invoices whose services are referenced to main expense centers', () => {
+  // eslint-disable-next-line
+  it('/distribution_fee_center/automatic Automatically distributes invoices with referenced services to main expense centers', () => {
     return agent.post('/distribution_fee_center/automatic')
       .send(automaticInvoices)
       .then((res) => {
@@ -199,7 +200,7 @@ describe('(/fee_center_distribution) The /fee_center  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /distribution_fee_center/getDistributed  Obtaining the list of all distributions of costs and profits made manually', () => {
+  it('GET /distribution_fee_center/getDistributed retunrs all distributions of costs and profits made manually', () => {
     return agent.get('/distribution_fee_center/getDistributed')
       .then(res => {
         helpers.api.listed(res, 4);

--- a/test/integration/employee.js
+++ b/test/integration/employee.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 
@@ -275,12 +276,13 @@ describe('(/employees) the employees API endpoint', () => {
    * @param {object} emp The employee object to test
    * @param {object} update The correct employee update
    */
-  function checkValidUpdate(employee, update) {
+  function checkValidUpdate(person, update) {
+    // eslint-disable-next-line
     for (const i in update) {
       if (i === 'dob' || i === 'date_embauche') {
-        expect(new Date(employee[i])).to.equalDate(new Date(update[i]));
+        expect(new Date(person[i])).to.equalDate(new Date(update[i]));
       } else {
-        expect(employee[i]).to.equal(update[i]);
+        expect(person[i]).to.equal(update[i]);
       }
     }
   }

--- a/test/integration/employeeConfig.js
+++ b/test/integration/employeeConfig.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/exchange.js
+++ b/test/integration/exchange.js
@@ -1,4 +1,5 @@
-/* global expect, chai, agent */
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/fiscalYear.extra.js
+++ b/test/integration/fiscalYear.extra.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 const moment = require('moment');
 const helpers = require('./helpers');
 
@@ -66,7 +67,7 @@ describe('(/fiscal) Fiscal Year extra operations', () => {
       .catch(helpers.handler);
   });
 
-  it('POST /fiscal/:id/opening_balance forbid to set the opening balance of a fiscal year which is not the first', () => {
+  it('POST /fiscal/:id/opening_balance cannot set opening balance for second fiscal year', () => {
     // define a not first fiscal year information
     openingBalance.id = fiscalYear2017.id;
     openingBalance.fiscal = fiscalYear2017;
@@ -134,5 +135,4 @@ describe('(/fiscal) Fiscal Year extra operations', () => {
   function flatDate(_date_) {
     return moment(_date_).format('YYYY-MM-DD');
   }
-
 });

--- a/test/integration/fiscalYear.js
+++ b/test/integration/fiscalYear.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 
@@ -118,13 +119,13 @@ describe('(/fiscal) Fiscal Year', () => {
 
   it('GET /enterprises/:id/fiscal_start getting the earliest fiscal year date', () => {
     const mockEnterpriseFiscalEntity = {
-      enterpriseId: 1,
-      earliestFiscalDate: {
-        string: '2015-01-01T00:00:00.000Z',
-        year: 2015,
-        day: 1,
-        month: 0,
-      }
+      enterpriseId : 1,
+      earliestFiscalDate : {
+        string : '2015-01-01T00:00:00.000Z',
+        year : 2015,
+        day : 1,
+        month : 0,
+      },
     };
 
     return agent.get(`/enterprises/${mockEnterpriseFiscalEntity.enterpriseId}/fiscal_start`)

--- a/test/integration/functions.js
+++ b/test/integration/functions.js
@@ -1,4 +1,5 @@
-/* global expect, chai, agent */
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 
@@ -25,7 +26,7 @@ describe('(/functions) The /functions  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('POST /FUNCTIONS should create a new Function', () => {
+  it('POST /functions should create a new Function', () => {
     return agent.post('/functions')
       .send(fonction)
       .then((res) => {
@@ -35,7 +36,7 @@ describe('(/functions) The /functions  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /FUNCTIONS/:ID should not be found for unknown id', () => {
+  it('GET /functions/:id should not be found for unknown id', () => {
     return agent.get('/functions/unknownFunction')
       .then((res) => {
         helpers.api.errored(res, 404);
@@ -43,7 +44,7 @@ describe('(/functions) The /functions  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('PUT /FUNCTIONS  should update an existing Function ', () => {
+  it('PUT /functions should update an existing Function ', () => {
     return agent.put(`/functions/${fonction.id}`)
       .send({ fonction_txt : 'Imagerie Medicale' })
       .then((res) => {
@@ -54,7 +55,7 @@ describe('(/functions) The /functions  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /FUNCTIONS/:ID returns a single Function ', () => {
+  it('GET /functions/:id returns a single Function ', () => {
     return agent.get(`/functions/${fonction.id}`)
       .then((res) => {
         expect(res).to.have.status(200);
@@ -63,7 +64,7 @@ describe('(/functions) The /functions  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('DELETE /FUNCTIONS/:ID will send back a 404 if the Function does not exist', () => {
+  it('DELETE /functions/:id will send back a 404 if the Function does not exist', () => {
     return agent.delete('/functions/unknownFunction')
       .then((res) => {
         helpers.api.errored(res, 404);

--- a/test/integration/grades.js
+++ b/test/integration/grades.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/groups.js
+++ b/test/integration/groups.js
@@ -1,9 +1,9 @@
-/* global expect, chai, agent */
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 
 describe('(/groups) Group subscriptions API', () => {
-
 
   const invalidKey = 'notakey';
   const validKey = 'debtor_group_invoicing_fee';

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -1,4 +1,4 @@
-
+/* eslint-disable no-unused-expressions */
 
 // import plugins
 const uuid = require('uuid/v4');
@@ -191,7 +191,8 @@ api.deleted = function deleted(res) {
  */
 api.listed = function listed(res, len) {
   // make sure that the response has the correct HTTP headers
-  expect(res, `${res.req.method} ${res.req.path} returned ${res.res.statusCode} ${res.res.statusMesage}.`).to.have.status(200);
+  expect(res,
+    `${res.req.method} ${res.req.path} returned ${res.res.statusCode} ${res.res.statusMesage}.`).to.have.status(200);
   expect(res, `${res.req.method} ${res.req.path} did not return JSON.`).to.be.json;
 
   // assert that the length is the expected length.

--- a/test/integration/invoicingFees.js
+++ b/test/integration/invoicingFees.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/locations.js
+++ b/test/integration/locations.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const _ = require('lodash');
 const helpers = require('./helpers');
@@ -114,7 +115,7 @@ describe('(/locations) Locations Interface', () => {
   });
 
 
-  it('GET /locations/detail/ Return a Global list of all locations with all information (Country, Province, District and Village) ', () => {
+  it('GET /locations/detail/ returns a list of all locations country, province, district and village', () => {
     return agent.get('/locations/detail/')
       .then((res) => {
         expect(res).to.have.status(200);

--- a/test/integration/login.js
+++ b/test/integration/login.js
@@ -106,7 +106,9 @@ describe('(/auth/login) The login API', () => {
 
         expect(res).to.have.status(200);
         expect(res.body).to.have.keys('enterprise', 'user', 'project', 'paths');
-        expect(res.body.user).to.contain.all.keys('id', 'enterprise_id', 'display_name', 'project_id', 'username', 'email');
+        expect(res.body.user).to.contain.all.keys(
+          'id', 'enterprise_id', 'display_name', 'project_id', 'username', 'email'
+        );
         expect(res.body.enterprise).to.contain.all.keys('id', 'currency_id', 'currencySymbol', 'settings');
         expect(res.body.project).to.contain.all.keys('id', 'name', 'abbr', 'enterprise_id');
         expect(res.body.paths[0]).to.contain.all.keys('path', 'authorized');

--- a/test/integration/patientDocuments.js
+++ b/test/integration/patientDocuments.js
@@ -1,4 +1,5 @@
-/* global expect, chai, agent */
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const fs = require('fs');
 const path = require('path');
@@ -23,7 +24,7 @@ describe('(patients/:uuid/documents) Patient Documents', () => {
       .then((res) => {
         expect(res).to.have.status(201);
         expect(res.body).to.have.property('uuids');
-        docId = res.body.uuids[0];
+        [docId] = res.body.uuids;
       })
       .catch(helpers.api.handler);
   });
@@ -60,7 +61,9 @@ describe('(patients/:uuid/documents) Patient Documents', () => {
     return agent.get(`/patients/${patientUuid}/documents`)
       .then((res) => {
         helpers.api.listed(res, 4);
-        expect(res.body[0]).to.have.keys('uuid', 'label', 'link', 'timestamp', 'mimetype', 'size', 'user_id', 'display_name');
+        expect(res.body[0]).to.have.keys(
+          'uuid', 'label', 'link', 'timestamp', 'mimetype', 'size', 'user_id', 'display_name'
+        );
       })
       .catch(helpers.api.handler);
   });

--- a/test/integration/patientInvoiceCreditNote.js
+++ b/test/integration/patientInvoiceCreditNote.js
@@ -1,5 +1,5 @@
-/* global chai, expect, agent */
-
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/patientPictures.js
+++ b/test/integration/patientPictures.js
@@ -1,4 +1,4 @@
-/* global expect, chai, agent */
+/* global expect, agent */
 
 const fs = require('fs');
 const path = require('path');
@@ -7,11 +7,9 @@ const helpers = require('./helpers');
 const fixtures = path.resolve(__dirname, '../fixtures');
 
 describe('(patients/:uuid/pictures) Patient Pictures', () => {
-
-
   const patientUuid = '274c51ae-efcc-4238-98c6-f402bfb39866';
 
-  it('POST /patients/:uuid/pictures should Set Picture to a patient', () => {
+  it('POST /patients/:uuid/pictures should set the patient\'s picture', () => {
     return agent.post(`/patients/${patientUuid}/pictures`)
       .attach('pictures', fs.createReadStream(`${fixtures}/patient.png`))
       .then((res) => {

--- a/test/integration/payroll.js
+++ b/test/integration/payroll.js
@@ -1,6 +1,6 @@
-/* global expect, chai, agent */
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
-const uuid = require('uuid/v4');
 const helpers = require('./helpers');
 
 /*

--- a/test/integration/payrollConfig.js
+++ b/test/integration/payrollConfig.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/priceList.js
+++ b/test/integration/priceList.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/projects.js
+++ b/test/integration/projects.js
@@ -1,4 +1,5 @@
-/* global expect, chai, agent */
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/purchase.js
+++ b/test/integration/purchase.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 const SearchTests = require('./purchase.search.js');

--- a/test/integration/purchase.search.js
+++ b/test/integration/purchase.search.js
@@ -1,4 +1,4 @@
-/* global expect, chai, agent */
+/* global agent */
 
 /**
  * @overview PurchaseOrderSearch
@@ -6,7 +6,6 @@
  * @description
  * This file contains search tests for the purchase orders API.
  */
-
 const helpers = require('./helpers');
 
 module.exports = PurchaseOrderSearch;

--- a/test/integration/rubrics.js
+++ b/test/integration/rubrics.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/services.js
+++ b/test/integration/services.js
@@ -1,4 +1,5 @@
-/* global expect, chai, agent */
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -8,7 +8,6 @@
  * @requires q
  * @requires chai-http
  * @requires chai-datetime
- *
  */
 
 
@@ -26,12 +25,6 @@ global.baseUrl = baseUrl;
 before(() => {
   console.log('Setting up test suite...');
 
-  // workaround for low node versions
-  if (!global.Promise) {
-    const q = require('q');
-    chai.request.addPromises(q.Promise);
-  }
-
   // attach plugins
   chai.use(chaiHttp);
   chai.use(chaiDatetime);
@@ -40,7 +33,7 @@ before(() => {
   global.chai = chai;
   global.expect = chai.expect;
   global.agent = chai.request.agent(baseUrl);
-  const agent = global.agent;
+  const { agent } = global;
 
   // base user defined in test data
   const user = { username : 'superuser', password : 'superuser', project : 1 };

--- a/test/integration/subsidy.js
+++ b/test/integration/subsidy.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/suppliers.js
+++ b/test/integration/suppliers.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/system.js
+++ b/test/integration/system.js
@@ -1,4 +1,4 @@
-/* global expect, chai, agent */
+/* global expect, agent */
 
 const helpers = require('./helpers');
 

--- a/test/integration/tags.js
+++ b/test/integration/tags.js
@@ -1,4 +1,5 @@
-/* global expect, chai, agent */
+/* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 
@@ -98,5 +99,4 @@ describe('(/tags) The tags API endpoint', () => {
       })
       .catch(helpers.handler);
   });
-
 });

--- a/test/integration/users.js
+++ b/test/integration/users.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 

--- a/test/integration/vouchers.js
+++ b/test/integration/vouchers.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const uuid = require('uuid/v4');
 const helpers = require('./helpers');

--- a/test/integration/weekEndConfig.js
+++ b/test/integration/weekEndConfig.js
@@ -1,4 +1,5 @@
 /* global expect, agent */
+/* eslint-disable no-unused-expressions */
 
 const helpers = require('./helpers');
 
@@ -8,12 +9,6 @@ const helpers = require('./helpers');
  * This test suite implements full CRUD on the /payroll/weekend_configuration  HTTP API endpoint.
  */
 describe('(/payroll/weekend_configuration) The /payroll/weekend_configuration  API endpoint', () => {
-  // weekend_configuration we will add during this test suite.
-
-  const weekEndUpdate = {
-    label : 'WeekEnd Updated',
-  };
-
   const weekEndConfig = {
     label : 'Configuration Week end 2013',
   };


### PR DESCRIPTION
Chai forces us to use a syntax that allows naked property calls without
function calls.  This makes ESLint go crazy.  In most places, I've
escaped the ESLint rule where appropriate, so that new contributors
don't fight ESLint as hard.  I've also pruned extraneous code.