### PR TITLE
fix(reports): render debit/credit sums in account

### DIFF
--- a/server/controllers/finance/reports/reportAccounts/report.handlebars
+++ b/server/controllers/finance/reports/reportAccounts/report.handlebars
@@ -110,12 +110,12 @@
           <th class="text-right">{{footer.invertedRate}}</th>
           <th class="text-right">
             {{#if footer.shouldDisplayDebitCredit}}
-              {{currency footer.debit footer.transactionCurrencyId}}
+              {{currency footer.totals.debit footer.transactionCurrencyId}}
             {{/if}}
           </th>
           <th class="text-right">
             {{#if footer.shouldDisplayDebitCredit}}
-              {{currency footer.credit footer.transactionCurrencyId}}
+              {{currency footer.totals.credit footer.transactionCurrencyId}}
             {{/if}}
           </th>
           <th class="text-right">

--- a/server/controllers/finance/reports/reportAccountsMultiple/report.handlebars
+++ b/server/controllers/finance/reports/reportAccountsMultiple/report.handlebars
@@ -110,12 +110,12 @@
             <th class="text-right">{{footer.invertedRate}}</th>
             <th class="text-right">
               {{#if footer.shouldDisplayDebitCredit}}
-                {{currency footer.debit footer.transactionCurrencyId}}
+                {{currency footer.totals.debit footer.transactionCurrencyId}}
               {{/if}}
             </th>
             <th class="text-right">
               {{#if footer.shouldDisplayDebitCredit}}
-                {{currency footer.credit footer.transactionCurrencyId}}
+                {{currency footer.totals.credit footer.transactionCurrencyId}}
               {{/if}}
             </th>
             <th class="text-right">


### PR DESCRIPTION
Renders the debit/credit sums in the foot of the account reports if the entire report is composed of the same currency (every transaction has the same currency).

It used to look like this:

![image](https://user-images.githubusercontent.com/896472/70714586-b9000c80-1ce8-11ea-83a7-af77aa4eeb59.png)


Now it looks like this:
![image](https://user-images.githubusercontent.com/896472/70714616-c6b59200-1ce8-11ea-85d5-1a62f9c0234b.png)
