### PR TITLE
refactor(Make Exchange Rates human readable)

### DIFF
--- a/client/src/modules/exchange/exchange.modal.html
+++ b/client/src/modules/exchange/exchange.modal.html
@@ -53,7 +53,8 @@
         </div>
         <div class="col-xs-10">
           <div class="input-group">
-            <input class="form-control" type="number" name="rate" ng-model="ModalCtrl.rate.rate" required>
+            <!-- Improve me Prevent exchange rate equal 0 -->
+            <input class="form-control" min="0.000000000001" type="number" name="rate" ng-model="ModalCtrl.rate.rate" required>
             <span class="input-group-addon">{{ ModalCtrl.symbol(ModalCtrl.rate.currency.id) }}</span>
           </div>
         </div>

--- a/client/src/modules/templates/bhExchange.tmpl.html
+++ b/client/src/modules/templates/bhExchange.tmpl.html
@@ -31,7 +31,13 @@
 
     <ul class="list-unstyled">
       <li data-exchange-rate-element ng-repeat="rate in $ctrl.rates | orderBy:'-date'">
-        <i class="fa fa-clock-o"></i> <b>{{ rate.rate }} {{ $ctrl.formatCurrency(rate.currency_id) }} </b>
+        <i class="fa fa-clock-o"></i>
+          <span ng-if="rate.rate < 0.1">
+            <b> <em> (1 / {{(1 / rate.rate) | number:0 }}) </em> {{ $ctrl.formatCurrency(rate.currency_id) }} </b>
+          </span>
+          <span ng-if="rate.rate >= 0.1">
+            <b>{{ rate.rate}} {{ $ctrl.formatCurrency(rate.currency_id) }} </b>
+          </span>
         <span translate>EXCHANGE.RATE_SET</span> <span am-time-ago="rate.date"></span>.
         <br />
         <span class="icon-spacer text-muted"><i>{{rate.date | date : 'medium'}}</i></span>


### PR DESCRIPTION
- Addition of the minimum value of the exchange rate to prevent the
  exchange rate equal to zero
- Show exchange rates less than 0.1 as a fraction for example 1/1630
  instead of 0.0006134

closes #3838