### PR TITLE
fix(inventory): improve PDF rendering

### DIFF
--- a/server/controllers/inventory/reports/items.handlebars
+++ b/server/controllers/inventory/reports/items.handlebars
@@ -2,7 +2,6 @@
 
 <body>
   <div class="container">
-
     <!-- header  -->
     <div class="row">
       <div class="col-xs-4">

--- a/server/controllers/inventory/reports/prices.handlebars
+++ b/server/controllers/inventory/reports/prices.handlebars
@@ -1,69 +1,62 @@
 {{> head title="INVENTORY.PRICE_LIST_REPORT" }}
 
 <body>
-
   {{> header }}
 
   <h3 class="text-center">{{translate "INVENTORY.PRICES"}}</h3>
 
-  <!-- body  -->
-  <div class="row">
-    <div class="col-xs-12">
+  <table class="table table-condensed table-bordered table-report">
+    <thead>
+      <tr>
+        <th class="text-center">{{translate "FORM.LABELS.CODE"}}</th>
+        <th class="text-center">{{translate "FORM.LABELS.CONSUMABLE"}}</th>
+        <th class="text-center">{{translate "FORM.LABELS.LABEL"}}</th>
+        <th class="text-center">{{translate "FORM.LABELS.UNIT_PRICE"}}</th>
+        <th class="text-center">{{translate "FORM.LABELS.DEFAULT_QUANTITY"}}</th>
+        <th class="text-center">{{translate "FORM.LABELS.TYPE"}}</th>
+        <th class="text-center">{{translate "FORM.LABELS.UNIT"}}</th>
+      </tr>
+    </thead>
+    <tbody>
 
-      <table class="table table-condensed table-bordered">
-        <thead>
+      <!-- for each inventory group -->
+      {{#each groups as | items name |}}
+
+        <!-- this is the inventory group header -->
+        <tr style="border:none">
+          <th colspan="3" style="border:none; border-bottom: solid black 2px;" class="text-uppercase">
+            {{ name }}
+          </th>
+
+          <th colspan="4" style="border:none; border-bottom: solid black 2px;" class="text-right">
+            ({{ items.length }} {{ translate "TABLE.AGGREGATES.RECORDS" }})
+          </th>
+        </tr>
+
+        <!-- these are the items for each group -->
+        {{#each items as | item | }}
           <tr>
-            <th class="text-center">{{translate "FORM.LABELS.CODE"}}</th>
-            <th class="text-center">{{translate "FORM.LABELS.CONSUMABLE"}}</th>
-            <th class="text-center">{{translate "FORM.LABELS.LABEL"}}</th>
-            <th class="text-center">{{translate "FORM.LABELS.UNIT_PRICE"}}</th>
-            <th class="text-center">{{translate "FORM.LABELS.DEFAULT_QUANTITY"}}</th>
-            <th class="text-center">{{translate "FORM.LABELS.TYPE"}}</th>
-            <th class="text-center">{{translate "FORM.LABELS.UNIT"}}</th>
+            <td>{{item.code}}</div>
+            <td>{{item.consumable}}</div>
+            <td style="text-overflow:ellipsis">
+              <span style="margin-left: 10px;">{{ item.label }}</span>
+            </td>
+            <td class="text-right" style="min-width:150px;">
+              {{currency item.price ../../metadata.enterprise.currency_id}}
+            </td>
+            <td class="text-right">{{ item.default_quantity }}</td>
+            <td>{{ item.type }}</td>
+            <td>{{ item.unit }}</td>
           </tr>
-        </thead>
-        <tbody>
+        {{/each}}
 
-          <!-- for each inventory group -->
-          {{#each groups as | items name |}}
-
-            <!-- this is the inventory group header -->
-            <tr style="border:none">
-              <th colspan="3" style="border:none; border-bottom: solid black 2px;" class="text-uppercase">
-                {{ name }}
-              </th>
-
-              <th colspan="4" style="border:none; border-bottom: solid black 2px;" class="text-right">
-                ({{ items.length }} {{ translate "TABLE.AGGREGATES.RECORDS" }})
-              </th>
-            </tr>
-
-            <!-- these are the items for each group -->
-            {{#each items as | item | }}
-              <tr>
-                <td>{{item.code}}</div>
-                <td>{{item.consumable}}</div>                                
-                <td style="text-overflow:ellipsis">
-                  <span style="margin-left: 10px;">{{ item.label }}</span>
-                </td>
-                <td class="text-right" style="min-width:150px;">
-                  {{currency item.price ../../metadata.enterprise.currency_id}}
-                </td>
-                <td class="text-right">{{ item.default_quantity }}</td>
-                <td>{{ item.type }}</td>
-                <td>{{ item.unit }}</td>
-              </tr>
-            {{/each}}
-
-            {{#unless @last }}
-              <!-- blank line -->
-              <tr style="border:none;">
-                <th style="border:none;"></th>
-              </tr>
-            {{/unless}}
-          {{/each}}
-        </tbody>
-      </table>
-    </div>
-  </div>
+        {{#unless @last }}
+          <!-- blank line -->
+          <tr style="border:none;">
+            <th style="border:none;"></th>
+          </tr>
+        {{/unless}}
+      {{/each}}
+    </tbody>
+  </table>
 </body>


### PR DESCRIPTION
Ensures the PDF render downloads the inventory list in A4 landscape
format.  Interestingly, this does not cause the list to grow or shrink,
but greatly improve legibility.  Also rewrites the rendering code to use
async/await.