### PR TITLE
fix: css compile in production mode

### DIFF
--- a/client/src/modules/application/exchange.html
+++ b/client/src/modules/application/exchange.html
@@ -7,8 +7,6 @@
   </div>
 </div>
 
-
-
 <div class="flex-content">
   <div class="container-fluid">
 

--- a/gulpfile.js/client-css.js
+++ b/gulpfile.js/client-css.js
@@ -90,7 +90,7 @@ const compileCSS = isProduction
 function compileLess() {
   return src(LESS_PATH)
     .pipe(gulpLess(LESS_CONFIG))
-    .pipe(gulpif(isProduction, cssnano({ zindex : false })))
+    .pipe(gulpif(isProduction, postcss([cssnano({ zindex : false })])))
     .pipe(dest(`${CLIENT_FOLDER}/css`));
 }
 


### PR DESCRIPTION
The CSS doesn't compile properly in production mode due to updating our
CSS minification procedures.  It is fixed.