### PR TITLE
fix(stock): movements report download crash

### DIFF
--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -163,6 +163,7 @@ function getLots(sqlQuery, parameters, finalClauseParameter) {
 
   const query = filters.applyQuery(sql);
   const queryParameters = filters.parameters();
+
   return db.exec(query, queryParameters);
 }
 

--- a/server/controllers/stock/reports/stock/movements_report.js
+++ b/server/controllers/stock/reports/stock/movements_report.js
@@ -12,58 +12,50 @@ const {
  *
  * GET /reports/stock/movements
  */
-function stockMovementsReport(req, res, next) {
-  let options = {};
+async function stockMovementsReport(req, res, next) {
   let display = {};
-  let hasFilter = false;
-
-  const data = {};
-  let report;
   const optionReport = _.extend(req.query, pdfOptions, {
     filename : 'TREE.STOCK_MOVEMENTS',
+    csvKey : 'rows',
+    renameKeys : false,
   });
 
   // set up the report with report manager
   try {
-    if (req.query.identifiers && req.query.display) {
-      options = JSON.parse(req.query.identifiers);
-      display = JSON.parse(req.query.display);
-      hasFilter = Object.keys(display).length > 0;
+    if (req.query.displayNames) {
+      display = JSON.parse(req.query.displayNames);
+      delete req.query.displayNames;
     }
 
-    report = new ReportManager(STOCK_MOVEMENTS_REPORT_TEMPLATE, req.session, optionReport);
+    const report = new ReportManager(STOCK_MOVEMENTS_REPORT_TEMPLATE, req.session, optionReport);
+
+    const rows = await Stock.getLotsMovements(null, req.query);
+    rows.forEach(row => {
+      row.cost = util.roundDecimal(row.quantity * row.unit_cost, 3);
+    });
+
+    const data = {
+      rows,
+      display,
+      filters : formatFilters(req.query),
+    };
+
+    // group by depot
+    let depots = _.groupBy(rows, d => d.depot_text);
+
+    // make sure that they keys are sorted in alphabetical order
+    depots = _.mapValues(depots, lines => {
+      _.sortBy(lines, 'depot_text');
+      return lines;
+    });
+
+    data.depots = depots;
+
+    const result = await report.render(data);
+    res.set(result.headers).send(result.report);
   } catch (e) {
-    return next(e);
+    next(e);
   }
-
-  return Stock.getLotsMovements(null, options)
-    .then((rows) => {
-      data.rows = rows.map(row => {
-        row.cost = util.roundDecimal(row.quantity * row.unit_cost, 3);
-        return row;
-      });
-      data.hasFilter = hasFilter;
-      data.csv = rows;
-      data.display = display;
-      data.filters = formatFilters(display);
-
-      // group by depot
-      let depots = _.groupBy(rows, d => d.depot_text);
-
-      // make sure that they keys are sorted in alphabetical order
-      depots = _.mapValues(depots, lines => {
-        _.sortBy(lines, 'depot_text');
-        return lines;
-      });
-
-      data.depots = depots;
-      return report.render(data);
-    })
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next)
-    .done();
 }
 
 module.exports = stockMovementsReport;

--- a/server/controllers/stock/reports/stock_movements.report.handlebars
+++ b/server/controllers/stock/reports/stock_movements.report.handlebars
@@ -18,21 +18,7 @@
       </h4>
 
       <!-- filters  -->
-      {{#if hasFilter}}
-        <p class="pills">
-          {{#each filters}}
-            <span class="label label-primary text-capitalize">
-              <i class="fa fa-filter"></i> {{translate this.displayName}}
-
-              {{#if this.comparitor}} {{this.comparitor}}
-              {{else}}: {{/if}}
-
-              {{#if this.isDate}} {{date this.value}}
-              {{else}} {{translate this.value}} {{/if}}
-            </span>
-          {{/each}}
-        </p>
-      {{/if}}
+      {{> filterbar filters=filters }}
 
       <!-- list of data  -->
       <table class="table table-condensed table-bordered table-report">


### PR DESCRIPTION
This commit fixes the stock movements report download so that it doesn't crash anymore.  However, the renameKeys() functionality no longer works.

Closes #4280.