### PR TITLE
fix(cloud-init): set working directory

### DIFF
--- a/docs/cloud-init.yml
+++ b/docs/cloud-init.yml
@@ -60,6 +60,7 @@ write_files:
 
       [Service]
       Environment=NODE_ENV=production
+      WorkingDirectory=/opt/bhima/bin/
       Type=simple
       User=bhima
       ExecStart=/usr/bin/node /opt/bhima/bin/server/app.js


### PR DESCRIPTION
We need to set the working directory to be able to find the `.env` file.

@mbayopanda can you confirm this solves the issue we ran into?