### PR TITLE
chore: make POS PDF font size smaller

### DIFF
--- a/server/lib/template/partials/point-of-sale-stylesheet.handlebars
+++ b/server/lib/template/partials/point-of-sale-stylesheet.handlebars
@@ -17,6 +17,7 @@
     padding : 0;
     width: 100%;
     height: 100%;
+    font-size: 8pt !important;
   }
 
   p {


### PR DESCRIPTION
Sets the font size smaller on the PDF point of sale receipt.

This is what it looks like on my machine.
![image](https://user-images.githubusercontent.com/896472/72432014-5d68e900-3796-11ea-8333-85cbdf218c8d.png)

Ideally, we should have this as a setting somewhere, but for expediency, this PR will solve our clients' issues.

Closes https://github.com/IMA-WorldHealth/bhima/issues/4059