### PR TITLE
chore(payroll): rm unnecessary db.transaction()

### DIFF
--- a/server/controllers/payroll/multiplePayroll/find.js
+++ b/server/controllers/payroll/multiplePayroll/find.js
@@ -27,32 +27,32 @@ function find(options) {
 
   const sql = `
     SELECT payroll.employee_uuid, payroll.reference, payroll.code, payroll.date_embauche, payroll.nb_enfant,
-    payroll.individual_salary, payroll.account_id, payroll.creditor_uuid, payroll.display_name, payroll.sex,
-    payroll.uuid, payroll.payroll_configuration_id, payroll.currency_id, payroll.paiement_date, payroll.base_taxable, 
-    payroll.basic_salary, payroll.gross_salary, payroll.grade_salary, payroll.text, payroll.net_salary, 
-    payroll.working_day, payroll.total_day, payroll.daily_salary, payroll.amount_paid,
-    payroll.status_id, payroll.status, (payroll.net_salary - payroll.amount_paid) AS balance
+      payroll.individual_salary, payroll.account_id, payroll.creditor_uuid, payroll.display_name, payroll.sex,
+      payroll.uuid, payroll.payroll_configuration_id, payroll.currency_id, payroll.paiement_date, payroll.base_taxable,
+      payroll.basic_salary, payroll.gross_salary, payroll.grade_salary, payroll.text, payroll.net_salary,
+      payroll.working_day, payroll.total_day, payroll.daily_salary, payroll.amount_paid,
+      payroll.status_id, payroll.status, (payroll.net_salary - payroll.amount_paid) AS balance
     FROM(
       SELECT BUID(employee.uuid) AS employee_uuid, employee.reference, employee.code, employee.date_embauche,
         employee.nb_enfant,employee.individual_salary, creditor_group.account_id,
         BUID(employee.creditor_uuid) AS creditor_uuid,
-        UPPER(patient.display_name) AS display_name, patient.sex, BUID(paiement.uuid) AS uuid, 
-        paiement.payroll_configuration_id,  paiement.currency_id, paiement.paiement_date, paiement.base_taxable, 
-        paiement.basic_salary, paiement.gross_salary, grade.basic_salary AS grade_salary, grade.text, 
-        paiement.net_salary, paiement.working_day, paiement.total_day, paiement.daily_salary, paiement.amount_paid, 
+        UPPER(patient.display_name) AS display_name, patient.sex, BUID(paiement.uuid) AS uuid,
+        paiement.payroll_configuration_id,  paiement.currency_id, paiement.paiement_date, paiement.base_taxable,
+        paiement.basic_salary, paiement.gross_salary, grade.basic_salary AS grade_salary, grade.text,
+        paiement.net_salary, paiement.working_day, paiement.total_day, paiement.daily_salary, paiement.amount_paid,
         paiement.status_id, paiement_status.text AS status
-        FROM employee 
-        JOIN creditor ON creditor.uuid = employee.creditor_uuid  
-        JOIN creditor_group ON creditor_group.uuid = creditor.group_uuid 
-        JOIN patient ON patient.uuid = employee.patient_uuid 
+        FROM employee
+        JOIN creditor ON creditor.uuid = employee.creditor_uuid
+        JOIN creditor_group ON creditor_group.uuid = creditor.group_uuid
+        JOIN patient ON patient.uuid = employee.patient_uuid
         JOIN grade ON employee.grade_uuid = grade.uuid
         JOIN paiement ON paiement.employee_uuid = employee.uuid
         JOIN payroll_configuration ON payroll_configuration.id = paiement.payroll_configuration_id
         JOIN config_employee ON config_employee.id = payroll_configuration.config_employee_id
-        JOIN config_employee_item ON config_employee_item.employee_uuid = employee.uuid        
+        JOIN config_employee_item ON config_employee_item.employee_uuid = employee.uuid
         JOIN paiement_status ON paiement_status.id = paiement.status_id
         WHERE paiement.payroll_configuration_id = '${options.payroll_configuration_id}'
-      UNION 
+      UNION
         SELECT BUID(employee.uuid) AS employee_uuid, employee.reference, employee.code, employee.date_embauche,
         employee.nb_enfant, employee.individual_salary, creditor_group.account_id,
         BUID(employee.creditor_uuid) AS creditor_uuid, UPPER(patient.display_name) AS display_name,
@@ -61,18 +61,18 @@ function find(options) {
         0 AS gross_salary, grade.basic_salary AS grade_salary, grade.text, 0 AS net_salary, 0 AS working_day,
         0 AS total_day, 0 AS daily_salary, 0 AS amount_paid, 1 AS status_id,
         'PAYROLL_STATUS.WAITING_FOR_CONFIGURATION' AS status
-        FROM employee 
-        JOIN creditor ON creditor.uuid = employee.creditor_uuid  
-        JOIN creditor_group ON creditor_group.uuid = creditor.group_uuid 
-        JOIN patient ON patient.uuid = employee.patient_uuid 
+        FROM employee
+        JOIN creditor ON creditor.uuid = employee.creditor_uuid
+        JOIN creditor_group ON creditor_group.uuid = creditor.group_uuid
+        JOIN patient ON patient.uuid = employee.patient_uuid
         JOIN grade ON employee.grade_uuid = grade.uuid
         JOIN config_employee_item ON config_employee_item.employee_uuid = employee.uuid
         JOIN config_employee ON config_employee.id = config_employee_item.config_employee_id
-        JOIN payroll_configuration ON payroll_configuration.config_employee_id = config_employee.id        
+        JOIN payroll_configuration ON payroll_configuration.config_employee_id = config_employee.id
         WHERE employee.uuid NOT IN (
-          SELECT paiement.employee_uuid 
-          FROM paiement 
-          WHERE paiement.payroll_configuration_id = '${options.payroll_configuration_id}') 
+          SELECT paiement.employee_uuid
+          FROM paiement
+          WHERE paiement.payroll_configuration_id = '${options.payroll_configuration_id}')
           AND payroll_configuration.id = '${options.payroll_configuration_id}'
     ) AS payroll`;
 

--- a/server/controllers/payroll/multiplePayroll/index.js
+++ b/server/controllers/payroll/multiplePayroll/index.js
@@ -20,7 +20,7 @@ const makeCommitment = require('./makeCommitment');
 
 /**
  * @method search
- * @description search Payroll Paiement
+ * @description search Payroll payments
  */
 function search(req, res, next) {
   find.find(req.query)
@@ -38,11 +38,9 @@ function configuration(req, res, next) {
   getConfig.getConfigurationData(payrollConfigurationId, params)
     .then((rows) => {
       const dataManaged = manageConfig.manageConfigurationData(rows, params);
-
       res.status(200).json(dataManaged);
     })
-    .catch(next)
-    .done();
+    .catch(next);
 }
 
 // search Payroll Paiement


### PR DESCRIPTION
We've replaced a db.transaction() with a Promise.all() call.  Since no
data updates were taking place (they are all SELECT queries), we don't
need the table locks of db.transaction().  It may also result in a minor
performance increase since queries are run in parallel.