### PR TITLE
fix(cash): prevent multiple barcode read()s

### DIFF
--- a/client/src/modules/cash/cash-form.service.js
+++ b/client/src/modules/cash/cash-form.service.js
@@ -207,8 +207,7 @@ function CashFormService(AppCache, Session, Patients, Exchange) {
 
     // bind the enterprise currency value
     this.totals.enterpriseCurrencyTotal = total;
-    this.totals.currentExchangeRate =
-      Exchange.getExchangeRate(this.details.currency_id, this.details.date);
+    this.totals.currentExchangeRate = Exchange.getExchangeRate(this.details.currency_id, this.details.date);
     this.totals.foreignCurrencyTotal = total * this.totals.currentExchangeRate;
   };
 

--- a/client/src/modules/patients/patients.service.js
+++ b/client/src/modules/patients/patients.service.js
@@ -2,9 +2,8 @@ angular.module('bhima.services')
   .service('PatientService', PatientService);
 
 PatientService.$inject = [
-  'SessionService', '$uibModal', 'DocumentService', 'VisitService',
-  'FilterService', 'appcache', 'PeriodService', 'PrototypeApiService',
-  '$httpParamSerializer', 'LanguageService', 'bhConstants',
+  'SessionService', '$uibModal', 'DocumentService', 'VisitService', 'FilterService', 'appcache', 'PeriodService',
+  'PrototypeApiService', '$httpParamSerializer', 'LanguageService', 'bhConstants', 'HttpCacheService',
 ];
 
 /**
@@ -24,7 +23,7 @@ PatientService.$inject = [
  */
 function PatientService(
   Session, $uibModal, Documents, Visits, Filters, AppCache, Periods, Api,
-  $httpParamSerializer, Languages, bhConstants
+  $httpParamSerializer, Languages, bhConstants, HttpCache
 ) {
   const baseUrl = '/patients/';
   const service = new Api(baseUrl);
@@ -81,6 +80,14 @@ function PatientService(
       .then(service.util.unwrapHttpResponse);
   }
 
+  const callback = (uuid, options) => {
+    const path = `/patients/${uuid}/finance/balance`;
+    return service.$http.get(path, options)
+      .then(service.util.unwrapHttpResponse);
+  };
+
+  const balanceCache = HttpCache(callback);
+
   /**
    * @method balance
    *
@@ -89,10 +96,8 @@ function PatientService(
    *
    * @param {String} uuid The patient's UUID
    */
-  function balance(uuid) {
-    const path = `/patients/${uuid}/finance/balance`;
-    return service.$http.get(path)
-      .then(service.util.unwrapHttpResponse);
+  function balance(uuid, options, cacheBust = false) {
+    return balanceCache(uuid, options, cacheBust);
   }
 
   /**


### PR DESCRIPTION
Prevents multiple HTTP requests from being sent after each barcode
scan to read in invoices.  Should increase server performance.

Steps to reproduce:
 1. Launch the server
 2. Find a (valid) invoice barcode to scan.  
 3. Go the the cash module (`/cash`).
 4. Find the invoice via the "scan from barcode" dropdown option.
 5. Observe that only two HTTP requests are sent to the server instead of multiple.

Closes #3839.