### PR TITLE
fix(cron): adjust weekly unit test

### DIFF
--- a/test/server-unit/cron/addDynamicDatesOptions.spec.js
+++ b/test/server-unit/cron/addDynamicDatesOptions.spec.js
@@ -51,9 +51,6 @@ describe('cronEmailReport', () => {
 
       expect(dateFrom.toDate().getDay()).to.equal(0);
       expect(dateTo.toDate().getDay()).to.equal(6);
-
-      expect(dateFrom.toDate().getMonth()).to.equal(today.getMonth());
-      expect(dateTo.toDate().getMonth()).to.equal(today.getMonth());
     });
 
 


### PR DESCRIPTION
The weekly unit test assumed that you would never have the start and
the end of a week in two different months. This is clearly untrue.
We've removed this test and have not replaced it.