### PR TITLE
fix(xls): export XLS files without currency symbol

### DIFF
--- a/server/lib/renderers/html.js
+++ b/server/lib/renderers/html.js
@@ -16,6 +16,7 @@ const debug = require('debug')('renderers:html');
 const util = require('../util');
 const hbs = require('../template');
 const translateHelperFactory = require('../helpers/translate');
+const finance = require('../template/helpers/finance');
 
 const headers = {
   'Content-Type' : 'text/html',
@@ -39,13 +40,19 @@ function renderHTML(data, template, options = {}) {
 
   moment.locale(options.lang);
 
-
   debug(`initializing ${options.lang} translation locale`);
   // make sure that we have the appropriate language set.  If options.lang is
   // not specified, will default to English.  To change this behavior, see the
   // factory code.
   const translate = translateHelperFactory(options.lang);
   hbs.helpers.translate = translate;
+
+  // NOTE(@jniles) - if the file is an XLS file that is being converted to
+  // excel, we don't do anything for the currency besides returning it.
+  if (options.skipCurrencyRendering) {
+    hbs.helpers.currency = finance.currencyWithoutSymbol;
+    hbs.helpers.debcred = finance.currencyWithoutSymbol;
+  }
 
   debug(`rendering HTML file`);
 

--- a/server/lib/renderers/xls.js
+++ b/server/lib/renderers/xls.js
@@ -2,6 +2,7 @@
  * @description
  * This library is just a shim to ensure API uniformity with other renderers.
  * it renders an Excel report from html.
+ *
  * @module lib/renderers/xls
  * @requires juice
  */
@@ -17,6 +18,8 @@ exports.extension = '.xls';
 exports.headers = headers;
 
 async function render(data, template, options) {
+  options.skipCurrencyRendering = true;
+
   const htmlString = juice(await html.render(data, template, options));
 
   // NOTE(@jniles)

--- a/server/lib/template/helpers/finance.js
+++ b/server/lib/template/helpers/finance.js
@@ -1,6 +1,6 @@
 const accountingjs = require('accounting-js');
-const NumberToText = require('../../../lib/NumberToText');
 const Handlebars = require('handlebars');
+const NumberToText = require('../../../lib/NumberToText');
 
 const USD_FMT = { precision : 2 };
 
@@ -18,6 +18,18 @@ function currency(value = 0, currencyId) {
   // @TODO - super-hardcoded values for the moment.  Can we do better?
   const fmt = (Number(currencyId) === 1) ? FC_FMT : USD_FMT;
   return new Handlebars.SafeString(accountingjs.formatMoney(value, fmt));
+}
+
+/**
+ * @function currencyWithoutSymbol
+ *
+ * @description
+ * This exists purely to allow the HTML renderer to turn off currency
+ * rendering.  It has the same API as the currency helper.
+ */
+// eslint-disable-next-line
+function currencyWithoutSymbol(value = 0, currencyId) {
+  return Number(value).toFixed(2);
 }
 
 /**
@@ -77,3 +89,4 @@ exports.indentAccount = indentAccount;
 exports.numberToText = numberToText;
 exports.percentage = percentage;
 exports.precision = precision;
+exports.currencyWithoutSymbol = currencyWithoutSymbol;


### PR DESCRIPTION
Implements a feature asked for by our clients to remove the currency symbol from the HTML -> Excel render.  This allows users to sum the numbers are ordinary values rather than parse the currency symbol.

Closes #3764.