### PR TITLE
fix(payroll): salaries report fits on page

### DIFF
--- a/server/controllers/payroll/reports/multipayroll.handlebars
+++ b/server/controllers/payroll/reports/multipayroll.handlebars
@@ -15,7 +15,7 @@
         <h4 class="text-center">
           <strong>
           <span class="text-capitalize">
-            {{translate this.displayName}} : {{this.value}} 
+            {{translate this.displayName}} : {{this.value}}
           </span
           </strong>
         </h4>

--- a/server/controllers/payroll/reports/multipayroll.js
+++ b/server/controllers/payroll/reports/multipayroll.js
@@ -35,14 +35,6 @@ function build(req, res, next) {
   // delete options.payroll_configuration_id;
   delete options.currency_id;
 
-  _.extend(options, {
-    filename : 'TREE.MULTI_PAYROLL',
-    csvKey : 'multipayroll',
-    orientation : 'portrait',
-    footerRight : '[page] / [toPage]',
-    footerFontSize : '7',
-  });
-
   let report;
 
   // set up the report with report manager
@@ -60,12 +52,10 @@ function build(req, res, next) {
   PayrollConfig.lookupPayrollConfig(options.payroll_configuration_id)
     .then(config => {
       data.payrollTitle = config.label;
-
       return Payroll.find(options);
     })
     .then(rows => {
       data.rows = rows;
-
       return report.render(data);
     })
     .then(result => {

--- a/server/controllers/payroll/reports/payrollReportGenerator.handlebars
+++ b/server/controllers/payroll/reports/payrollReportGenerator.handlebars
@@ -1,94 +1,94 @@
 {{> head title="FORM.LABELS.PAYSLIP"}}
-<body>
-  <!-- body  -->      
-    <header class="row">
-      <div class="col-xs-6" style="font-size: 20px">
-        <h3 style="margin: 0px;"> {{enterprise.name}} </h3>
-        <address style="margin-bottom: 0px;">
-          {{enterprise.location}}
-        </address>
-        <div>{{enterprise.email}}</div>
-        <div>{{enterprise.phone}}</div>
-      </div>
-    </header>    
-    <br>
-    <br>  
-    <h3 class="text-center text-uppercase">
-      <strong> {{ payrollPeriod.label }} </strong>
-    </h3>
-    <br>
-    <br>
 
-  <section>
-    <div class="row">
-      <div class="col-xs-12">
-        <table class="table table-bordered table-condensed table-report" style="font-size: 10px">
-          <thead>
-            <tr class="text-capitalize">
-              <th style="width: 1%;">{{translate 'TABLE.COLUMNS.NR' }}</th>
-              <th></th>
-              <th style="width: 15%;">{{translate 'TABLE.COLUMNS.NAME' }}</th>
-              {{#each rubrics}}
-                <th>{{ abbr }}</th>
-              {{/each}}
-              <th>{{translate 'TABLE.COLUMNS.BASIC_SALARY' }}</th>
-              <th>{{translate 'TABLE.COLUMNS.NET_TAXABLE' }}</th>
-              <th>{{translate 'TABLE.COLUMNS.NET_NON_TAXABLE' }}</th>
-              <th>{{translate 'TABLE.COLUMNS.GROSS_SALARY' }}</th>
-              <th>{{translate 'TABLE.COLUMNS.DEDUCTIONS' }}</th>
-              <th style="width: 4%;">{{translate 'TABLE.COLUMNS.NET_SALARY' }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {{#each dataEmployees}}
-              <tr class="text-capitalize">
-                <td> {{add @index 1}} </td>
-                <td> {{text}} </td>
-                <td><strong> {{display_name}} </strong></td>
-                {{#each rubricTaxable}}
-                  <td style="text-align: right;">
-                    {{#if result_equiv}} 
-                      {{currency (multiply result_equiv ../../payrollPeriod.exchangeRate) ../../payrollPeriod.currency}}
-                    {{/if}}
-                  </td>
-                {{/each}}
-                {{#each rubricNonTaxable}}
-                  <td style="text-align: right;">
-                    {{#if result_equiv}} 
-                      {{currency (multiply result_equiv ../../payrollPeriod.exchangeRate) ../../payrollPeriod.currency}}
-                    {{/if}}
-                  </td>
-                {{/each}}
-                {{#each rubricsChargeEmployee}}
-                  <td style="text-align: right;">
-                    {{#if result_equiv}}
-                      {{currency (multiply result_equiv ../../payrollPeriod.exchangeRate) ../../payrollPeriod.currency}}
-                    {{/if}}
-                  </td>
-                {{/each}}
-                <td style="text-align: right;"> {{currency (multiply basic_salary_equiv ../payrollPeriod.exchangeRate) ../payrollPeriod.currency }} </td>
-                <td style="text-align: right;"> {{currency (multiply somRubTaxable_equiv ../payrollPeriod.exchangeRate) ../payrollPeriod.currency}} </td>
-                <td style="text-align: right;"> {{currency (multiply somRubNonTaxable_equiv ../payrollPeriod.exchangeRate) ../payrollPeriod.currency}} </td>
-                <td style="text-align: right;"> {{currency (multiply gross_salary_equiv ../payrollPeriod.exchangeRate) ../payrollPeriod.currency}} </td>
-                <td style="text-align: right;"> {{currency (multiply somChargeEmployee_equiv ../payrollPeriod.exchangeRate) ../payrollPeriod.currency}} </td>
-                <td style="text-align: right;"> <strong> {{currency (multiply net_salary_equiv ../payrollPeriod.exchangeRate) ../payrollPeriod.currency}} </strong></td>
-              </tr>
-            {{/each}}
-          </tbody>
-          <tr class="text-capitalize">
-            <td style="text-align: right; width: 16%;" colspan="3"><strong>{{translate 'TABLE.COLUMNS.TOTAL' }} </strong></td>
-            {{#each rubrics}}
-              <td style="text-align: right;"><strong>{{currency (multiply total ../payrollPeriod.exchangeRate) ../payrollPeriod.currency}}</strong></td>
-            {{/each}}
-            <td style="text-align: right;"><strong> {{currency (multiply total_basic_salary payrollPeriod.exchangeRate) payrollPeriod.currency}} </strong></td>
-            <td style="text-align: right;"><strong> {{currency (multiply total_taxable payrollPeriod.exchangeRate) payrollPeriod.currency}} </strong></td>
-            <td style="text-align: right;"><strong> {{currency (multiply total_non_taxable payrollPeriod.exchangeRate) payrollPeriod.currency}} </strong></td>
-            <td style="text-align: right;"><strong> {{currency (multiply total_gross_salary payrollPeriod.exchangeRate) payrollPeriod.currency}} </strong></td>
-            <td style="text-align: right;"><strong> {{currency (multiply total_deduction payrollPeriod.exchangeRate) payrollPeriod.currency}} </strong></td>
-            <td style="text-align: right;width: 4%;"><strong>{{currency (multiply total_net_salary payrollPeriod.exchangeRate) payrollPeriod.currency}}</strong></td>
-          </tr>
-        </table>
-      <div>    
+<body>
+  <header class="row">
+    <div class="col-xs-6" style="font-size: 20px">
+      <h3 style="margin: 0px;"> {{enterprise.name}} </h3>
+      <address style="margin-bottom: 0px;">
+        {{enterprise.location}}
+      </address>
+      <div>{{enterprise.email}}</div>
+      <div>{{enterprise.phone}}</div>
     </div>
-  </section>
+  </header>
+
+  <br>
+  <br>
+
+  <h3 class="text-center text-uppercase">
+    <strong> {{ payrollPeriod.label }} </strong>
+  </h3>
+
+  <br>
+
+  <div class="row">
+    <div class="col-xs-12">
+      <table class="table table-bordered table-condensed table-report" style="font-size: 10px">
+        <thead>
+          <tr class="text-capitalize">
+            <th style="width: 1%;">{{translate 'TABLE.COLUMNS.NR' }}</th>
+            <th></th>
+            <th style="width: 15%;">{{translate 'TABLE.COLUMNS.NAME' }}</th>
+            {{#each rubrics}}
+              <th>{{ abbr }}</th>
+            {{/each}}
+            <th>{{translate 'TABLE.COLUMNS.BASIC_SALARY' }}</th>
+            <th>{{translate 'TABLE.COLUMNS.NET_TAXABLE' }}</th>
+            <th>{{translate 'TABLE.COLUMNS.NET_NON_TAXABLE' }}</th>
+            <th>{{translate 'TABLE.COLUMNS.GROSS_SALARY' }}</th>
+            <th>{{translate 'TABLE.COLUMNS.DEDUCTIONS' }}</th>
+            <th style="width: 4%;">{{translate 'TABLE.COLUMNS.NET_SALARY' }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each dataEmployees}}
+            <tr class="text-capitalize">
+              <td> {{add @index 1}} </td>
+              <td> {{text}} </td>
+              <td><strong> {{display_name}} </strong></td>
+              {{#each rubricTaxable}}
+                <td style="text-align: right;">
+                  {{#if result_equiv}}
+                    {{currency (multiply result_equiv ../../payrollPeriod.exchangeRate) ../../payrollPeriod.currency}}
+                  {{/if}}
+                </td>
+              {{/each}}
+              {{#each rubricNonTaxable}}
+                <td style="text-align: right;">
+                  {{#if result_equiv}}
+                    {{currency (multiply result_equiv ../../payrollPeriod.exchangeRate) ../../payrollPeriod.currency}}
+                  {{/if}}
+                </td>
+              {{/each}}
+              {{#each rubricsChargeEmployee}}
+                <td style="text-align: right;">
+                  {{#if result_equiv}}
+                    {{currency (multiply result_equiv ../../payrollPeriod.exchangeRate) ../../payrollPeriod.currency}}
+                  {{/if}}
+                </td>
+              {{/each}}
+              <td style="text-align: right;"> {{currency (multiply basic_salary_equiv ../payrollPeriod.exchangeRate) ../payrollPeriod.currency }} </td>
+              <td style="text-align: right;"> {{currency (multiply somRubTaxable_equiv ../payrollPeriod.exchangeRate) ../payrollPeriod.currency}} </td>
+              <td style="text-align: right;"> {{currency (multiply somRubNonTaxable_equiv ../payrollPeriod.exchangeRate) ../payrollPeriod.currency}} </td>
+              <td style="text-align: right;"> {{currency (multiply gross_salary_equiv ../payrollPeriod.exchangeRate) ../payrollPeriod.currency}} </td>
+              <td style="text-align: right;"> {{currency (multiply somChargeEmployee_equiv ../payrollPeriod.exchangeRate) ../payrollPeriod.currency}} </td>
+              <td style="text-align: right;"> <strong> {{currency (multiply net_salary_equiv ../payrollPeriod.exchangeRate) ../payrollPeriod.currency}} </strong></td>
+            </tr>
+          {{/each}}
+        </tbody>
+        <tr class="text-capitalize">
+          <td style="text-align: right; width: 16%;" colspan="3"><strong>{{translate 'TABLE.COLUMNS.TOTAL' }} </strong></td>
+          {{#each rubrics}}
+            <td style="text-align: right;"><strong>{{currency (multiply total ../payrollPeriod.exchangeRate) ../payrollPeriod.currency}}</strong></td>
+          {{/each}}
+          <td style="text-align: right;"><strong> {{currency (multiply total_basic_salary payrollPeriod.exchangeRate) payrollPeriod.currency}} </strong></td>
+          <td style="text-align: right;"><strong> {{currency (multiply total_taxable payrollPeriod.exchangeRate) payrollPeriod.currency}} </strong></td>
+          <td style="text-align: right;"><strong> {{currency (multiply total_non_taxable payrollPeriod.exchangeRate) payrollPeriod.currency}} </strong></td>
+          <td style="text-align: right;"><strong> {{currency (multiply total_gross_salary payrollPeriod.exchangeRate) payrollPeriod.currency}} </strong></td>
+          <td style="text-align: right;"><strong> {{currency (multiply total_deduction payrollPeriod.exchangeRate) payrollPeriod.currency}} </strong></td>
+          <td style="text-align: right;width: 4%;"><strong>{{currency (multiply total_net_salary payrollPeriod.exchangeRate) payrollPeriod.currency}}</strong></td>
+        </tr>
+      </table>
+    <div>
+  </div>
 </body>

--- a/server/lib/renderers/html.js
+++ b/server/lib/renderers/html.js
@@ -83,5 +83,7 @@ async function renderHTML(data, template, options = {}) {
   debug(`rendering HTML file`);
 
   const html = await hbs.render(template, data);
-  return inlineSource(html, { attribute : false, rootpath : '/', compress : false });
+  return inlineSource(html, {
+    attribute : false, rootpath : '/', compress : false, swallowErrors : true,
+  });
 }

--- a/server/lib/renderers/pdf.js
+++ b/server/lib/renderers/pdf.js
@@ -107,6 +107,15 @@ async function renderPDF(context, template, options = {}) {
   debug('Page created.  Rendering HTML content on page.');
   await page.setContent(inlinedHtml.trim());
 
+  // FIXME(@jniles) - for some reason, puppeteer seems to be inconsistent on the
+  // kind of page rendering sizes, but this seems to work for making pages landscaped.
+  // See: https://github.com/puppeteer/puppeteer/issues/3834#issuecomment-549007667
+  if (options.orientation === 'landscape') {
+    await page.addStyleTag(
+      { content : '@page { size: A4 landscape; }' },
+    );
+  }
+
   debug('Rendering PDF with chromium');
   const pdf = await page.pdf(pdfOptions);
 


### PR DESCRIPTION
With the change to puppeteer, the salaries report seems to have started
running off the page.  This fixes the report and allows other reports to
take advantage of specifying options.orientation as 'landscape' to set
the page rendering to A4 landscape mode.

_Fig 2: After - All columns fit_
![image](https://user-images.githubusercontent.com/896472/71988321-fdbb8c80-322f-11ea-8899-b99d726f7a40.png)
