### PR TITLE
fix(ci): skip dependabot commit messages.

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -6,3 +6,5 @@ status = [
 delete_merged_branches = true
 
 timeout_sec = 14400
+
+cut_body_after = "</details>"


### PR DESCRIPTION
This commit ensures that dependabot commit messages are stripped before
merging into the master branch to avoid having the ci-skip directive
take hold.