### PR TITLE
fix(reports): allow saving Items in Stock

### DIFF
--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -213,7 +213,7 @@ function getLotsDepot(depotUuid, params, finalClause) {
     JOIN inventory_unit iu ON iu.id = i.unit_id
     JOIN inventory_group ig ON ig.uuid = i.group_uuid
     JOIN depot d ON d.uuid = m.depot_uuid
-    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid  
+    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
   `;
 
   const groupByClause = finalClause || ` GROUP BY l.uuid, m.depot_uuid ${excludeToken} ORDER BY i.code, l.label `;

--- a/server/controllers/stock/reports/stock/inventories_report.js
+++ b/server/controllers/stock/reports/stock/inventories_report.js
@@ -1,5 +1,5 @@
 const {
-  _, ReportManager, Stock, formatFilters, pdfOptions, STOCK_INVENTORIES_REPORT_TEMPLATE,
+  _, ReportManager, Stock, formatFilters, STOCK_INVENTORIES_REPORT_TEMPLATE,
 } = require('../common');
 
 /**
@@ -20,9 +20,10 @@ async function stockInventoriesReport(req, res, next) {
   const data = {};
 
   // optionReports
-  const optionReport = _.extend(req.query, pdfOptions, {
+  const optionReport = _.extend({}, req.query, {
     filename : 'TREE.STOCK_INVENTORY',
   });
+
 
   try {
     if (req.query.identifiers && req.query.display) {
@@ -33,6 +34,8 @@ async function stockInventoriesReport(req, res, next) {
     } else {
       options = req.query;
     }
+
+    delete options.label;
 
     const report = new ReportManager(STOCK_INVENTORIES_REPORT_TEMPLATE, req.session, optionReport);
     const rows = await Stock.getInventoryQuantityAndConsumption(options);
@@ -55,6 +58,7 @@ async function stockInventoriesReport(req, res, next) {
     });
 
     data.depots = depots;
+
     const result = await report.render(data);
     res.set(result.headers).send(result.report);
   } catch (e) {

--- a/server/models/procedures/stock.sql
+++ b/server/models/procedures/stock.sql
@@ -271,7 +271,6 @@ BEGIN
   SET fluxId = 13;
   INSERT INTO stock_movement (`uuid`, `document_uuid`, `depot_uuid`, `lot_uuid`, `flux_id`, `date`, `quantity`, `unit_cost`, `is_exit`, `user_id`)
   VALUES (HUID(UUID()), documentUuid, depotUuid, lotUuid, fluxId, CURRENT_DATE(), stockLotQuantity, inventoryUnitCost, 0, userId);
-
 END $$
 
 DROP PROCEDURE IF EXISTS `stockValue`$$


### PR DESCRIPTION
Fixes saving the "items in stock" report that was accidentally applying a filter based on the filename.

Closes #4109.