### PR TITLE
feat(patients): add patient groups to record page

### DIFF
--- a/client/src/modules/patients/record/patient-record.html
+++ b/client/src/modules/patients/record/patient-record.html
@@ -69,6 +69,13 @@
 
                   <dt translate>TABLE.COLUMNS.GENDER</dt>
                   <dd id="gender">{{::PatientRecordCtrl.patient.sex}}</dd>
+
+                  <dt translate>FORM.LABELS.GROUPS_PATIENT_TITLE</dt>
+                  <ul class="list-unstyled">
+                    <li ng-repeat="group in PatientRecordCtrl.patient.groups track by group.uuid">
+                      {{group.name}}
+                    </li>
+                  </ul>
                 </dl>
               </div>
 


### PR DESCRIPTION
Adds the patient groups to the patient record page so they are quite  visible.  It looks like this:

![image](https://user-images.githubusercontent.com/896472/74438200-e93f6500-4e69-11ea-9160-e93c3ae638d3.png)


Closes #4155.