### PR TITLE
fix(stock): sort registries correctly

### DIFF
--- a/client/src/modules/stock/lots/registry.service.js
+++ b/client/src/modules/stock/lots/registry.service.js
@@ -49,10 +49,13 @@ function LotsRegistryService(uiGridConstants, Session) {
     }, {
       field : 'quantity',
       displayName : 'STOCK.QUANTITY',
+      cellClass : 'text-right',
       headerCellFilter : 'translate',
+      type : 'number',
     }, {
       field : 'unit_cost',
       displayName : 'STOCK.UNIT_COST',
+      cellClass : 'text-right',
       headerCellFilter : 'translate',
       type : 'number',
       cellFilter : 'currency: '.concat(Session.enterprise.currency_id),
@@ -75,21 +78,25 @@ function LotsRegistryService(uiGridConstants, Session) {
     }, {
       field : 'delay_expiration',
       displayName : 'STOCK.EXPIRATION',
+      cellClass : 'text-right',
       headerCellFilter : 'translate',
     }, {
       field : 'avg_consumption',
       displayName : 'STOCK.CMM',
+      cellClass : 'text-right',
       headerCellFilter : 'translate',
       type : 'number',
     }, {
       field : 'S_MONTH',
       displayName : 'STOCK.MSD',
+      cellClass : 'text-right',
       headerCellFilter : 'translate',
       type : 'number',
     }, {
       field : 'lifetime',
       displayName : 'STOCK.LIFETIME',
       headerCellFilter : 'translate',
+      cellClass : 'text-right',
       cellTemplate     : 'modules/stock/lots/templates/lifetime.cell.html',
       type : 'number',
       sort : {
@@ -101,12 +108,14 @@ function LotsRegistryService(uiGridConstants, Session) {
       displayName : 'STOCK.LOT_LIFETIME',
       headerCellFilter : 'translate',
       cellTemplate     : 'modules/stock/lots/templates/lot_lifetime.cell.html',
+      cellClass : 'text-right',
       type : 'number',
     }, {
       field : 'S_RISK',
       displayName : 'STOCK.RISK',
       headerCellFilter : 'translate',
       cellTemplate     : 'modules/stock/lots/templates/risk.cell.html',
+      cellClass : 'text-right',
       type : 'number',
       sort : {
         direction : uiGridConstants.DESC,

--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -15,7 +15,7 @@ StockMovementsController.$inject = [
 function StockMovementsController(
   Stock, Notify, uiGridConstants, Modal,
   Languages, Session, Flux, ReceiptModal, Grouping, $state, Columns, GridState, $httpParamSerializer,
-  $translate
+  $translate,
 ) {
   const vm = this;
   const cacheKey = 'movements-grid';
@@ -117,6 +117,7 @@ function StockMovementsController(
     }, {
       field : 'flux_id',
       displayName : 'STOCK.FLUX',
+      aggregationHideLabel : true,
       headerCellFilter : 'translate',
       cellTemplate : 'modules/stock/movements/templates/flux.cell.html',
     }, {


### PR DESCRIPTION
Fixes the stock management so that the registries sort correctly instead of sorting alphabetically for numbers.

Closes #4069.  Closes https://github.com/IMA-WorldHealth/bhima/issues/4057.