### PR TITLE
Update improve payroll

### DIFF
--- a/client/src/modules/payroll/rubrics/modals/rubric.modal.html
+++ b/client/src/modules/payroll/rubrics/modals/rubric.modal.html
@@ -23,7 +23,7 @@
 
     <div class="form-group" ng-class="{ 'has-error' : RubricForm.$submitted && RubricForm.label.$invalid }">
       <label class="control-label" translate>FORM.LABELS.ABBREVIATION</label>
-      <input name="abbr" ng-model="RubricModalCtrl.rubric.abbr" ng-maxlength="6" autocomplete="off" class="form-control" required>
+      <input name="abbr" ng-model="RubricModalCtrl.rubric.abbr" ng-maxlength="20" autocomplete="off" class="form-control" required>
       <div class="help-block" ng-messages="RubricForm.abbr.$error" ng-show="RubricForm.$submitted">
         <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
       </div>

--- a/server/controllers/payroll/multiplePayroll/commitment.js
+++ b/server/controllers/payroll/multiplePayroll/commitment.js
@@ -22,7 +22,8 @@ const DECIMAL_PRECISION = 2;
 
 function commitments(employees, rubrics, rubricsConfig, account, projectId, userId, exchangeRates, currencyId) {
   const accountPayroll = account[0].account_id;
-  const periodPayroll = moment(account[0].dateFrom).format('MM-YYYY');
+  const periodPayroll = moment(account[0].dateTo).format('MM-YYYY');
+  const datePeriodTo = moment(account[0].dateTo).format('YYYY-MM-DD');
   const labelPayroll = account[0].label;
   const commitmentUuid = util.uuid();
   const voucherCommitmentUuid = db.bid(commitmentUuid);
@@ -107,7 +108,7 @@ function commitments(employees, rubrics, rubricsConfig, account, projectId, user
 
   const voucherCommitment = {
     uuid : voucherCommitmentUuid,
-    date : new Date(),
+    date : datePeriodTo,
     project_id : projectId,
     currency_id : currencyId,
     user_id : userId,
@@ -142,7 +143,7 @@ function commitments(employees, rubrics, rubricsConfig, account, projectId, user
     // Social charge on remuneration
     voucherChargeRemuneration = {
       uuid : voucherChargeRemunerationUuid,
-      date : new Date(),
+      date : datePeriodTo,
       project_id : projectId,
       currency_id : currencyId,
       user_id : userId,
@@ -173,7 +174,7 @@ function commitments(employees, rubrics, rubricsConfig, account, projectId, user
   if (rubricsWithholdings.length) {
     voucherWithholding = {
       uuid : voucherWithholdingUuid,
-      date : new Date(),
+      date : datePeriodTo,
       project_id : projectId,
       currency_id : currencyId,
       user_id : userId,

--- a/server/controllers/payroll/multiplePayroll/getConfig.js
+++ b/server/controllers/payroll/multiplePayroll/getConfig.js
@@ -3,6 +3,14 @@ const db = require('../../../lib/db');
 function getConfigurationData(payrollConfigurationId, params) {
   const transaction = db.transaction();
 
+  // @lomame
+  /*
+  * Before we had to prevent the edition of all the headings which were taxes,
+  * but it can be made that there are taxes which is not calculated expressed as a percentage,
+  * to allow the edition of this kind of tax, it would be enough to exclude the only
+  * tax which is expressed as a percentage neither and which
+  * is not nor éditable reason why we had excluded the IPR
+  */
   const sql = `
     SELECT config_rubric_item.id, config_rubric_item.config_rubric_id, config_rubric_item.rubric_payroll_id, 
     payroll_configuration.label AS PayrollConfig,
@@ -10,7 +18,7 @@ function getConfigurationData(payrollConfigurationId, params) {
     FROM config_rubric_item
     JOIN rubric_payroll ON rubric_payroll.id = config_rubric_item.rubric_payroll_id
     JOIN payroll_configuration ON payroll_configuration.config_rubric_id = config_rubric_item.config_rubric_id
-    WHERE payroll_configuration.id = ? AND rubric_payroll.is_percent = 0 AND rubric_payroll.is_tax = 0
+    WHERE payroll_configuration.id = ? AND rubric_payroll.is_percent = 0 AND rubric_payroll.is_ipr = 0
     AND rubric_payroll.is_seniority_bonus = 0 AND rubric_payroll.is_family_allowances = 0
     ORDER BY rubric_payroll.label ASC;
   `;

--- a/server/controllers/payroll/multiplePayroll/index.js
+++ b/server/controllers/payroll/multiplePayroll/index.js
@@ -10,8 +10,6 @@
  * @requires db
  */
 
-const db = require('../../../lib/db');
-
 const find = require('./find');
 const getConfig = require('./getConfig');
 const manageConfig = require('./manageConfig');

--- a/server/controllers/payroll/multiplePayroll/makeCommitment.js
+++ b/server/controllers/payroll/multiplePayroll/makeCommitment.js
@@ -5,12 +5,13 @@
  *
  *
  * @requires db
- * @requires EmployeeData
+ * @requires configurationData
+ * @requires transac
+ * @requires Exchange
  */
 
 const q = require('q');
 const db = require('../../../lib/db');
-const EmployeeData = require('../employees');
 const configurationData = require('./find');
 const transac = require('./commitment');
 const Exchange = require('../../finance/exchange');

--- a/test/end-to-end/vouchers/vouchers.search.js
+++ b/test/end-to-end/vouchers/vouchers.search.js
@@ -7,8 +7,8 @@ module.exports = VoucherRegistrySearch;
 
 function VoucherRegistrySearch() {
   const gridId = 'voucher-grid';
-  const NUM_VOUCHERS = 16;
-  const NUM_USER_RECORDS = 16;
+  const NUM_VOUCHERS = 13;
+  const NUM_USER_RECORDS = 13;
   const NUM_DESCRIPTION_RECORDS = 2;
   const NUM_TRANSACTION_TYPE_RECORD = 1;
   const transactionTypes = ['Autres Depenses'];

--- a/test/end-to-end/vouchers/vouchers.search.js
+++ b/test/end-to-end/vouchers/vouchers.search.js
@@ -1,5 +1,3 @@
-const helpers = require('../shared/helpers');
-
 const GU = require('../shared/GridUtils');
 
 const SearchModal = require('../shared/search.page');

--- a/test/end-to-end/vouchers/vouchers.spec.js
+++ b/test/end-to-end/vouchers/vouchers.spec.js
@@ -6,7 +6,7 @@ const GridRow = require('../shared/GridRow');
 const components = require('../shared/components');
 
 describe('Voucher Registry', () => {
-  const NUM_VOUCHERS = 14;
+  const NUM_VOUCHERS = 16;
   const gridId = 'voucher-grid';
 
   before(() => helpers.navigate('vouchers'));

--- a/test/end-to-end/vouchers/vouchers.spec.js
+++ b/test/end-to-end/vouchers/vouchers.spec.js
@@ -6,7 +6,7 @@ const GridRow = require('../shared/GridRow');
 const components = require('../shared/components');
 
 describe('Voucher Registry', () => {
-  const NUM_VOUCHERS = 16;
+  const NUM_VOUCHERS = 17;
   const gridId = 'voucher-grid';
 
   before(() => helpers.navigate('vouchers'));

--- a/test/end-to-end/vouchers/vouchers.spec.js
+++ b/test/end-to-end/vouchers/vouchers.spec.js
@@ -6,7 +6,7 @@ const GridRow = require('../shared/GridRow');
 const components = require('../shared/components');
 
 describe('Voucher Registry', () => {
-  const NUM_VOUCHERS = 17;
+  const NUM_VOUCHERS = 14;
   const gridId = 'voucher-grid';
 
   before(() => helpers.navigate('vouchers'));


### PR DESCRIPTION
- Sanitaze code remove unused require employees
- Use the date to instead the current days for commitment of paiement in
  accounting
- Update the max length of abbreviation of rubrics
- remove unused require
- Before we had to prevent the edition of all the headings which were
  taxes, but it can be made that there are taxes which is not calculated
  expressed as a percentage, to allow the edition of this kind of tax, it
  would be enough to exclude the only tax which is expressed as a
  percentage neither and which is not nor éditable reason why we had
  excluded the IPR
- closes #3754