### PR TITLE
perf(users): use GROUP_CONCAT for roles/depots

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -15,6 +15,7 @@
             "CANCEL": "Cancel",
             "CANCEL_EDIT": "Cancel Edit",
             "CASHBOX_MANAGEMENT": "Cashbox Management",
+            "CASHBOXES": "Cashboxes",
             "CLEAR": "Clear",
             "CLOSE": "Close",
             "CONFIGURE": "Configure",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -15,6 +15,7 @@
             "CANCEL": "Annuler",
             "CANCEL_EDIT": "Annuler Modifier",
             "CASHBOX_MANAGEMENT": "Gestion des Caisses",
+            "CASHBOXES": "Caisses",
             "CLEAR": "Effacer",
             "CLOSE": "Fermer",
             "CONFIGURE": "Configurer",

--- a/client/src/modules/payroll/rubrics/modals/rubric.modal.html
+++ b/client/src/modules/payroll/rubrics/modals/rubric.modal.html
@@ -43,7 +43,7 @@
         value="RubricModalCtrl.rubric.is_monetary_value"
         on-change-callback="RubricModalCtrl.isMonetaryValueSetting(value)">
       </bh-yes-no-radios>
-  
+
       <bh-yes-no-radios
         label="PAYROLL_RUBRIC.INDICE_TO_GRAPE"
         value="RubricModalCtrl.rubric.indice_to_grap"
@@ -325,7 +325,7 @@
         </div>
       </div>
     </div>
-   
+
   </div>
   </div>
   <div class="modal-footer">

--- a/client/src/modules/templates/bhRubricSelect.tmpl.html
+++ b/client/src/modules/templates/bhRubricSelect.tmpl.html
@@ -2,12 +2,12 @@
     <div
       class="form-group"
       ng-class="{ 'has-error' : RubricSelectForm.$submitted && rubricForm.config_id.$invalid }">
-  
+
       <label class="control-label text-capitalize" translate>
         {{ ::$ctrl.label }}
       </label>
-  
-      <ng-transclude></ng-transclude>  
+
+      <ng-transclude></ng-transclude>
       <ui-select
         name="config_id"
         ng-model="$ctrl.rubrics"
@@ -24,10 +24,9 @@
           <span ng-bind-html="rubric.label | highlight:$select.search"></span>
         </ui-select-choices>
       </ui-select>
-  
+
       <div class="help-block" ng-messages="rubricForm.config_id.$error" ng-show="RubricSelectForm.$submitted">
         <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
       </div>
     </div>
   </div>
-  

--- a/client/src/modules/users/users.js
+++ b/client/src/modules/users/users.js
@@ -59,6 +59,13 @@ function UsersController($state, $uibModal, Users, Notify, Modal, uiGridConstant
         cellClass : muteDisabledCells,
       },
       {
+        field : 'cashboxes',
+        displayName : 'FORM.LABELS.CASHBOXES',
+        headerCellFilter : 'translate',
+        enableFiltering : true,
+        cellClass : muteDisabledCells,
+      },
+      {
         field : 'action',
         displayName : '',
         cellTemplate : '/modules/users/templates/grid/action.cell.html',

--- a/client/src/modules/users/users.service.js
+++ b/client/src/modules/users/users.service.js
@@ -31,6 +31,9 @@ function UserService(Api) {
     delete user.lastLogin;
     delete user.id;
     delete user.active;
+    delete user.roles;
+    delete user.cashboxes;
+    delete user.depots;
 
     return service.$http.put(`/users/${id}`, user)
       .then(service.util.unwrapHttpResponse);

--- a/client/src/modules/vouchers/complex-voucher.ctrl.js
+++ b/client/src/modules/vouchers/complex-voucher.ctrl.js
@@ -17,12 +17,11 @@ ComplexJournalVoucherController.$inject = [
  *
  * @constructor
  *
- * TODO - Implement caching mechanism for incomplete forms (via AppCache)
  * TODO/FIXME - this error notification system needs serious refactor.
  */
 function ComplexJournalVoucherController(
   Vouchers, Currencies, Session, FindEntity, FindReference, Notify, Toolkit,
-  Receipts, bhConstants, uiGridConstants, VoucherForm, $timeout, Rates
+  Receipts, bhConstants, uiGridConstants, VoucherForm, $timeout, Rates,
 ) {
   const vm = this;
 
@@ -136,7 +135,6 @@ function ComplexJournalVoucherController(
    * @param {object} result
    */
   function updateView(result) {
-
     $timeout(() => {
       // transaction type
       vm.Voucher.details.type_id = result.type_id || vm.Voucher.details.type_id;

--- a/client/src/modules/vouchers/voucher-form.service.js
+++ b/client/src/modules/vouchers/voucher-form.service.js
@@ -19,7 +19,7 @@ VoucherFormService.$inject = [
  */
 function VoucherFormService(
   Vouchers, Constants, Session, VoucherItem, AppCache, Store, Accounts,
-  $timeout, $translate, Exchange, FormatTreeData
+  $timeout, $translate, Exchange, FormatTreeData,
 ) {
   // Error Flags
   // must have transaction_type for certain cases

--- a/server/controllers/admin/users/index.js
+++ b/server/controllers/admin/users/index.js
@@ -49,12 +49,15 @@ async function lookupUser(id) {
     SELECT user.id, user.username, user.email, user.display_name,
       user.active, user.last_login AS lastLogin, user.deactivated,
       GROUP_CONCAT(DISTINCT role.label ORDER BY role.label DESC SEPARATOR ', ') AS roles,
-      GROUP_CONCAT(DISTINCT depot.text ORDER BY depot.text DESC SEPARATOR ', ') AS depots
+      GROUP_CONCAT(DISTINCT depot.text ORDER BY depot.text DESC SEPARATOR ', ') AS depots,
+      GROUP_CONCAT(DISTINCT cb.label ORDER BY cb.label DESC SEPARATOR ', ') AS cashboxes
     FROM user
       LEFT JOIN user_role ur ON user.id = ur.user_id
       LEFT JOIN role ON role.uuid = ur.role_uuid
       LEFT JOIN depot_permission dp ON dp.user_id = user.id
       LEFT JOIN depot ON dp.depot_uuid = depot.uuid
+      LEFT JOIN cashbox_permission ON user.id = cashbox_permission.user_id
+      LEFT JOIN cash_box cb ON cashbox_permission.cashbox_id = cb.id
     WHERE user.id = ?
     GROUP BY user.id;
   `.trim();
@@ -91,12 +94,15 @@ async function list(req, res, next) {
     const sql = `
       SELECT user.id, user.display_name, user.username, user.deactivated,
         GROUP_CONCAT(DISTINCT role.label ORDER BY role.label DESC SEPARATOR ', ') AS roles,
-        GROUP_CONCAT(DISTINCT depot.text ORDER BY depot.text DESC SEPARATOR ', ') AS depots
+        GROUP_CONCAT(DISTINCT depot.text ORDER BY depot.text DESC SEPARATOR ', ') AS depots,
+      GROUP_CONCAT(DISTINCT cb.label ORDER BY cb.label DESC SEPARATOR ', ') AS cashboxes
       FROM user
         LEFT JOIN user_role ur ON user.id = ur.user_id
         LEFT JOIN role ON role.uuid = ur.role_uuid
         LEFT JOIN depot_permission dp ON dp.user_id = user.id
         LEFT JOIN depot ON dp.depot_uuid = depot.uuid
+        LEFT JOIN cashbox_permission ON user.id = cashbox_permission.user_id
+        LEFT JOIN cash_box cb ON cashbox_permission.cashbox_id = cb.id
       GROUP BY user.id;
     `.trim();
 

--- a/server/controllers/payroll/rubricConfig/index.js
+++ b/server/controllers/payroll/rubricConfig/index.js
@@ -18,7 +18,7 @@ function lookupRubricConfig(id) {
 // Lists the Payroll RubricConfigs
 function list(req, res, next) {
   const sql = `
-    SELECT c.id, c.label FROM config_rubric AS c   
+    SELECT c.id, c.label FROM config_rubric AS c
   ;`;
 
   db.exec(sql)
@@ -98,7 +98,7 @@ function del(req, res, next) {
 */
 function listConfig(req, res, next) {
   const sql = `
-    SELECT config_rubric_item.id, config_rubric_item.config_rubric_id, config_rubric_item.rubric_payroll_id 
+    SELECT config_rubric_item.id, config_rubric_item.config_rubric_id, config_rubric_item.rubric_payroll_id
       FROM config_rubric_item
     WHERE config_rubric_item.config_rubric_id = ?;
   `;


### PR DESCRIPTION
Uses GROUP_CONCAT() to ensure that roles and depots are assigned to users instead of using JavaScript Objects.  This is also helpful because we can order the values in alphabetical order.

It looks like this:
![image](https://user-images.githubusercontent.com/896472/74438475-89958980-4e6a-11ea-9a21-6dfcca2d45e9.png)


Closes #4136