### PR TITLE
fix(accounts): order transactions chronologically

### DIFF
--- a/server/controllers/finance/accounts/transactions.js
+++ b/server/controllers/finance/accounts/transactions.js
@@ -72,7 +72,7 @@ function getGeneralLedgerSQL(options) {
   `;
 
   filters.setGroup('GROUP BY record_uuid');
-  filters.setOrder('ORDER BY created_at ASC, trans_date ASC');
+  filters.setOrder('ORDER BY trans_date ASC, created_at ASC');
 
   const query = filters.applyQuery(sql);
   const parameters = [...subquery.parameters, ...filters.parameters()];


### PR DESCRIPTION
Orders first by the transaction date, then by the creation date.

Closes #3868.

Proof:
![FixedAccountOrdering](https://user-images.githubusercontent.com/896472/63943010-babe0100-ca66-11e9-8a1f-3cdb971bdfc2.PNG)
