### PR TITLE
fix: make ids of links in sidebar unique

### DIFF
--- a/client/src/modules/templates/navigation.tmpl.html
+++ b/client/src/modules/templates/navigation.tmpl.html
@@ -8,7 +8,7 @@ Limitations of current templating structure:
 
     <!-- first level: unit -->
     <li ng-repeat="unit in $ctrl.units track by unit.id">
-      <a ng-click="$ctrl.toggleUnit(unit)" data-unit-key="{{ ::unit.key }}" id="{{::unit.id}}">
+      <a ng-click="$ctrl.toggleUnit(unit)" data-unit-key="{{ ::unit.key }}" id="SidebarNavigation_Unit_{{::unit.key}}">
         <span
           class="fa"
           ng-class="{
@@ -25,7 +25,11 @@ Limitations of current templating structure:
         <li ng-repeat="child in unit.children track by child.id" ng-class="{ 'selected' : child.selected }" class="subtree">
 
           <!-- if there is a subtree, this is the top level node -->
-          <a ng-click="$ctrl.toggleUnit(child)" ng-if="$ctrl.isParentNode(child)" data-unit-key="{{ ::child.key }}"  id="{{::child.id}}">
+          <a
+            ng-click="$ctrl.toggleUnit(child)"
+            ng-if="$ctrl.isParentNode(child)"
+            data-unit-key="{{ ::child.key }}"
+            id="SidebarNavigation_Child_{{::child.key}}">
             <span
               class="fa"
               ng-class="{
@@ -37,7 +41,11 @@ Limitations of current templating structure:
           </a>
 
           <!-- otherwise, it is just a plan link -->
-          <a ng-click="$ctrl.navigate(child)" ng-if="$ctrl.isChildNode(child)" data-unit-key="{{ ::child.key }}"  id="{{::child.id}}">
+          <a
+            ng-click="$ctrl.navigate(child)"
+            ng-if="$ctrl.isChildNode(child)"
+            data-unit-key="{{ ::child.key }}"
+            id="SidebarNavigation_Child_{{::child.key}}">
             <span class="fa fa-file-o"></span>
             <span class="tree-title" translate>{{child.key}}</span>
           </a>
@@ -46,7 +54,11 @@ Limitations of current templating structure:
 
             <!-- third level: subchild -->
             <li ng-repeat="subchild in child.children track by subchild.id" ng-class="{ 'selected' : subchild.selected }" class="subtree">
-              <a ng-click="$ctrl.navigate(subchild)" ng-class="{ 'selected' : subchild.selected }" data-unit-key="{{ ::subchild.key }}" id="{{::subchild.id}}">
+              <a
+                ng-click="$ctrl.navigate(subchild)"
+                ng-class="{ 'selected' : subchild.selected }"
+                data-unit-key="{{ ::subchild.key }}"
+                id="SidebarNavigation_Subchild_{{::subchild.key}}">
                 <span class="fa fa-file-o"></span>
                 <span class="tree-title" translate>{{subchild.key}}</span>
               </a>


### PR DESCRIPTION
The links in the sidebar had only a simple number (from DB) as the HTML id, this PR changes it, so that the ids communicate better what they stand for and the change to have duplicate ids is less (see #4220)