### PR TITLE
Feature: use previous purchase price of medicine in Purchase Order

### DIFF
--- a/client/src/modules/purchases/create/PurchaseOrderForm.js
+++ b/client/src/modules/purchases/create/PurchaseOrderForm.js
@@ -38,7 +38,7 @@ function PurchaseOrderFormService(Inventory, AppCache, Store, Pool, PurchaseOrde
     this.inventory = new Pool({ identifier : 'uuid', data : [] });
 
     // set up the inventory
-    Inventory.read(null, { locked : 0 })
+    Inventory.read(null, { locked : 0, use_previous_price : 1 })
       .then((data) => {
         this.inventory.initialize('uuid', data);
       });

--- a/client/src/modules/purchases/create/PurchaseOrderForm.js
+++ b/client/src/modules/purchases/create/PurchaseOrderForm.js
@@ -234,12 +234,6 @@ function PurchaseOrderFormService(Inventory, AppCache, Store, Pool, PurchaseOrde
     // remove the item from the pool
     const inventoryItem = this.inventory.use(item.inventory_uuid);
 
-    /**
-    * FIX ME or NEED Discussion, The Purchase Order must Used Purchase Price and not
-    * Used Inventory Selling price
-    */
-    inventoryItem.price = 0;
-
     // configure the PurchaseOrderFormItem with the inventory values
     item.configure(inventoryItem);
 

--- a/server/controllers/finance/purchases.js
+++ b/server/controllers/finance/purchases.js
@@ -222,10 +222,9 @@ function create(req, res, next) {
         }
 
         // Just to prevent cases where the order interval is less than 0
-
         transactionWrapper.addQuery(
           'UPDATE inventory SET purchase_interval = ?, last_purchase = ?, num_purchase = ?  WHERE uuid = ?',
-          [purchaseInterval, datePurchase, numPurchase, db.bid(row.inventory_uuid)]
+          [purchaseInterval, datePurchase, numPurchase, db.bid(row.inventory_uuid)],
         );
 
       });
@@ -454,7 +453,7 @@ function purchaseStatus(req, res, next) {
 
         transaction.addQuery(
           'UPDATE inventory SET delay = ?, num_delivery = ? WHERE uuid = ?',
-          [delay, numDelivery, row.inventory_uuid]
+          [delay, numDelivery, row.inventory_uuid],
         );
       });
 

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -60,7 +60,6 @@ exports.getItemsMetadata = getItemsMetadata;
 exports.getItemsMetadataById = getItemsMetadataById;
 exports.createItemsMetadata = createItemsMetadata;
 exports.updateItemsMetadata = updateItemsMetadata;
-exports.hasBoth = hasBoth;
 exports.errors = errors;
 exports.errorHandler = errorHandler;
 exports.remove = remove;
@@ -168,13 +167,12 @@ async function updateItemsMetadata(record, identifier, session) {
 /**
 * Find all inventory UUIDs in the database.
 *
-* @function getItemIds
+* @function getIds
 * @return {Promise} Returns a database query promise
 */
 function getIds() {
   // TODO - should we be filtering on enterprise id in these queries?
   const sql = 'SELECT i.uuid FROM inventory AS i;';
-
   return db.exec(sql);
 }
 
@@ -255,20 +253,6 @@ function getItemsMetadataById(uid) {
     WHERE i.uuid = ?;`;
 
   return db.one(sql, [db.bid(uid), uid, 'inventory']);
-}
-
-
-/**
-* Coerces values in to truth-y and false-y values.  Returns true if
-* the result is equivalent.
-*
-* @function hasBoth
-* @param m any value
-* @param n any value
-* @return {Boolean} Returns true if m and n are both truthy or both falsey
-*/
-function hasBoth(m, n) {
-  return !m === !n;
 }
 
 /**

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -186,15 +186,15 @@ function getIds() {
 function getItemsMetadata(params) {
   db.convert(params, ['inventory_uuids', 'uuid', 'group_uuid']);
 
-  const usePreviousPrice = !!params.use_previous_price;
+  const usePreviousPrice = params.use_previous_price && parseInt(params.use_previous_price, 10);
   delete params.usePreviousPrice;
 
   const filters = new FilterParser(params, { tableAlias : 'inventory', autoParseStatements : false });
 
-  const previousPriceQuery = `(
-    SELECT IFNULL(pi.unit_price, inventory.price) FROM purchase_item pi JOIN purchase p ON pi.purchase_uuid = p.uuid
-    WHERE pi.inventory_uuid = inventory.uuid ORDER BY p.date DESC LIMIT 1
-  ) AS price`;
+  const previousPriceQuery = `IFNULL(
+    (SELECT pi.unit_price FROM purchase_item pi JOIN purchase p ON pi.purchase_uuid = p.uuid
+    WHERE pi.inventory_uuid = inventory.uuid ORDER BY p.date DESC LIMIT 1)
+  , inventory.price) AS price`;
 
   const sql = `
    SELECT BUID(inventory.uuid) as uuid, inventory.code, inventory.text AS label, iu.abbr AS unit,

--- a/test/integration/inventory/metadata.js
+++ b/test/integration/inventory/metadata.js
@@ -122,4 +122,36 @@ describe('(/inventory/metadata) The inventory metadata http API', () => {
       })
       .catch(helpers.handler);
   });
+
+  const quinineUuid = '43F3DECBFCE9426E940ABC2150E62186';
+  const atenololUuid = '1300BC8619514668A29B9B0F9B40891A';
+  const quinineInventoryPrice = 0.15;
+  const quininePreviousPrice = 200;
+  it('GET /inventory/metadata?use_previous_price=1 uses previous purchase price', () => {
+    let oldQuinine;
+    let oldAtenolol;
+    return agent.get('/inventory/metadata')
+      .query({ use_previous_price : 0 })
+      .then(res => {
+        oldQuinine = res.body.filter(i => i.uuid === quinineUuid).pop();
+        oldAtenolol = res.body.filter(i => i.uuid === atenololUuid).pop();
+
+        return agent.get('/inventory/metadata')
+          .query({ use_previous_price : 1 });
+      })
+      .then(res => {
+        const newQuinine = res.body.filter(i => i.uuid === quinineUuid).pop();
+        const newAtenolol = res.body.filter(i => i.uuid === atenololUuid).pop();
+
+        expect(oldQuinine.uuid).to.equal(newQuinine.uuid);
+        expect(oldQuinine.code).to.equal(newQuinine.code);
+        expect(oldQuinine.price).to.not.equal(newQuinine.price);
+        expect(oldQuinine.price).to.equal(quinineInventoryPrice);
+        expect(newQuinine.price).to.equal(quininePreviousPrice);
+
+        // price should be unchanged for items not bought
+        expect(oldAtenolol.price).to.equal(newAtenolol.price);
+      })
+      .catch(helpers.handler);
+  });
 });


### PR DESCRIPTION
Implements the feature described in #4119.

This feature uses the last purchase price of the inventory item as the price in a new purchase order instead of the inventory price.  This makes better sense, since the inventory price is often the sale price, not that purchase price.

Closes #4119.