### PR TITLE
fix(purchases): use prev price in optimal PO

### DIFF
--- a/client/src/js/services/Pool.js
+++ b/client/src/js/services/Pool.js
@@ -1,7 +1,7 @@
 angular.module('bhima.services')
   .service('Pool', PoolService);
 
-PoolService.$inject = [ 'Store' ];
+PoolService.$inject = ['Store'];
 
 function PoolService(Store) {
 
@@ -10,22 +10,15 @@ function PoolService(Store) {
   }
 
   // initialize the stores with data
-  Pool.prototype.initialize = function initialize(identifier, data) {
-
-    // make sure the data array is defined
-    data = data || [];
-
-    // default to indexing on 'id'
-    identifier = identifier || 'id';
-
+  Pool.prototype.initialize = function initialize(identifier = 'id', data = []) {
     this.available = new Store({
-      identifier : identifier,
-      data : data
+      identifier,
+      data,
     });
 
     this.unavailable = new Store({
-      identifier : identifier,
-      data : []
+      identifier,
+      data : [],
     });
 
     this._size = data.length;
@@ -33,7 +26,7 @@ function PoolService(Store) {
 
   // remove the item from the pool
   Pool.prototype.use = function use(id) {
-    var item = this.available.get(id);
+    const item = this.available.get(id);
     if (item) {
       this.available.remove(id);
       this.unavailable.post(item);
@@ -45,12 +38,12 @@ function PoolService(Store) {
 
   // return the unavailable item to the pool
   Pool.prototype.release = function release(id) {
-    var item = this.unavailable.get(id);
+    const item = this.unavailable.get(id);
     if (item) {
       this.unavailable.remove(id);
       this.available.post(item);
     }
-    
+
     return item;
   };
 

--- a/client/src/modules/purchases/create/PurchaseOrderForm.js
+++ b/client/src/modules/purchases/create/PurchaseOrderForm.js
@@ -344,11 +344,10 @@ function PurchaseOrderFormService(Inventory, AppCache, Store, Pool, PurchaseOrde
       rows.push(row);
     });
 
-    const optimized = rows.filter(inventory => inventory.quantity > 0);
-    const optimizedSorted = optimized.sort((a, b) => Number(b.quantity) - Number(a.quantity));
-
-    return optimizedSorted;
-
+    // sort by the inventory description
+    return rows
+      .filter(inventory => inventory.quantity > 0)
+      .sort((a, b) => a.description.localeCompare(b.description));
   };
 
   return PurchaseOrderForm;

--- a/client/src/modules/purchases/create/PurchaseOrderForm.js
+++ b/client/src/modules/purchases/create/PurchaseOrderForm.js
@@ -41,6 +41,10 @@ function PurchaseOrderFormService(Inventory, AppCache, Store, Pool, PurchaseOrde
     Inventory.read(null, { locked : 0, use_previous_price : 1 })
       .then((data) => {
         this.inventory.initialize('uuid', data);
+
+        // FIXME(@jniles) - this is a hack. We should actually put a list() method on the
+        // PoolService to get all data out of it.
+        this.inventory._data = angular.copy(data);
       });
 
     // setup the rows of the grid as a store
@@ -313,19 +317,21 @@ function PurchaseOrderFormService(Inventory, AppCache, Store, Pool, PurchaseOrde
   /**
    * @method formatOptimalPurchase
    *
-   * This Service analyzes for all existing repositories, Inventories that have reached a point of order,
-   * then calculates the overall quantity ordered for each Inventory
+   * This functions analyzses all inventory items and selects those that have reached a point of re-order,
+   * then calculates the overall quantity ordered for each inventory.
    *
-   * @param {*} inventories - This is the list of all inventories
-   * @param {*} stock - it is the data of the inventories having reached their point of order
+   * @param {Array} stock - the data of the inventories having reached their point of order
    */
-  PurchaseOrderForm.formatOptimalPurchase = function formatOptimalPurchase(inventories, stock) {
+  PurchaseOrderForm.prototype.formatOptimalPurchase = function formatOptimalPurchase(stock) {
     const rows = [];
+
+    // grab inventory from Pool
+    const inventories = this.inventory._data;
 
     inventories.forEach(inventory => {
       const row = new PurchaseOrderItem(inventory);
       row.quantity = 0;
-      row.unit_price = null;
+      // row.unit_price = null;
       row._invalid = true;
       row._valid = false;
 

--- a/client/src/modules/purchases/create/createUpdate.html
+++ b/client/src/modules/purchases/create/createUpdate.html
@@ -113,9 +113,14 @@
                 type="button"
                 ng-click="PurchaseCtrl.optimalPurchase()"
                 id="optimal_purchase"
-                ng-disabled="!PurchaseCtrl.supplier">
-                <i class="fa fa-shopping-cart"></i>
-                <span translate>FORM.BUTTONS.OPTIMAL_PURCHASE_ORDER </span>
+                ng-disabled="!PurchaseCtrl.supplier || PurchaseCtrl.optimalPurchaseLoading">
+                <span ng-hide="PurchaseCtrl.optimalPurchaseLoading">
+                  <i class="fa fa-shopping-cart"></i>
+                  <span translate>FORM.BUTTONS.OPTIMAL_PURCHASE_ORDER </span>
+                </span>
+                <span ng-show="PurchaseCtrl.optimalPurchaseLoading">
+                  <span class="fa fa-circle-o-notch fa-spin"></span> <span translate>FORM.INFO.LOADING</span>
+                </span>
               </button>
             </div>
 


### PR DESCRIPTION
Adds the previous purchase price into the optimal purchase order
scenario. Also reduces the number of HTTP requests by removing the
Inventory service call from the purchase controller and simply using the
inventory items that are already in the PurchaseFormService.

It also fixes the migration script so that we can migrate IMCK/Vanga successfully.

Closes #4326.

Here is it in action:
![bjqALdiEPF](https://user-images.githubusercontent.com/896472/80501916-eb449a80-8967-11ea-87d4-fd7c7a245b3b.gif)
