### PR TITLE
fix: dismiss fiscal loading indicator once loaded

### DIFF
--- a/client/src/modules/fiscal/fiscal.closingBalance.html
+++ b/client/src/modules/fiscal/fiscal.closingBalance.html
@@ -24,7 +24,6 @@
             style="height : 800px;"
             ui-grid="FiscalCBCtrl.gridOptions">
 
-            
             <bh-grid-loading-indicator
               loading-state="FiscalCBCtrl.loading"
               empty-state="FiscalCBCtrl.gridOptions.data.length === 0"

--- a/client/src/modules/fiscal/fiscal.closingBalance.js
+++ b/client/src/modules/fiscal/fiscal.closingBalance.js
@@ -161,7 +161,7 @@ function FiscalClosingBalanceController(
    * Load the balance until a given period.
    */
   function loadFinalBalance(showHiddenAccounts) {
-    vm.loading = false;
+    vm.loading = true;
     vm.hasError = false;
     Fiscal.getClosingBalance(fiscalYearId)
       .then(data => {
@@ -193,7 +193,7 @@ function FiscalClosingBalanceController(
         Notify.handleError(err);
       })
       .finally(() => {
-        vm.loading = true;
+        vm.loading = false;
       });
   }
 


### PR DESCRIPTION
The loading indicator on the fiscal year closing balances page would load indefinitely due to a swapped boolean.  The variables have been changed so that the loading indicator is reset once the grid is populated.