### PR TITLE
Fix(tests): wait for navigation on patient record

### DIFF
--- a/test/end-to-end/patient/record.spec.js
+++ b/test/end-to-end/patient/record.spec.js
@@ -45,7 +45,7 @@ describe('Patient Record', () => {
   it(`View and complete a patient's medical sheet`, async () => {
     await element(by.id('form_1')).click();
     await fillForm.fillPatientSheet(dataMedicalSheet);
-    helpers.navigate(url);
+    await helpers.navigate(url);
   });
 
   it('downloads and correctly displays patient information', async () => {


### PR DESCRIPTION
We've been experiencing lots of crashes on master.  This may be in part because we don't wait for navigation on the Patient Record page.  This commit fixes that issue.

An example of this bug is shown in this log:
https://travis-ci.org/IMA-WorldHealth/bhima/builds/614450716#L1024