### PR TITLE
Fix: add balances to entry exit cash report

### DIFF
--- a/server/controllers/finance/accounts/transactions.js
+++ b/server/controllers/finance/accounts/transactions.js
@@ -200,6 +200,8 @@ async function getAccountTransactions(options, openingBalance = 0) {
   const hasLastCumSum = !_.isUndefined(lastTransaction && lastTransaction.cumsum);
   const lastCumSum = hasLastCumSum ? lastTransaction.cumsum : (totals.balance * totals.rate);
 
+  // tells the report if it is safe to render the debit/credit sum.  It is only safe
+  // if the currency_id is consistent throughout the entire span
   const lastCurrencyId = (lastTransaction && lastTransaction.currency_id) || totals.currency_id;
   const shouldDisplayDebitCredit = transactions.every(txn => txn.currency_id === lastCurrencyId);
 

--- a/server/controllers/finance/reports/cashReport/index.js
+++ b/server/controllers/finance/reports/cashReport/index.js
@@ -99,8 +99,7 @@ async function document(req, res, next) {
     // Update By @lomamech
     // As the report of the boxes can only be viewed in the company currency,
     // we set the variable isEnterpriseCurrency to true
-    params.currency_id = req.session.enterprise.currency_id;
-    params.isEnterpriseCurrency = true;
+    params.currency_id = cashbox.currency_id;
 
     // get the opening balance for the acount
     const header = await AccountExtras.getOpeningBalanceForDate(cashbox.account_id, params.dateFrom);

--- a/server/controllers/finance/reports/cashReport/index.js
+++ b/server/controllers/finance/reports/cashReport/index.js
@@ -58,7 +58,7 @@ const templates = {
  * @function document
  * @description process and render the cash report document
  */
-function document(req, res, next) {
+async function document(req, res, next) {
   const params = req.query;
   let report;
 
@@ -80,68 +80,59 @@ function document(req, res, next) {
   try {
     const TEMPLATE = templates[params.format] || templates.NORMAL;
     report = new ReportManager(TEMPLATE, req.session, params);
-  } catch (e) {
-    next(e);
-    return;
+
+    // set parameters so that they provide
+    params.enterprise_id = req.session.enterprise.id;
+    params.includeUnpostedValues = true;
+
+    const context = {};
+
+    // determine if we are showing the income and/or expense categories
+    context.hasIncome = ['ENTRY_AND_EXIT', 'ENTRY'].includes(params.type);
+    context.hasExpense = ['ENTRY_AND_EXIT', 'EXIT'].includes(params.type);
+    context.hasBoth = context.hasIncome && context.hasExpense;
+
+    const cashbox = await getCashboxByAccountId(params.account_id);
+    _.merge(context, { cashbox });
+
+    // determine the currency rendering
+    // Update By @lomamech
+    // As the report of the boxes can only be viewed in the company currency,
+    // we set the variable isEnterpriseCurrency to true
+    params.currency_id = req.session.enterprise.currency_id;
+    params.isEnterpriseCurrency = true;
+
+    // get the opening balance for the acount
+    const header = await AccountExtras.getOpeningBalanceForDate(cashbox.account_id, params.dateFrom);
+    _.merge(context, { header });
+
+    // get the account's transactions
+    const [txns, transactionTypes] = await Promise.all([
+      AccountTransactions.getAccountTransactions(params, header.balance),
+      db.exec(`SELECT id, text FROM transaction_type;`),
+    ]);
+
+    _.merge(context, txns, {
+      dateFrom : params.dateFrom,
+      dateTo : params.dateTo,
+    });
+
+    // map the transaction types to each transaction by their ID
+    const map = _.keyBy(transactionTypes, 'id');
+    context.transactions.forEach(txn => {
+      txn.transactionType = map[txn.transaction_type_id].text;
+    });
+
+    // if we have a split format, split along the lines of income and expense.
+    if (params.format === 'SPLIT') {
+      const income = txns.transactions.filter(txn => txn.debit > 0);
+      const expense = txns.transactions.filter(txn => txn.credit > 0);
+      _.merge(context, { income, expense });
+    }
+
+    const result = await report.render(context);
+    res.set(result.headers).send(result.report);
+  } catch (err) {
+    next(err);
   }
-
-  // set parameters so that they provide
-  params.enterprise_id = req.session.enterprise.id;
-  params.includeUnpostedValues = true;
-
-  const context = {};
-
-  // determine if we are showing the income and/or expense categories
-  context.hasIncome = ['ENTRY_AND_EXIT', 'ENTRY'].includes(params.type);
-  context.hasExpense = ['ENTRY_AND_EXIT', 'EXIT'].includes(params.type);
-  context.hasBoth = context.hasIncome && context.hasExpense;
-
-  getCashboxByAccountId(params.account_id)
-    .then(cashbox => {
-      _.merge(context, { cashbox });
-
-      // determine the currency rendering
-      // Update By @lomamech
-      // As the report of the boxes can only be viewed in the company currency,
-      // we set the variable isEnterpriseCurrency to true
-
-      params.currency_id = req.session.enterprise.currency_id;
-      params.isEnterpriseCurrency = true;
-
-      // get the opening balance for the acount
-      return AccountExtras.getOpeningBalanceForDate(cashbox.account_id, params.dateFrom);
-    })
-    .then(header => {
-      _.merge(context, { header });
-      // get the account's transactions
-      return Promise.all([
-        AccountTransactions.getAccountTransactions(params, header.balance),
-        db.exec(`SELECT id, text FROM transaction_type;`),
-      ]);
-    })
-    .then(([txns, transactionTypes]) => {
-      _.merge(context, txns, {
-        dateFrom : params.dateFrom,
-        dateTo : params.dateTo,
-      });
-
-      // map the transaction types to each transaction by their ID
-      const map = _.keyBy(transactionTypes, 'id');
-      context.transactions.forEach(txn => {
-        txn.transactionType = map[txn.transaction_type_id].text;
-      });
-
-      // if we have a split format, split along the lines of income and expense.
-      if (params.format === 'SPLIT') {
-        const income = txns.transactions.filter(txn => txn.debit > 0);
-        const expense = txns.transactions.filter(txn => txn.credit > 0);
-        _.merge(context, { income, expense });
-      }
-
-      return report.render(context);
-    })
-    .then(result => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next);
 }

--- a/server/controllers/finance/reports/cashReport/report_combined.handlebars
+++ b/server/controllers/finance/reports/cashReport/report_combined.handlebars
@@ -35,8 +35,8 @@
         <tbody>
           {{#each transactions as |txn| }}
             <tr {{#unless txn.posted}}style="font-style: italic !important;"{{/unless}}>
-              <td>{{ txn.trans_id }}</td>
               <td>{{ date txn.trans_date }}</td>
+              <td>{{ txn.trans_id }}</td>
               <td>{{ txn.document_reference }}</td>
               <td style="white-space : nowrap;  text-overflow : ellipsis; overflow : hidden; max-width : 400px;" title="{{ txn.description }}">
                 {{ txn.description }}
@@ -48,7 +48,7 @@
                 {{currency txn.credit txn.currency_id}}
               </td>
               <td class="text-right">
-                {{debcred this.exchangedBalance ../metadata.enterprise.currency_id}}
+                {{debcred txn.exchangedBalance ../metadata.enterprise.currency_id}}
               </td>
               <td class="text-right">
                 {{debcred txn.cumsum ../metadata.enterprise.currency_id}}
@@ -60,8 +60,19 @@
         </tbody>
         <tfoot>
           <tr>
-            <th colspan="7">{{ date footer.date }}</th>
-            <th class="text-right">{{ debcred footer.exchangedCumSum metadata.enterprise.currency_id}}</th>
+            <th colspan="4">{{ date footer.date }}</th>
+            <th class="text-right">
+              {{#if footer.shouldDisplayDebitCredit }}
+                {{ currency footer.totals.debit cashbox.currency_id }}
+              {{/if}}
+            </th>
+            <th class="text-right">
+              {{#if footer.shouldDisplayDebitCredit }}
+                {{ currency footer.totals.credit cashbox.currency_id }}
+              {{/if}}
+            </th>
+            <th class="text-right">{{ debcred footer.exchangedBalance metadata.enterprise.currency_id }}</th>
+            <th class="text-right">{{ debcred footer.exchangedCumSum metadata.enterprise.currency_id }}</th>
           </tr>
         </tfoot>
       </table>

--- a/server/controllers/finance/reports/cashReport/report_separated.handlebars
+++ b/server/controllers/finance/reports/cashReport/report_separated.handlebars
@@ -112,7 +112,7 @@
         <p class="text-right">
           <strong>{{translate "TABLE.COLUMNS.BALANCE"}}:</strong>
           <span>{{debcred footer.exchangedCumSum txn.currency_id}}</span>
-        </p>        
+        </p>
       {{/if}}
 
       <br />


### PR DESCRIPTION
This PR adds the feature to show the balance at the foot of the cash report if all transactions within the range are in the same currency.  It also migrates the controller to async/await and corrects the column ordering that was previously incorrect.

Closes #3727