### PR TITLE
fix: account reference dropdown header links

### DIFF
--- a/client/src/modules/account_reference/templates/action.cell.html
+++ b/client/src/modules/account_reference/templates/action.cell.html
@@ -6,9 +6,7 @@
   </a>
 
   <ul data-row-menu="{{row.entity.abbr}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
-    <li class="dropdown-header text-ellipsis"  style="max-width:250px;">
-      <a>{{row.entity.abbr}}</a>
-    </li>
+    <li class="dropdown-header text-ellipsis" style="max-width:250px;">{{row.entity.abbr}}</li>
 
     <li class="divider"></li>
 

--- a/client/src/modules/account_reference_type/templates/action.cell.html
+++ b/client/src/modules/account_reference_type/templates/action.cell.html
@@ -6,25 +6,23 @@
     </a>
 
     <ul data-row-menu="{{row.entity.label}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
-      <li class="dropdown-header text-ellipsis"  style="max-width:250px;">
-        <a> {{row.entity.label}} </a>
-      </li>
-    
+      <li class="dropdown-header text-ellipsis"  style="max-width:250px;">{{row.entity.label}}</li>
+
       <li class="divider"></li>
 
       <li>
         <a data-method="edit-record" ng-click="grid.appScope.edit(row.entity)" href>
           <i class="fa fa-edit"></i> <span translate>TABLE.COLUMNS.EDIT</span>
         </a>
-      </li>	
-      <li class="divider"></li>	
+      </li>
+      <li class="divider"></li>
       <li>
         <a data-method="delete-record" ng-click="grid.appScope.remove(row.entity.id)" href>
           <span class="text-danger">
             <i class="fa fa-trash"></i> <span translate>FORM.BUTTONS.DELETE</span>
           </span>
         </a>
-      </li>	
+      </li>
     </ul>
   </span>
 


### PR DESCRIPTION
Fixes the link rendering on the dropdown headers for the account references and the account reference type.  Previously, it was displayed like a link, but didn't have an action when clicked.  Now, it looks like a title, the way that bootstrap wishes.

**Demo**
![2019-05-20_09-25-20](https://user-images.githubusercontent.com/896472/58007083-660eff80-7ae1-11e9-8246-b4d035ad3e5b.gif)
_Fig 1: Showing the improvements to the dropdown header_