### PR TITLE
Feat: render display values on server

### DIFF
--- a/client/src/js/services/FilterService.js
+++ b/client/src/js/services/FilterService.js
@@ -158,6 +158,14 @@ function FilterService() {
     if (clientTimestamp) {
       httpFilters.client_timestamp = (new Date()).toJSON();
     }
+
+    // make displayValue for client.
+    const displayValues = Object.entries(this.getDisplayValueMap())
+      .map(([key, value]) => `${key}:${value}`)
+      .join(',');
+
+    Object.assign(httpFilters, { displayValues });
+
     return httpFilters;
   };
 

--- a/server/controllers/finance/reports/cash/index.js
+++ b/server/controllers/finance/reports/cash/index.js
@@ -194,9 +194,10 @@ async function report(req, res, next) {
       data.amounts = await db.exec(costSql, [uuids]);
     }
 
-    const project = await (query.project_id
-      ? Projects.findDetails(query.project_id)
-      : Promise.resolve({}));
+    let project = {};
+    if (query.project_id) {
+      project = await Projects.findDetails(query.project_id);
+    }
 
     data.project = project;
     const result = await reportInstance.render(data);

--- a/server/controllers/finance/reports/shared.js
+++ b/server/controllers/finance/reports/shared.js
@@ -181,6 +181,9 @@ const filters = [{
 // into human-readable text to be placed in the report, showing the properties
 // filtered on.
 function formatFilters(qs) {
+
+  const displayValueMap = parseDisplayValues(qs.displayValues);
+
   return filters.filter(filter => {
     const value = qs[filter.field];
 
@@ -189,12 +192,26 @@ function formatFilters(qs) {
         const service = new PeriodService(new Date());
         filter.value = service.periods[value].translateKey;
       } else {
-        filter.value = value;
+
+        // if there is a display value for this field, show it.  Otherwise, default
+        // to the old value
+        filter.value = displayValueMap[filter.field] || value;
       }
+
       return true;
     }
     return false;
   });
+}
+
+
+function parseDisplayValues(displayValues = '') {
+  return displayValues.split(',')
+    .reduce((map, keypair) => {
+      const [key, value] = keypair.split(':');
+      map[key] = value;
+      return map;
+    }, {});
 }
 
 exports.formatFilters = formatFilters;

--- a/server/controllers/inventory/reports/prices.handlebars
+++ b/server/controllers/inventory/reports/prices.handlebars
@@ -5,6 +5,8 @@
 
   <h3 class="text-center">{{translate "INVENTORY.PRICES"}}</h3>
 
+  {{>filterbar filters=filters}}
+
   <table class="table table-condensed table-bordered table-report">
     <thead>
       <tr>

--- a/server/controllers/inventory/reports/prices.js
+++ b/server/controllers/inventory/reports/prices.js
@@ -14,12 +14,15 @@ const _ = require('lodash');
 const ReportManager = require('../../../lib/ReportManager');
 const inventorycore = require('../inventory/core');
 
+const shared = require('../../finance/reports/shared');
+
 module.exports = prices;
 
 const TEMPLATE = './server/controllers/inventory/reports/prices.handlebars';
 
 async function prices(req, res, next) {
   const params = _.clone(req.query);
+  const filters = shared.formatFilters(params);
 
   const qs = _.extend(req.query, {
     csvKey : 'groups',
@@ -41,7 +44,7 @@ async function prices(req, res, next) {
       return lines;
     });
 
-    const result = await report.render({ groups });
+    const result = await report.render({ groups, filters });
     res.set(result.headers).send(result.report);
   } catch (e) {
     next(e);

--- a/server/controllers/stock/reports/common.js
+++ b/server/controllers/stock/reports/common.js
@@ -158,8 +158,6 @@ async function getDepotMovement(documentUuid, enterprise, isExit) {
 // Extensible PDF layout options
 const pdfOptions = {
   orientation : 'landscape',
-  footerRight : '[page] / [toPage]',
-  footerFontSize : '7',
 };
 
 async function getVoucherReferenceForStockMovement(documentUuid) {

--- a/server/controllers/stock/reports/stock/inventory_report.js
+++ b/server/controllers/stock/reports/stock/inventory_report.js
@@ -2,6 +2,8 @@ const {
   _, db, ReportManager, Stock, pdfOptions, STOCK_INVENTORY_REPORT_TEMPLATE,
 } = require('../common');
 
+const shared = require('../../../finance/shared');
+
 /**
  * @method stockInventoryReport
  *
@@ -11,47 +13,37 @@ const {
  *
  * GET /reports/stock/inventory
  */
-function stockInventoryReport(req, res, next) {
-  const data = {};
-  let options;
-  let report;
-
+async function stockInventoryReport(req, res, next) {
   const optionReport = _.extend(req.query, pdfOptions, {
     filename : 'TREE.STOCK_INVENTORY_REPORT',
   });
 
+  const filters = shared.formatFilters(req.query);
+
   // set up the report with report manager
   try {
-    options = req.query.params ? JSON.parse(req.query.params) : {};
-    report = new ReportManager(STOCK_INVENTORY_REPORT_TEMPLATE, req.session, optionReport);
+    const options = req.query.params ? JSON.parse(req.query.params) : {};
+    const report = new ReportManager(STOCK_INVENTORY_REPORT_TEMPLATE, req.session, optionReport);
+
+    const [inventory, depot, rows] = await Promise.all([
+      await db.one('SELECT code, text FROM inventory WHERE uuid = ?;', [db.bid(options.inventory_uuid)]),
+      await db.one('SELECT text FROM depot WHERE uuid = ?;', [db.bid(options.depot_uuid)]),
+      await Stock.getInventoryMovements(options),
+    ]);
+
+    const data = { filters, inventory, depot };
+
+    data.rows = rows.movements;
+    data.totals = rows.totals;
+    data.result = rows.result;
+    data.csv = rows.movements;
+    data.dateTo = options.dateTo;
+
+    const result = await report.render(data);
+    res.set(result.headers).send(result.report);
   } catch (e) {
-    return next(e);
+    next(e);
   }
-
-  return db.one('SELECT code, text FROM inventory WHERE uuid = ?;', [db.bid(options.inventory_uuid)])
-    .then((inventory) => {
-      data.inventory = inventory;
-
-      return db.one('SELECT text FROM depot WHERE uuid = ?;', [db.bid(options.depot_uuid)]);
-    })
-    .then((depot) => {
-      data.depot = depot;
-      return Stock.getInventoryMovements(options);
-    })
-    .then((rows) => {
-      data.rows = rows.movements;
-      data.totals = rows.totals;
-      data.result = rows.result;
-      data.csv = rows.movements;
-      data.dateTo = options.dateTo;
-
-      return report.render(data);
-    })
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next)
-    .done();
 }
 
 module.exports = stockInventoryReport;

--- a/server/controllers/stock/reports/stock_inventory.report.handlebars
+++ b/server/controllers/stock/reports/stock_inventory.report.handlebars
@@ -3,7 +3,8 @@
 <body>
 
   <div class="container">
-  {{> header}}
+    {{> header}}
+
 
   <!-- body  -->
   <div class="row">
@@ -24,6 +25,10 @@
       </h4>
 
       <br>
+
+      <!-- filters  -->
+      {{> filterbar filters=filters }}
+
 
       <!-- list of data  -->
       <table class="table table-condensed table-report">


### PR DESCRIPTION
Implements the ability to use the client's displayValues on the server for rendering HTML and PDF reports.  It implements the design discussed in #2233 to allow reports to be updated without any changes to their rendering functions or the HTTP query itself.

I have gone through and brushed up the code of most registries with async/await as part of this.

**Before**
![image](https://user-images.githubusercontent.com/896472/80388679-15338980-88a2-11ea-818b-b99ed3fe0d2d.png)


**After**
![image](https://user-images.githubusercontent.com/896472/80388460-d00f5780-88a1-11ea-888f-208cf77b5be2.png)

Closes #2233.