### PR TITLE
fix: condition appcache on hostname

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -184,7 +184,7 @@ function startupConfig(
 
 // set the proper key prifix
 function localStorageConfig($localStorageProvider) {
-  const PREFIX = 'bhima-';
+  const PREFIX = `bh-${window.location.hostname}-`;
   $localStorageProvider.setKeyPrefix(PREFIX);
 }
 


### PR DESCRIPTION
Allows you to have multiple different BHIMA tabs open on different hosts without sharing the same appcache content.