### PR TITLE
chore(inventory): default delay to 1

### DIFF
--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -785,7 +785,7 @@ CREATE TABLE `inventory` (
   `sellable` TINYINT(1)   NOT NULL DEFAULT 1,
   `note` text  NULL,
   `locked` TINYINT(1) NOT NULL DEFAULT 0,
-  `delay` DECIMAL(10,4) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Delivery time',
+  `delay` DECIMAL(10,4) UNSIGNED NOT NULL DEFAULT 1 COMMENT 'Delivery time',
   `avg_consumption` DECIMAL(10,4) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Average consumption' ,
   `purchase_INTerval` DECIMAL(10,4) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Purchase Order INTerval' ,
   `last_purchase` DATE NULL COMMENT 'This element allows to store the date of the last purchase order of the product in order to allow the calculation without making much of the average ordering INTerval',


### PR DESCRIPTION
Makes the default delay "1" instead of "0" to allow CMM calculations to be valid by default.

Closes #4265.