### PR TITLE
fix(inventory): display sellable flag on edit

### DIFF
--- a/client/src/modules/inventory/list/modals/actions.modal.js
+++ b/client/src/modules/inventory/list/modals/actions.modal.js
@@ -8,7 +8,7 @@ InventoryListActionsModalController.$inject = [
 
 function InventoryListActionsModalController(
   Account, Inventory, Notify, Instance,
-  $state, util, AppCache, SessionService, $rootScope
+  $state, util, AppCache, SessionService, $rootScope,
 ) {
   const vm = this;
   const cache = AppCache('InventoryList');

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -246,7 +246,7 @@ function getItemsMetadataById(uid) {
   const sql = `
     SELECT BUID(i.uuid) as uuid, i.code, i.text AS label, i.price, iu.abbr AS unit,
       it.text AS type, ig.name AS groupName, BUID(ig.uuid) AS group_uuid, ig.expires,
-      ig.unique_item, i.consumable, i.locked, i.stock_min,
+      ig.unique_item, i.consumable, i.locked, i.stock_min, i.sellable,
       i.stock_max, i.created_at AS timestamp, i.type_id, i.unit_id, i.unit_weight, i.unit_volume,
       ig.sales_account, i.default_quantity, i.avg_consumption, i.delay, i.purchase_interval,
       i.last_purchase, i.num_purchase


### PR DESCRIPTION
Fixes a bug reported by HEV where the sellable flag was not displayed on the client while editing the inventory item, leading to much confusion.

Here is the bug:
![scTlAAr8g0](https://user-images.githubusercontent.com/896472/72417006-356a8d00-3778-11ea-9347-87cc9a2f1963.gif)

And here is the fix:
![wp30dbSgVE](https://user-images.githubusercontent.com/896472/72416997-300d4280-3778-11ea-86e2-96216541a823.gif)
