### PR TITLE
fix(tests): attempt to fix flakey voucher tests

### DIFF
--- a/test/end-to-end/shared/FormUtils.js
+++ b/test/end-to-end/shared/FormUtils.js
@@ -8,19 +8,19 @@ const { expect } = require('chai');
 // However, this decision can be reviewed
 const buttons = {
   create : () => $('[data-method="create"]').click(),
-  search : function search() { return $('[data-method="search"]').click(); },
-  submit : function submit() { return $('[data-method="submit"]').click(); },
-  cancel : function cancel() { return $('[data-method="cancel"]').click(); },
-  edit   : function edit() { return $('[data-method="edit"]').click(); },
-  clear  : function clear() { return $('[data-method="clear"]').click(); },
-  print  : function print() { return $('[data-method="print"]').click(); },
-  back   : function back() { return $('[data-method="back"]').click(); },
-  reset  : function reset() { return $('[data-method="reset"]').click(); },
-  delete : function delet() { return $('[data-method="delete"]').click(); },
-  configure : function configure() { return $('[data-method="configure"]').click(); },
-  add : function configure() { return $('[data-method="add"]').click(); },
-  save : function configure() { return $('[data-method="save"]').click(); },
-  grouping : function grouping() { return $('[data-method="grouping"]').click(); },
+  search : () => $('[data-method="search"]').click(),
+  submit : () => $('[data-method="submit"]').click(),
+  cancel : () => $('[data-method="cancel"]').click(),
+  edit   : () => $('[data-method="edit"]').click(),
+  clear  : () => $('[data-method="clear"]').click(),
+  print  : () => $('[data-method="print"]').click(),
+  back   : () => $('[data-method="back"]').click(),
+  reset  : () => $('[data-method="reset"]').click(),
+  delete : () => $('[data-method="delete"]').click(),
+  configure : () => $('[data-method="configure"]').click(),
+  add : () => $('[data-method="add"]').click(),
+  save : () => $('[data-method="save"]').click(),
+  grouping : () => $('[data-method="grouping"]').click(),
 };
 
 // This methods are for easily working with modals.  Works with the same custom
@@ -47,7 +47,7 @@ const validation = {
   error : async function error(model) {
     expect(
       await element(by.model(model)).getAttribute('class'),
-      `Expected ${model} to be invalid, but could not find the ng-invalid class.`
+      `Expected ${model} to be invalid, but could not find the ng-invalid class.`,
     ).to.contain('ng-invalid');
   },
 
@@ -55,7 +55,7 @@ const validation = {
   ok : async function success(model) {
     expect(
       await element(by.model(model)).getAttribute('class'),
-      `Expected ${model} to be valid, but could not find the ng-valid class.`
+      `Expected ${model} to be valid, but could not find the ng-valid class.`,
     ).to.contain('ng-valid');
   },
 };
@@ -105,7 +105,7 @@ module.exports = {
   exists : async function exists(locator, bool) {
     expect(
       await element(locator).isPresent(),
-      `Expected locator ${locator.toString()} to ${bool ? 'not ' : ' '}exist.`
+      `Expected locator ${locator.toString()} to ${bool ? 'not ' : ' '}exist.`,
     ).to.equal(bool);
   },
 
@@ -113,7 +113,7 @@ module.exports = {
   visible : async function visible(locator, bool) {
     expect(
       await element(locator).isDisplayed(),
-      `Expected locator ${locator.toString()} to ${bool ? 'not ' : ' '}be visible.`
+      `Expected locator ${locator.toString()} to ${bool ? 'not ' : ' '}be visible.`,
     ).to.equal(bool);
   },
 
@@ -244,7 +244,7 @@ module.exports = {
     await $(selector).click();
 
     const option = anchor.element(by.cssContainingText('[uib-dropdown-menu] > li', label));
-    return option.click();
+    await option.click();
   },
 
   /**
@@ -260,7 +260,7 @@ module.exports = {
   hasText : async function hasText(locator, text) {
     expect(
       await element(locator).getText(),
-      `Expected locator ${locator.toString()} to contain "${text}".`
+      `Expected locator ${locator.toString()} to contain "${text}".`,
     ).to.equal(text);
   },
 

--- a/test/end-to-end/transactionType/transactionType.spec.js
+++ b/test/end-to-end/transactionType/transactionType.spec.js
@@ -46,7 +46,7 @@ describe('transaction types', () => {
     await components.notification.hasSuccess();
   });
 
-  it('dont creates a new transaction type for missing type', async () => {
+  it('don\'t create a new transaction type for missing type', async () => {
     await FU.buttons.create();
     await element(by.model('$ctrl.transactionType.type')).click();
     await FU.buttons.submit();
@@ -55,12 +55,11 @@ describe('transaction types', () => {
     await FU.validation.error('$ctrl.transactionType.type');
 
     await FU.modal.cancel();
-
     await components.notification.hasDanger();
   });
 
 
-  it('Dont creates a new transaction type for missing required values', async () => {
+  it('Don\'t create a new transaction type for missing required values', async () => {
     await FU.buttons.create();
     await FU.buttons.submit();
 
@@ -69,7 +68,6 @@ describe('transaction types', () => {
     await FU.validation.error('$ctrl.transactionType.type');
 
     await FU.modal.cancel();
-
     await components.notification.hasDanger();
   });
 });

--- a/test/end-to-end/vouchers/complex.spec.js
+++ b/test/end-to-end/vouchers/complex.spec.js
@@ -1,6 +1,7 @@
-/* global by */
+/* global by browser */
 /* eslint no-await-in-loop:off */
 
+const EC = require('protractor').ExpectedConditions;
 const helpers = require('../shared/helpers');
 const components = require('../shared/components');
 const ComplexVoucherPage = require('./complex.page');
@@ -93,62 +94,7 @@ describe('Complex Vouchers', () => {
     await FU.exists(by.id('receipt-confirm-created'), true);
 
     // close the modal
-    await $('[data-method="close"]').click();
-  });
-
-  it.skip('forbid submit when there is no transfer type for financial account', async () => {
-    const page = new ComplexVoucherPage();
-
-    /*
-     * the voucher we will use in this page
-     * NOTE: the Caisse Aux is a financial account which involve that we
-     * specify the transfer type
-     */
-    const voucher = {
-      date        : new Date(),
-      description : 'Complex voucher test e2e',
-      rows        : [
-        {
-          account : 'CASH PAYMENT CLIENT', debit : 17, credit : 0, entity : { type : 'D', name : 'Test 2 Patient' },
-        },
-        {
-          account : 'Caisse Aux', debit : 0, credit : 17, reference : { type : 'voucher', index : 0 },
-        },
-      ],
-    };
-
-    // configure the date to today
-    await page.date(voucher.date);
-
-    // set the description
-    await page.description(voucher.description);
-
-    // set the currency to USD
-    await page.currency(2);
-
-    // loop through each row and assign the correct form values
-    let idx = 0;
-    // eslint-disable-next-line
-    for (const row of voucher.rows) {
-      const current = page.row(idx);
-      await current.account(row.account);
-      await current.debit(row.debit);
-      await current.credit(row.credit);
-      if (row.entity) {
-        await current.entity(row.entity.type, row.entity.name);
-      }
-      if (row.reference) {
-        await current.reference(row.reference.type, row.reference.index);
-      }
-
-      idx += 1;
-    }
-
-    // submit the page
-    await page.submit();
-
-    // expect a danger notification
-    await components.notification.hasDanger();
+    await FU.modal.close();
   });
 
   it('Convention import invoices and payment via the tool', async () => {
@@ -164,6 +110,8 @@ describe('Complex Vouchers', () => {
 
     // click on the convention tool
     await FU.dropdown('[toolbar-dropdown]', detail.tool);
+
+    await browser.wait(EC.visibilityOf($('[uib-modal-window]')), 1500);
 
     await components.cashboxSelect.set(detail.cashbox);
 
@@ -186,7 +134,7 @@ describe('Complex Vouchers', () => {
     await FU.exists(by.id('receipt-confirm-created'), true);
 
     // close the modal
-    await $('[data-method="close"]').click();
+    await FU.modal.close();
   });
 
   it('Support Patient Invoices by an Account via the tool', async () => {
@@ -202,6 +150,8 @@ describe('Complex Vouchers', () => {
 
     // click on the Support Patient Tool
     await FU.dropdown('[toolbar-dropdown]', detail.tool);
+
+    await browser.wait(EC.visibilityOf($('[uib-modal-window]')), 1500);
 
     // select account
     await components.accountSelect.set(detail.accountNumber);
@@ -225,7 +175,7 @@ describe('Complex Vouchers', () => {
     await FU.exists(by.id('receipt-confirm-created'), true);
 
     // close the modal
-    await $('[data-method="close"]').click();
+    await FU.modal.close();
   });
 
   it('Generic Income via the tool', async () => {
@@ -240,6 +190,8 @@ describe('Complex Vouchers', () => {
     // click on the convention tool
     await FU.dropdown('[toolbar-dropdown]', detail.tool);
 
+    await browser.wait(EC.visibilityOf($('[uib-modal-window]')), 1500);
+
     // select the cashbox (the first ie Fc)
     await FU.uiSelect('ToolCtrl.cashbox', detail.cashbox);
 
@@ -262,7 +214,7 @@ describe('Complex Vouchers', () => {
     await FU.exists(by.id('receipt-confirm-created'), true);
 
     // close the modal
-    await $('[data-method="close"]').click();
+    await FU.modal.close();
   });
 
   it('Generic Expense via the tool', async () => {
@@ -277,6 +229,8 @@ describe('Complex Vouchers', () => {
     // click on the convention tool
     await FU.dropdown('[toolbar-dropdown]', detail.tool);
 
+    await browser.wait(EC.visibilityOf($('[uib-modal-window]')), 1500);
+
     // select the cashbox (the first ie Fc)
     await FU.uiSelect('ToolCtrl.cashbox', detail.cashbox);
 
@@ -299,40 +253,7 @@ describe('Complex Vouchers', () => {
     await FU.exists(by.id('receipt-confirm-created'), true);
 
     // close the modal
-    await $('[data-method="close"]').click();
-  });
-
-  it.skip('Cash Transfer via the tool', async () => {
-    const detail = {
-      tool    : 'Transfert d\'argent',
-      cashbox : 'Caisse Aux',
-      account : '58511010', // 58511010 - Virement des fonds Caisse Auxiliaire - Caisse Principale USD
-      amount  : 200,
-    };
-
-    // click on the convention tool
-    await FU.dropdown('[toolbar-dropdown]', detail.tool);
-
-    // select the cashbox (the first ie $)
-    await FU.uiSelect('ToolCtrl.cashbox', detail.cashbox);
-
-    // select the account
-    await components.accountSelect.set(detail.account);
-
-    // amount
-    await components.currencyInput.set(detail.amount);
-
-    // validate selection
-    await FU.modal.submit();
-
-    // submit voucher
-    await FU.buttons.submit();
-
-    // make sure a receipt was opened
-    await FU.exists(by.id('receipt-confirm-created'), true);
-
-    // close the modal
-    await $('[data-method="close"]').click();
+    await FU.modal.close();
   });
 
   it('Employees Salary Paiement via the tool', async () => {
@@ -348,6 +269,8 @@ describe('Complex Vouchers', () => {
 
     // click on the Support Patient Tool
     await FU.dropdown('[toolbar-dropdown]', detail.tool);
+
+    await browser.wait(EC.visibilityOf($('[uib-modal-window]')), 1500);
 
     // Select Cashbox
     await components.cashboxSelect.set(detail.cashbox);
@@ -370,6 +293,6 @@ describe('Complex Vouchers', () => {
     await FU.exists(by.id('receipt-confirm-created'), true);
 
     // close the modal
-    await $('[data-method="close"]').click();
+    await FU.modal.close();
   });
 });


### PR DESCRIPTION
This PR basically does two things:
 1. Removes skipped complex voucher tests and calls "modal.close()" instead of clicking the first close button (just in case).
 2. Ensures that the application waits for the modals to clear on the complex voucher page before trying to trigger the generic income/expense tests.

The hope is this will reduce the intermittent failures we get in the complex voucher module.
