### PR TITLE
refactor(report): ameliorate Articles in Stock

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -191,8 +191,8 @@
       "DESCRIPTION": "This report shows the balance of invoices which are not completely paid or overpaid during a period."
     },
     "STOCK": {
-      "TITLE": "Stock Report",
-      "DESCRIPTION": "This report shows the stock of products, their average consumption and their status.",
+      "TITLE": "Articles in Stock Report",
+      "DESCRIPTION": "This report shows the stock of products, their average monthly consumption and indicates if a reorder is needed.  The items are ordered by inventory group, then by their name.  By default, all products in every depot is displayed, but these can be filtered by specifying an individual product or depot.",
       "ALL_DEPOTS": "All Depots",
       "ONE_DEPOT": "One Specific Depot",
       "ALL_INVENTORIES": "All Inventories",

--- a/client/src/modules/reports/generate/inventory_report/inventory_report.config.js
+++ b/client/src/modules/reports/generate/inventory_report/inventory_report.config.js
@@ -8,7 +8,7 @@ InventoryReportConfigController.$inject = [
 
 function InventoryReportConfigController(
   $sce, Notify, SavedReports, AppCache, reportData, $state,
-  Languages, moment
+  Languages, moment,
 ) {
   const vm = this;
   const cache = new AppCache('configure_stock_report');
@@ -17,11 +17,14 @@ function InventoryReportConfigController(
   vm.previewGenerated = false;
 
   vm.dateTo = new Date();
-  vm.delay = 1;
-  vm.purchaseInterval = 1;
+  vm.includeEmptyLot = 1;
 
   // chech cached configuration
   checkCachedConfiguration();
+
+  vm.onSelectIncludeEmptyLot = (value) => {
+    vm.includeEmptyLot = value;
+  };
 
   vm.onSelectDepot = function onSelectDepot(depot) {
     vm.depot = depot;
@@ -48,15 +51,13 @@ function InventoryReportConfigController(
     if (form.$invalid) { return 0; }
 
     if (!vm.chooseOneDepot) { vm.depot = {}; }
-
     if (!vm.chooseOneInventory) { vm.inventory = {}; }
 
     const params = {
       depot_uuid : vm.depot.uuid,
       inventory_uuid : vm.inventory.uuid,
-      inventory_delay : vm.delay,
-      purchase_interval : vm.purchaseInterval,
       dateTo : vm.dateTo,
+      includeEmptyLot : vm.includeEmptyLot,
     };
 
     // update cached configuration
@@ -65,10 +66,7 @@ function InventoryReportConfigController(
     // format date for the server
     params.dateTo = moment(params.dateTo).format('YYYY-MM-DD');
 
-    const options = {
-      params,
-      lang : Languages.key,
-    };
+    const options = { lang : Languages.key, ...params };
 
     vm.reportDetails = options;
 

--- a/client/src/modules/reports/generate/inventory_report/inventory_report.html
+++ b/client/src/modules/reports/generate/inventory_report/inventory_report.html
@@ -31,37 +31,12 @@
             on-change="ReportConfigCtrl.onSelectDate(date)">
           </bh-date-editor>
 
-          <!-- delay -->
-          <div class="form-group col-xs-12 col-sm-6"
-            ng-class="{ 'has-error' : ConfigForm.$submitted && ConfigForm.delay.$invalid }">
-
-            <label class="control-label" translate>FORM.LABELS.DELAY</label>
-            <div class="input-group">
-              <input class="form-control" type="number" bh-integer name="delay" ng-model="ReportConfigCtrl.delay">
-              <span class="input-group-addon" translate>FORM.LABELS.MONTH</span>
-            </div>
-
-            <div class="help-block" ng-messages="ConfigForm.delay.$error" ng-show="ConfigForm.$submitted">
-              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-            </div>
-          </div>
-
-          <!-- purchase interval -->
-          <div class="form-group col-xs-12 col-sm-6"
-            ng-class="{ 'has-error' : ConfigForm.$submitted && ConfigForm.purchase_interval.$invalid }">
-
-            <label class="control-label" translate>FORM.LABELS.PURCHASE_INTERVAL</label>
-            <div class="input-group">
-              <input class="form-control" type="number" bh-integer name="purchase_interval" ng-model="ReportConfigCtrl.purchaseInterval">
-              <span class="input-group-addon" translate>FORM.LABELS.MONTH</span>
-            </div>
-
-            <div class="help-block" ng-messages="ConfigForm.purchase_interval.$error" ng-show="ConfigForm.$submitted">
-              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-            </div>
-          </div>
-
-          <div class="clearfix"></div>
+          <bh-yes-no-radios
+            label="STOCK.INCLUDE_EMPTY_LOT"
+            value="ReportConfigCtrl.includeEmptyLot"
+            help-text="STOCK.INCLUDE_EMPTY_LOT_HELP"
+            on-change-callback="ReportConfigCtrl.onSelectIncludeEmptyLot(value)">
+          </bh-yes-no-radios>
 
           <!-- depot options -->
           <div class="checkbox">

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -497,7 +497,7 @@ function getInventoryQuantityAndConsumption(params) {
     LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
   `;
 
-  const clause = ` GROUP BY l.inventory_uuid, m.depot_uuid ${excludeToken} ORDER BY i.code, i.text `;
+  const clause = ` GROUP BY l.inventory_uuid, m.depot_uuid ${excludeToken} ORDER BY ig.name, i.text `;
 
   return getLots(sql, params, clause)
     .then(inventories => processStockConsumptionAverage(inventories, params.dateTo))

--- a/server/controllers/stock/reports/stock/inventories_report.js
+++ b/server/controllers/stock/reports/stock/inventories_report.js
@@ -11,68 +11,55 @@ const {
  *
  * GET /reports/stock/inventories
  */
-function stockInventoriesReport(req, res, next) {
+async function stockInventoriesReport(req, res, next) {
   let options = {};
   let display = {};
   let hasFilter = false;
-  let report;
   let filters;
 
   const data = {};
-  const bundle = {};
 
   // optionReports
   const optionReport = _.extend(req.query, pdfOptions, {
     filename : 'TREE.STOCK_INVENTORY',
   });
 
-  // set up the report with report manager
   try {
     if (req.query.identifiers && req.query.display) {
       options = JSON.parse(req.query.identifiers);
       display = JSON.parse(req.query.display);
       hasFilter = Object.keys(display).length > 0;
       filters = formatFilters(display);
-    } else if (req.query.params) {
-      options = JSON.parse(req.query.params);
-      bundle.delay = options.inventory_delay;
-      bundle.purchaseInterval = options.purchase_interval;
+    } else {
+      options = req.query;
     }
 
-    report = new ReportManager(STOCK_INVENTORIES_REPORT_TEMPLATE, req.session, optionReport);
+    const report = new ReportManager(STOCK_INVENTORIES_REPORT_TEMPLATE, req.session, optionReport);
+    const rows = await Stock.getInventoryQuantityAndConsumption(options);
+
+    data.rows = rows;
+    data.hasFilter = hasFilter;
+    data.filters = filters;
+    data.csv = rows;
+    data.display = display;
+
+    data.dateTo = options.dateTo;
+
+    // group by depot
+    let depots = _.groupBy(rows, d => d.depot_text);
+
+    // make sure that they keys are sorted in alphabetical order
+    depots = _.mapValues(depots, lines => {
+      _.sortBy(lines, 'depot_text');
+      return lines;
+    });
+
+    data.depots = depots;
+    const result = await report.render(data);
+    res.set(result.headers).send(result.report);
   } catch (e) {
-    return next(e);
+    next(e);
   }
-
-  return Stock.getInventoryQuantityAndConsumption(options)
-    .then((rows) => {
-      data.rows = rows;
-      data.hasFilter = hasFilter;
-      data.filters = filters;
-      data.csv = rows;
-      data.display = display;
-
-      data.dateTo = options.dateTo;
-      data.delay = bundle.delay || 1;
-      data.purchaseInterval = bundle.purchaseInterval || 1;
-
-      // group by depot
-      let depots = _.groupBy(rows, d => d.depot_text);
-
-      // make sure that they keys are sorted in alphabetical order
-      depots = _.mapValues(depots, lines => {
-        _.sortBy(lines, 'depot_text');
-        return lines;
-      });
-
-      data.depots = depots;
-      return report.render(data);
-    })
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next)
-    .done();
 }
 
 module.exports = stockInventoriesReport;

--- a/server/controllers/stock/reports/stock_value.report.handlebars
+++ b/server/controllers/stock/reports/stock_value.report.handlebars
@@ -50,12 +50,12 @@
             <tr>
               <th colspan="3" class="text-right">{{ translate "FORM.LABELS.TOTAL"}}</th>
               <th class="text-right">{{ currency stocktotal ./currency_id }}</th>
-            </tr>  
+            </tr>
           {{/if}}
 
-          
+
         </tbody>
-       
+
       </table>
     </div>
   </div>


### PR DESCRIPTION
Improves the articles in stock report by the following:
 1. Removes the options to add lead time and reorder interval.  These
    are automatically computed.
 2. Adds an option to filter lots based on if they have a quantity or
    not.
 3. Orders first by the inventory group, then the inventory name.

Finally, I've added some better English text description.

![L6ELEQAch4](https://user-images.githubusercontent.com/896472/72352352-6304f700-36e2-11ea-8d20-dccd4066c8c3.gif)

**Note** - the translations for the INCLUDE_EMPTY_LOT will come from https://github.com/IMA-WorldHealth/bhima/pull/4086 when it is merged :)

Closes #4079. Closes #4090.