### PR TITLE
perf(bhUnique): cache validator results for 15s

### DIFF
--- a/client/src/js/services/UniqueValidatorService.js
+++ b/client/src/js/services/UniqueValidatorService.js
@@ -1,7 +1,7 @@
 angular.module('bhima.services')
-.service('UniqueValidatorService', UniqueValidatorService);
+  .service('UniqueValidatorService', UniqueValidatorService);
 
-UniqueValidatorService.$inject = ['$http', 'util'];
+UniqueValidatorService.$inject = ['$http', 'util', 'HttpCacheService'];
 
 /**
  * Unique Validator Service
@@ -22,11 +22,14 @@ UniqueValidatorService.$inject = ['$http', 'util'];
  *
  * @module services/UniqueValidorService
  */
-function UniqueValidatorService($http, util) {
-  var service = this;
+function UniqueValidatorService($http, util, HttpCache) {
+  const service = this;
 
   // expose service API
   service.check = check;
+
+  // cache subsequent requests for 15 seconds
+  const fetcher = HttpCache(callback);
 
   /**
    * This method will make a request to a provided server end point to validate
@@ -45,14 +48,18 @@ function UniqueValidatorService($http, util) {
    * @param {String} url     Target server API URL
    * @param {String} value   Value to check against server API endpoint
    */
-  function check(url, value) {
-    var existsApiPhrase = '/exists';
+  function callback(url, value) {
+    const existsApiPhrase = '/exists';
 
     // sanitise the URL - append a '/' to the end if it does not exist
-    var baseUrl = url.endsWith('/') ? url : url.concat('/');
-    var target = baseUrl.concat(value, existsApiPhrase);
+    const baseUrl = url.endsWith('/') ? url : url.concat('/');
+    const target = baseUrl.concat(value, existsApiPhrase);
 
     return $http.get(target)
       .then(util.unwrapHttpResponse);
+  }
+
+  function check(url, value, cacheBust = false) {
+    return fetcher(url, value, cacheBust);
   }
 }

--- a/test/client-unit/directives/bhUnique.spec.js
+++ b/test/client-unit/directives/bhUnique.spec.js
@@ -1,11 +1,10 @@
 /* global inject, expect */
 describe('(directive) bhUnique', () => {
-
-
-  let $scope; let
-    form;
+  let $scope;
+  let form;
 
   let MockUniqueValidatorService;
+  let $flushPendingTasks;
 
   // these represent values that the external $http request would return as
   // already registered in the database
@@ -29,7 +28,7 @@ describe('(directive) bhUnique', () => {
     $provide.service('UniqueValidatorService', MockUniqueValidatorService);
   }));
 
-  beforeEach(inject(($compile, $rootScope) => {
+  beforeEach(inject(($compile, $rootScope, _$flushPendingTasks_) => {
     $scope = $rootScope;
 
     const element = angular.element(`
@@ -44,6 +43,7 @@ describe('(directive) bhUnique', () => {
 
     $compile(element)($scope);
     form = $scope.form;
+    $flushPendingTasks = _$flushPendingTasks_;
   }));
 
   it('rejects a value that already exists', () => {
@@ -53,6 +53,7 @@ describe('(directive) bhUnique', () => {
 
     form.uniqueValue.$setViewValue(existingValue);
     $scope.$digest();
+    $flushPendingTasks();
 
     expect($scope.models.uniqueValue).to.equal(undefined);
     expect(form.uniqueValue.$valid).to.equal(false);
@@ -63,6 +64,7 @@ describe('(directive) bhUnique', () => {
 
     form.uniqueValue.$setViewValue(uniqueValue);
     $scope.$digest();
+    $flushPendingTasks();
 
     expect($scope.models.uniqueValue).to.equal(uniqueValue);
     expect(form.uniqueValue.$valid).to.equal(true);


### PR DESCRIPTION
Improves system performance by caching the results of the bhUnique async validator for 15 seconds to prevent sending too many HTTP queries.  Leverages the HttpCache service to do so.

Here is what it looks like in action.  Normally, every keystroke would result in a new HTTP request.  In this case, only the new unique values result in a new `$http` request as shown in the console.
![vkhsPHvsNs](https://user-images.githubusercontent.com/896472/80274698-49594f80-86d4-11ea-9e63-77b28d86d73e.gif)


Closes #3427.