### PR TITLE
Release 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bhima",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "A rural hospital information management system.",
   "main": "npm run build",
   "scripts": {


### PR DESCRIPTION
This commit will be used as reference for the bhima v1.8.2 release which contains some code fixing.

The cloud init file get the last release version, since v1.8.1 has some bugs building BHIMA with cloud-init  will build the application with these bugs (such as bhDepotSelect doesn't have label)