### PR TITLE
fix(tests): specify date & time precision

### DIFF
--- a/test/client-unit/services/util.spec.js
+++ b/test/client-unit/services/util.spec.js
@@ -28,7 +28,7 @@ describe('util', () => {
     // you should be able to pass in a context to use as this
     const context = { y : 0 };
     fn = util.once(function cb() {
-      this.y = this.y + 3;
+      this.y += 3;
     }, context);
 
     fn();
@@ -84,7 +84,7 @@ describe('util', () => {
   });
 
   it('#formatDate() should take a date and transform it into a format passed in as a second argument.', () => {
-    const date = new Date('2018-01-31');
+    const date = new Date('2018-01-31 12:00:00');
     const expected = '31/01/2018';
     const format = 'DD/MM/YYYY';
 
@@ -224,7 +224,7 @@ describe('util', () => {
   });
 
   it(`
-  #grouptBy() should returns an object with properties the values of the given property, 
+  #grouptBy() should returns an object with properties the values of the given property,
   and value an array of objects having for the given property the value which correspond
   to the property
   `, () => {

--- a/test/integration/fiscalYear.extra.js
+++ b/test/integration/fiscalYear.extra.js
@@ -5,7 +5,7 @@ const helpers = require('./helpers');
 
 describe('(/fiscal) Fiscal Year extra operations', () => {
   const url = '/fiscal';
-  const date = new Date('2017-08-24');
+  const date = new Date('2017-08-24 12:00:00');
 
   const fiscalYear2015 = {
     id : 1,
@@ -35,7 +35,8 @@ describe('(/fiscal) Fiscal Year extra operations', () => {
    * from the date 2017-08-24
    */
   it(`GET /fiscal/date?date=${flatDate(date)} returns the fiscal year from a given date`, () => {
-    return agent.get(url.concat(`/date?date=${date}`))
+    return agent.get(url.concat('/date'))
+      .query({ date })
       .then(res => {
         helpers.api.listed(res, 1);
         const [fy] = res.body;


### PR DESCRIPTION
Fixes a few timezone bugs in tests due to the lack of the time component in a few tests.