### PR TITLE
fix(stock): Remove patient reference after submit

### DIFF
--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -414,6 +414,7 @@ function StockExitController(
     vm.reference = null;
     vm.displayName = null;
     vm.inventoryNotAvailable = [];
+    delete vm.selectedEntityUuid;
   }
 
   function submit(form) {

--- a/test/end-to-end/stock/stock.exit.spec.js
+++ b/test/end-to-end/stock/stock.exit.spec.js
@@ -42,7 +42,7 @@ function StockExiTests() {
 
   it(`Should distribute the stock to the patient ${PATIENT} linked with the invoice ${INVOICE} `, async () => {
     // select the patient
-    await page.setPatient(PATIENT, INVOICE, true);
+    await page.setPatient(PATIENT, INVOICE);
 
     await page.setDate(new Date());
 


### PR DESCRIPTION
We rarely want to distribute to the same patient twice in a row. Instead of making the user manually clear the patient, we simply remove it after a successful distribution.

Here is the fix in action:
![PBqsjs6UcZ](https://user-images.githubusercontent.com/896472/72425185-8fbf1a00-3787-11ea-8ca4-e2050d58786b.gif)

Closes  #4074.