### PR TITLE
fix(app): do not crash on unCaughtException

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -87,7 +87,13 @@ require('./config/express').errorHandling(app);
 // ensure the process terminates gracefully when an error occurs.
 process.on('uncaughtException', (e) => {
   debug('process.onUncaughException: %o', e);
-  process.exit(1);
+  /**
+   * TODO(@jniles) - crash the server on uncaught exceptions.  At the moment, we cannot
+   * do this because of a longstanding bug in wkhtmltopdf that prevents us from catching
+   * errors does to broken src="" links.  It occurs if the enterprise logo is destroyed.
+   * SEE: https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2051
+   */
+  // process.exit(1);
 });
 
 // crash on unhandled promise rejections


### PR DESCRIPTION
This reverses an earlier decision to crash the server
onUncaughtExceptions.  Unfortunately, we cannot catch wkhtmltopdf
exceptions and a simple missing <img src> will cause the server to
crash.  In particular, the enterprise logo will crash the server, and we
have no guarantees if this will occur in production.  Once we merge #3984
we may revisit this decision.