### PR TITLE
fix: parse <head> contents from XLS renderer

### DIFF
--- a/server/lib/renderers/xls.js
+++ b/server/lib/renderers/xls.js
@@ -16,8 +16,16 @@ exports.render = render;
 exports.extension = '.xls';
 exports.headers = headers;
 
-
 async function render(data, template, options) {
   const htmlString = juice(await html.render(data, template, options));
-  return Buffer.from(htmlString, 'utf-8');
+
+  // NOTE(@jniles)
+  // This code replaces the <head></head> contents to avoid CSS <link> errors when
+  // opening in MS Excel.
+  const start = htmlString.substring(0, htmlString.search('<head>'));
+  const end = htmlString.substring(htmlString.search('</head>') + 7);
+
+  const tmpl = `${start}${end}`;
+
+  return Buffer.from(tmpl, 'utf-8');
 }


### PR DESCRIPTION
This removes are links from the <head> so they don't give us errors when we open the report in XLS.