### PR TITLE
fix(stock): improve stock lots pdf renderer

### DIFF
--- a/server/controllers/stock/reports/stock_lots.report.handlebars
+++ b/server/controllers/stock/reports/stock_lots.report.handlebars
@@ -5,109 +5,90 @@
   {{> header}}
 
   <!-- body  -->
-  <div class="row">
-    <div class="col-xs-12">
+  <!-- page title  -->
+  <h2 class="text-center text-uppercase">
+    {{translate 'TREE.STOCK_LOTS'}}
+  </h2>
 
-      <!-- page title  -->
-      <h2 class="text-center text-uppercase">
-        {{translate 'TREE.STOCK_LOTS'}}
-      </h2>
+  <h4 class="text-center">
+    {{date}}
+  </h4>
 
-      <h4 class="text-center">
-        {{date}}
-      </h4>
+  <!-- filters  -->
+  {{> filterbar filters=filters }}
 
-      <!-- filters  -->
-      {{#if hasFilter}}
-          <p class="pills">
-            {{#each filters}}
-              <span class="label label-primary text-capitalize">
-                <i class="fa fa-filter"></i> {{translate this.displayName}}
+  <!-- list of data  -->
+  <table class="table table-condensed table-bordered table-report">
+    <thead>
+      <tr>
+        <th>{{translate 'STOCK.CODE'}}</th>
+        <th>{{translate 'STOCK.INVENTORY'}}</th>
+        <th>{{translate 'STOCK.INVENTORY_GROUP'}}</th>
+        <th>{{translate 'STOCK.LOT'}}</th>
+        <th>{{translate 'STOCK.QUANTITY'}}</th>
+        <th>{{translate 'STOCK.INVENTORY_UNIT'}}</th>
+        <th>{{translate 'STOCK.ENTRY_DATE'}}</th>
+        <th>{{translate 'STOCK.EXPIRATION_DATE'}}</th>
+        <th>{{translate 'STOCK.EXPIRATION'}}</th>
+        <th>{{translate 'STOCK.CMM'}}</th>
+        <th>{{translate 'STOCK.MSD'}}</th>
+        <th>{{translate 'STOCK.LIFETIME'}}</th>
+        <th>{{translate 'STOCK.LOT_LIFETIME'}}</th>
+        <th>{{translate 'STOCK.RISK'}}</th>
+        <th>{{translate 'STOCK.RISK_QUANTITY'}}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <!-- for each depots which contains lots -->
+      {{#each depots as | items name |}}
 
-                {{#if this.comparitor}} {{this.comparitor}}
-                {{else}}: {{/if}}
+        <!-- this is the depot group header -->
+        <tr style="border:none">
+          <th style="border:none; border-bottom: solid black 2px;" class="text-uppercase" colspan="10">
+            {{ name }}
+          </th>
 
-                {{#if this.isDate}} {{date this.value}}
-                {{else}} {{translate this.value}} {{/if}}
+          <th colspan="5" style="border:none; border-bottom: solid black 2px;" class="text-right">
+            ({{ items.length }} {{ translate "TABLE.AGGREGATES.RECORDS" }})
+          </th>
+        </tr>
 
-              </span>
-            {{/each}}
-          </p>
-        {{/if}}
-
-      <!-- list of data  -->
-      <table class="table table-condensed table-bordered table-report">
-        <thead>
+        <!-- these are the items for each group -->
+        {{#each items as | item | }}
           <tr>
-            <th>{{translate 'STOCK.CODE'}}</th>
-            <th>{{translate 'STOCK.INVENTORY'}}</th>
-            <th>{{translate 'STOCK.INVENTORY_GROUP'}}</th>
-            <th>{{translate 'STOCK.LOT'}}</th>
-            <th>{{translate 'STOCK.QUANTITY'}}</th>
-            <th>{{translate 'STOCK.INVENTORY_UNIT'}}</th>
-            <th>{{translate 'STOCK.ENTRY_DATE'}}</th>
-            <th>{{translate 'STOCK.EXPIRATION_DATE'}}</th>
-            <th>{{translate 'STOCK.EXPIRATION'}}</th>
-            <th>{{translate 'STOCK.CMM'}}</th>
-            <th>{{translate 'STOCK.MSD'}}</th>
-            <th>{{translate 'STOCK.LIFETIME'}}</th>
-            <th>{{translate 'STOCK.LOT_LIFETIME'}}</th>
-            <th>{{translate 'STOCK.RISK'}}</th>
-            <th>{{translate 'STOCK.RISK_QUANTITY'}}</th>
+            <td>{{code}}</td>
+            <td>{{text}}</td>
+            <td>{{group_name}}</td>
+            <td>{{label}}</td>
+            <td class="text-right">{{quantity}}</td>
+            <td class="text-right">{{unit_type}}</td>
+            <td class="text-right">{{date entry_date}}</td>
+            {{#if item.expires}}
+              <td class="text-right">{{date expiration_date}}</td>
+              <td class="text-right">{{delay_expiration}}</td>
+            {{else}}
+              <td class="text-center"> - </td>
+              <td class="text-center"> - </td>
+            {{/if}}
+            <td class="text-right">{{avg_consumption}}</td>
+            <td class="text-right">{{S_MONTH}}</td>
+            <td class="text-right">{{lifetime}}</td>
+            <td class="text-right">{{S_LOT_LIFETIME}}</td>
+            <td class="text-right">{{S_RISK}}</td>
+            <td class="text-right">{{S_RISK_QUANTITY}}</td>
           </tr>
-        </thead>
-        <tbody>
-          <!-- for each depots which contains lots -->
-          {{#each depots as | items name |}}
+        {{else}}
+            {{> emptyTable columns=15}}
+        {{/each}}
 
-            <!-- this is the depot group header -->
-            <tr style="border:none">
-              <th style="border:none; border-bottom: solid black 2px;" class="text-uppercase">
-                {{ name }}
-              </th>
-
-              <th colspan="14" style="border:none; border-bottom: solid black 2px;" class="text-right">
-                ({{ items.length }} {{ translate "TABLE.AGGREGATES.RECORDS" }})
-              </th>
-            </tr>
-
-            <!-- these are the items for each group -->
-            {{#each items as | item | }}
-              <tr>
-                <td>{{code}}</td>
-                <td>{{text}}</td>
-                <td>{{group_name}}</td>
-                <td>{{label}}</td>
-                <td class="text-right">{{quantity}}</td>
-                <td class="text-right">{{unit_type}}</td>
-                <td class="text-right">{{date entry_date}}</td>
-                {{#if item.expires}}
-                  <td class="text-right">{{date expiration_date}}</td>
-                  <td class="text-right">{{delay_expiration}}</td>
-                {{else}}
-                  <td class="text-center"> - </td>
-                  <td class="text-center"> - </td>
-                {{/if}}
-                <td class="text-right">{{avg_consumption}}</td>
-                <td class="text-right">{{S_MONTH}}</td>
-                <td class="text-right">{{lifetime}}</td>
-                <td class="text-right">{{S_LOT_LIFETIME}}</td>
-                <td class="text-right">{{S_RISK}}</td>
-                <td class="text-right">{{S_RISK_QUANTITY}}</td>
-              </tr>
-            {{/each}}
-
-            <!-- blank row  -->
-            {{#unless @last }}
-              <!-- blank line -->
-              <tr style="border:none;">
-                <th style="border:none;"></th>
-              </tr>
-            {{/unless}}
-
-          {{/each}}
-        </tbody>
-      </table>
-    </div>
-  </div>
+        <!-- blank row  -->
+        {{#unless @last }}
+          <!-- blank line -->
+          <tr style="border:none;">
+            <th style="border:none;"></th>
+          </tr>
+        {{/unless}}
+      {{/each}}
+    </tbody>
+  </table>
 </body>


### PR DESCRIPTION
Ensures the group header in the stock lots report doesn't overflow and reflow the page.  This improves legibility.