### PR TITLE
fix(invoices): improve registry PDF rendering

### DIFF
--- a/server/controllers/finance/reports/invoices/index.js
+++ b/server/controllers/finance/reports/invoices/index.js
@@ -49,8 +49,7 @@ function report(req, res, next) {
   _.extend(query, {
     filename : 'INVOICE_REGISTRY.TITLE',
     csvKey : 'rows',
-    footerRight : '[page] / [toPage]',
-    footerFontSize : '8',
+    orientation : 'landscape',
   });
 
   try {
@@ -175,15 +174,15 @@ function receipt(req, res, next) {
 
         if (invoiceResponse.exchange) {
           invoiceResponse.invoiceBalance.exchangedDebit = _.round(
-            invoiceResponse.invoiceBalance.debit * invoiceResponse.exchange
+            invoiceResponse.invoiceBalance.debit * invoiceResponse.exchange,
           );
 
           invoiceResponse.invoiceBalance.exchangedCredit = _.round(
-            invoiceResponse.invoiceBalance.credit * invoiceResponse.exchange
+            invoiceResponse.invoiceBalance.credit * invoiceResponse.exchange,
           );
 
           invoiceResponse.invoiceBalance.exchangedBalance = _.round(
-            invoiceResponse.invoiceBalance.balance * invoiceResponse.exchange
+            invoiceResponse.invoiceBalance.balance * invoiceResponse.exchange,
           );
         }
       }

--- a/server/controllers/finance/reports/invoices/report.handlebars
+++ b/server/controllers/finance/reports/invoices/report.handlebars
@@ -3,62 +3,52 @@
 <body>
   {{> header}}
 
-  <!-- body  -->
-  <div class="row">
-    <div class="col-xs-12">
+  <!-- page title  -->
+  <h2 class="text-center text-uppercase">
+    {{translate 'INVOICE_REGISTRY.TITLE'}}
+  </h2>
 
-      <!-- page title  -->
-      <h2 class="text-center text-uppercase">
-        {{translate 'INVOICE_REGISTRY.TITLE'}}
-      </h2>
+  <br />
 
-      <h3 class="text-center">
-        {{#if project.id}}{{project.name}}<br>{{/if}}
-        <small>{{date aggregates.minDate }} - {{date aggregates.maxDate}}</small>
-      </h3>
+  {{> filterbar filters=filters }}
 
-      <br>
-
-      {{> filterbar filters=filters }}
-
-      <!-- invoices listed  -->
-      <table class="table table-condensed table-bordered">
-        <thead>
-          <tr>
-            <th>{{translate 'TABLE.COLUMNS.REFERENCE'}}</th>
-            <th>{{translate 'TABLE.COLUMNS.BILLING_DATE'}}</th>
-            <th>{{translate 'TABLE.COLUMNS.PATIENT'}}</th>
-            <th>{{translate 'TABLE.COLUMNS.AMOUNT'}}</th>
-            <th>{{translate 'TABLE.COLUMNS.SERVICE'}}</th>
-            <th>{{translate 'TABLE.COLUMNS.CREATED_BY'}}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each rows}}
-            <tr>
-              <td title="{{reference}}">{{reference}}</td>
-              <td class="text-right">{{date date}}</td>
-              <td title="{{patientName}}">{{patientName}}</td>
-              <td class="text-right">{{currency cost currency_id}}</td>
-              <td>{{serviceName}}</td>
-              <td>{{display_name}}</td>
-            </tr>
-          {{else}}
-            {{> emptyTable columns=6}}
-          {{/each}}
-        </tbody>
-        <tfoot>
-          <tr>
-            <th colspan="3">{{ translate 'TABLE.AGGREGATES.NUM_INVOICES' }}: {{ aggregates.numInvoices }} </th>
-            <th class="text-right">{{currency aggregates.amount metadata.enterprise.currency_id }}</th>
-            <th colspan="2"></th>
-          </tr>
-        </tfoot>
-      </table>
-    </div>
-  </div>
+  <!-- invoices listed  -->
+  <table class="table table-condensed table-report">
+    <thead>
+      <tr>
+        <th>{{translate 'TABLE.COLUMNS.REFERENCE'}}</th>
+        <th>{{translate 'TABLE.COLUMNS.BILLING_DATE'}}</th>
+        <th>{{translate 'TABLE.COLUMNS.PATIENT'}}</th>
+        <th>{{translate 'TABLE.COLUMNS.AMOUNT'}}</th>
+        <th>{{translate 'TABLE.COLUMNS.SERVICE'}}</th>
+        <th>{{translate 'TABLE.COLUMNS.CREATED_BY'}}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each rows}}
+        <tr>
+          <td title="{{reference}}">{{reference}}</td>
+          <td class="text-right">{{date date}}</td>
+          <td title="{{patientName}}">{{patientName}}</td>
+          <td class="text-right">{{currency cost currency_id}}</td>
+          <td>{{serviceName}}</td>
+          <td>{{display_name}}</td>
+        </tr>
+      {{else}}
+        {{> emptyTable columns=6}}
+      {{/each}}
+    </tbody>
+    <tfoot>
+      <tr>
+        <th colspan="3">{{ translate 'TABLE.AGGREGATES.NUM_INVOICES' }}: {{ aggregates.numInvoices }} </th>
+        <th class="text-right">{{currency aggregates.amount metadata.enterprise.currency_id }}</th>
+        <th colspan="2"></th>
+      </tr>
+    </tfoot>
+  </table>
 
   {{#if aggregates}}
+    <br />
     <div class="row">
       <div class="col-xs-6">
 


### PR DESCRIPTION
Cleans up the invoice registry pdf renderer download by forcing it to
render in landscape instead of portrait. Also removes some large but
extraneous elements.