### PR TITLE
docs: improve Digital Ocean deployment docs

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.2.1)
+    activesupport (6.0.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -204,9 +204,9 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.14.0)
     multipart-post (2.1.1)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    octokit (4.16.0)
+    octokit (4.17.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.2)
@@ -218,7 +218,7 @@ GEM
     rouge (3.13.0)
     ruby-enum (0.7.2)
       i18n
-    rubyzip (2.2.0)
+    rubyzip (2.3.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -235,8 +235,8 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
-    unicode-display_width (1.6.1)
-    zeitwerk (2.2.2)
+    unicode-display_width (1.7.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby

--- a/docs/cloud-init.yml
+++ b/docs/cloud-init.yml
@@ -94,9 +94,6 @@ write_files:
 
 runcmd:
 
-# configure SSH
-  - sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin no/' /etc/ssh/sshd_config
-
 # configure UFW
   - ufw default deny incoming
   - ufw default allow outgoing
@@ -155,3 +152,6 @@ runcmd:
   - apt-get -y update
   - apt-get -y install python-certbot-nginx
   - (crontab -l 2>/dev/null; echo "0 0 1 * * /usr/bin/certbot renew > /var/log/letsencrypt/letsencrypt.log") | crontab -
+
+  - apt-get autoremove -y -qq
+  - apt-get autoclean -y -qq

--- a/docs/en/for-developers/installing-bhima.md
+++ b/docs/en/for-developers/installing-bhima.md
@@ -1,5 +1,7 @@
 # Installing BHIMA
 
+_Note: these are the instructions for installing the BHIMA development environment.  If you wish to deploy BHIMA in production, check out our [deployment instructions for Digital Ocean](../getting-started/deploying-digital-ocean.md)._
+
 The BHIMA software can be complex to install.  We only officially support Linux, so the following guide assumes you are setting up BHIMA on Debian-based Linux environment.
 
 This guide will get you up and running with bhima locally. Please note that bhima is under active development and tends to move fast and break things. If you are interested in development progress, shoot us a line at [developers@imaworldhealth.org](mailto:developers@imaworldhealth.org).

--- a/docs/en/getting-started/deploying-digital-ocean.md
+++ b/docs/en/getting-started/deploying-digital-ocean.md
@@ -1,5 +1,5 @@
 <style>
-    .guilabel {
+  .guilabel {
     border: 1px solid #7fbbe3 !important;
     background: #e7f2fa;
     font-size: 80%;
@@ -7,16 +7,17 @@
     border-radius: 4px;
     padding: 2.4px 6px;
     margin: auto 2px;
-    color:#001
-    }
+    color:#001;
+    white-space: nowrap;
+  }
 
-    .left40 {
-      margin-left:40px
-    }
+  .left40 {
+    margin-left:40px
+  }
 </style>
 
 
-# Installing BHIMA on DigitalOcean
+# Deploying BHIMA on DigitalOcean
 
 <i> Follow these steps below posted at https://docs.opendatakit.org/aggregate-digital-ocean</i>
 

--- a/docs/en/getting-started/index.md
+++ b/docs/en/getting-started/index.md
@@ -1,0 +1,2 @@
+
+Welcome!  The first thing you'll want to do is [deploy on Digital Ocean](./deploying-digital-ocean).

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -4,12 +4,12 @@ Welcome! This manual is for the Basic Hospital Information Management Applicatio
 
 This manual is split into chapters:
 
-1. Getting Started
-2. [Finance Modules](./finance/index.md)
-3. [Medical Records](./medical-records/index.md)
-4. [Inventory and Stock Management](./stock-management/index.md)
+1. [Getting Started](./getting-started)
+2. [Finance Modules](./finance)
+3. [Medical Records](./medical-records)
+4. [Inventory and Stock Management](./stock-management)
 5. Reporting and Statistics
-6. [Developer Reference](./for-developers/index.md)
+6. [Developer Reference](./for-developers)
 
 # About
 

--- a/docs/fr/for-developers/installing-bhima.md
+++ b/docs/fr/for-developers/installing-bhima.md
@@ -1,5 +1,7 @@
 # Installation de BHIMA
 
+NB: ce sont les instructions pour installer l'environnement de développement BHIMA. Si vous souhaitez déployer BHIMA en production, consultez nos [instructions de déploiement pour Digital Ocean](../getting-started/deploying-digital-ocean.md).
+
 Le logiciel BHIMA peut être complexe à installer. Nous ne prenons officiellement en charge que Linux. Le guide suivant suppose donc que vous configurez BHIMA dans un environnement Linux basé sur Debian.
 
 Ce guide vous permettra de vous familiariser avec bhima localement. Veuillez noter que bhima est en développement actif et a tendance à aller vite et à casser des choses. Si vous êtes intéressé par les progrès du développement, envoyez-nous une ligne à [developers@imaworldhealth.org](mailto: developers@imaworldhealth.org).

--- a/docs/fr/getting-started/deploying-digital-ocean.md
+++ b/docs/fr/getting-started/deploying-digital-ocean.md
@@ -1,6 +1,6 @@
 
 <style>
-    .guilabel {
+  .guilabel {
     border: 1px solid #7fbbe3 !important;
     background: #e7f2fa;
     font-size: 80%;
@@ -8,16 +8,17 @@
     border-radius: 4px;
     padding: 2.4px 6px;
     margin: auto 2px;
-    color:#001
-    }
+    color:#001;
+    white-space: nowrap;
+  }
 
-    .left40 {
-      margin-left:40px
-    }
+  .left40 {
+    margin-left:40px
+  }
 </style>
 
 
-# Installing BHIMA on DigitalOcean
+# Deploying BHIMA on DigitalOcean
 
 <i> Suivez ces étapes ci-dessous posté à https://docs.opendatakit.org/aggregate-digital-ocean</i>
 

--- a/docs/fr/getting-started/index.md
+++ b/docs/fr/getting-started/index.md
@@ -1,0 +1,3 @@
+
+
+Welcome!  The first thing you'll want to do is [deploy on Digital Ocean](./deploying-digital-ocean).

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -4,17 +4,16 @@ Bienvenue! Ce manuel est destiné à l’application de base de gestion des info
 
 Ce manuel est divisé en chapitres:
 
-1. Commencer
-2. [Modules Finance](./finance/index.md)
-3. [Dossiers médicaux](./medical-records/index.md)
-4. [Gestion des stocks](./stock-management/index.md)
+1. [Commencer](./getting-started/)
+2. [Modules Finance](./finance/)
+3. [Dossiers médicaux](./medical-records/)
+4. [Gestion des stocks](./stock-management/)
 5. [Références des Comptes](./references-comptes)
 6. [Centre des frais](./centre-des-frais)
 7. [Ressources humaines](./payroll)
-8. [Seuil de rentabilité](./break-even) 
+8. [Seuil de rentabilité](./break-even)
 9. Rapports et statistiques
-
-10. [Référence développeur](./for-developers/index.md)
+10. [Référence développeur](./for-developers/)
 
 ## A propos
 


### PR DESCRIPTION
Properly link the deployment documentation from the getting-started section of the documentation.  These instructions have been tested in production.