### PR TITLE
feat(reports): add file type detection

### DIFF
--- a/client/src/modules/reports/baseReports.service.js
+++ b/client/src/modules/reports/baseReports.service.js
@@ -98,4 +98,58 @@ function BaseReportService($http, Modal, util, Languages) {
 
     return instance.result;
   }
+
+  function parseFileUrlToExtension(url) {
+    const parts = url.split('.');
+    const extension = parts[parts.length - 1];
+    return extension;
+  }
+
+  /**
+   * @function parseFileUrlToIcon
+   *
+   * @description
+   * Takes in a URL string with an given extension (.pdf, .doc, etc) and
+   * returns the font awesome class name associated with that icon.
+   */
+  function parseFileUrlToIcon(url) {
+    const extension = parseFileUrlToExtension(url);
+
+    let icon;
+
+    switch (extension) {
+    case 'doc':
+    case 'docx':
+      icon = 'fa-file-word-o';
+      break;
+    case 'pdf':
+      icon = 'fa-file-pdf-o';
+      break;
+    case 'xlsx':
+    case 'xls':
+      icon = 'fa-file-excel-o';
+      break;
+    case 'zip':
+    case 'gz':
+      icon = 'fa-file-archive-o';
+      break;
+    case 'png':
+    case 'jpeg':
+    case 'jpg':
+    case 'svg':
+      icon = 'fa-file-image-o';
+      break;
+    case 'csv':
+      icon = 'fa-file-csv-o';
+      break;
+    default:
+      icon = 'fa-file-o';
+      break;
+    }
+
+    return icon;
+  }
+
+  service.parseFileUrlToIcon = parseFileUrlToIcon;
+  service.parseFileUrlToExtension = parseFileUrlToExtension;
 }

--- a/client/src/modules/reports/baseReports.service.js
+++ b/client/src/modules/reports/baseReports.service.js
@@ -100,6 +100,7 @@ function BaseReportService($http, Modal, util, Languages) {
   }
 
   function parseFileUrlToExtension(url) {
+    if (!url) { return ''; }
     const parts = url.split('.');
     const extension = parts[parts.length - 1];
     return extension;

--- a/client/src/modules/reports/reportsArchive.js
+++ b/client/src/modules/reports/reportsArchive.js
@@ -8,14 +8,22 @@ ReportsArchiveController.$inject = [
 function ReportsArchiveController($state, SavedReports, Notify, reportData) {
   const vm = this;
 
-  const typeTemplate = '<div class="ui-grid-cell-contents"><i class="fa fa-file-pdf-o"></i></div>';
-  const dateTemplate = `<div class="ui-grid-cell-contents">
-      {{ row.entity.timestamp | date }} (<span am-time-ago="row.entity.timestamp"></span>)
-    </div>`;
+  const typeTemplate = `
+  <div class="ui-grid-cell-contents">
+    <i class="fa" ng-class="row.entity.icon" ng-attr-title="{{row.entity.extension}}"></i>
+  </div>`.trim();
 
-  const printTemplate = `<div class="ui-grid-cell-contents">
+  const dateTemplate = `
+    <div class="ui-grid-cell-contents">
+      {{ row.entity.timestamp | date }} (<span am-time-ago="row.entity.timestamp"></span>)
+    </div>`.trim();
+
+  const printTemplate = `
+  <div class="ui-grid-cell-contents">
+    <span ng-if="row.entity.isPrintable">
       <bh-pdf-link pdf-url="/reports/archive/{{row.entity.uuid}}"></bh-pdf-link>
-    </div>`;
+    </span>
+  </div>`.trim();
 
   const reportId = reportData.id;
   vm.key = $state.params.key;
@@ -80,6 +88,12 @@ function ReportsArchiveController($state, SavedReports, Notify, reportData) {
     // Load archived reports
     SavedReports.listSavedReports(reportId)
       .then((results) => {
+        results.forEach(row => {
+          row.icon = SavedReports.parseFileUrlToIcon(row.link);
+          row.extension = SavedReports.parseFileUrlToExtension(row.link);
+          row.isPrintable = row.extension === 'pdf';
+        });
+
         vm.gridOptions.data = results;
       })
       .catch(() => {

--- a/test/client-unit/services/BaseReportService.spec.js
+++ b/test/client-unit/services/BaseReportService.spec.js
@@ -1,0 +1,66 @@
+/* global inject, expect */
+/* eslint no-unused-expressions:off */
+describe('BaseReportService', () => {
+  // shared services
+  let SavedReports;
+
+  // load bhima.services
+  beforeEach(module(
+    'pascalprecht.translate',
+    'tmh.dynamicLocale',
+    'ngStorage',
+    'angularMoment',
+    'ui.bootstrap',
+    'bhima.services',
+  ));
+
+
+  let parseExtension;
+  let parseIcon;
+  beforeEach(inject((_BaseReportService_) => {
+    SavedReports = _BaseReportService_;
+    parseExtension = SavedReports.parseFileUrlToExtension;
+    parseIcon = SavedReports.parseFileUrlToIcon;
+  }));
+
+  describe('#parseUrlToExtension()', () => {
+    it('correctly parses simple paths', () => {
+      expect(parseExtension('image.jpg')).to.equal('jpg');
+      expect(parseExtension('image.svg')).to.equal('svg');
+      expect(parseExtension('doc.docx')).to.equal('docx');
+
+      expect(parseExtension('/this/is/some/path.pdf')).to.equal('pdf');
+      expect(parseExtension('https://github.com/cool.gif')).to.equal('gif');
+
+    });
+
+    it('handles error cases', () => {
+      expect(parseExtension('')).to.equal('');
+      expect(parseExtension()).to.equal('');
+    });
+
+    it('correctly parses complex paths', () => {
+      expect(parseExtension('a.file.with.decimals.pdf')).to.equal('pdf');
+      expect(parseExtension('/more/complex/file.with/decimals.gz')).to.equal('gz');
+    });
+  });
+
+  describe('#parseUrlToIcon()', () => {
+    it('correctly parses paths to guess their icons', () => {
+      expect(parseIcon('icon.png')).to.equal('fa-file-image-o');
+      expect(parseIcon('icon.svg')).to.equal('fa-file-image-o');
+
+      expect(parseIcon('document.doc')).to.equal('fa-file-word-o');
+      expect(parseIcon('document.docx')).to.equal('fa-file-word-o');
+
+      expect(parseIcon('msexcel.xls')).to.equal('fa-file-excel-o');
+      expect(parseIcon('msexcel.xlsx')).to.equal('fa-file-excel-o');
+
+      expect(parseIcon('unknown.what')).to.equal('fa-file-o');
+
+
+      expect(parseIcon('report.pdf')).to.equal('fa-file-pdf-o');
+    });
+  });
+
+});


### PR DESCRIPTION
Adds file type detection to the reports archive page so that we are not
proposing to the user to print reports that are not printable (xlsx for
example).  It also adds features to provide the correct font awesome
icon depending on the extension to help a user determine which kind of
file they will be downloading.

**Example**
![RZoqUH5TAk](https://user-images.githubusercontent.com/896472/73257918-e899a400-41c4-11ea-9898-76bb6bd0a333.gif)
