### PR TITLE
docs: remove references to bower

### DIFF
--- a/docs/en/for-developers/installing-bhima.md
+++ b/docs/en/for-developers/installing-bhima.md
@@ -79,11 +79,6 @@ To execute the build scripts, you can use either `yarn` or `npm`. We'll use `yar
 
 yarn install
 
-
-# bower is now installed in ./node_modules/.bin/bower
-#install client-side dependencies with bower
-./node_modules/.bin/bower install -f
-
 #If this command gives you an error (I.E. if you’re running Parallels), try running the following command:
 git config -global url."https://".insteadOf git://
 ```

--- a/docs/fr/for-developers/installing-bhima.md
+++ b/docs/fr/for-developers/installing-bhima.md
@@ -79,12 +79,7 @@ Pour exécuter les scripts de construction, vous pouvez utiliser `yarn` ou` npm`
 
 yarn install
 
-
-# bower est maintenant installé dans ./node_modules/.bin/bower
-#installe les dépendances côté client avec bower
-./node_modules/.bin/bower install -f
-
-#Si cette commande vous donne une erreur (par exemple, si vous utilisez Parallels), essayez d’exécuter la commande suivante:
+# Si cette commande vous donne une erreur (par exemple, si vous utilisez Parallels), essayez d’exécuter la commande suivante:
 git config -global url. "https: //" .insteadOf git: //
 ```
 


### PR DESCRIPTION
We removed bower in #3319, but our installation instructions were never
updated.  I've corrected this.