### PR TITLE
chore(ci): bump testing versions to latest LTS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ image:
   - Ubuntu1604
   - Ubuntu1804
 
-stack: node 10, mysql, redis
+stack: node 12, mysql, redis
 
 install:
   - bash ./sh/setup-ci-env.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
 
 language: node_js
 node_js:
-  - lts/dubnium
+  - lts/erbium
 
 before_script:
   - yarn build


### PR DESCRIPTION
Node v12 just went into LTS.  I've changed our testing to use the latest LTS.