### PR TITLE
fix(inventory): allow deletion from inventory

### DIFF
--- a/server/controllers/inventory/index.js
+++ b/server/controllers/inventory/index.js
@@ -208,15 +208,18 @@ function getInventoryItemsById(req, res, next) {
 
 
 /**
- * DELETE /inventory/:uuid
- * delete an inventory group
+ * DELETE /inventory/metadata/:uuid
+ *
+ * @description
+ * Delete an inventory item from the database
  */
-function deleteInventory(req, res, next) {
-
-  core.remove(req.params.uuid)
-    .then(res.sendStatus(204))
-    .catch(error => core.errorHandler(error, req, res, next))
-    .done();
+async function deleteInventory(req, res, next) {
+  try {
+    await core.remove(req.params.uuid);
+    res.sendStatus(204);
+  } catch (err) {
+    core.errorHandler(err, req, res, next);
+  }
 }
 
 // ======================= inventory group =============================

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -227,11 +227,10 @@ function getItemsMetadata(params) {
 }
 
 
-// This function helps to delete an invetory
-
+// This function helps to delete an inventory
 function remove(_uuid) {
-  const sql = `DELETE FROM inventory WHERE uuid = HUID(?)`;
-  return db.exec(sql, _uuid);
+  const sql = `DELETE FROM inventory WHERE uuid = ?`;
+  return db.exec(sql, db.bid(_uuid));
 }
 
 /**

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -2,3 +2,6 @@ DROP TABLE department;
 
 DELETE FROM role_unit WHERE unit_id = 215;
 DELETE FROM unit WHERE id = 215;
+
+ALTER TABLE inventory_log DROP FOREIGN KEY `inventory_log_ibfk_1`;
+

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -2345,7 +2345,6 @@ CREATE TABLE `inventory_log` (
   PRIMARY KEY (`uuid`),
   KEY `inventory_uuid` (`inventory_uuid`),
   KEY `user_id` (`user_id`),
-  FOREIGN KEY (`inventory_uuid`) REFERENCES `inventory` (`uuid`),
   FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 


### PR DESCRIPTION
This commit removes the foreign key constraints from the inventory_log
to allow deletion from the inventory.  It also fixes the http headers
sent twice error in the error handler.

Closes #4147.