### PR TITLE
fix: display correct currency in account footer

### DIFF
--- a/server/controllers/finance/reports/reportAccounts/index.js
+++ b/server/controllers/finance/reports/reportAccounts/index.js
@@ -19,7 +19,6 @@ const TEMPLATE = './server/controllers/finance/reports/reportAccounts/report.han
  *  1. A header with the opening balance line.  This opening balance line is
  *  converted on the date of the `dateFrom` range.
  *  2. All general ledger transactions that
- *
  */
 function document(req, res, next) {
   let report;
@@ -91,6 +90,7 @@ function document(req, res, next) {
           warnMultipleFiscalYears : true,
         });
       }
+
       return report.render(bundle);
     })
     .then((result) => {

--- a/server/controllers/finance/reports/reportAccounts/report.handlebars
+++ b/server/controllers/finance/reports/reportAccounts/report.handlebars
@@ -119,10 +119,10 @@
             {{/if}}
           </th>
           <th class="text-right">
-            {{debcred footer.exchangedBalance footer.currency_id }}
+            {{debcred footer.exchangedBalance footer.totals.currency_id }}
           </th>
           <th class="text-right">
-            {{debcred footer.exchangedCumSum footer.currency_id }}
+            {{debcred footer.exchangedCumSum footer.totals.currency_id }}
           </th>
         </tr>
       </tfoot>


### PR DESCRIPTION
Fixes a display issue with the currency in the footer of the account statement.  Previously it rendered an unknown currency, now it renders the enterprise currency.