### PR TITLE
make id of multiple_payroll_indice inputs unique

### DIFF
--- a/client/src/modules/multiple_payroll_indice/modals/config.modal.html
+++ b/client/src/modules/multiple_payroll_indice/modals/config.modal.html
@@ -17,13 +17,13 @@
 
     <div class="col-lg-12">
       <div class="col-lg-6" style="margin-top: 16px">
-        <div 
+        <div
         ng-show ="(rubConfigured.indice_to_grap && rubConfigured.is_indice)"
         ng-repeat ="rubConfigured in ConfigPaiementModalCtrl.rubrics" class="form-group">
-        
+
         <bh-input-text
           ng-if="!rubConfigured.is_monetary_value"
-          key="{{rubConfigured.id}}"
+          key="{{'ConfigPaiementForm_' + rubConfigured.label}}"
           label="{{rubConfigured.label}}"
           text-value="ConfigPaiementModalCtrl.selectedRubrics[rubConfigured.id]"
           required = "true"
@@ -47,7 +47,7 @@
       </div>
       </div>
     </div>
-    
+
   </div>
 
   <div ng-if="!ConfigPaiementModalCtrl.isEnterpriseCurrency" class="modal-body badge badge-warning" style="max-height: 70vh; overflow:auto;">

--- a/test/end-to-end/staffingIndice/payroll-indice.spec.js
+++ b/test/end-to-end/staffingIndice/payroll-indice.spec.js
@@ -35,8 +35,8 @@ describe('Multipayroll (indice)', () => {
   it(`should a config Staffing indice for ${conf1.display_name}`, async () => {
     const menu = await openDropdownMenu(conf1.display_name);
     await menu.edit().click();
-    await components.inpuText.set('13', 26);
-    await components.inpuText.set('14', 2);
+    await components.inpuText.set('ConfigPaiementForm_Jours_prestes', 26);
+    await components.inpuText.set('ConfigPaiementForm_Jours_supplementaires', 2);
 
     await FU.buttons.submit();
     await components.notification.hasSuccess();
@@ -45,8 +45,8 @@ describe('Multipayroll (indice)', () => {
   it(`should a config Staffing indice for ${conf2.display_name}`, async () => {
     const menu = await openDropdownMenu(conf2.display_name);
     await menu.edit().click();
-    await components.inpuText.set('13', 23);
-    await components.inpuText.set('14', 0);
+    await components.inpuText.set('ConfigPaiementForm_Jours_prestes', 23);
+    await components.inpuText.set('ConfigPaiementForm_Jours_supplementaires', 0);
 
     await FU.buttons.submit();
     await components.notification.hasSuccess();


### PR DESCRIPTION
This PR changes the HTML id of the payment forms to be not only the id that comes from the Database, but a text + the label from the database. This should make the id unique.

It fixes the example given in #4220 but there are many more places with similar issued

before:
![image](https://user-images.githubusercontent.com/2425577/78020342-04f6c000-7371-11ea-8254-14667abd4421.png)

now:
![image](https://user-images.githubusercontent.com/2425577/78021242-987cc080-7372-11ea-8d94-d6d1472e6a67.png)

