### PR TITLE
fix(reports): multiple account statement currency rendering

### DIFF
--- a/server/controllers/finance/reports/account_statement/report.handlebars
+++ b/server/controllers/finance/reports/account_statement/report.handlebars
@@ -27,7 +27,7 @@
             <th class="text-right">{{translate 'TABLE.COLUMNS.DEBIT'}}</th>
             <th class="text-right">{{translate 'TABLE.COLUMNS.CREDIT'}}</th>
             <th>{{translate 'TABLE.COLUMNS.RECIPIENT'}}</th>
-            <th>{{translate 'TABLE.COLUMNS.REFERENCE'}}</th> 
+            <th>{{translate 'TABLE.COLUMNS.REFERENCE'}}</th>
           </tr>
         </thead>
         <tbody>

--- a/server/controllers/finance/reports/reportAccountsMultiple/index.js
+++ b/server/controllers/finance/reports/reportAccountsMultiple/index.js
@@ -61,7 +61,7 @@ async function document(req, res, next) {
     // get all the opening balances for the accounts concerned
     const balances = await Promise.all(
       accountIds
-        .map(accountId => AccountsExtra.getOpeningBalanceForDate(accountId, params.dateFrom, false))
+        .map(accountId => AccountsExtra.getOpeningBalanceForDate(accountId, params.dateFrom, false)),
     );
 
     // get the transactions for each account
@@ -69,8 +69,8 @@ async function document(req, res, next) {
       balances.map(
         ({ balance, accountId }) => {
           return getAccountTransactions(_.extend({ account_id : accountId }, params, bundle), +balance * rate);
-        }
-      )
+        },
+      ),
     );
 
     // get the account metadata

--- a/server/controllers/finance/reports/reportAccountsMultiple/report.handlebars
+++ b/server/controllers/finance/reports/reportAccountsMultiple/report.handlebars
@@ -119,10 +119,10 @@
               {{/if}}
             </th>
             <th class="text-right">
-              {{debcred footer.exchangedBalance footer.currency_id }}
+              {{debcred footer.exchangedBalance ../params.currency_id }}
             </th>
             <th class="text-right">
-              {{debcred footer.exchangedCumSum footer.currency_id }}
+              {{debcred footer.exchangedCumSum ../params.currency_id }}
             </th>
           </tr>
         </tfoot>


### PR DESCRIPTION
Fixes a bug in the totals of the multiple account statement where the
currencies are now rendered according to what the user has selected
rather than defaulting to $USD.

Closes #4045.

**Demo**
![image](https://user-images.githubusercontent.com/896472/70713253-e0a1a580-1ce5-11ea-810b-f9080695b6fe.png)
