### PR TITLE
feat(stock): add filter on patient

### DIFF
--- a/client/src/i18n/en/patient_registry.json
+++ b/client/src/i18n/en/patient_registry.json
@@ -6,6 +6,7 @@
     "INVOICES":"View Invoices",
     "INVOICE": "Invoice",
     "VOUCHERS" : "View Vouchers",
+    "STOCK_MOVEMENTS" : "View Stock Movements",
     "MONTH":"month",
     "MONTHS":"months",
     "PAYMENTS":"View Cash Payments",

--- a/client/src/i18n/fr/patient_registry.json
+++ b/client/src/i18n/fr/patient_registry.json
@@ -5,6 +5,7 @@
     "DAYS":"jours",
     "INVOICES":"Les Factures",
     "VOUCHERS":"Les Bordereaux",
+    "STOCK_MOVEMENTS" : "Les Mouvements de Stock",
     "INVOICE":"La facture",
     "MONTH":"mois",
     "MONTHS":"mois",

--- a/client/src/modules/patients/templates/action.cell.html
+++ b/client/src/modules/patients/templates/action.cell.html
@@ -43,5 +43,10 @@
         <span class="fa fa-address-card-o"></span> <span translate>PATIENT_REGISTRY.VOUCHERS</span>
       </a>
     </li>
+    <li>
+      <a data-method="stock-movements" ui-sref="stockMovements({ filters : [{ key : 'patientReference', value : row.entity.reference, displayValue: row.entity.display_name }, { key : 'period', value : 'allTime' }]})" href>
+        <span class="fa fa-list-alt"></span> <span translate>PATIENT_REGISTRY.STOCK_MOVEMENTS</span>
+      </a>
+    </li>
   </ul>
 </div>

--- a/client/src/modules/stock/StockFilterer.service.js
+++ b/client/src/modules/stock/StockFilterer.service.js
@@ -26,6 +26,7 @@ function StockFiltererService(Filters, AppCache, Periods, $httpParamSerializer, 
     { key : 'includeEmptyLot', label : 'LOTS.INCLUDE_EXHAUSTED_LOTS' },
     { key : 'text', label : 'STOCK.DEPOT' },
     { key : 'is_warehouse', label : 'DEPOT.WAREHOUSE' },
+    { key : 'patientReference', label : 'FORM.LABELS.REFERENCE_PATIENT' },
     { key : 'requestor_uuid', label : 'REQUISITION.RECEIVER' },
     {
       key : 'dateFrom', label : 'FORM.LABELS.DATE', comparitor : '>', valueFilter : 'date',

--- a/client/src/modules/stock/movements/modals/search.modal.html
+++ b/client/src/modules/stock/movements/modals/search.modal.html
@@ -18,6 +18,7 @@
           <!-- movements  -->
           <div class="form-group">
             <bh-clear on-clear="$ctrl.clear('is_exit')"></bh-clear>
+            <br/>
             <div class="radio">
               <label>
                 <input type="radio" name="is_exit" value="0" ng-model="$ctrl.searchQueries.is_exit">
@@ -43,6 +44,20 @@
               ng-change="$ctrl.onSelectReference($ctrl.searchQueries.reference)">
 
             <div class="help-block" ng-messages="ModalForm.reference.$error">
+              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            </div>
+          </div>
+
+          <!-- patient reference -->
+          <div class="form-group" ng-class="{ 'has-error' : ModalForm.patientReference.$invalid }">
+            <label class="control-label" translate>FORM.LABELS.REFERENCE_PATIENT</label>
+            <bh-clear on-clear="$ctrl.clear('patientReference')"></bh-clear>
+            <input
+              name="patientReference"
+              class="form-control"
+              ng-model="$ctrl.searchQueries.patientReference"">
+
+            <div class="help-block" ng-messages="ModalForm.patientReference.$error">
               <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
             </div>
           </div>

--- a/client/src/modules/stock/movements/modals/search.modal.js
+++ b/client/src/modules/stock/movements/modals/search.modal.js
@@ -13,6 +13,7 @@ function SearchMovementsModalController(data, Notify, Instance, Flux, $translate
 
   const searchQueryOptions = [
     'is_exit', 'depot_uuid', 'inventory_uuid', 'label', 'flux_id', 'dateFrom', 'dateTo', 'user_id',
+    'patientReference',
   ];
 
   vm.filters = data;

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -93,6 +93,12 @@ function getLotFilters(parameters) {
   filters.equals('flux_id', 'flux_id', 'm', true);
   filters.equals('reference', 'text', 'dm');
 
+  // NOTE(@jniles):
+  // this filters the lots on the entity_uuid associated with the text reference.  It is
+  // an "IN" filter because the patient could have a patient_uuid or debtor_uuid specified.
+  filters.custom('patientReference',
+    'entity_uuid IN (SELECT uuid FROM entity_map WHERE text = ?)');
+
   filters.period('defaultPeriod', 'date');
   filters.period('defaultPeriodEntry', 'entry_date', 'l');
   filters.period('period', 'date');

--- a/test/integration/stock/stock.js
+++ b/test/integration/stock/stock.js
@@ -60,8 +60,20 @@ describe('(/stock/) The Stock HTTP API', () => {
       .then((res) => {
         helpers.api.listed(res, shared.depotPrincipalMvt);
       })
-      .catch(helpers.handler)
+      .catch(helpers.handler),
   );
+
+  // list all movement relatives to patient 'PA.TPA.2'
+  it(
+    `GET /stock/lots/movements?patientReference=PA.TPA.2 returns two movements for patient PA.TPA.2`,
+    () => agent.get('/stock/lots/movements')
+      .query({ patientReference : 'PA.TPA.2' })
+      .then((res) => {
+        helpers.api.listed(res, 2);
+      })
+      .catch(helpers.handler),
+  );
+
 
   // list all stock exit relatives to 'Depot Principal'
   it(
@@ -71,7 +83,7 @@ describe('(/stock/) The Stock HTTP API', () => {
       .then((res) => {
         helpers.api.listed(res, 5);
       })
-      .catch(helpers.handler)
+      .catch(helpers.handler),
   );
 
   // (report) render all stock exit
@@ -82,7 +94,7 @@ describe('(/stock/) The Stock HTTP API', () => {
       .then((res) => {
         expect(res.body.rows.length).to.equal(22);
       })
-      .catch(helpers.handler)
+      .catch(helpers.handler),
   );
 
   // (report) render all stock exit relatives to 'Depot Principal'
@@ -93,7 +105,7 @@ describe('(/stock/) The Stock HTTP API', () => {
       .then((res) => {
         expect(res.body.rows.length).to.equal(20);
       })
-      .catch(helpers.handler)
+      .catch(helpers.handler),
   );
 
   // list all stock entry relatives to 'Depot Principal'
@@ -103,7 +115,7 @@ describe('(/stock/) The Stock HTTP API', () => {
       .then((res) => {
         helpers.api.listed(res, 20);
       })
-      .catch(helpers.handler)
+      .catch(helpers.handler),
   );
 
   // get initial quantity of QUININE-A in 'Depot Principal'
@@ -158,6 +170,6 @@ describe('(/stock/) The Stock HTTP API', () => {
         helpers.api.listed(res, 1);
         expect(res.body[0].quantity).to.be.equal(0);
       })
-      .catch(helpers.handler)
+      .catch(helpers.handler),
   );
 });


### PR DESCRIPTION
This commit adds a filter to the stock movements registry to allow filtering on a specific patient via both the search modal and by filtering from the patient registry.

![vu1eSWgtSw](https://user-images.githubusercontent.com/896472/72258061-69756f00-360d-11ea-9d51-a622a0f8db9c.gif)
_GIF 1: Regular Filtering on Patient_

![CrMHmqnP0m](https://user-images.githubusercontent.com/896472/72266649-14425900-361f-11ea-817f-6f717a3f9eb5.gif)
_GIF 2: Filtering via the Patient Registry_

Closes #4080.