### PR TITLE
feat(purchase): add barcode to purchase orders

### DIFF
--- a/server/controllers/finance/reports/cash/receipt.handlebars
+++ b/server/controllers/finance/reports/cash/receipt.handlebars
@@ -21,6 +21,7 @@
           </span> <br>
           <strong>{{payment.reference}}</strong> <br>
         </h3>
+
         <div>
           {{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time>
           {{translate "REPORT.BY"}} {{metadata.user.username}}

--- a/server/controllers/inventory/reports/purchases.receipt.handlebars
+++ b/server/controllers/inventory/reports/purchases.receipt.handlebars
@@ -1,35 +1,44 @@
 {{> head title="PURCHASES.RECEIPT.TITLE"}}
 
-<body  class="container" style="font-size: 0.9em;">
-
-  {{> header}}
-
+<body class="container">
   <header>
-    <!-- page title  -->
     <div class="row">
-      <div class="col-xs-12">
-        <h2 class="text-center">
-          <span class="text-uppercase">
-            {{translate "PURCHASES.RECEIPT.TITLE" }} N&deg;
-            {{purchase.reference}}
-          </span>
-        </h2>
-      </div>
-    </div>
+      {{> enterpriseDetails }}
 
-    <!-- order details -->
-    <div class="row" style="border: 1px solid #ccc; padding: 5px; margin-bottom: 15px;">
-      <div class="col-xs-6">
-        <span class="text-capitalize">{{translate "FORM.LABELS.SUPPLIER"}}</span>: <strong>{{purchase.supplier}}</strong> <br>
-        <span class="text-capitalize">{{translate "FORM.LABELS.DATE"}}</span>: {{date purchase.date}} <br>
-        <span class="text-capitalize">{{translate "FORM.LABELS.REFERENCE"}}</span>: {{purchase.reference}} <br>
-        <span class="text-capitalize">{{translate "FORM.LABELS.NOTES"}}</span>: <strong>{{purchase.note}}</strong> <br>
-        <span class="text-capitalize">{{translate "FORM.LABELS.AUTHOR"}}</span>: <strong>{{purchase.author}}</strong>
+      <div class="col-xs-5 text-right">
+        <div>
+          {{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time>
+          {{translate "REPORT.BY"}} {{metadata.user.display_name}}
+        </div>
+
+        <br/>
+
+        {{#if metadata.enterprise.settings.enable_barcodes}}
+          <small>{{> barcode value=purchase.barcode}}</small>
+          <br>
+        {{/if}}
       </div>
     </div>
   </header>
 
-  <table class="table table-bordered table-condensed">
+  <!-- page title  -->
+  <h2 class="text-center text-uppercase">
+    {{translate "PURCHASES.RECEIPT.TITLE" }} N&deg;
+    {{purchase.reference}}
+  </h2>
+
+  <!-- order details -->
+  <div class="row" style="border: 1px solid #ccc; padding: 5px; margin-bottom: 15px;">
+    <div class="col-xs-6">
+      <span class="text-capitalize">{{translate "FORM.LABELS.SUPPLIER"}}</span>: <strong>{{purchase.supplier}}</strong> <br>
+      <span class="text-capitalize">{{translate "FORM.LABELS.DATE"}}</span>: {{date purchase.date}} <br>
+      <span class="text-capitalize">{{translate "FORM.LABELS.REFERENCE"}}</span>: {{purchase.reference}} <br>
+      <span class="text-capitalize">{{translate "FORM.LABELS.NOTES"}}</span>: <strong>{{purchase.note}}</strong> <br>
+      <span class="text-capitalize">{{translate "FORM.LABELS.AUTHOR"}}</span>: <strong>{{purchase.author}}</strong>
+    </div>
+  </div>
+
+  <table class="table table-condensed table-report">
     <thead>
       <th>{{translate "FORM.LABELS.INVENTORY_ITEM" }}</th>
       <th>{{translate "FORM.LABELS.QUANTITY" }}</th>
@@ -53,5 +62,5 @@
       </tr>
     </tfoot>
   </table>
-
+  <script>JsBarcode('.barcode').init();</script>
 </body>

--- a/server/controllers/stock/reports/stock_entry_purchase.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_entry_purchase.receipt.handlebars
@@ -5,8 +5,8 @@
 
   <header>
     <!-- headings  -->
-    {{> stockReceiptHeader 
-      title="STOCK.RECEIPT.ENTRY_PURCHASE" 
+    {{> stockReceiptHeader
+      title="STOCK.RECEIPT.ENTRY_PURCHASE"
       entity=details.depot_name
       reference=details.document_reference
       barcode=details.barcode


### PR DESCRIPTION
This commit adds barcodes to the purchase order receipts.  I've also re-balanced the size of the fonts on the purchase receipt to be more in line with the other modules (invoice, cash, etc).

Closes #4272.

It looks like this:
![image](https://user-images.githubusercontent.com/896472/78897578-4fabc280-7a6a-11ea-8969-3079f11f67c8.png)

Note that the yellow highlight is to indicate what is in the barcode to demonstrate the barcode is working, and this has been removed from the actual receipt.