### PR TITLE
fix: throw on uncaughtExceptions

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -87,13 +87,7 @@ require('./config/express').errorHandling(app);
 // ensure the process terminates gracefully when an error occurs.
 process.on('uncaughtException', (e) => {
   debug('process.onUncaughException: %o', e);
-  /**
-   * TODO(@jniles) - crash the server on uncaught exceptions.  At the moment, we cannot
-   * do this because of a longstanding bug in wkhtmltopdf that prevents us from catching
-   * errors does to broken src="" links.  It occurs if the enterprise logo is destroyed.
-   * SEE: https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2051
-   */
-  // process.exit(1);
+  process.exit(1);
 });
 
 // crash on unhandled promise rejections


### PR DESCRIPTION
Crash the server on uncaughtExceptions.  Since we stripped out WKHTMLTOPDF, we should be catching only bugs in BHIMA that should be fixed.

Closes #4050.