### PR TITLE
fix(cash): add clear() button to reference

### DIFF
--- a/client/src/modules/cash/payments/templates/search.modal.html
+++ b/client/src/modules/cash/payments/templates/search.modal.html
@@ -28,6 +28,7 @@
           <!-- cash human readable reference  -->
           <div class="form-group">
             <label class="control-label" translate>FORM.LABELS.REFERENCE</label>
+            <bh-clear on-clear="$ctrl.clear('reference')"></bh-clear>
             <input type="text" class="form-control" name="reference" ng-model="$ctrl.searchQueries.reference">
           </div>
 


### PR DESCRIPTION
Adds in a clear() button on the cash reference field.

Closes #4375.

Here it is in action:
![UIvjE2EGk0](https://user-images.githubusercontent.com/896472/80490705-b03b6a80-8959-11ea-8cbc-4c5d4004fb80.gif)
