### PR TITLE
display associated invoice for stock movment

### DIFF
--- a/server/controllers/stock/reports/stock_exit_patient.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_exit_patient.receipt.handlebars
@@ -22,6 +22,11 @@
       <div class="col-xs-6">
         <span class="text-capitalize">{{translate 'STOCK.DEPOT'}}</span>: <strong>{{details.depot_name}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.DOCUMENT'}}</span>: <strong>{{details.document_reference}}</strong> <br>
+        
+        {{#if details.hasInvoiceReference}}
+        <span class="text-capitalize">{{translate 'FORM.LABELS.INVOICE'}}</span>: <strong>{{details.invoice_reference}}</strong> <br>
+        {{/if}}
+
         {{#if details.voucher_reference}}
           <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: <strong>{{details.voucher_reference}}</strong> <br>
         {{/if}}


### PR DESCRIPTION
This PR help to display the associated invoice reference for a stock movement to a patient
closes #4120.

![mvt-invoice](https://user-images.githubusercontent.com/25838121/75868067-d20beb80-5e07-11ea-9218-1b0aef522f15.PNG)

