### PR TITLE
chore(purchase): refactor receipt + queries

### DIFF
--- a/server/controllers/finance/reports/purchases/report.handlebars
+++ b/server/controllers/finance/reports/purchases/report.handlebars
@@ -31,7 +31,7 @@
           <td>{{date date}}</td>
           <td>{{author}}</td>
           <td>{{note}}</td>
-          <td>{{currency cost currency_id}}</td>
+          <td>{{currency cost ../metadata.enterprise.currency_id}}</td>
           <td><strong>{{translate status}} </strong></td>
         </tr>
       {{else}}

--- a/server/controllers/inventory/reports/purchases.receipt.handlebars
+++ b/server/controllers/inventory/reports/purchases.receipt.handlebars
@@ -1,17 +1,20 @@
 {{> head title="PURCHASES.RECEIPT.TITLE"}}
 
-<body class="container">
+<div class="container" style="font-size: 0.9em;">
   <header>
     <div class="row">
       {{> enterpriseDetails }}
 
       <div class="col-xs-5 text-right">
+        <h3 class="text-uppercase" style="margin: 0px;">
+          {{translate "PURCHASES.RECEIPT.TITLE" }} <br />
+          <strong>{{purchase.reference}}</strong> <br>
+        </h3>
+
         <div>
           {{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time>
           {{translate "REPORT.BY"}} {{metadata.user.display_name}}
         </div>
-
-        <br/>
 
         {{#if metadata.enterprise.settings.enable_barcodes}}
           <small>{{> barcode value=purchase.barcode}}</small>
@@ -22,10 +25,6 @@
   </header>
 
   <!-- page title  -->
-  <h2 class="text-center text-uppercase">
-    {{translate "PURCHASES.RECEIPT.TITLE" }} N&deg;
-    {{purchase.reference}}
-  </h2>
 
   <!-- order details -->
   <div class="row" style="border: 1px solid #ccc; padding: 5px; margin-bottom: 15px;">
@@ -34,13 +33,15 @@
       <span class="text-capitalize">{{translate "FORM.LABELS.DATE"}}</span>: {{date purchase.date}} <br>
       <span class="text-capitalize">{{translate "FORM.LABELS.REFERENCE"}}</span>: {{purchase.reference}} <br>
       <span class="text-capitalize">{{translate "FORM.LABELS.NOTES"}}</span>: <strong>{{purchase.note}}</strong> <br>
-      <span class="text-capitalize">{{translate "FORM.LABELS.AUTHOR"}}</span>: <strong>{{purchase.author}}</strong>
+      <span class="text-capitalize">{{translate 'TABLE.COLUMNS.RESPONSIBLE'}}</span>: <strong>{{purchase.author}}</strong>
     </div>
   </div>
 
   <table class="table table-condensed table-report">
     <thead>
+      <th>{{translate "FORM.LABELS.CODE" }}</th>
       <th>{{translate "FORM.LABELS.INVENTORY_ITEM" }}</th>
+      <th>{{translate "FORM.LABELS.TYPE" }}</th>
       <th>{{translate "FORM.LABELS.QUANTITY" }}</th>
       <th>{{translate "FORM.LABELS.UNIT_PRICE" }}</th>
       <th>{{translate "FORM.LABELS.TOTAL" }}</th>
@@ -48,7 +49,9 @@
     <tbody>
       {{#each purchase.items}}
         <tr>
+          <td>{{this.code}}</td>
           <td>{{this.text}}</td>
+          <td>{{this.unit}}</td>
           <td class="text-right">{{this.quantity}}</td>
           <td class="text-right">{{currency this.unit_price ../metadata.enterprise.currency_id}}</td>
           <td class="text-right">{{currency this.total ../metadata.enterprise.currency_id}}</td>
@@ -57,10 +60,10 @@
     </tbody>
     <tfoot>
       <tr>
-        <td class="text-left" colspan="3">{{translate "FORM.LABELS.TOTAL"}}</td>
+        <td class="text-left" colspan="5">{{translate "FORM.LABELS.TOTAL"}} ({{purchase.items.length}} {{ translate "TABLE.AGGREGATES.RECORDS" }})</td>
         <td class="text-right" >{{currency purchase.cost metadata.enterprise.currency_id}}</td>
       </tr>
     </tfoot>
   </table>
   <script>JsBarcode('.barcode').init();</script>
-</body>
+</div>

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -764,8 +764,6 @@ CREATE TABLE `icd10` (
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `inventory`;
-
-
 CREATE TABLE `inventory` (
   `enterprise_id` SMALLINT(5) UNSIGNED NOT NULL,
   `uuid` BINARY(16) NOT NULL,


### PR DESCRIPTION
Refactors the purchase receipt to look more like the other receipts in
the system. Also includes the inventory code for the medications used at
the hospital.  Finally, the queries have been migrated to depend more
thoroughly on document_map.

Closes #4303.

Here is what it looks like for IMCK:
![image](https://user-images.githubusercontent.com/896472/80695079-4c39b300-8acd-11ea-9253-00d111c4a691.png)

Here is what it looks like for HEV:
![image](https://user-images.githubusercontent.com/896472/80695247-860ab980-8acd-11ea-813e-be3f4486a1b0.png)

Also, since I changed the `reference` query, here is proof that it works:
![gPBOfSXQr4](https://user-images.githubusercontent.com/896472/80695485-e4379c80-8acd-11ea-8708-dc09d3c9b365.gif)
