### PR TITLE
fix(cashflow): use Pivot() for byService results

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -27,7 +27,8 @@
     "CASH_EXPENSE": "Expenses",
     "CASHFLOW_BY_SERVICE": {
       "TITLE": "Cash flow By Service",
-      "DESCRIPTION": "This report shows the changes in the accounts and revenues of the balance sheet on cash by Services"
+      "DESCRIPTION": "This report shows the changes in the accounts and revenues of the balance sheet on cash by Services",
+      "GAIN_OR_LOSS_ON_EXCHANGE" : "Gain or Loss on Exchange"
     },
     "CASHFLOW": {
       "TITLE": "Cash Flow Physical Report",
@@ -83,7 +84,7 @@
       "SHOW_UNVERIFIED_TRANSACTIONS": "Include Unverified Transactions",
       "SHOW_UNVERIFIED_TRANSACTIONS_HELP": "Enable to include records from the Journal which have not been audited by the accountant as well as records from the General Ledger the accountant has verified.  This view must be treated as a projection until the accountant has approved the Journal transactions and moved them to the General Ledger."
     },
-    
+
     "DEBTOR_SUMMARY" : {
       "TITLE": "Debtors summary report",
       "DESCRIPTION": "This report details the amount to paid in every inventory group for an invoice during a period, for a specific debor group"

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -27,7 +27,8 @@
     "CASH_EXPENSE" : "Dépenses",
     "CASHFLOW_BY_SERVICE": {
       "TITLE" : "Journal de Ventilation",
-      "DESCRIPTION" : "Ce rapport affiche les variations des comptes et des revenus du bilan sur la trésorerie."
+      "DESCRIPTION" : "Ce rapport affiche les variations des comptes et des revenus du bilan sur la trésorerie.",
+      "GAIN_OR_LOSS_ON_EXCHANGE" : "Gain ou Perte sur Échange"
     },
     "CASHFLOW" : {
       "TITLE" : "Rapports de flux de trésorerie physique",

--- a/server/controllers/finance/reports/cashflow/index.js
+++ b/server/controllers/finance/reports/cashflow/index.js
@@ -68,7 +68,7 @@ async function reportByService(req, res, next) {
   const whereQuery = `
     WHERE cash.is_caution = 0 AND cash.reversed = 0
       AND DATE(cash.date) >= DATE(?) AND DATE(cash.date) <= DATE(?)
-      AND cash.cashbox_id =  ?
+      AND cash.cashbox_id = ? AND cash.currency_id = ?
   `;
 
   const pivotQuery = `
@@ -98,7 +98,7 @@ async function reportByService(req, res, next) {
      * | NULL    |  35000.0000 |         9500.0000 |     5000.0000 |      20000.0000 | 69500.0000 |
      * +--------------+-------------+-------------------+---------------+-----------------+-------+
      */
-    const [rows] = await db.exec(pivotQuery, [dateFrom, dateTo, cashbox.id]);
+    const [rows] = await db.exec(pivotQuery, [dateFrom, dateTo, cashbox.id, cashbox.currency_id]);
     const totals = rows.pop();
     delete totals.uuid;
 

--- a/server/controllers/finance/reports/cashflow/index.js
+++ b/server/controllers/finance/reports/cashflow/index.js
@@ -102,6 +102,15 @@ async function reportByService(req, res, next) {
     const totals = rows.pop();
     delete totals.uuid;
 
+    // early exit if no information got returned from our query
+    if (!rows || !rows.length) {
+      const rendered = await serviceReport.render({
+        cashbox, dateTo, dateFrom,
+      });
+      res.set(rendered.headers).send(rendered.report);
+      return;
+    }
+
     // we need to supplement the pivot table with the following information -
     // patient's name, the patient's identifier
     const cashUuids = rows.map(row => row.uuid);

--- a/server/controllers/finance/reports/cashflow/index.js
+++ b/server/controllers/finance/reports/cashflow/index.js
@@ -33,7 +33,7 @@ exports.reporting = reporting;
  * @todo - factor in cash reversals.
  * @todo - factor in posting journal balances
  */
-function reportByService(req, res, next) {
+async function reportByService(req, res, next) {
   const dateFrom = new Date(req.query.dateFrom);
   const dateTo = new Date(req.query.dateTo);
   const cashboxAccountId = req.query.cashboxId;
@@ -58,143 +58,91 @@ function reportByService(req, res, next) {
     return;
   }
 
-  const data = {};
-  data.dateFrom = dateFrom;
-  data.dateTo = dateTo;
-
-  let emptyCashValues = false;
-
-  // get the cash flow data
-  const cashflowByServiceSql = `
-    SELECT uuid, reference, date, cashAmount, invoiceAmount, currency_id, service_id,
-      display_name, name, (@cumsum := cashAmount + @cumsum) AS cumsum
-    FROM (
-      SELECT BUID(cash.uuid) AS uuid,
-        dm.text AS reference, cash.date, cash.amount AS cashAmount,
-        SUM(invoice.cost) AS invoiceAmount, cash.currency_id,
-        service.id AS service_id, patient.display_name, service.name
-      FROM cash JOIN cash_item ON cash.uuid = cash_item.cash_uuid
-        JOIN invoice ON cash_item.invoice_uuid = invoice.uuid
-        JOIN project ON cash.project_id = project.id
-        JOIN patient ON patient.debtor_uuid = cash.debtor_uuid
-        JOIN service ON invoice.service_id = service.id
-        JOIN document_map dm ON dm.uuid = cash.uuid
-      WHERE cash.is_caution = 0 AND cash.reversed = 0
-        AND DATE(cash.date) >= DATE(?) AND DATE(cash.date) <= DATE(?)
-        AND cash.cashbox_id =  ?
-      GROUP BY cash.uuid
-      ORDER BY cash.date, cash.reference
-    )c, (SELECT @cumsum := 0)z
-    ORDER BY date, reference;
-  `;
-
-  // get all service names in alphabetical order
-  const serviceSql = `
-    SELECT DISTINCT service.name FROM service WHERE service.id IN (?) ORDER BY name;
-  `;
-
-  // get the totals of the captured records
-  const serviceAggregationSql = `
-    SELECT service.name, SUM(cash.amount) AS totalCashIncome, SUM(invoice.cost) AS totalAcruelIncome
-    FROM cash JOIN cash_item ON cash.uuid = cash_item.cash_uuid
+  const tableQuery = `
+    cash JOIN cash_item ON cash.uuid = cash_item.cash_uuid
       JOIN invoice ON cash_item.invoice_uuid = invoice.uuid
-      JOIN service ON invoice.service_id = service.id
+      JOIN service ON service.id = invoice.service_id
+  `;
+
+  const whereQuery = `
     WHERE cash.is_caution = 0 AND cash.reversed = 0
       AND DATE(cash.date) >= DATE(?) AND DATE(cash.date) <= DATE(?)
-      AND cash.cashbox_id = ?
-    GROUP BY service.name
-    ORDER BY service.name;
+      AND cash.cashbox_id =  ?
+  `;
+
+  const pivotQuery = `
+    CALL Pivot('${tableQuery}', 'cash.uuid', 'service.name', 'cash_item.amount', "${whereQuery}", '');
   `;
 
   const cashboxDetailsSql = `
-    SELECT cb.id, cb.label FROM cash_box cb JOIN cash_box_account_currency cba
+    SELECT cb.id, cb.label, cba.currency_id FROM cash_box cb JOIN cash_box_account_currency cba
       ON cb.id = cba.cash_box_id
     WHERE cba.id = ?;
   `;
 
-  // pick up the cashbox's details
-  db.one(cashboxDetailsSql, cashboxAccountId)
-    .then(cashbox => {
-      data.cashbox = cashbox;
-      return db.exec(cashflowByServiceSql, [dateFrom, dateTo, cashbox.id]);
-    })
-    .then((rows) => {
-      data.rows = rows;
+  try {
 
-      // return an empty array if no rows
-      if (!rows.length) {
-        emptyCashValues = true;
-        return [];
-      }
+    // pick up the cashbox's details
+    const cashbox = await db.one(cashboxDetailsSql, cashboxAccountId);
 
-      // get a list of unique service ids
-      const serviceIds = rows
-        .map(row => row.service_id)
-        .filter((id, index, array) => array.indexOf(id) === index);
+    /*
+     * This query returns a table like:
+     * +--------------+-------------+-------------------+---------------+-----------------+-------+
+     * | uuid    | Dentisterie | Pavillion Medical | Poly-Clinique | Salle D'Urgence | Total      |
+     * +--------------+-------------+-------------------+---------------+-----------------+-------+
+     * | binary  |  35000.0000 |            0.0000 |        0.0000 |          0.0000 | 35000.0000 |
+     * | binary  |      0.0000 |         9500.0000 |        0.0000 |          0.0000 |  9500.0000 |
+     * | binary  |      0.0000 |            0.0000 |        0.0000 |      20000.0000 | 20000.0000 |
+     * | binary  |      0.0000 |            0.0000 |     5000.0000 |          0.0000 |  5000.0000 |
+     * | NULL    |  35000.0000 |         9500.0000 |     5000.0000 |      20000.0000 | 69500.0000 |
+     * +--------------+-------------+-------------------+---------------+-----------------+-------+
+     */
+    const [rows] = await db.exec(pivotQuery, [dateFrom, dateTo, cashbox.id]);
+    const totals = rows.pop();
+    delete totals.uuid;
 
-      // execute the service SQL
-      return db.exec(serviceSql, [serviceIds]);
-    })
-    .then((services) => {
-      // if nothing matches the selection criteria, continue with nothing
-      if (emptyCashValues) {
-        return [];
-      }
+    // we need to supplement the pivot table with the following information -
+    // patient's name, the patient's identifier
+    const cashUuids = rows.map(row => row.uuid);
+    const payments = await db.exec(`
+      SELECT c.uuid, dm.text as reference, em.text as patientReference, d.text as patientName
+      FROM cash c JOIN  document_map dm ON c.uuid = dm.uuid
+        JOIN entity_map em ON c.debtor_uuid = em.uuid
+        JOIN debtor d ON c.debtor_uuid = d.uuid
+      WHERE c.uuid IN (?);
+    `, [cashUuids]);
 
-      const { rows } = data;
-      delete data.rows;
+    // map of uuid -> payment record
+    const dictionary = _.groupBy(payments, 'uuid');
 
-      // Infer currencyId from first row.  Note that currencies are separated by
-      // accounts - therefore, we will always have a uniform currency_id throughout
-      // the record set.
-      data.currencyId = rows[0].currency_id;
+    // loop through all records, merging in relevant information
+    let cumsum = 0;
 
-      // map services to their service names
-      data.services = services.map(service => service.name);
+    const services = Object.keys(totals || {});
 
-      const xAxis = data.services.length;
+    const matrix = rows.map(row => {
+      // grab the payment from the eictionary
+      const [payment] = dictionary[row.uuid];
 
-      // fill the matrix with nulls except the correct columns
-      const matrix = rows.map((row) => {
-        // fill line with each service + two lines for cash payment identifier and patient name
-        const line = _.fill(Array(xAxis + 3), null);
+      // calculate the cumulative sum
+      cumsum += row.Total;
 
-        // each line has the cash payment reference and then the patient name
-        line[0] = row.reference;
-        line[1] = row.display_name;
+      // grab matrix values
+      const values = services.map(key => row[key]);
+      const patient = `${payment.patientReference} - ${payment.patientName}`;
+      return [payment.reference, patient, ...values, cumsum];
+    });
 
-        // get the index of the service name and fill in the correct cell in the matrix
-        const idx = data.services.indexOf(row.name) + 2;
-        line[idx] = row.cashAmount;
+    Object.assign(totals, { cumsum });
 
-        // get the far right row as the total
-        line[xAxis + 2] = row.cumsum;
-        return line;
-      });
+    const rendered = await serviceReport.render({
+      matrix, totals, cashbox, dateTo, dateFrom, services,
+    });
 
-      // bind to the view
-      data.matrix = matrix;
-
-      // query the aggregates
-      return db.exec(serviceAggregationSql, [dateFrom, dateTo, data.cashbox.id]);
-    })
-    .then((aggregates) => {
-      data.aggregates = aggregates;
-
-      // the total of everything is just the last running balance amount
-      if (data.matrix) {
-        const lastRow = data.matrix[data.matrix.length - 1];
-        const lastRowTotalIdx = lastRow.length - 1;
-        aggregates.push({ totalCashIncome : lastRow[lastRowTotalIdx] });
-      }
-
-      return serviceReport.render(data);
-    })
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next)
-    .done();
+    res.set(rendered.headers).send(rendered.report);
+  } catch (e) {
+    next(e);
+  }
 }
 
 /**
@@ -272,10 +220,10 @@ function report(req, res, next) {
           source.transaction_text, source.account_label, ${periodString},
           source.transaction_type, source.transaction_type_id, source.account_id
         FROM (
-          SELECT 
+          SELECT
           a.number AS account_number, a.label AS account_label,
           SUM(gl.debit_equiv - gl.credit_equiv) AS balance,
-          gl.transaction_type_id, tt.type AS transaction_type, tt.text AS transaction_text, 
+          gl.transaction_type_id, tt.type AS transaction_type, tt.text AS transaction_text,
           gl.account_id, gl.period_id
           FROM general_ledger AS gl
           JOIN account AS a ON a.id = gl.account_id
@@ -295,7 +243,7 @@ function report(req, res, next) {
                 AND DATE(i.date) >= DATE(?) AND DATE(i.date) <= DATE(?)
               ) AS rev
             )
-          ) GROUP BY gl.transaction_type_id, gl.account_id, gl.period_id  
+          ) GROUP BY gl.transaction_type_id, gl.account_id, gl.period_id
         ) AS source
         GROUP BY transaction_type_id, account_id;
       `;
@@ -455,63 +403,62 @@ function totalPeriods(data, incomeTotal, expenseTotal, transferTotal) {
 }
 
 async function reporting(options, session) {
-  try {
-    const dateFrom = new Date(options.dateFrom);
-    const dateTo = new Date(options.dateTo);
-    const data = {};
+  const dateFrom = new Date(options.dateFrom);
+  const dateTo = new Date(options.dateTo);
+  const data = {};
 
-    // convert cashboxesIds parameters in array format ['', '', ...]
-    // this parameter can be sent as a string or an array we force the conversion into an array
-    const cashboxesIds = _.values(options.cashboxesIds);
+  // convert cashboxesIds parameters in array format ['', '', ...]
+  // this parameter can be sent as a string or an array we force the conversion into an array
+  const cashboxesIds = _.values(options.cashboxesIds);
 
-    _.extend(options, { orientation : 'landscape' });
+  _.extend(options, { orientation : 'landscape' });
 
-    // catch missing required parameters
-    if (!dateFrom || !dateTo || !cashboxesIds.length) {
-      throw new BadRequest(
-        'ERRORS.BAD_REQUEST',
-        'There are some missing information among dateFrom, dateTo or cashboxesId'
-      );
-    }
+  // catch missing required parameters
+  if (!dateFrom || !dateTo || !cashboxesIds.length) {
+    throw new BadRequest(
+      'ERRORS.BAD_REQUEST',
+      'There are some missing information among dateFrom, dateTo or cashboxesId'
+    );
+  }
 
-    const serviceReport = new ReportManager(TEMPLATE, session, options);
+  const serviceReport = new ReportManager(TEMPLATE, session, options);
 
-    data.dateFrom = dateFrom;
-    data.dateTo = dateTo;
+  data.dateFrom = dateFrom;
+  data.dateTo = dateTo;
 
-    data.cashboxes = await getCashboxesDetails(cashboxesIds);
-    data.cashAccountIds = data.cashboxes.map(cashbox => cashbox.account_id);
+  data.cashboxes = await getCashboxesDetails(cashboxesIds);
+  data.cashAccountIds = data.cashboxes.map(cashbox => cashbox.account_id);
 
-    data.cashLabels = _.chain(data.cashboxes)
-      .map(cashbox => `${cashbox.label}`).uniq().join(' | ')
-      .value();
+  data.cashLabels = _.chain(data.cashboxes)
+    .map(cashbox => `${cashbox.label}`).uniq().join(' | ')
+    .value();
 
-    data.cashLabelSymbol = _.chain(data.cashboxes)
-      .map(cashbox => cashbox.symbol).uniq().join(' + ');
+  data.cashLabelSymbol = _.chain(data.cashboxes)
+    .map(cashbox => cashbox.symbol).uniq().join(' + ');
 
-    data.cashLabelDetails = data.cashboxes.map(cashbox => `${cashbox.account_number} - ${cashbox.account_label}`);
+  data.cashLabelDetails = data.cashboxes.map(cashbox => `${cashbox.account_number} - ${cashbox.account_label}`);
 
-    // build periods columns from calculated period
-    const periods = await Fiscal.getPeriodsFromDateRange(data.dateFrom, data.dateTo);
-    data.periodDates = periods.map(p => p.start_date);
-    data.periods = periods.map(p => p.id);
-    data.colspan = data.periods.length + 1;
-    // build periods string for query
-    const periodParams = [];
-    const periodString = data.periods.length ? data.periods.map(periodId => {
-      periodParams.push(periodId, periodId);
-      return `SUM(IF(source.period_id = ?, source.balance, 0)) AS "?"`;
-    }).join(',') : '"NO_PERIOD" AS period';
+  // build periods columns from calculated period
+  const periods = await Fiscal.getPeriodsFromDateRange(data.dateFrom, data.dateTo);
+  data.periodDates = periods.map(p => p.start_date);
+  data.periods = periods.map(p => p.id);
+  data.colspan = data.periods.length + 1;
+  // build periods string for query
+  const periodParams = [];
+  const periodString = data.periods.length ? data.periods.map(periodId => {
+    periodParams.push(periodId, periodId);
+    return `SUM(IF(source.period_id = ?, source.balance, 0)) AS "?"`;
+  }).join(',') : '"NO_PERIOD" AS period';
 
-    const query = `
+  const query = `
         SELECT
           source.transaction_text, source.account_label, ${periodString},
           source.transaction_type, source.transaction_type_id, source.account_id
         FROM (
-          SELECT 
+          SELECT
           a.number AS account_number, a.label AS account_label,
           SUM(gl.debit_equiv - gl.credit_equiv) AS balance,
-          gl.transaction_type_id, tt.type AS transaction_type, tt.text AS transaction_text, 
+          gl.transaction_type_id, tt.type AS transaction_type, tt.text AS transaction_text,
           gl.account_id, gl.period_id
           FROM general_ledger AS gl
           JOIN account AS a ON a.id = gl.account_id
@@ -531,61 +478,58 @@ async function reporting(options, session) {
                 AND DATE(i.date) >= DATE(?) AND DATE(i.date) <= DATE(?)
               ) AS rev
             )
-          ) GROUP BY gl.transaction_type_id, gl.account_id, gl.period_id  
+          ) GROUP BY gl.transaction_type_id, gl.account_id, gl.period_id
         ) AS source
         GROUP BY transaction_type_id, account_id;
       `;
 
-    const params = [...periodParams,
-      [data.cashAccountIds],
-      data.dateFrom,
-      data.dateTo,
-      data.dateFrom,
-      data.dateTo,
-      data.dateFrom,
-      data.dateTo,
-      data.dateFrom,
-      data.dateTo];
-    const rows = await db.exec(query, params);
+  const params = [...periodParams,
+    [data.cashAccountIds],
+    data.dateFrom,
+    data.dateTo,
+    data.dateFrom,
+    data.dateTo,
+    data.dateFrom,
+    data.dateTo,
+    data.dateFrom,
+    data.dateTo];
+  const rows = await db.exec(query, params);
 
-    // split incomes from expenses
-    const incomes = _.chain(rows).filter({ transaction_type : 'income' }).groupBy('transaction_text').value();
-    const expenses = _.chain(rows).filter({ transaction_type : 'expense' }).groupBy('transaction_text').value();
-    const others = _.chain(rows).filter({ transaction_type : 'other' }).groupBy('transaction_text').value();
+  // split incomes from expenses
+  const incomes = _.chain(rows).filter({ transaction_type : 'income' }).groupBy('transaction_text').value();
+  const expenses = _.chain(rows).filter({ transaction_type : 'expense' }).groupBy('transaction_text').value();
+  const others = _.chain(rows).filter({ transaction_type : 'other' }).groupBy('transaction_text').value();
 
-    const incomeTextKeys = _.keys(incomes);
-    const expenseTextKeys = _.keys(expenses);
-    const otherTextKeys = _.keys(others);
+  const incomeTextKeys = _.keys(incomes);
+  const expenseTextKeys = _.keys(expenses);
+  const otherTextKeys = _.keys(others);
 
-    const incomeTotalByTextKeys = aggregateTotalByTextKeys(data, incomes);
-    const expenseTotalByTextKeys = aggregateTotalByTextKeys(data, expenses);
-    const otherTotalByTextKeys = aggregateTotalByTextKeys(data, others);
+  const incomeTotalByTextKeys = aggregateTotalByTextKeys(data, incomes);
+  const expenseTotalByTextKeys = aggregateTotalByTextKeys(data, expenses);
+  const otherTotalByTextKeys = aggregateTotalByTextKeys(data, others);
 
-    const incomeTotal = aggregateTotal(data, incomeTotalByTextKeys);
-    const expenseTotal = aggregateTotal(data, expenseTotalByTextKeys);
-    const otherTotal = aggregateTotal(data, otherTotalByTextKeys);
-    const totalPeriodColumn = totalPeriods(data, incomeTotal, expenseTotal, otherTotal);
+  const incomeTotal = aggregateTotal(data, incomeTotalByTextKeys);
+  const expenseTotal = aggregateTotal(data, expenseTotalByTextKeys);
+  const otherTotal = aggregateTotal(data, otherTotalByTextKeys);
+  const totalPeriodColumn = totalPeriods(data, incomeTotal, expenseTotal, otherTotal);
 
-    _.extend(data, {
-      incomes,
-      expenses,
-      others,
-      incomeTextKeys,
-      expenseTextKeys,
-      incomeTotalByTextKeys,
-      expenseTotalByTextKeys,
-      otherTotalByTextKeys,
-      incomeTotal,
-      expenseTotal,
-      otherTextKeys,
-      otherTotal,
-      totalPeriodColumn,
-    });
+  _.extend(data, {
+    incomes,
+    expenses,
+    others,
+    incomeTextKeys,
+    expenseTextKeys,
+    incomeTotalByTextKeys,
+    expenseTotalByTextKeys,
+    otherTotalByTextKeys,
+    incomeTotal,
+    expenseTotal,
+    otherTextKeys,
+    otherTotal,
+    totalPeriodColumn,
+  });
 
-    return serviceReport.render(data);
-  } catch (error) {
-    throw error;
-  }
+  return serviceReport.render(data);
 }
 
 /**

--- a/server/controllers/finance/reports/cashflow/reportByService.handlebars
+++ b/server/controllers/finance/reports/cashflow/reportByService.handlebars
@@ -29,14 +29,14 @@
           <tbody>
             {{#each matrix as | row |}}
               <tr>
-                {{#each row as |value |}}
+                {{#each row as |value|}}
                   {{! this is the balance calculation }}
                   {{#if @last}}
-                    <th class="text-right">{{currency value ../../currencyId}}</th>
+                    <th class="text-right">{{currency value ../../cashbox.currency_id}}</th>
 
                   {{! this is the rest of the matrix }}
                   {{else}}
-                    <td {{#unless @first}}class="text-right"{{/unless}}>
+                    <td {{#gt @index 2}}class="text-right"{{/gt}}>
                       {{#if @first}}
                         {{value}}
                       {{else}}
@@ -45,7 +45,7 @@
                         {{/equal}}
                         {{#gt @index 2}}
                           {{#if value}}
-                            {{currency value ../../currencyId}}
+                            {{currency value ../../cashbox.currency_id}}
                           {{/if}}
                         {{/gt}}
                       {{/if}}
@@ -61,8 +61,8 @@
           <tfoot>
             <tr class="text-capitalize text-center" style="background-color: #ddd;">
               <th colspan="2">{{translate "TABLE.COLUMNS.TOTAL" }}</th>
-              {{#each aggregates as | aggregate |}}
-                <th class="text-right">{{currency aggregate.totalCashIncome ../currencyId}}</th>
+              {{#each totals as |value| }}
+                <th class="text-right">{{currency value ../cashbox.currency_id}}</th>
               {{/each}}
             </tr>
           </tfoot>

--- a/server/controllers/finance/reports/cashflow/reportByService.handlebars
+++ b/server/controllers/finance/reports/cashflow/reportByService.handlebars
@@ -56,6 +56,14 @@
             {{else}}
               {{> emptyTable columns=3}}
             {{/each}}
+
+            {{! adds in a single line for gain/loss on exchange during the period if it exists }}
+            {{#if gainOrLossOnExchange}}
+              <tr class="text-capitalize text-center">
+                <th colspan="3">{{translate "REPORT.CASHFLOW_BY_SERVICE.GAIN_OR_LOSS_ON_EXCHANGE"}}</th>
+                <th class="text-right" colspan={{services.length}}>{{currency gainOrLossOnExchange cashbox.currency_id}}</th>
+              </tr>
+            {{/if}}
           </tbody>
 
           <tfoot>

--- a/server/models/procedures/analysis.sql
+++ b/server/models/procedures/analysis.sql
@@ -6,12 +6,12 @@ DELIMITER $$
 DROP PROCEDURE IF EXISTS Pivot$$
 
 CREATE PROCEDURE Pivot(
-  IN tbl_name VARCHAR(99),    -- table name (or db.tbl)
-  IN base_cols VARCHAR(99),   -- column(s) on the left, separated by commas
-  IN pivot_col VARCHAR(64),   -- name of column to put across the top
-  IN tally_col VARCHAR(64),   -- name of column to SUM up
-  IN where_clause VARCHAR(99),  -- empty string or "WHERE ..."
-  IN order_by VARCHAR(99) -- empty string or "ORDER BY ..."; usually the base_cols
+  IN tbl_name TEXT,    -- table name (or db.tbl)
+  IN base_cols TEXT,   -- column(s) on the left, separated by commas
+  IN pivot_col TEXT,   -- name of column to put across the top
+  IN tally_col TEXT,   -- name of column to SUM up
+  IN where_clause TEXT,  -- empty string or "WHERE ..."
+  IN order_by TEXT -- empty string or "ORDER BY ..."; usually the base_cols
 )
 DETERMINISTIC
 SQL SECURITY INVOKER
@@ -26,7 +26,7 @@ BEGIN
   SET @cc1 = "CONCAT('SUM(IF(&p = ', &v, ', &t, 0)) AS ', &v)" COLLATE utf8mb4_unicode_ci;
 
   SET @cc2 = REPLACE(@cc1, '&p' , pivot_col) COLLATE utf8mb4_unicode_ci;
-  
+
   SET @cc3 = REPLACE(@cc2, '&t', tally_col) COLLATE utf8mb4_unicode_ci;
   -- select @cc2, @cc3;
   SET @qval = CONCAT("'\"', val, '\"'") COLLATE utf8mb4_unicode_ci;
@@ -39,7 +39,7 @@ BEGIN
       'SELECT GROUP_CONCAT(', @cc4, ' SEPARATOR ",\n") INTO @sums',
       ' FROM ( ', @subq, ' ) AS top') COLLATE utf8mb4_unicode_ci;
 
-  SELECT @stmt;
+  -- SELECT @stmt;
   PREPARE _sql FROM @stmt;
   EXECUTE _sql;           -- Intermediate step: build SQL for columns
   DEALLOCATE PREPARE _sql;
@@ -56,7 +56,7 @@ BEGIN
       '\n', order_by
     ) COLLATE utf8mb4_unicode_ci;
 
-  SELECT @stmt2;          -- The statement that generates the result
+  -- SELECT @stmt2;          -- The statement that generates the result
   PREPARE _sql FROM @stmt2;
   EXECUTE _sql;           -- The resulting pivot table ouput
   DEALLOCATE PREPARE _sql;

--- a/server/models/procedures/analysis.sql
+++ b/server/models/procedures/analysis.sql
@@ -16,6 +16,13 @@ CREATE PROCEDURE Pivot(
 DETERMINISTIC
 SQL SECURITY INVOKER
 BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+      GET DIAGNOSTICS CONDITION 1 @sqlstate = RETURNED_SQLSTATE,
+        @errno = MYSQL_ERRNO, @text = MESSAGE_TEXT;
+      SET @full_error = CONCAT("ERROR ", @errno, " (", @sqlstate, "): ", @text);
+      SELECT @full_error;
+    END;
 
   -- Find the distinct values
   -- Build the SUM()s


### PR DESCRIPTION
Rewrites the cashflow by service report to use `Pivot()` instead of
manually executing queries.  The change fixes a bug where the columns
didn't sum to the cumsum.  There are two drawbacks with this method:
 1. The cumulative summation is done in JS.  Unfortunately, the Pivot()
 function doesn't support this, although we may be able to add it in the
 future.
 2. The results are not ordered.  Ideally they should be ordered by
 date.

Fixes #3837.