### PR TITLE
chore(reports): clean up cron email configurations.

### DIFF
--- a/client/src/js/components/bhCronEmailReport/bhCronEmailReport.html
+++ b/client/src/js/components/bhCronEmailReport/bhCronEmailReport.html
@@ -5,8 +5,8 @@
       <i class="fa fa-envelope-o"></i>
       <span translate>CRON.AUTO_EMAIL_REPORT</span>
     </div>
-    <div class="panel-body">
-      <form name="CronForm" bh-submit="$ctrl.submit(CronForm)" novalidate>
+    <form name="CronForm" bh-submit="$ctrl.submit(CronForm)" novalidate>
+      <div class="panel-body">
         <!-- label -->
         <bh-input-text
           key="label"
@@ -15,16 +15,16 @@
           autocomplete="off"
           required="true">
         </bh-input-text>
-  
+
         <!-- group -->
         <bh-entity-group-select
           uuid="$ctrl.cron.entity_group_uuid"
           on-select-callback="$ctrl.onSelectEntityGroup(entityGroup)"
           required="true">
         </bh-entity-group-select>
-  
+
         <!-- frequency -->
-        <bh-cron-select 
+        <bh-cron-select
           id="$ctrl.cron.cron_id"
           on-select-callback="$ctrl.onSelectCron(cron)"
           required="true">
@@ -36,14 +36,14 @@
           value="$ctrl.cron.has_dynamic_dates"
           on-change-callback="$ctrl.onChangeDynamicDates(value)">
         </bh-yes-no-radios>
-  
-        <div class="text-right">
-          <button data-method="save-cron-report" type="submit" class="btn btn-primary" translate>
-            CRON.SAVE
-          </button>
-        </div>
-      </form>
-    </div>
+
+      </div>
+      <div class="text-right panel-footer">
+        <bh-loading-button loading-state="CronForm.$loading">
+          <span translate>CRON.SAVE</span>
+        </bh-loading-button>
+      </div>
+    </form>
   </div>
 
   <!-- table -->

--- a/client/src/js/components/bhCronEmailReport/bhCronEmailReport.js
+++ b/client/src/js/components/bhCronEmailReport/bhCronEmailReport.js
@@ -39,14 +39,16 @@ function bhCronEmailReportController(CronEmailReports, Notify, Session, BaseRepo
   $ctrl.$onInit = init;
 
   function init() {
+    $ctrl.isEmailFeatureEnabled = Session.enterprise.settings.enable_auto_email_report;
+
     loadReportDetails($ctrl.reportKey)
       .then(([report]) => {
         $ctrl.cron = {
           report_id : report.id,
           has_dynamic_dates : 0,
         };
-        $ctrl.isEmailFeatureEnabled = Session.enterprise.settings.enable_auto_email_report;
-        load(report.id);
+
+        return load(report.id);
       });
   }
 
@@ -76,7 +78,6 @@ function bhCronEmailReportController(CronEmailReports, Notify, Session, BaseRepo
     $ctrl.sendingPending = true;
     CronEmailReports.send(id)
       .then(() => {
-        $ctrl.sendingPending = false;
         Notify.success('CRON.EMAIL_SENT_SUCCESSFULLY');
       })
       .catch(Notify.handleError)
@@ -94,11 +95,11 @@ function bhCronEmailReportController(CronEmailReports, Notify, Session, BaseRepo
   function submit(cronForm) {
     if ($ctrl.reportForm.$invalid) {
       Notify.warn('CRON.PLEASE_FILL_REPORT_FORM');
-      return;
+      return false;
     }
 
     if (cronForm.$invalid) {
-      return;
+      return false;
     }
 
     const params = {
@@ -106,7 +107,7 @@ function bhCronEmailReportController(CronEmailReports, Notify, Session, BaseRepo
       reportOptions : $ctrl.reportDetails,
     };
 
-    CronEmailReports.create(params)
+    return CronEmailReports.create(params)
       .then(() => reset(cronForm))
       .then(() => init())
       .catch(Notify.handleError);

--- a/client/src/modules/entities/entities.html
+++ b/client/src/modules/entities/entities.html
@@ -7,16 +7,14 @@
 
     <div class="toolbar">
       <div class="toolbar-item">
-        <button class="btn btn-default text-capitalize" id="create" ui-sref="entities.create" data-method="create">
+        <button class="btn btn-default text-capitalize" ui-sref="entities.create" data-method="create">
           <span class="fa fa-plus"></span> <span translate>ENTITY.ADD_ENTITY</span>
         </button>
       </div>
 
-      <div class="toolbar-item">
-        <bh-filter-toggle
-          on-toggle="EntityCtrl.toggleFilter()">
-        </bh-filter-toggle>
-      </div>
+      <bh-filter-toggle
+        on-toggle="EntityCtrl.toggleFilter()">
+      </bh-filter-toggle>
     </div>
   </div>
 </div>

--- a/client/src/modules/entities/entities.js
+++ b/client/src/modules/entities/entities.js
@@ -12,7 +12,7 @@ EntityController.$inject = [
  * This controller is responsible of handling entities
  */
 function EntityController(
-  Entity, ModalService, Notify, uiGridConstants, $state, $translate
+  Entities, ModalService, Notify, uiGridConstants, $state, $translate,
 ) {
   const vm = this;
 
@@ -83,7 +83,7 @@ function EntityController(
   function loadEntities() {
     vm.loading = true;
 
-    Entity.read()
+    Entities.read()
       .then(data => {
         // format location
         vm.gridOptions.data = data.map(entity => {
@@ -103,7 +103,7 @@ function EntityController(
       .then(bool => {
         if (!bool) { return; }
 
-        Entity.delete(entity.uuid)
+        Entities.delete(entity.uuid)
           .then(() => {
             Notify.success('FORM.INFO.DELETE_SUCCESS');
             loadEntities();
@@ -113,8 +113,8 @@ function EntityController(
   }
 
   // update an existing entity
-  function editEntity(entityObject) {
-    $state.go('entities.edit', { entity : entityObject });
+  function editEntity({ uuid }) {
+    $state.go('entities.edit', { uuid });
   }
 
   loadEntities();

--- a/client/src/modules/entities/entities.routes.js
+++ b/client/src/modules/entities/entities.routes.js
@@ -18,9 +18,9 @@ angular.module('bhima.routes')
       })
 
       .state('entities.edit', {
-        url : '/edit',
+        url : '/:uuid/edit',
         params : {
-          entity : { value : {} },
+          uuid : { value : null },
           creating : { value : false },
         },
         onEnter : ['$uibModal', entityModal],

--- a/client/src/modules/entities/modals/entity.modal.html
+++ b/client/src/modules/entities/modals/entity.modal.html
@@ -24,7 +24,7 @@
     </div>
 
     <!-- entity type -->
-    <bh-entity-type-select 
+    <bh-entity-type-select
       id="EntityModalCtrl.entity.entity_type_id"
       on-select-callback="EntityModalCtrl.onSelectEntityType(type)"
       required="true">

--- a/client/src/modules/entities/modals/entity.modal.js
+++ b/client/src/modules/entities/modals/entity.modal.js
@@ -8,8 +8,18 @@ EntityModalController.$inject = [
 function EntityModalController($state, Entities, Notify) {
   const vm = this;
 
-  vm.entity = $state.params.entity || {};
   vm.isCreating = !!($state.params.creating);
+  vm.entity = {};
+
+  function startup() {
+    if (!vm.isCreating) {
+      Entities.read($state.params.uuid)
+        .then(entity => {
+          vm.entity = entity;
+        })
+        .catch(Notify.handleError);
+    }
+  }
 
   // exposed methods
   vm.submit = submit;
@@ -55,4 +65,6 @@ function EntityModalController($state, Entities, Notify) {
   function cancel() {
     $state.go('entities');
   }
+
+  startup();
 }

--- a/client/src/modules/entities/templates/action.tmpl.html
+++ b/client/src/modules/entities/templates/action.tmpl.html
@@ -1,6 +1,6 @@
-<div 
-  class="ui-grid-cell-contents text-center" 
-  uib-dropdown dropdown-append-to-body 
+<div
+  class="ui-grid-cell-contents text-center"
+  uib-dropdown dropdown-append-to-body
   data-row="{{ row.entity.display_name }}">
   <a uib-dropdown-toggle href>
     <span data-action="open-dropdown-menu" translate>FORM.BUTTONS.ACTIONS</span>

--- a/client/src/modules/entity_group/entity_group.html
+++ b/client/src/modules/entity_group/entity_group.html
@@ -7,16 +7,14 @@
 
     <div class="toolbar">
       <div class="toolbar-item">
-        <button class="btn btn-default text-capitalize" id="create" ui-sref="entityGroup.create" data-method="create">
+        <button class="btn btn-default text-capitalize" ui-sref="entityGroup.create" data-method="create">
           <span class="fa fa-plus"></span> <span translate>ENTITY.GROUP.ADD</span>
         </button>
       </div>
 
-      <div class="toolbar-item">
-        <bh-filter-toggle
-          on-toggle="EntityGroupCtrl.toggleFilter()">
-        </bh-filter-toggle>
-      </div>
+      <bh-filter-toggle
+        on-toggle="EntityGroupCtrl.toggleFilter()">
+      </bh-filter-toggle>
     </div>
   </div>
 </div>

--- a/client/src/modules/entity_group/entity_group.js
+++ b/client/src/modules/entity_group/entity_group.js
@@ -12,7 +12,7 @@ EntityGroupController.$inject = [
  * This controller is responsible of handling entity group
  */
 function EntityGroupController(
-  EntityGroup, ModalService, Notify, uiGridConstants, $state
+  EntityGroup, ModalService, Notify, uiGridConstants, $state,
 ) {
   const vm = this;
 

--- a/client/src/modules/entity_group/entity_group.routes.js
+++ b/client/src/modules/entity_group/entity_group.routes.js
@@ -18,7 +18,7 @@ angular.module('bhima.routes')
       })
 
       .state('entityGroup.edit', {
-        url : '/edit',
+        url : '/:uuid/edit',
         params : {
           uuid : { value : null },
           creating : { value : false },

--- a/client/src/modules/entity_group/modals/entity_group.modal.html
+++ b/client/src/modules/entity_group/modals/entity_group.modal.html
@@ -24,7 +24,7 @@
     </div>
 
     <!-- entity type -->
-    <bh-entity-select-multiple 
+    <bh-entity-select-multiple
       entity-uuids="EntityGroupModalCtrl.group.entities"
       on-select-callback="EntityGroupModalCtrl.onSelectEntities(entities)"
       required="true">
@@ -34,7 +34,7 @@
   </div>
 
   <div class="modal-footer">
-    <button data-method="cancel" type="button" class="btn btn-default" ui-sref="entityGroup">
+    <button data-method="cancel" type="button" class="btn btn-default" ui-sref="^">
       <span translate>FORM.BUTTONS.CANCEL</span>
     </button>
 

--- a/client/src/modules/entity_group/templates/action.tmpl.html
+++ b/client/src/modules/entity_group/templates/action.tmpl.html
@@ -1,6 +1,6 @@
-<div 
-  class="ui-grid-cell-contents text-center" 
-  uib-dropdown dropdown-append-to-body 
+<div
+  class="ui-grid-cell-contents text-center"
+  uib-dropdown dropdown-append-to-body
   data-row="{{ row.entity.display_name }}">
   <a uib-dropdown-toggle href>
     <span data-action="open-dropdown-menu" translate>FORM.BUTTONS.ACTIONS</span>

--- a/server/controllers/admin/cronEmailReport/index.js
+++ b/server/controllers/admin/cronEmailReport/index.js
@@ -17,8 +17,8 @@ const { addDynamicDatesOptions } = require('./utils');
 
 const CURRENT_JOBS = new Map();
 
-// TODO(@jniles) - move this into a session variable
 const DEVELOPER_ADDRESS = 'developers@imaworldhealth.org';
+const DEFAULT_LANGUAGE = 'fr';
 const RETRY_COUNT = 5;
 
 function find(options = {}) {
@@ -215,6 +215,11 @@ async function sendEmailReportDocument(record) {
     // dynamic dates in the report params if needed
     if (record.has_dynamic_dates) {
       options = addDynamicDatesOptions(record.cron_id, options);
+    }
+
+    // add in default language if the language isn't specified.
+    if (!options.lang) {
+      options.lang = DEFAULT_LANGUAGE;
     }
 
     const fn = dbReports[record.report_key];

--- a/server/controllers/admin/cronEmailReport/index.js
+++ b/server/controllers/admin/cronEmailReport/index.js
@@ -141,12 +141,12 @@ function send(req, res, next) {
  * @param {any} params params of the function
  */
 function addJob(frequency, cb, ...params) {
-  const cj = new Cron(frequency, () => cb(...params));
-  cj.start();
+  const job = new Cron(frequency, () => cb(...params));
+  job.start();
 
-  const nextRunDate = cj.nextDate().format('YYYY-MM-DD HH:mm:ss');
+  const nextRunDate = job.nextDate().format('YYYY-MM-DD HH:mm:ss');
   debug(`Added and started new job.  Next run at: ${nextRunDate}`);
-  return cj;
+  return job;
 }
 
 /**
@@ -175,7 +175,7 @@ async function launchCronEmailReportJobs() {
 /**
  * @function createEmailReportJob
  * @param {object} record A row of cron email report
- * @param {*} cb The function to run
+ * @param {function} cb The function to run
  */
 function createEmailReportJob(record, cb, ...params) {
   const job = addJob(record.cron_value, cb, ...params);
@@ -242,7 +242,7 @@ async function sendEmailReportDocument(record) {
       retries : RETRY_COUNT,
       onFailedAttempt : async (error) => {
         // eslint-disable-next-line
-        debug(`(${record.label}) Sending report failed with ${error.name}. Attempt ${error.attemptNumber} of ${RETRY_COUNT}.`);
+        debug(`(${record.label}) Sending report failed with ${error.toString()}. Attempt ${error.attemptNumber} of ${RETRY_COUNT}.`);
 
         // delay by 10 seconds
         await delay(10000);

--- a/server/controllers/admin/cronEmailReport/utils.js
+++ b/server/controllers/admin/cronEmailReport/utils.js
@@ -1,0 +1,48 @@
+const BhMoment = require('../../../lib/bhMoment');
+
+/**
+ * @function addDynamicDatesOptions
+ *
+ * @param {Number} cronId - the identifier of the cron task from the database.
+ * @param {Object} options - the options object saved with the report information
+ *
+ * @returns {Object} the newly configured objects objection with starting and ending dates
+ */
+function addDynamicDatesOptions(cronId, options) {
+  // cron ids
+  const DAILY = 1;
+  const WEEKLY = 2;
+  const MONTHLY = 3;
+  const YEARLY = 4;
+
+  const period = new BhMoment(new Date());
+
+  switch (cronId) {
+  case DAILY:
+    options.dateFrom = period.day().dateFrom;
+    options.dateTo = period.day().dateTo;
+    break;
+
+  case WEEKLY:
+    options.dateFrom = period.week().dateFrom;
+    options.dateTo = period.week().dateTo;
+    break;
+
+  case MONTHLY:
+    options.dateFrom = period.month().dateFrom;
+    options.dateTo = period.month().dateTo;
+    break;
+
+  case YEARLY:
+    options.dateFrom = period.year().dateFrom;
+    options.dateTo = period.year().dateTo;
+    break;
+
+  default:
+    break;
+  }
+
+  return options;
+}
+
+module.exports = { addDynamicDatesOptions };

--- a/server/controllers/finance/reports/ohada_balance_sheet/index.js
+++ b/server/controllers/finance/reports/ohada_balance_sheet/index.js
@@ -7,6 +7,7 @@
  * @module reports/ohada_balance_sheet
  *
  * @requires lodash
+ * @requires q
  * @requires lib/ReportManager
  * @requires lib/errors/BadRequest
  */
@@ -24,10 +25,8 @@ const TEMPLATE = './server/controllers/finance/reports/ohada_balance_sheet/repor
 // default report parameters
 const DEFAULT_PARAMS = {
   csvKey : 'accounts',
-  filename : 'TREE.BALANCE',
+  filename : 'REPORT.OHADA.BALANCE_SHEET',
   orientation : 'landscape',
-  footerRight : '[page] / [toPage]',
-  fontSize : 8,
 };
 
 const balanceSheetAssetTable = balanceSheetElement.balanceSheetAssetTable();
@@ -40,6 +39,7 @@ exports.reporting = reporting;
 exports.aggregateReferences = aggregateReferences;
 
 /**
+ * @function reporting
  * @description this function helps to get html document of the report in server side
  * so that we can use it with others modules on the server side
  * @param {object} options the report options
@@ -48,15 +48,9 @@ exports.aggregateReferences = aggregateReferences;
 function reporting(options, session) {
   const params = options;
   const context = {};
-  let report;
 
   _.defaults(params, DEFAULT_PARAMS);
-
-  try {
-    report = new ReportManager(TEMPLATE, session, params);
-  } catch (e) {
-    throw e;
-  }
+  const report = new ReportManager(TEMPLATE, session, params);
 
   return balanceSheetElement.getFiscalYearDetails(params.fiscal_id)
     .then(fiscalYear => {
@@ -74,7 +68,8 @@ function reporting(options, session) {
         currentPeriodReferences,
         previousPeriodReferences,
         currentConditionalReferences,
-        previousConditionalReferences]);
+        previousConditionalReferences,
+      ]);
     })
     .spread((currentData, previousData, currentConditional, previousConditional) => {
       if (currentConditional.length) {
@@ -246,7 +241,7 @@ function reporting(options, session) {
       });
 
       /**
-       * liabilities have by default a creditor sold (negative value),
+       * liabilities have by default a creditor balance (negative value),
        * in order to present them correctly to users they must be converted into positive
        * values, so for doing that we will multiply them by -1
        */

--- a/server/controllers/finance/reports/ohada_balance_sheet/report.handlebars
+++ b/server/controllers/finance/reports/ohada_balance_sheet/report.handlebars
@@ -1,8 +1,7 @@
-{{> head title="TREE.BALANCE_SHEET"}}
+{{> head title="REPORT.OHADA.BALANCE_SHEET"}}
 
 <body>
 
-<div class="container">
   {{> header}}
 
   <!-- body  -->
@@ -18,9 +17,7 @@
       <table style="margin-bottom: 15px; font-size: 10px;" class="table table-striped table-condensed table-report table-bordered">
         <thead>
           <tr style="background-color:#ddd;">
-            <th>&nbsp;</th>
-            <th>&nbsp;</th>
-            <th>&nbsp;</th>
+            <th colspan="3">&nbsp;</th>
             <th class="text-center" colspan="3">{{translate "REPORT.OHADA.EXERCISE"}} {{fiscalYear.details.current_fiscal_year}}</th>
             {{#if fiscalYear.details.previous_fiscal_year}}
               <th class="text-center">{{translate "REPORT.OHADA.EXERCISE"}} {{fiscalYear.details.previous_fiscal_year}}</th>
@@ -38,7 +35,7 @@
             {{/if}}
           </tr>
         </thead>
-        
+
         <tbody>
           {{#each assetTable as | poste |}}
             <tr {{#if poste.is_title}} class="text-uppercase" style="background-color:#efefef; font-weight: bold;"{{/if}}>
@@ -60,9 +57,7 @@
       <table style="margin-bottom: 15px; font-size: 10px;" class="table table-striped table-condensed table-report table-bordered">
         <thead>
           <tr style="background-color:#ddd;">
-            <th>&nbsp;</th>
-            <th>&nbsp;</th>
-            <th>&nbsp;</th>
+            <th colspan="3">&nbsp;</th>
             <th class="text-center">{{translate "REPORT.OHADA.EXERCISE"}} {{fiscalYear.details.current_fiscal_year}}</th>
             {{#if fiscalYear.details.previous_fiscal_year}}
               <th class="text-center">{{translate "REPORT.OHADA.EXERCISE"}} {{fiscalYear.details.previous_fiscal_year}}</th>
@@ -78,7 +73,7 @@
             {{/if}}
           </tr>
         </thead>
-        
+
         <tbody>
           {{#each liabilityTable as | poste |}}
             <tr {{#if poste.is_title}} class="text-uppercase" style="background-color:#efefef; font-weight: bold;"{{/if}}>
@@ -91,7 +86,6 @@
           {{/each}}
         </tbody>
       </table>
-
     </div>
   </div>
 
@@ -101,5 +95,4 @@
     <em>*{{translate 'REPORT.OHADA.ADP'}}: {{translate 'REPORT.OHADA.ADP_LONG'}}</em>
   </p>
 
-</div>
 </body>

--- a/server/lib/mailer.js
+++ b/server/lib/mailer.js
@@ -94,6 +94,7 @@ exports.email = async function email(address, subject, message, options = {}) {
   };
 
   if (options.bcc) {
+    debug(`#email(): BCC-ed addresses: `, options.bcc.join(', '));
     Object.assign(mail, { bcc : options.bcc });
   }
 

--- a/server/models/bhima.sql
+++ b/server/models/bhima.sql
@@ -376,11 +376,13 @@ INSERT INTO `indicator_type`(`id`, `text`,`translate_key`)VALUES
   (3, 'fianance', 'DASHBOARD.FINANCE');
 
 -- cron
+-- NOTE(@jniles): the cron syntax for month is 0-indexed, but the cron
+-- syntax for day is 1-indexed.
 INSERT INTO `cron` (`label`, `value`) VALUES
   ('CRON.DAILY', '0 1 * * *'),
   ('CRON.WEEKLY', '0 1 * * 0'),
   ('CRON.MONTHLY', '0 1 30 * *'),
-  ('CRON.YEARLY', '0 1 31 12 *');
+  ('CRON.YEARLY', '0 1 31 11 *');
 
 -- Survey Form Type
 INSERT INTO `survey_form_type` (`id`, `label`, `type`, `is_list`) VALUES

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -3,3 +3,7 @@ Migrate to next
  */
 -- @lomamech 2020-03-24
 ALTER TABLE `enterprise_setting` ADD COLUMN `month_average_consumption` SMALLINT(5) NOT NULL DEFAULT 6;
+
+-- author: @jniles 2020-03-30
+-- Update yearly cron syntax to 0-indexing rather than 1-indexing.
+UPDATE `cron` SET `value` = '0 1 31 11 *' WHERE `label` = 'CRON.YEARLY';

--- a/test/end-to-end/entities/entities.spec.js
+++ b/test/end-to-end/entities/entities.spec.js
@@ -31,7 +31,7 @@ describe('Entity Management', () => {
       entity.gender,
       entity.phone,
       entity.email,
-      entity.address
+      entity.address,
     );
   });
 
@@ -41,7 +41,7 @@ describe('Entity Management', () => {
       updateEntity.display_name,
       updateEntity.type,
       null, null, null,
-      updateEntity.address
+      updateEntity.address,
     );
   });
 

--- a/test/end-to-end/reports/page.js
+++ b/test/end-to-end/reports/page.js
@@ -40,7 +40,7 @@ class ReportPage {
   // save for auto mailing
   async saveAutoMailing() {
     const anchor = $(this.cronEmailReportwAnchor);
-    await anchor.element(by.css('[data-method="save-cron-report"]')).click();
+    await anchor.element(by.css('[data-method="submit"]')).click();
   }
 
   // config report

--- a/test/server-unit/cron/addDynamicDatesOptions.spec.js
+++ b/test/server-unit/cron/addDynamicDatesOptions.spec.js
@@ -16,21 +16,15 @@ describe('cronEmailReport', () => {
     });
 
 
-    it('#addDynamicDatesOptions() skips if hasDynamicDates is false', () => {
-      const options = { id : 1, label : 'Some ole options' };
-      const processed = addDynamicDatesOptions(1, false, options);
-      expect(processed).to.deep.equal(options);
-    });
-
     it('#addDynamicDatesOptions() does nothing if cronId is unrecognized', () => {
       const options = { id : 1, label : 'Some ole options' };
-      const processed = addDynamicDatesOptions(123, true, options);
+      const processed = addDynamicDatesOptions(123, options);
       expect(processed).to.deep.equal(options);
     });
 
     it('#addDynamicDatesOptions() sets the DAILY schedule to the current day', () => {
       const options = { id : 1, label : 'A schedule' };
-      const processed = addDynamicDatesOptions(DAILY, true, options);
+      const processed = addDynamicDatesOptions(DAILY, options);
       expect(processed.dateFrom).to.be.a('object');
       expect(processed.dateTo).to.be.a('object');
 
@@ -43,7 +37,7 @@ describe('cronEmailReport', () => {
     it('#addDynamicDatesOptions() sets the WEEKLY schedule to the current week', () => {
       const options = { id : 1, label : 'A schedule' };
 
-      const { dateFrom, dateTo } = addDynamicDatesOptions(WEEKLY, true, options);
+      const { dateFrom, dateTo } = addDynamicDatesOptions(WEEKLY, options);
       expect(dateFrom).to.be.a('object');
       expect(dateTo).to.be.a('object');
 
@@ -57,7 +51,7 @@ describe('cronEmailReport', () => {
     it('#addDynamicDatesOptions() sets the MONTHLY schedule to the current month', () => {
       const options = { id : 1, label : 'A schedule' };
 
-      const { dateFrom, dateTo } = addDynamicDatesOptions(MONTHLY, true, options);
+      const { dateFrom, dateTo } = addDynamicDatesOptions(MONTHLY, options);
       expect(dateFrom).to.be.a('object');
       expect(dateTo).to.be.a('object');
 
@@ -72,7 +66,7 @@ describe('cronEmailReport', () => {
     it('#addDynamicDatesOptions() sets the YEARLY schedule to the current year', () => {
       const options = { id : 1, label : 'A schedule' };
 
-      const { dateFrom, dateTo } = addDynamicDatesOptions(YEARLY, true, options);
+      const { dateFrom, dateTo } = addDynamicDatesOptions(YEARLY, options);
       expect(dateFrom).to.be.a('object');
       expect(dateTo).to.be.a('object');
 


### PR DESCRIPTION
This PR cleans up the entities, entity_groups, and automatic reports configurations.  It does the following things:
  1. Ensures that entity and entity groups have edit states that you can link via URL.  This is accomplished by embedding the :uuid in the state URL and downloading the information in the modal
  2. Cleans up the HTML somewhat for both modules
  3. Adds a loading button to the cron configuration.

It also fixes some bugs in the email reports.  Notably, it improves the logging and makes sure month dates are 0-indexed.

Closes https://github.com/IMA-WorldHealth/bhima/issues/3967