### PR TITLE
Improvements to inventory changes report

### DIFF
--- a/client/src/i18n/en/inventory.json
+++ b/client/src/i18n/en/inventory.json
@@ -39,6 +39,9 @@
         "INVENTORY_PRICE_INFO" : "inventory_price : the sale price of the inventory in the enterprise currency",
         "COLUMNS_INFO" : "Note about some columns",
         "SELLABLE" : "Sellable",
-        "VIEW_ARTICLES_IN_STOCK" : "View Items in Stock"
+        "VIEW_ARTICLES_IN_STOCK" : "View Items in Stock",
+        "PREVIOUS_VALUE" : "Previous Value",
+        "UPDATED_VALUE" : "Updated Value",
+        "CHANGES" : "Changes"
     }
 }

--- a/client/src/i18n/fr/inventory.json
+++ b/client/src/i18n/fr/inventory.json
@@ -39,6 +39,9 @@
         "INVENTORY_PRICE_INFO" : "inventory_price : le prix de vente de l'inventaire dans la monnaie de l'entreprise",
         "COLUMNS_INFO" : "Note sur certaines colonnes",
         "SELLABLE" : "A vendre",
-        "VIEW_ARTICLES_IN_STOCK" : "Voir les articles en stock"
+        "VIEW_ARTICLES_IN_STOCK" : "Voir les articles en stock",
+        "PREVIOUS_VALUE" : "Valeur Précédente",
+        "UPDATED_VALUE" : "Nouvelle Valeur",
+        "CHANGES" : "Changements"
     }
 }

--- a/server/controllers/inventory/reports/changes.handlebars
+++ b/server/controllers/inventory/reports/changes.handlebars
@@ -11,33 +11,63 @@
     <small>{{date dateFrom }} - {{date dateTo}}</small>
   </h3>
 
-  <!-- body  -->
-  <div class="row">
-    <div class="col-xs-12">
-      {{#each ./inventories as | inventory |}}
-        <div class="row">
-          <h5><strong>{{inventory.inventory_name}}</strong></h5>
-          {{#each inventory.logs as  | log |}}
-          <div class="col-lg-12" style="border: 1px dashed #ddd; padding: 10px">
+  <table class="table table-report table-condensed">
+    <thead>
+      <tr>
+        <th>{{translate "FORM.LABELS.DATE"}}</th>
+        <th>{{translate "FORM.LABELS.USER"}}</th>
+        <th>{{translate "FORM.LABELS.LABEL"}}</th>
+        <th>{{translate "INVENTORY.PREVIOUS_VALUE"}}</th>
+        <th>{{translate "INVENTORY.UPDATED_VALUE"}}</th>
+      </tr>
+    </thead>
 
-            <span><b>{{ translate log.col}}</b></span>
-            <span> {{ translate 'FORM.LABELS.UPDATED'}}</span>
-            <span>{{translate 'FORM.LABELS.FROM'}}</span>
-            <span class="text-danger"><b>{{log.value.from}}</b></span>
-            <span> {{ translate 'FORM.LABELS.TO'}}</span>
-            <span class="text-primary"><b>{{log.value.to}}</b></span>
-            <br />
-            <div style="font-size:10px">
-              <span><i class="fa fa-certificate"></i></span>
-              <span>{{ timestamp log.date  }}</span>
-              <span>{{ translate 'FORM.LABELS.BY'}}</span>
-              <b><span>{{log.userName}}</span></b>
-            </div>
-          </div>
+    {{#each ./inventories as | inventory |}}
+      <tbody>
+        <tr>
+          <th colspan="4">
+            {{inventory.group_name}} <span>&#x7c;</span> {{inventory.code}} - {{inventory.label}}
+          </th>
+          <th colspan="1" class="text-right">
+            ({{inventory.logs.length}} {{translate "INVENTORY.CHANGES"}})
+          </th>
+        </tr>
+
+        {{#each inventory.logs as | log |}}
+          <tr>
+            <td>{{timestamp log.date}}</td>
+            <td>{{log.userName}}</td>
+            <td>{{translate log.col}}</td>
+            <td class="text-right">{{log.value.from}}</td>
+            <td class="text-right">{{log.value.to}}</td>
+          </tr>
         {{/each}}
-      </div>
-      <br/>
+      </tbody>
+    {{else}}
+      <tbody>
+        {{> emptyTable columns=5 }}
+      </tbody>
     {{/each}}
-    </div>
-  </div>
+  </table>
+
+
+  <br />
+
+  <table style="max-width:50%" class="table table-condensed table-report">
+    <thead>
+      <tr>
+        <th>{{translate "FORM.LABELS.USER"}}</th>
+        <th>{{translate "INVENTORY.CHANGES"}}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each userChanges as | row |}}
+        <tr>
+          <td>{{row.user}}</td>
+          <td class="text-right">{{row.numberOfChanges}}</td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+
 </body>

--- a/server/controllers/inventory/reports/changes.js
+++ b/server/controllers/inventory/reports/changes.js
@@ -1,4 +1,3 @@
-
 /**
  * @overview Inventory Changes Report
  *
@@ -19,6 +18,28 @@ module.exports = inventoryChanges;
 
 const TEMPLATE = './server/controllers/inventory/reports/changes.handlebars';
 
+function processChangeLog(records) {
+  return _.flatMap(records, (record) => {
+    record.changes = JSON.parse(record.changes);
+    const prev = formatKeys(record.changes.last);
+    const next = formatKeys(record.changes.current);
+
+    const keys = Object.keys(next);
+
+    // loop through updated columns and create rows for them.
+    return keys.map((key) => {
+      return ({
+        uuid : record.uuid,
+        col : core.inventoryColsMap[key],
+        value : getValue(prev, next, key),
+        date : record.log_timestamp,
+        userName : record.user_name,
+        update : true,
+      });
+    });
+  });
+}
+
 async function inventoryChanges(req, res, next) {
   const params = _.clone(req.query);
   const metadata = _.clone(req.session);
@@ -28,52 +49,42 @@ async function inventoryChanges(req, res, next) {
     const { dateFrom, dateTo } = params;
 
     const inventorySql = `
-      SELECT DISTINCT BUID(iv.uuid) as uuid, iv.text AS inventory_name
-      FROM inventory_log ivl
-      JOIN inventory iv ON iv.uuid = ivl.inventory_uuid
-      JOIN user u ON u.id = ivl.user_id
-      WHERE ivl.log_timestamp BETWEEN DATE(?) AND DATE(?)
-      ORDER BY iv.text
+      SELECT BUID(iv.uuid) AS uuid, iv.code, iv.text AS label, iv.created_at,
+      iv.updated_at, ivt.text AS type, ivu.text AS unit, ivg.name AS groupName
+      FROM inventory iv
+        JOIN inventory_type ivt ON iv.type_id = ivt.id
+        JOIN inventory_group ivg ON iv.group_uuid = ivg.uuid
+        JOIN inventory_unit ivu ON iv.unit_id = ivu.id
+      WHERE iv.uuid IN (
+        SELECT inventory_log.inventory_uuid FROM inventory_log
+        WHERE inventory_log.log_timestamp BETWEEN DATE(?) AND DATE(?)
+      )
+      ORDER BY iv.text;
     `;
 
     const logsSql = `
-      SELECT BUID(iv.uuid) as uuid, iv.text as label, ivl.text AS changes,
-         u.display_name as userName, ivl.log_timestamp
+      SELECT BUID(ivl.inventory_uuid) AS uuid, ivl.text AS changes, u.display_name as user_name,
+        ivl.log_timestamp
       FROM inventory_log ivl
-      JOIN inventory iv ON iv.uuid = ivl.inventory_uuid
-      JOIN user u ON u.id = ivl.user_id
+        JOIN user u ON u.id = ivl.user_id
       WHERE ivl.log_timestamp BETWEEN DATE(?) AND DATE(?)
-      ORDER BY iv.text ASC , ivl.log_timestamp DESC
+        AND ivl.text->"$.action" = "UPDATE"
+      ORDER BY ivl.log_timestamp DESC;
     `;
 
+
     const inventories = await db.exec(inventorySql, [dateFrom, dateTo]);
-    const inventoriesMap = {};
-    inventories.forEach(iv => {
-      iv.logs = [];
-      inventoriesMap[iv.uuid] = iv;
-    });
+    const logs = await db.exec(logsSql, [dateFrom, dateTo]);
 
-    const results = await db.exec(logsSql, [dateFrom, dateTo]);
+    // parse the changes to avoid doing that later
+    const changelog = processChangeLog(logs);
 
-    results.forEach(row => {
-      const { action, last, current } = JSON.parse(row.changes);
-      formatKeys(last);
-      formatKeys(current);
+    // group changelog by the inventory uuid
+    const changeMap = _.groupBy(changelog, 'uuid');
 
-      if (action !== 'UPDATE') return;
-
-      const updatedKeys = Object.keys(current);
-
-      updatedKeys.forEach(col => {
-        inventoriesMap[row.uuid].logs.push({
-          col : core.inventoryColsMap[col],
-          value : getValue(last, current, col),
-          date : row.log_timestamp,
-          userName : row.userName,
-          update : true,
-        });
-      });
-
+    // attach logs to each inventory item
+    inventories.forEach(inventory => {
+      inventory.logs = changeMap[inventory.uuid];
     });
 
     const renderResult = await report.render({ inventories, dateFrom, dateTo });
@@ -85,6 +96,7 @@ async function inventoryChanges(req, res, next) {
 
 function formatKeys(record) {
   record.label = record.text;
+  if (!record.label) { delete record.label; }
   return _.omit(record, ['group_uuid', 'type_id', 'unit_id', 'text']);
 }
 

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -808,7 +808,6 @@ CREATE TABLE `inventory` (
 
 
 DROP TABLE IF EXISTS `inventory_group`;
-
 CREATE TABLE `inventory_group` (
   `uuid` BINARY(16) NOT NULL,
   `name` varchar(100) NOT NULL,
@@ -829,8 +828,6 @@ CREATE TABLE `inventory_group` (
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
 
-
-
 DROP TABLE IF EXISTS `inventory_type`;
 CREATE TABLE `inventory_type` (
   `id` TINYINT(3) UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -839,9 +836,7 @@ CREATE TABLE `inventory_type` (
   UNIQUE KEY `inventory_type_1` (`text`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
-
 DROP TABLE IF EXISTS `inventory_unit`;
-
 CREATE TABLE `inventory_unit` (
   `id` smallINT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
   `abbr` varchar(10) NOT NULL,


### PR DESCRIPTION
This Pull Request refactors the SQL and presentation of in the inventory changes report.  The presentation is now an HTML table that is more amenable to printing.  Here is an example:
![image](https://user-images.githubusercontent.com/896472/79433742-694a8e00-7fc5-11ea-9ef1-c98a13c167f1.png)

The inventory items are first ordered by inventory group, then by the current label of the inventory item.  The number of changes made to the inventory is shown in the header for each item.

At the bottom of the page, we provide an overview of the users who made the most modifications.  This will help an administrator easily detect if someone who was not authorized to make a modification made it.

Here is what that looks like:
![image](https://user-images.githubusercontent.com/896472/79434007-b595ce00-7fc5-11ea-8adf-b793c612cd5f.png)


Closes #4287.
