### PR TITLE
fix(reports): handle unpaid balance errors

### DIFF
--- a/server/controllers/finance/reports/unpaid-invoice-payments/report.handlebars
+++ b/server/controllers/finance/reports/unpaid-invoice-payments/report.handlebars
@@ -43,6 +43,8 @@
               {{/each}}
               <td class="text-right">{{ row.Total }}</td>
             </tr>
+          {{else}}
+            {{> emptyTable columns=3}}
           {{/each}}
           <tr>
             {{#each totals as |value key|}}


### PR DESCRIPTION
The Unpaid Invoices errors would throw SQL errors if there was no data
for the range (since that is what the Pivot() function does).  The
report has been updated to catch and gracefully handle certain data
errors so that it simply informs the user that there is no data for
that range.

Closes #3575.

**Demo**
![2019-03-26_10-14-42](https://user-images.githubusercontent.com/896472/55004329-69d64800-4fb0-11e9-98ae-10275a5ccef2.gif)
