### PR TITLE
fix(reports):  use the correct shared lib

### DIFF
--- a/server/controllers/stock/reports/stock/inventory_report.js
+++ b/server/controllers/stock/reports/stock/inventory_report.js
@@ -2,7 +2,7 @@ const {
   _, db, ReportManager, Stock, pdfOptions, STOCK_INVENTORY_REPORT_TEMPLATE,
 } = require('../common');
 
-const shared = require('../../../finance/shared');
+const shared = require('../../../finance/reports/shared');
 
 /**
  * @method stockInventoryReport


### PR DESCRIPTION
I accidentally broke the shared library reference.  This fix references the correct shared library and allows the report to render.