### PR TITLE
chore(install): do not enforce password meter

### DIFF
--- a/client/src/js/components/bhStrengthMeter.js
+++ b/client/src/js/components/bhStrengthMeter.js
@@ -23,7 +23,10 @@ StrengthMeterController.$inject = [
  * input.
  */
 function StrengthMeterController(PasswordMeterService, Session) {
-  this.showStrengthMeter = (Session.enterprise && Session.enterprise.settings.enable_password_validation)
-   || !Session.enterprise;
-  this.counter = () => PasswordMeterService.counter(this.password);
+
+  this.$onInit = () => {
+    this.showStrengthMeter = (Session.enterprise && Session.enterprise.settings.enable_password_validation)
+     || !Session.enterprise;
+    this.counter = () => PasswordMeterService.counter(this.password);
+  };
 }

--- a/client/src/modules/install/install.html
+++ b/client/src/modules/install/install.html
@@ -43,7 +43,7 @@
   </div>
 
   <!-- project -->
-  <bh-hidden-field show-text='FORM.LABELS.PROJECT' hide-text ='FORM.BUTTONS.CLOSE'>
+  <bh-hidden-field show-text="FORM.LABELS.PROJECT" hide-text="FORM.BUTTONS.CLOSE">
   <div class="panel panel-default">
     <div class="panel-heading">
       <i class="fa fa-cubes"></i>
@@ -91,11 +91,9 @@
           name="password"
           ng-model="InstallCtrl.setup.user.password"
           class="form-control"
-          bh-password-meter
           type="password" required>
 
-          <bh-strength-meter password="InstallForm.password.$viewValue"></bh-strength-meter>
-
+        <bh-strength-meter password="InstallForm.password.$viewValue"></bh-strength-meter>
 
         <div class="help-block" ng-messages="InstallForm.password.$error" ng-show="InstallForm.$submitted && InstallForm.password.$error.password">
           <div ng-messages-include="modules/users/templates/password.policy.html"></div>


### PR DESCRIPTION
This removes the validation on strict passwords for the installation page.  It should make things less confusing for users getting up and running quickly.

Closes #4243.