### PR TITLE
feat(stock): rm 0 quantity in decrease adjustment

### DIFF
--- a/client/src/modules/stock/adjustment/adjustment.html
+++ b/client/src/modules/stock/adjustment/adjustment.html
@@ -136,7 +136,7 @@
         <div class="col-xs-6 col-xs-offset-6">
           <div class="text-right">
             <button class="btn btn-default" ng-click="StockCtrl.suspend(StockForm)" type="button" translate>
-              FORM.BUTTONS.SUSPEND
+              FORM.BUTTONS.CLEAR
             </button>
 
             <bh-loading-button loading-state="StockForm.$loading" disabled="!StockCtrl.validForSubmit">

--- a/client/src/modules/stock/adjustment/adjustment.js
+++ b/client/src/modules/stock/adjustment/adjustment.js
@@ -16,7 +16,7 @@ StockAdjustmentController.$inject = [
  */
 function StockAdjustmentController(
   Notify, Session, util, bhConstants, ReceiptModal, StockForm,
-  Stock, uiGridConstants
+  Stock, uiGridConstants,
 ) {
   const vm = this;
 
@@ -143,6 +143,22 @@ function StockAdjustmentController(
     } else if (vm.adjustmentOption === 'decrease') {
       vm.adjustmentType = 'FORM.LABELS.DECREASE';
     }
+
+    vm.Stock.store.data.forEach(item => {
+      item.lots = getVisibleLots(item);
+    });
+  }
+
+  /**
+   * @function getVisibleLots
+   *
+   * @description
+   * Only shows lots with positive quantities if the adjustment option is to decrease
+   * the quantity in stock.
+   */
+  function getVisibleLots(item) {
+    return item.lotsFull
+      .filter(v => (vm.adjustmentOption === 'decrease' ? v.quantity > 0 : true));
   }
 
   // configure item
@@ -151,7 +167,8 @@ function StockAdjustmentController(
     // get lots
     Stock.lots.read(null, { depot_uuid : vm.depot.uuid, inventory_uuid : item.inventory.inventory_uuid })
       .then((lots) => {
-        item.lots = lots;
+        item.lotsFull = lots;
+        item.lots = getVisibleLots(item);
       })
       .catch(Notify.handleError);
   }

--- a/server/controllers/stock/reports/stock/entry/entryFromIntegration.js
+++ b/server/controllers/stock/reports/stock/entry/entryFromIntegration.js
@@ -9,7 +9,7 @@ const ENTRY_FROM_INTEGRATION_ID = 13;
  */
 function fetch(depotUuid, dateFrom, dateTo, showDetails) {
   const sql = `
-  SELECT 
+  SELECT
     i.code, i.text, iu.text AS unit_text, BUID(m.document_uuid) AS document_uuid,
     SUM(m.quantity) as quantity, m.date, m.description,
     u.display_name AS user_display_name,
@@ -17,11 +17,11 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
-    JOIN inventory_unit iu ON iu.id = i.unit_id 
+    JOIN inventory_unit iu ON iu.id = i.unit_id
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN user u ON u.id = m.user_id
     LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
-  WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${ENTRY_FROM_INTEGRATION_ID} AND d.uuid = ? 
+  WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${ENTRY_FROM_INTEGRATION_ID} AND d.uuid = ?
     AND (DATE(m.date) BETWEEN DATE(?) AND DATE(?))
   GROUP BY i.uuid`;
 


### PR DESCRIPTION
Adds a feature requested by our clients in Vanga to remove lots with 0 quantity from the grid if you are doing a downwards adjustment.

Closes #4062.

This is what it looks like:

![emywtIplwW](https://user-images.githubusercontent.com/896472/72427394-f21a1980-378b-11ea-9f0b-b65438ad1ca2.gif)
