### PR TITLE
fix(report): render client debt currencies

### DIFF
--- a/server/controllers/finance/reports/client_debts/report.handlebars
+++ b/server/controllers/finance/reports/client_debts/report.handlebars
@@ -1,8 +1,6 @@
 {{> head title="REPORT.CLIENT_SUMMARY.TITLE"}}
 
-<body>
-
-<div class="container">
+<body class="container">
   {{> header}}
 
   <!-- body  -->
@@ -31,14 +29,14 @@
             <th>{{debcred employeesDebtsTotal.balance metadata.enterprise.currency_id}}</th>
           </tr>
         </tbody>
-        
+
         {{#if showDetails}}
         <tbody>
           {{#each employeesDebts as | emp |}}
             <tr>
               <td>{{ emp.reference }}</td>
               <td>{{ emp.display_name }}</td>
-              <td>{{debcred emp.balance metadata.enterprise.currency_id}}</td>
+              <td>{{debcred emp.balance ../metadata.enterprise.currency_id}}</td>
             </tr>
           {{/each}}
           <tr><td colspan="3">&nbsp;</td></tr>
@@ -51,14 +49,14 @@
             <th>{{debcred notEmployeesDebtsTotal.balance metadata.enterprise.currency_id}}</th>
           </tr>
         </tbody>
-        
+
         {{#if showDetails}}
         <tbody>
           {{#each notEmployeesDebts as | emp |}}
             <tr>
               <td>{{ emp.reference }}</td>
               <td>{{ emp.display_name }}</td>
-              <td>{{debcred emp.balance metadata.enterprise.currency_id}}</td>
+              <td>{{debcred emp.balance ../metadata.enterprise.currency_id}}</td>
             </tr>
           {{/each}}
           <tr><td colspan="3">&nbsp;</td></tr>
@@ -78,7 +76,7 @@
             <tr>
               <td>{{ emp.reference }}</td>
               <td>{{ emp.display_name }}</td>
-              <td>{{debcred emp.balance metadata.enterprise.currency_id}}</td>
+              <td>{{debcred emp.balance ../metadata.enterprise.currency_id}}</td>
             </tr>
           {{/each}}
           <tr><td colspan="3">&nbsp;</td></tr>
@@ -88,6 +86,4 @@
       </table>
     </div>
   </div>
-
-</div>
 </body>

--- a/server/controllers/finance/reports/debtors/index.js
+++ b/server/controllers/finance/reports/debtors/index.js
@@ -95,7 +95,7 @@ async function queryContext(params = {}) {
 
      SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 1, (gl.debit_equiv - gl.credit_equiv)*
      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS sixty,
-    
+
      SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 2, (gl.debit_equiv - gl.credit_equiv)*
      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS ninety,
 
@@ -110,10 +110,10 @@ async function queryContext(params = {}) {
     SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) BETWEEN 30 AND 59, (gl.debit_equiv - gl.credit_equiv) *
     IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS sixty,
 
-    SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) BETWEEN 60 AND 89, (gl.debit_equiv - gl.credit_equiv) * 
+    SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) BETWEEN 60 AND 89, (gl.debit_equiv - gl.credit_equiv) *
     IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS ninety,
-    
-    SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) > 90, (gl.debit_equiv - gl.credit_equiv) * 
+
+    SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) > 90, (gl.debit_equiv - gl.credit_equiv) *
     IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS excess,
   `;
 


### PR DESCRIPTION
Fixes a bug with the currency rendering of the client debt report.
Renders the enterprise currency at every level, not just the top level.

Partially addresses #4014.

![image](https://user-images.githubusercontent.com/896472/70131585-d696fb80-1682-11ea-94d1-b88f46d9c14d.png)
