### PR TITLE
chore: combine date/username lines on receipt head

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -99,6 +99,7 @@
     "PERIOD_START": "Start",
     "PERIOD_STOP": "Stop",
     "PRODUCED_BY": "Produced by",
+    "BY": "by",
     "PRODUCED_DATE": "Production Date",
     "PRODUCED_ON": "Produced on",
     "SINCE": "Since",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -93,6 +93,7 @@
     "PERIOD_START": "Début",
     "PERIOD_STOP": "Fin",
     "PRODUCED_BY": "Produit par",
+    "BY" : "par",
     "PRODUCED_DATE": "Date de génération",
     "PRODUCED_ON": "Produit le",
     "SINCE": "Depuis",

--- a/server/controllers/finance/reports/cash/receipt.handlebars
+++ b/server/controllers/finance/reports/cash/receipt.handlebars
@@ -20,12 +20,15 @@
             {{/with}}
           </span> <br>
           <strong>{{payment.reference}}</strong> <br>
-          <small>{{date payment.date}}</small> <br>
-          {{#if metadata.enterprise.settings.enable_barcodes}}
-            <small>{{> barcode value=details.barcode}}</small> <br>
-          {{/if}}
-          <br>
         </h3>
+        <div>
+          {{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time>
+          {{translate "REPORT.BY"}} {{metadata.user.username}}
+        </div>
+
+        {{#if metadata.enterprise.settings.enable_barcodes}}
+          <small>{{> barcode value=details.barcode}}</small> <br>
+        {{/if}}
       </div>
     </div>
 

--- a/server/controllers/finance/reports/invoices/receipt.handlebars
+++ b/server/controllers/finance/reports/invoices/receipt.handlebars
@@ -18,13 +18,15 @@
         <h3 style="margin: 0px;">
           <span class="text-uppercase">{{translate 'FORM.LABELS.INVOICE'}}</span> <br>
           <strong>{{reference}}</strong> <br>
-          <small>{{date date}}</small> <br>
-
-          {{#if metadata.enterprise.settings.enable_barcodes}}
-            <small>{{> barcode value=barcode}}</small><br>
-          {{/if}}
-          <br>
         </h3>
+        <div>
+          {{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time>
+          {{translate "REPORT.BY"}} {{metadata.user.username}}
+        </div>
+
+        {{#if metadata.enterprise.settings.enable_barcodes}}
+          <small>{{> barcode value=barcode}}</small><br>
+        {{/if}}
       </div>
     </div>
 

--- a/server/controllers/finance/reports/vouchers/receipt.handlebars
+++ b/server/controllers/finance/reports/vouchers/receipt.handlebars
@@ -12,7 +12,7 @@
           </span><br>{{details.creditNoteVoucher.reference}}
         </div>
       {{/if}}
-  
+
       {{> enterpriseDetails }}
 
       <div class="col-xs-5 text-right">
@@ -20,10 +20,13 @@
           <div class="text-uppercase">{{translate details.text}}</div>
           <div><strong>{{details.reference}}</strong></div>
         </h3>
-        <div>{{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time></div>
-        <div>{{translate "REPORT.PRODUCED_BY"}} {{metadata.user.username}}</div>
+        <div>
+          {{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time>
+          {{translate "REPORT.BY"}} {{metadata.user.username}}
+        </div>
+
         {{#if metadata.enterprise.settings.enable_barcodes}}
-          <div>{{> barcode value=details.barcode}}</div>
+          <small>{{> barcode value=details.barcode}}</small>
         {{/if}}
       </div>
     </div>

--- a/server/lib/template/partials/header.handlebars
+++ b/server/lib/template/partials/header.handlebars
@@ -2,7 +2,9 @@
 <header class="row">
   {{> enterpriseDetails }}
   <div class="col-xs-5 text-right">
-    <div>{{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time></div>
-    <div>{{translate "REPORT.PRODUCED_BY"}} {{metadata.user.display_name}}</div>
+    <div>
+      {{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time>
+      {{translate "REPORT.BY"}} {{metadata.user.display_name}}
+    </div>
   </div>
 </header>


### PR DESCRIPTION
The receipt header used to have separate lines for dates and username of the printer.  This wasted paper and space.  We've now switched to printing them both on the same line.

**Before Change**
![firefox_2019-05-20_10-53-20](https://user-images.githubusercontent.com/896472/58013203-0a973e80-7aee-11e9-8ffb-5a16d3809987.png)
_Fig 1: Separate lines for user and date_

**After Change**
![firefox_2019-05-20_10-57-44](https://user-images.githubusercontent.com/896472/58013256-2bf82a80-7aee-11e9-9863-e5f343de498e.png)
_Fig 2: Single line for user and date_