### PR TITLE
Add exchange rate info in exploitation report

### DIFF
--- a/client/src/i18n/en/exchange.json
+++ b/client/src/i18n/en/exchange.json
@@ -8,6 +8,8 @@
     "INVOICE_DISCLAIMER" : "Exchange rate based on the latest enterprise exchange:",
     "NEW_RATE" : "New Exchange Rate",
     "ON" : "on",
+    "FOR" : "for",
+    "AT_THE_DATE": "at the date",
     "RATE_SET" : "Rate last set",
     "REVIEW" : "Review Rates",
     "REVIEW_RATE" : "Review the exchange rate",

--- a/client/src/i18n/fr/exchange.json
+++ b/client/src/i18n/fr/exchange.json
@@ -10,6 +10,8 @@
     "RATE_SET" : "Taux configuré",
     "REVIEW" : "Revoir le taux",
     "ON" : "sur",
+    "FOR" : "pour",
+    "AT_THE_DATE": "à la date",
     "REVIEW_RATE" : "Revoir le taux",
     "SET_AS" : "Defini comme",
     "SET_EXCHANGE_RATE" : "Définir le taux de change",

--- a/server/controllers/finance/reports/operating/index.js
+++ b/server/controllers/finance/reports/operating/index.js
@@ -40,8 +40,11 @@ function document(req, res, next) {
 
   let queries;
   let range;
+  let lastRateUsed;
+  let firstCurrency;
+  let secondCurrency;
   const enterpriseId = req.session.enterprise.id;
-
+  const enterpriseCurrencyId = req.session.enterprise.currency_id;
   const getQueryIncome = fiscal.getAccountBalancesByTypeId;
 
   const periods = {
@@ -53,6 +56,15 @@ function document(req, res, next) {
     range = dateRange;
     return Exchange.getExchangeRate(enterpriseId, params.currency_id, range.dateTo);
   }).then(exchangeRate => {
+    firstCurrency = enterpriseCurrencyId;
+    secondCurrency = params.currency_id;
+    lastRateUsed = exchangeRate.rate;
+
+    if (lastRateUsed && lastRateUsed < 1) {
+      lastRateUsed = (1 / lastRateUsed);
+      firstCurrency = params.currency_id;
+      secondCurrency = enterpriseCurrencyId;
+    }
 
     const rate = exchangeRate.rate || 1;
 
@@ -100,6 +112,9 @@ function document(req, res, next) {
         dateFrom : range.dateFrom,
         dateTo : range.dateTo,
         currencyId : params.currency_id,
+        firstCurrency,
+        secondCurrency,
+        rate : lastRateUsed,
       };
 
       formatData(context.expense, context.totalExpense, DECIMAL_PRECISION);

--- a/server/controllers/finance/reports/operating/report.handlebars
+++ b/server/controllers/finance/reports/operating/report.handlebars
@@ -14,6 +14,13 @@
       <h5 style="margin:15px; font-weight:bold" class="text-center text-uppercase">
         {{date this.dateFrom}} - {{date this.dateTo}}
       </h5>
+      <h5 class="text-center">
+        {{#if this.rate}}
+          {{translate 'EXCHANGE.EXCHANGE_RATES'}} : 
+          {{currency 1 this.firstCurrency}} = {{currency this.rate this.secondCurrency}} 
+          <i>(<span>{{translate 'EXCHANGE.AT_THE_DATE'}}</span> {{date this.dateTo}})</i>
+        {{/if}}
+      </h5>
       <table class="table table-condensed table-report table-bordered">
         <tbody>
           <tr>


### PR DESCRIPTION
This PR add exchange rate info in the exploitation report when the currency of the report is different from enterprise currency.

![image](https://user-images.githubusercontent.com/5445251/57382411-ced2af80-71a4-11e9-8d83-fccd800b114e.png)

Close #3711 