### PR TITLE
fix(grid): rendering bug on reversed records

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -875,6 +875,11 @@ a[disabled] {
   text-decoration : line-through;
 }
 
+.reversed {
+  text-decoration : line-through;
+  background-color: #ffb3b3 !important;
+}
+
 .dropdown-menu {
   z-index : 9999;
 }

--- a/client/src/modules/templates/row.reversed.html
+++ b/client/src/modules/templates/row.reversed.html
@@ -4,9 +4,8 @@
   ng-repeat="(colRenderIndex, col) in colContainer.renderedColumns track by col.uid"
   ui-grid-one-bind-id-grid="rowRenderIndex + '-' + col.uid + '-cell'"
   class="ui-grid-cell"
-  ng-class="{ 'ui-grid-row-header-cell': col.isRowHeader, 'strike' : row.entity.reversed }"
+  ng-class="{ 'ui-grid-row-header-cell': col.isRowHeader, 'reversed' : row.entity.reversed }"
   data-vals="{{col.isRowHeader}}"
   role="{{col.isRowHeader ? 'rowheader' : 'gridcell'}}"
-  ng-style="row.entity.reversed ? { 'background-color' : '#ffb3b3' } : { 'background-color' : 'none' }"
   ui-grid-cell>
 </div>


### PR DESCRIPTION
Fixes the rendering bug on reversed records that caused the red highlight to hang around on non-reversed records due to template caching.  The solution also removes an `ngStyle` tag.

Closes #3816.

