### PR TITLE
make id of actions in RoleActionForm unique

### DIFF
--- a/client/src/modules/roles/modal/roleActions.html
+++ b/client/src/modules/roles/modal/roleActions.html
@@ -16,7 +16,7 @@
         <li  class="list-group-item" ng-repeat="action in RoleActionsCtrl.actions track by action.id">
           <label class="radio-inline">
             <input type="checkbox" ng-model="action.affected" ng-true-value="1" ng-false-value="0" />
-            <span id="{{::action.id}}" translate>{{::action.description}}</span>
+            <span id="RoleActionForm_{{::action.description}}" translate>{{::action.description}}</span>
           </label>
         </li>
       </ul>

--- a/test/end-to-end/user/roles.spec.js
+++ b/test/end-to-end/user/roles.spec.js
@@ -4,7 +4,7 @@ const components = require('../shared/components');
 
 // the page object
 const page = new RolesPage();
-const canEditRoleAction = 1;
+const canEditRoleAction = 'RoleActionForm_FORM.LABELS.CAN_EDIT_ROLES';
 
 function RolesManagementTests() {
 


### PR DESCRIPTION
This PR changes the HTML id of the RoleActionForm to be not only the id that comes from the Database, but a text + the description from the database. This should make the id unique.

It fixes second part of #4220 see https://github.com/IMA-WorldHealth/bhima/issues/4220#issuecomment-607797037