### PR TITLE
feat(stock): allow mvnts filtering on invoice_uuid

### DIFF
--- a/client/src/modules/invoices/registry/templates/action.cell.html
+++ b/client/src/modules/invoices/registry/templates/action.cell.html
@@ -44,6 +44,12 @@
       </a>
     </li>
 
+    <li>
+      <a data-method="view-stock-movements" ui-sref="stockMovements({ filters : [{ key : 'invoice_uuid', value : row.entity.uuid, displayValue: row.entity.reference, cacheable:false}, { key : 'period', value : 'allTime', cacheable:false }]})" href>
+        <span class="fa fa-list-alt"></span> <span translate>PATIENT_REGISTRY.STOCK_MOVEMENTS</span>
+      </a>
+    </li>
+
     <!-- reverse or remove records -->
     <li class="divider"></li>
 

--- a/client/src/modules/patients/templates/action.cell.html
+++ b/client/src/modules/patients/templates/action.cell.html
@@ -44,7 +44,7 @@
       </a>
     </li>
     <li>
-      <a data-method="stock-movements" ui-sref="stockMovements({ filters : [{ key : 'patientReference', value : row.entity.reference, displayValue: row.entity.display_name }, { key : 'period', value : 'allTime' }]})" href>
+      <a data-method="stock-movements" ui-sref="stockMovements({ filters : [{ key : 'patientReference', value : row.entity.reference, displayValue: row.entity.display_name, cacheable:false }, { key : 'period', value : 'allTime', cacheable:false }]})" href>
         <span class="fa fa-list-alt"></span> <span translate>PATIENT_REGISTRY.STOCK_MOVEMENTS</span>
       </a>
     </li>

--- a/client/src/modules/stock/StockFilterer.service.js
+++ b/client/src/modules/stock/StockFilterer.service.js
@@ -13,6 +13,7 @@ function StockFiltererService(Filters, AppCache, Periods, $httpParamSerializer, 
   const customFiltersList = [
     { key : 'depot_uuid', label : 'STOCK.DEPOT' },
     { key : 'inventory_uuid', label : 'STOCK.INVENTORY' },
+    { key : 'invoice_uuid', label : 'FORM.LABELS.INVOICE' },
     { key : 'group_uuid', label : 'STOCK.INVENTORY_GROUP' },
     { key : 'label', label : 'STOCK.LOT' },
     { key : 'is_exit', label : 'STOCK.OUTPUT' },

--- a/client/src/modules/stock/movements/modals/search.modal.js
+++ b/client/src/modules/stock/movements/modals/search.modal.js
@@ -13,7 +13,7 @@ function SearchMovementsModalController(data, Notify, Instance, Flux, $translate
 
   const searchQueryOptions = [
     'is_exit', 'depot_uuid', 'inventory_uuid', 'label', 'flux_id', 'dateFrom', 'dateTo', 'user_id',
-    'patientReference', 'service_uuid',
+    'patientReference', 'service_uuid', 'invoice_uuid',
   ];
 
   vm.filters = data;

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -74,6 +74,7 @@ function getLotFilters(parameters) {
     'document_uuid',
     'entity_uuid',
     'service_uuid',
+    'invoice_uuid',
   ]);
 
   const filters = new FilterParser(params);
@@ -94,6 +95,7 @@ function getLotFilters(parameters) {
   filters.equals('flux_id', 'flux_id', 'm', true);
   filters.equals('reference', 'text', 'dm');
   filters.equals('service_uuid', 'uuid', 'serv');
+  filters.equals('invoice_uuid', 'invoice_uuid', 'm');
 
   // NOTE(@jniles):
   // this filters the lots on the entity_uuid associated with the text reference.  It is


### PR DESCRIPTION
Adds in the ability to filter stock movements on invoice_uuid by linking
from the invoice registry.

Closes #4099.