### PR TITLE
Refactor Employee and Multiple Payroll w/ Links and References

### DIFF
--- a/client/src/i18n/en/employee.json
+++ b/client/src/i18n/en/employee.json
@@ -9,6 +9,7 @@
   "REGISTER" : "Register Employee",
   "REGISTRATION_FORM" : "Registration Form",
   "TITLE":"Employee Management",
-  "NO_GRADE":"No grade assigned"
+  "NO_GRADE":"No grade assigned",
+  "VIEW_EMPLOYEE" : "View Employee"
  }
 }

--- a/client/src/i18n/fr/employee.json
+++ b/client/src/i18n/fr/employee.json
@@ -9,6 +9,7 @@
         "REGISTER" : "Nouveau employé",
         "REGISTRATION_FORM" : "Formulaire d'enregistrement",
         "TITLE" : "Gestion des employés",
-        "NO_GRADE":"Aucun grade enregistré"
+        "NO_GRADE":"Aucun grade enregistré",
+        "VIEW_EMPLOYEE" : "Voir Employé"
     }
 }

--- a/client/src/modules/employees/employee.service.js
+++ b/client/src/modules/employees/employee.service.js
@@ -1,7 +1,9 @@
 angular.module('bhima.services')
   .service('EmployeeService', EmployeeService);
 
-EmployeeService.$inject = ['FilterService', '$uibModal', 'PrototypeApiService', 'appcache', 'LanguageService', '$httpParamSerializer'];
+EmployeeService.$inject = [
+  'FilterService', '$uibModal', 'PrototypeApiService', 'appcache', 'LanguageService', '$httpParamSerializer',
+];
 
 /**
  * @class EmployeeService
@@ -96,14 +98,8 @@ function EmployeeService(Filters, $uibModal, Api, AppCache, Languages, $httpPara
   function openSearchModal(params) {
     return $uibModal.open({
       templateUrl : 'modules/employees/registry/search.modal.html',
-      size : 'md',
-      keyboard : false,
-      animation : false,
-      backdrop : 'static',
       controller : 'EmployeeRegistryModalController as ModalCtrl',
-      resolve : {
-        filters : function paramsProvider() { return params; },
-      },
+      resolve : { filters : () => params },
     }).result;
   }
 
@@ -118,7 +114,7 @@ function EmployeeService(Filters, $uibModal, Api, AppCache, Languages, $httpPara
     return $httpParamSerializer(options);
   }
 
-   // transform patient to employee
+  // transform patient to employee
   function patientToEmployee(data) {
     return service.$http.post(`/employees/patient_employee`, data)
       .then(service.util.unwrapHttpResponse);

--- a/client/src/modules/employees/registry/search.modal.html
+++ b/client/src/modules/employees/registry/search.modal.html
@@ -4,133 +4,133 @@
   data-modal="employee-search"
   novalidate>
 
-  <div class="modal-header" style="box-shadow : 0px 2px 4px -4px black; z-index:1000">
+  <div class="modal-header">
     <ol class="headercrumb">
       <li class="static" translate>EMPLOYEE.EMPLOYEE_DETAILS</li>
       <li class="title" translate>FORM.INFO.SEARCH</li>
     </ol>
   </div>
 
-  <uib-tabset>
-    <uib-tab index="0" heading="{{ 'FORM.LABELS.SEARCH_QUERIES' | translate}}" data-custom-filter-tab>
+  <div class="modal-body search-modal">
+    <uib-tabset>
+      <uib-tab index="0" heading="{{ 'FORM.LABELS.SEARCH_QUERIES' | translate}}" data-custom-filter-tab>
+        <div class="tab-body">
+          <bh-date-interval
+            label="FORM.LABELS.DATE_EMBAUCHE"
+            date-id="embauche-date"
+            date-from="ModalCtrl.searchQueries.dateEmbaucheFrom"
+            date-to="ModalCtrl.searchQueries.dateEmbaucheTo"
+            on-change="ModalCtrl.formatHiringDates()">
+          </bh-date-interval>
 
-      <div class="modal-body" style="max-height : 400px; overflow: auto;">
-        <bh-date-interval
-          label="FORM.LABELS.DATE_EMBAUCHE"
-          date-id="embauche-date"
-          date-from="ModalCtrl.searchQueries.dateEmbaucheFrom"
-          date-to="ModalCtrl.searchQueries.dateEmbaucheTo"
-          on-change="ModalCtrl.formatHiringDates()">
-        </bh-date-interval>
-        <br />
-
-        <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.name.$invalid }">
-          <label class="control-label" translate>FORM.LABELS.NAME</label>
-          <bh-clear on-clear="ModalCtrl.clear('display_name')"></bh-clear>
-          <input type="text" class="form-control" name="display_name" ng-model="ModalCtrl.searchQueries.display_name">
-          <div class="help-block" ng-messages="ModalForm.display_name.$error" ng-show="ModalForm.$submitted">
-            <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+          <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.reference.$invalid }">
+            <label class="control-label" translate>FORM.LABELS.REFERENCE</label>
+            <bh-clear on-clear="ModalCtrl.clear('reference')"></bh-clear>
+            <input type="text" class="form-control" name="reference" ng-model="ModalCtrl.searchQueries.reference">
+            <div class="help-block" ng-messages="ModalForm.reference.$error" ng-show="ModalForm.$submitted">
+              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            </div>
           </div>
-        </div>
 
-        <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.code.$invalid }">
-          <label class="control-label" translate>FORM.LABELS.REGISTRATION_NUMBER</label>
-          <bh-clear on-clear="ModalCtrl.clear('code')"></bh-clear>
-          <input type="text" class="form-control" name="code" ng-model="ModalCtrl.searchQueries.code">
-          <div class="help-block" ng-messages="ModalForm.code.$error" ng-show="ModalForm.$submitted">
-            <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+          <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.name.$invalid }">
+            <label class="control-label" translate>FORM.LABELS.NAME</label>
+            <bh-clear on-clear="ModalCtrl.clear('display_name')"></bh-clear>
+            <input type="text" class="form-control" name="display_name" ng-model="ModalCtrl.searchQueries.display_name">
+            <div class="help-block" ng-messages="ModalForm.display_name.$error" ng-show="ModalForm.$submitted">
+              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            </div>
           </div>
-        </div>
 
-        <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.reference.$invalid }">
-          <label class="control-label" translate>FORM.LABELS.REFERENCE</label>
-          <bh-clear on-clear="ModalCtrl.clear('reference')"></bh-clear>
-          <input type="text" class="form-control" name="reference" ng-model="ModalCtrl.searchQueries.reference">
-          <div class="help-block" ng-messages="ModalForm.reference.$error" ng-show="ModalForm.$submitted">
-            <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+          <div class="form-group" ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.code.$invalid }">
+            <label class="control-label" translate>FORM.LABELS.REGISTRATION_NUMBER</label>
+            <bh-clear on-clear="ModalCtrl.clear('code')"></bh-clear>
+            <input type="text" class="form-control" name="code" ng-model="ModalCtrl.searchQueries.code">
+            <div class="help-block" ng-messages="ModalForm.code.$error" ng-show="ModalForm.$submitted">
+              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            </div>
           </div>
-        </div>
 
-        <div class="radio">
-          <p class="control-label">
-            <strong translate>FORM.LABELS.GENDER</strong>
+          <div class="form-group">
+            <label class="control-label" translate>FORM.LABELS.GENDER</label>
             <bh-clear on-clear="ModalCtrl.clear('sex')"></bh-clear>
-          </p>
 
-          <label>
-            <input type="radio" id="male" name="sex" value="M" ng-model="ModalCtrl.searchQueries.sex">
-            <span translate>FORM.LABELS.MALE</span>
-          </label>
-        </div>
+            <div class="radio">
+              <label>
+                <input type="radio" id="male" name="sex" value="M" ng-model="ModalCtrl.searchQueries.sex">
+                <span translate>FORM.LABELS.MALE</span>
+              </label>
+            </div>
 
-        <div class="radio">
-          <label>
-            <input type="radio" id="female" name="sex" value="F" ng-model="ModalCtrl.searchQueries.sex">
-            <span translate>FORM.LABELS.FEMALE</span>
-          </label>
-        </div>
+            <div class="radio">
+              <label>
+                <input type="radio" id="female" name="sex" value="F" ng-model="ModalCtrl.searchQueries.sex">
+                <span translate>FORM.LABELS.FEMALE</span>
+              </label>
+            </div>
+          </div>
 
-        <bh-grade-select
-          grade-uuid="ModalCtrl.searchQueries.grade_uuid"
-          on-select-callback="ModalCtrl.onSelectGrade(grade)">
-          <bh-clear on-clear="ModalCtrl.clear('grade_uuid')"></bh-clear>
-        </bh-grade-select>
+          <bh-grade-select
+            grade-uuid="ModalCtrl.searchQueries.grade_uuid"
+            on-select-callback="ModalCtrl.onSelectGrade(grade)">
+            <bh-clear on-clear="ModalCtrl.clear('grade_uuid')"></bh-clear>
+          </bh-grade-select>
 
-        <bh-fonction-select
-          fonction-id="ModalCtrl.searchQueries.fonction_id"
-          on-select-callback="ModalCtrl.onSelectFonction(fonction)">
-          <bh-clear on-clear="ModalCtrl.clear('fonction_id')"></bh-clear>
-        </bh-fonction-select>
+          <bh-fonction-select
+            fonction-id="ModalCtrl.searchQueries.fonction_id"
+            on-select-callback="ModalCtrl.onSelectFonction(fonction)">
+            <bh-clear on-clear="ModalCtrl.clear('fonction_id')"></bh-clear>
+          </bh-fonction-select>
 
-        <bh-service-select
-          service-id="ModalCtrl.searchQueries.service_id"
-          on-select-callback="ModalCtrl.onSelectService(service)">
-          <bh-clear on-clear="ModalCtrl.clear('service_id')"></bh-clear>
-        </bh-service-select>
+          <bh-service-select
+            service-id="ModalCtrl.searchQueries.service_id"
+            on-select-callback="ModalCtrl.onSelectService(service)">
+            <bh-clear on-clear="ModalCtrl.clear('service_id')"></bh-clear>
+          </bh-service-select>
 
-        <div class="radio">
-          <p class="control-label">
-            <strong translate>FORM.LABELS.MEDICAL_NONMEDICAL_STAFF</strong>
+          <div class="form-group">
+            <label class="control-label" translate>FORM.LABELS.MEDICAL_NONMEDICAL_STAFF</label>
             <bh-clear on-clear="ModalCtrl.clear('is_medical')"></bh-clear>
-          </p>
 
-          <label>
-            <input type="radio" name="is_medical" value="1" ng-model="ModalCtrl.searchQueries.is_medical">
-            <span translate>FORM.LABELS.MEDICAL_STAFF</span>
-          </label>
+            <div class="radio">
+              <label>
+                <input type="radio" name="is_medical" value="1" ng-model="ModalCtrl.searchQueries.is_medical">
+                <span translate>FORM.LABELS.MEDICAL_STAFF</span>
+              </label>
+            </div>
+
+            <div class="radio">
+              <label>
+                <input type="radio" name="is_medical"  value="0" ng-model="ModalCtrl.searchQueries.is_medical">
+                <span translate>FORM.LABELS.NONMEDICAL_STAFF</span>
+              </label>
+            </div>
+          </div>
+
+          <bh-date-interval
+            label="FORM.LABELS.DOB"
+            date-id="dob-date"
+            date-from="ModalCtrl.searchQueries.dateBirthFrom"
+            date-to="ModalCtrl.searchQueries.dateBirthTo">
+          </bh-date-interval>
         </div>
+      </uib-tab>
 
-        <div class="radio">
-          <label>
-            <input type="radio" name="is_medical"  value="0" ng-model="ModalCtrl.searchQueries.is_medical">
-            <span translate>FORM.LABELS.NONMEDICAL_STAFF</span>
-          </label>
-        </div>
-
-        <bh-date-interval
-          label="FORM.LABELS.DOB"
-          date-id="dob-date"
-          date-from="ModalCtrl.searchQueries.dateBirthFrom"
-          date-to="ModalCtrl.searchQueries.dateBirthTo">
-        </bh-date-interval>
-      </div>
-    </uib-tab>
-
-    <uib-tab index="1" heading="{{ 'FORM.LABELS.DEFAULTS' | translate }}"  data-custom-filter-tab>
-      <div class="tab-body">
-        <div class="form-group" ng-class="{ 'has-error' : ModalForm.limit.$invalid }">
-          <label class="control-label" translate>FORM.LABELS.LIMIT</label>
-          <input name="limit"
-            type="number" min="0" bh-integer bh-max-integer class="form-control"
-            ng-model="ModalCtrl.defaultQueries.limit"
-            ng-change="ModalCtrl.onSelectLimit(ModalCtrl.defaultQueries.limit)">
-          <div class="help-block" ng-messages="ModalForm.limit.$error">
-            <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+      <uib-tab index="1" heading="{{ 'FORM.LABELS.DEFAULTS' | translate }}"  data-custom-filter-tab>
+        <div class="tab-body">
+          <div class="form-group" ng-class="{ 'has-error' : ModalForm.limit.$invalid }">
+            <label class="control-label" translate>FORM.LABELS.LIMIT</label>
+            <input name="limit"
+              type="number" min="0" bh-integer bh-max-integer class="form-control"
+              ng-model="ModalCtrl.defaultQueries.limit"
+              ng-change="ModalCtrl.onSelectLimit(ModalCtrl.defaultQueries.limit)">
+            <div class="help-block" ng-messages="ModalForm.limit.$error">
+              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            </div>
           </div>
         </div>
-      </div>
-    </uib-tab>
-  </uib-tabset>
+      </uib-tab>
+    </uib-tabset>
+  </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="ModalCtrl.cancel()" data-method="cancel" translate>
       FORM.BUTTONS.CLOSE

--- a/client/src/modules/employees/registry/search.modal.js
+++ b/client/src/modules/employees/registry/search.modal.js
@@ -2,8 +2,7 @@ angular.module('bhima.controllers')
   .controller('EmployeeRegistryModalController', EmployeeRegistryModalController);
 
 EmployeeRegistryModalController.$inject = [
-  '$uibModalInstance', 'bhConstants', 'moment', 'ServiceService', 'Store',
-  'util', 'filters', 'EmployeeService',
+  '$uibModalInstance', 'bhConstants', 'Store', 'util', 'filters', 'EmployeeService',
 ];
 
 /**
@@ -13,22 +12,22 @@ EmployeeRegistryModalController.$inject = [
  * This controller is responsible for setting up the filters for the employee
  * search functionality on the employee registry page.
  */
-function EmployeeRegistryModalController(ModalInstance, bhConstants, moment, Services, Store, util, filters, Employees) {
-  var vm = this;
-  var changes = new Store({ identifier : 'key' });
+function EmployeeRegistryModalController(ModalInstance, bhConstants, Store, util, filters, Employees) {
+  const vm = this;
+  const changes = new Store({ identifier : 'key' });
 
   // displayValues will be an id:displayValue pair
-  var displayValues = {};
+  const displayValues = {};
 
   vm.filters = filters;
   vm.searchQueries = {};
   vm.defaultQueries = {};
   vm.formatHiringDates = formatHiringDates;
 
-  var lastDisplayValues = Employees.filters.getDisplayValueMap();
+  const lastDisplayValues = Employees.filters.getDisplayValueMap();
 
   // these properties will be used to filter employee data form the client
-  var searchQueryOptions = [
+  const searchQueryOptions = [
     'display_name', 'sex', 'code', 'dateBirthFrom', 'dateBirthTo', 'dateEmbaucheFrom',
     'dateEmbaucheTo', 'grade_uuid', 'fonction_id', 'service_id', 'is_medical', 'reference',
   ];
@@ -88,27 +87,27 @@ function EmployeeRegistryModalController(ModalInstance, bhConstants, moment, Ser
 
   // returns the parameters to the parent controller
   function submit(form) {
-    if (form.$invalid) { return; }
+    if (form.$invalid) { return 0; }
 
     // push all searchQuery values into the changes array to be applied
-    angular.forEach(vm.searchQueries, function (value, key) {
+    angular.forEach(vm.searchQueries, (value, key) => {
       if (angular.isDefined(value)) {
         // default to the original value if no display value is defined
-        var displayValue = displayValues[key] || lastDisplayValues[key] || value;
-        changes.post({ key : key, value : value, displayValue : displayValue });
+        const displayValue = displayValues[key] || lastDisplayValues[key] || value;
+        changes.post({ key, value, displayValue });
       }
     });
 
-    var loggedChanges = changes.getAll();
+    const loggedChanges = changes.getAll();
     return ModalInstance.close(loggedChanges);
   }
 
 
-   // default filter limit - directly write to changes list
+  // default filter limit - directly write to changes list
   vm.onSelectLimit = function onSelectLimit(value) {
     // input is type value, this will only be defined for a valid number
     if (angular.isDefined(value)) {
-      changes.post({ key : 'limit', value : value });
+      changes.post({ key : 'limit', value });
     }
   };
 }

--- a/client/src/modules/employees/templates/action.cell.html
+++ b/client/src/modules/employees/templates/action.cell.html
@@ -1,4 +1,4 @@
-<div class="ui-grid-cell-contents" uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
+<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
   <a href>
     <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>

--- a/client/src/modules/employees/templates/action.cell.html
+++ b/client/src/modules/employees/templates/action.cell.html
@@ -1,13 +1,13 @@
-<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body uib-dropdown-toggle>
-  <a href>
-    <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
+<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body data-row="{{ row.entity.reference }}">
+  <a uib-dropdown-toggle href data-action="open-dropdown-menu">
+    <span translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
 
-  <ul data-action="{{ rowRenderIndex}}"  class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+  <ul data-row-menu="{{ row.entity.reference }}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
     <li class="dropdown-header">{{row.entity.reference}}</li>
     <li>
-      <a data-method="edit" ui-sref="employeeEdit({uuid : row.entity.uuid})" href>
+      <a data-method="edit-record" ui-sref="employeeEdit({uuid : row.entity.uuid})" href>
         <span class="fa fa-edit"></span> <span translate>TABLE.COLUMNS.EDIT</span>
       </a>
     </li>

--- a/client/src/modules/invoices/registry/registry.js
+++ b/client/src/modules/invoices/registry/registry.js
@@ -17,7 +17,7 @@ InvoiceRegistryController.$inject = [
 function InvoiceRegistryController(
   Invoices, bhConstants, Notify, Session, Receipt, uiGridConstants,
   ModalService, Sorting, Columns, GridState, $state, Modals, Receipts, util,
-  Barcode
+  Barcode,
 ) {
   const vm = this;
 

--- a/client/src/modules/multiple_payroll/multiple_payroll.js
+++ b/client/src/modules/multiple_payroll/multiple_payroll.js
@@ -5,7 +5,7 @@ angular.module('bhima.controllers')
 MultiplePayrollController.$inject = [
   'MultiplePayrollService', 'NotifyService',
   'GridSortingService', 'GridColumnService', 'GridStateService', '$state',
-  'ModalService', 'util', 'ReceiptModal', 'uiGridConstants', 'SessionService',
+  'ModalService', 'ReceiptModal', 'uiGridConstants', 'SessionService',
 ];
 
 /**
@@ -17,8 +17,8 @@ MultiplePayrollController.$inject = [
  * reordering, and many more features.
  */
 function MultiplePayrollController(
-  MultiplePayroll, Notify,
-  Sorting, Columns, GridState, $state, Modals, util, Receipts, uiGridConstants, Session,
+  MultiplePayroll, Notify, Sorting, Columns, GridState, $state,
+  Modals, Receipts, uiGridConstants, Session,
 ) {
   const vm = this;
   const cacheKey = 'multiple-payroll-grid';
@@ -31,19 +31,22 @@ function MultiplePayrollController(
   vm.clearGridState = clearGridState;
   vm.toggleInlineFilter = toggleInlineFilter;
 
-  // date format function
-  vm.format = util.formatDate;
-
   vm.loading = false;
   vm.activePosting = true;
   vm.activeConfig = true;
 
   const columnDefs = [{
+    field : 'reference',
+    displayName : 'TABLE.COLUMNS.REFERENCE',
+    headerCellFilter : 'translate',
+    aggregationType : uiGridConstants.aggregationTypes.count,
+    aggregationHideLabel : true,
+    footerCellClass : 'text-center',
+    sortingAlgorithm : Sorting.algorithms.sortByReference,
+  }, {
     field : 'display_name',
     displayName : 'FORM.LABELS.EMPLOYEE_NAME',
     headerCellFilter : 'translate',
-    aggregationType  : uiGridConstants.aggregationTypes.count,
-    aggregationHideLabel : true,
   }, {
     field : 'code',
     displayName : 'FORM.LABELS.CODE',
@@ -52,11 +55,13 @@ function MultiplePayrollController(
     field : 'net_salary',
     displayName : 'FORM.LABELS.NET_SALARY',
     headerCellFilter : 'translate',
+    cellClass : 'text-right',
     cellFilter : 'currency:row.entity.currency_id',
   }, {
     field : 'balance',
     displayName : 'FORM.LABELS.BALANCE',
     headerCellFilter : 'translate',
+    cellClass : 'text-right',
     cellFilter : 'currency:row.entity.currency_id',
   }, {
     field : 'status_id',
@@ -82,9 +87,7 @@ function MultiplePayrollController(
     flatEntityAccess  : true,
     fastWatch         : true,
     columnDefs,
-    onRegisterApi : function onRegisterApi(api) {
-      vm.gridApi = api;
-    },
+    onRegisterApi : (api) => { vm.gridApi = api; },
   };
 
   const gridColumns = new Columns(vm.gridOptions, cacheKey);
@@ -105,7 +108,7 @@ function MultiplePayrollController(
           MultiplePayroll.filters.replaceFilters(changes);
           MultiplePayroll.cacheFilters();
           vm.latestViewFilters = MultiplePayroll.filters.formatView();
-          return load(MultiplePayroll.filters.formatHTTP(true));
+          load(MultiplePayroll.filters.formatHTTP(true));
         }
       });
   }
@@ -301,7 +304,6 @@ function MultiplePayrollController(
         Notify.warn('FORM.WARNINGS.ATTENTION_PAYSLIPS');
       } else {
         const idPeriod = vm.latestViewFilters.defaultFilters[0]._value;
-
         Receipts.payrollReport(idPeriod, employeesRef, currencyId, socialCharge, conversionRate);
       }
     } else {

--- a/client/src/modules/multiple_payroll/multiple_payroll.js
+++ b/client/src/modules/multiple_payroll/multiple_payroll.js
@@ -36,7 +36,7 @@ function MultiplePayrollController(
   vm.activeConfig = true;
 
   const columnDefs = [{
-    field : 'reference',
+    field : 'hrreference',
     displayName : 'TABLE.COLUMNS.REFERENCE',
     headerCellFilter : 'translate',
     aggregationType : uiGridConstants.aggregationTypes.count,

--- a/client/src/modules/multiple_payroll/multiple_payroll.service.js
+++ b/client/src/modules/multiple_payroll/multiple_payroll.service.js
@@ -17,7 +17,7 @@ MultiplePayrollService.$inject = [
  */
 function MultiplePayrollService(
   Api, TransactionTypeStore, Modal, Filters, Periods, Languages,
-  $httpParamSerializer, AppCache, Transactions
+  $httpParamSerializer, AppCache, Transactions,
 ) {
   const service = new Api('/multiple_payroll/');
   const multiplePayrollFilters = new Filters();
@@ -119,13 +119,9 @@ function MultiplePayrollService(
   function openSearchModal(filters) {
     return Modal.open({
       templateUrl : 'modules/multiple_payroll/modals/search.modal.html',
-      size : 'md',
-      animation : false,
-      keyboard : false,
-      backdrop : 'static',
       controller : 'MultiPayrollSearchModalController as $ctrl',
       resolve : {
-        filters : function filtersProvider() { return filters; },
+        filters : () => filters,
       },
     }).result;
   }

--- a/client/src/modules/multiple_payroll/templates/action.tmpl.html
+++ b/client/src/modules/multiple_payroll/templates/action.tmpl.html
@@ -1,11 +1,11 @@
-<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body data-row="{{row.entity.reference}}">
+<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body data-row="{{row.entity.hrreference}}">
   <a uib-dropdown-toggle href data-action="open-dropdown-menu">
     <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
 
-  <ul data-action="{{rowRenderIndex}}" data-row-menu="{{row.entity.reference}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
-    <li class="dropdown-header">{{row.entity.reference}}</li>
+  <ul data-row-menu="{{row.entity.hrreference}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+    <li class="dropdown-header">{{row.entity.hrreference}}</li>
     <li ng-if="row.entity.status_id === 2 || row.entity.status_id === 1">
       <a data-method="config" ui-sref="multiple_payroll.config({uuid : row.entity.employee_uuid})" href>
         <i class="fa fa-cog"></i> <span translate>FORM.BUTTONS.CONFIGURE</span>
@@ -20,7 +20,7 @@
     <li class="divider"></li>
 
     <li>
-      <a data-method="employee" ui-sref="employeeRegistry({ filters : [{ key : 'reference', value : row.entity.reference, cacheable:false }]})" href>
+      <a data-method="employee" ui-sref="employeeRegistry({ filters : [{ key : 'hrreference', value : row.entity.hrreference, cacheable:false }]})" href>
         <i class="fa fa-user"></i> <span translate>EMPLOYEE.VIEW_EMPLOYEE</span>
       </a>
     </li>

--- a/client/src/modules/multiple_payroll/templates/action.tmpl.html
+++ b/client/src/modules/multiple_payroll/templates/action.tmpl.html
@@ -16,5 +16,13 @@
         <i class="fa fa-file-text-o"></i> <span translate>FORM.BUTTONS.PAYSLIP</span>
       </a>
     </li>
+
+    <li class="divider"></li>
+
+    <li>
+      <a data-method="employee" ui-sref="employeeRegistry({ filters : [{ key : 'reference', value : row.entity.reference, cacheable:false }]})" href>
+        <i class="fa fa-user"></i> <span translate>EMPLOYEE.VIEW_EMPLOYEE</span>
+      </a>
+    </li>
   </ul>
 </div>

--- a/client/src/modules/multiple_payroll/templates/action.tmpl.html
+++ b/client/src/modules/multiple_payroll/templates/action.tmpl.html
@@ -1,16 +1,17 @@
-<div class="ui-grid-cell-contents text-center" uib-dropdown dropdown-append-to-body>
-  <a uib-dropdown-toggle href>
+<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body data-row="{{row.entity.reference}}">
+  <a uib-dropdown-toggle href data-action="open-dropdown-menu">
     <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
 
-  <ul data-action="{{rowRenderIndex}}"  class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
-    <li ng-if="row.entity.status_id === 2 || row.entity.status_id === 1"> 
+  <ul data-action="{{rowRenderIndex}}" data-row-menu="{{row.entity.reference}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+    <li class="dropdown-header">{{row.entity.reference}}</li>
+    <li ng-if="row.entity.status_id === 2 || row.entity.status_id === 1">
       <a data-method="config" ui-sref="multiple_payroll.config({uuid : row.entity.employee_uuid})" href>
         <i class="fa fa-cog"></i> <span translate>FORM.BUTTONS.CONFIGURE</span>
       </a>
     </li>
-    <li ng-if="row.entity.status_id > 1"> 
+    <li ng-if="row.entity.status_id > 1">
       <a data-method="payslip" ng-click="grid.appScope.paySlip(row.entity)" href>
         <i class="fa fa-file-text-o"></i> <span translate>FORM.BUTTONS.PAYSLIP</span>
       </a>

--- a/client/src/modules/purchases/templates/cellStatus.tmpl.html
+++ b/client/src/modules/purchases/templates/cellStatus.tmpl.html
@@ -1,4 +1,4 @@
-<div class="ui-grid-cell-contents">        
+<div class="ui-grid-cell-contents">
   <div ng-if="row.entity.status_id === grid.appScope.status.WAITING_CONFIRMATION" class="label label-default" translate> PURCHASES.STATUS.WAITING_CONFIRMATION </div>
   <div ng-if="row.entity.status_id === grid.appScope.status.CONFIRMED" class="label label-primary" translate> PURCHASES.STATUS.CONFIRMED </div>
   <div ng-if="row.entity.status_id === grid.appScope.status.RECEIVED" class="label label-success" translate> PURCHASES.STATUS.RECEIVED </div>

--- a/server/controllers/payroll/multiplePayroll/find.js
+++ b/server/controllers/payroll/multiplePayroll/find.js
@@ -23,17 +23,16 @@ function find(options) {
     referenceEmployees = options.reference;
   }
 
-
   const sql = `
     SELECT payroll.employee_uuid, payroll.reference, payroll.code, payroll.date_embauche, payroll.nb_enfant,
       payroll.individual_salary, payroll.account_id, payroll.creditor_uuid, payroll.display_name, payroll.sex,
       payroll.uuid, payroll.payroll_configuration_id, payroll.currency_id, payroll.paiement_date, payroll.base_taxable,
       payroll.basic_salary, payroll.gross_salary, payroll.grade_salary, payroll.text, payroll.net_salary,
       payroll.working_day, payroll.total_day, payroll.daily_salary, payroll.amount_paid,
-      payroll.status_id, payroll.status, (payroll.net_salary - payroll.amount_paid) AS balance
+      payroll.status_id, payroll.status, (payroll.net_salary - payroll.amount_paid) AS balance, payroll.hrreference
     FROM(
-      SELECT BUID(employee.uuid) AS employee_uuid, em.text AS reference, employee.code, employee.date_embauche,
-        employee.nb_enfant,employee.individual_salary, creditor_group.account_id,
+      SELECT BUID(employee.uuid) AS employee_uuid, employee.reference, em.text AS hrreference, employee.code,
+        employee.date_embauche, employee.nb_enfant,employee.individual_salary, creditor_group.account_id,
         BUID(employee.creditor_uuid) AS creditor_uuid,
         UPPER(patient.display_name) AS display_name, patient.sex, BUID(paiement.uuid) AS uuid,
         paiement.payroll_configuration_id,  paiement.currency_id, paiement.paiement_date, paiement.base_taxable,
@@ -53,8 +52,8 @@ function find(options) {
         JOIN paiement_status ON paiement_status.id = paiement.status_id
         WHERE paiement.payroll_configuration_id = '${options.payroll_configuration_id}'
       UNION
-        SELECT BUID(employee.uuid) AS employee_uuid, em.text as reference, employee.code, employee.date_embauche,
-        employee.nb_enfant, employee.individual_salary, creditor_group.account_id,
+        SELECT BUID(employee.uuid) AS employee_uuid,  employee.reference, em.text AS hrreference, employee.code,
+          employee.date_embauche, employee.nb_enfant, employee.individual_salary, creditor_group.account_id,
         BUID(employee.creditor_uuid) AS creditor_uuid, UPPER(patient.display_name) AS display_name,
         patient.sex, NULL AS 'paiement_uuid', '${options.payroll_configuration_id}' AS payroll_configuration_id,
         '${options.currency_id}' AS currency_id, NULL AS paiement_date, 0 AS base_taxable, 0 AS basic_salary,

--- a/server/controllers/payroll/multiplePayroll/find.js
+++ b/server/controllers/payroll/multiplePayroll/find.js
@@ -8,7 +8,6 @@
 const db = require('../../../lib/db');
 const FilterParser = require('../../../lib/filter');
 
-
 function find(options) {
 
   // ensure epected options are parsed appropriately as binary
@@ -33,7 +32,7 @@ function find(options) {
       payroll.working_day, payroll.total_day, payroll.daily_salary, payroll.amount_paid,
       payroll.status_id, payroll.status, (payroll.net_salary - payroll.amount_paid) AS balance
     FROM(
-      SELECT BUID(employee.uuid) AS employee_uuid, employee.reference, employee.code, employee.date_embauche,
+      SELECT BUID(employee.uuid) AS employee_uuid, em.text AS reference, employee.code, employee.date_embauche,
         employee.nb_enfant,employee.individual_salary, creditor_group.account_id,
         BUID(employee.creditor_uuid) AS creditor_uuid,
         UPPER(patient.display_name) AS display_name, patient.sex, BUID(paiement.uuid) AS uuid,
@@ -42,6 +41,7 @@ function find(options) {
         paiement.net_salary, paiement.working_day, paiement.total_day, paiement.daily_salary, paiement.amount_paid,
         paiement.status_id, paiement_status.text AS status
         FROM employee
+        JOIN entity_map em ON employee.creditor_uuid = em.uuid
         JOIN creditor ON creditor.uuid = employee.creditor_uuid
         JOIN creditor_group ON creditor_group.uuid = creditor.group_uuid
         JOIN patient ON patient.uuid = employee.patient_uuid
@@ -53,7 +53,7 @@ function find(options) {
         JOIN paiement_status ON paiement_status.id = paiement.status_id
         WHERE paiement.payroll_configuration_id = '${options.payroll_configuration_id}'
       UNION
-        SELECT BUID(employee.uuid) AS employee_uuid, employee.reference, employee.code, employee.date_embauche,
+        SELECT BUID(employee.uuid) AS employee_uuid, em.text as reference, employee.code, employee.date_embauche,
         employee.nb_enfant, employee.individual_salary, creditor_group.account_id,
         BUID(employee.creditor_uuid) AS creditor_uuid, UPPER(patient.display_name) AS display_name,
         patient.sex, NULL AS 'paiement_uuid', '${options.payroll_configuration_id}' AS payroll_configuration_id,
@@ -62,6 +62,7 @@ function find(options) {
         0 AS total_day, 0 AS daily_salary, 0 AS amount_paid, 1 AS status_id,
         'PAYROLL_STATUS.WAITING_FOR_CONFIGURATION' AS status
         FROM employee
+        JOIN entity_map em ON employee.creditor_uuid = em.uuid
         JOIN creditor ON creditor.uuid = employee.creditor_uuid
         JOIN creditor_group ON creditor_group.uuid = creditor.group_uuid
         JOIN patient ON patient.uuid = employee.patient_uuid

--- a/server/controllers/payroll/multiplePayroll/index.js
+++ b/server/controllers/payroll/multiplePayroll/index.js
@@ -10,8 +10,8 @@
  * @requires db
  */
 
-const find = require('./find');
-const getConfig = require('./getConfig');
+const { find } = require('./find');
+const { getConfigurationData } = require('./getConfig');
 const manageConfig = require('./manageConfig');
 
 const setMultiConfiguration = require('./setMultiConfiguration');
@@ -23,7 +23,7 @@ const makeCommitment = require('./makeCommitment');
  * @description search Payroll payments
  */
 function search(req, res, next) {
-  find.find(req.query)
+  find(req.query)
     .then((rows) => {
       res.status(200).json(rows);
     })
@@ -35,7 +35,7 @@ function configuration(req, res, next) {
   const params = req.query;
   const payrollConfigurationId = req.params.id;
 
-  getConfig.getConfigurationData(payrollConfigurationId, params)
+  getConfigurationData(payrollConfigurationId, params)
     .then((rows) => {
       const dataManaged = manageConfig.manageConfigurationData(rows, params);
       res.status(200).json(dataManaged);

--- a/test/end-to-end/employees/registration.page.js
+++ b/test/end-to-end/employees/registration.page.js
@@ -7,20 +7,14 @@
  */
 
 const FU = require('../shared/FormUtils');
-const GA = require('../shared/GridAction');
-const GU = require('../shared/GridUtils');
 const components = require('../shared/components');
+const GridRow = require('../shared/GridRow');
 
 class RegistrationPage {
-  constructor() {
-    this.gridId = 'employee-registry';
-    this.multipayrollGrid = element(by.id(this.gridId));
-    this.actionLinkColumn = 8;
-  }
-
-  async editEmployeeName(label) {
-    const { rowIndex } = await GU.getGridIndexesMatchingText(this.gridId, label);
-    await GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'edit', this.gridId);
+  async editEmployee(reference) {
+    const row = new GridRow(reference);
+    await row.dropdown().click();
+    await row.edit().click();
   }
 
   createEmployee() {

--- a/test/end-to-end/employees/update.spec.js
+++ b/test/end-to-end/employees/update.spec.js
@@ -5,14 +5,13 @@ const RegistrationPage = require('./registration.page.js');
 describe('Update Employees', () => {
   const path = '#!/employees';
   const registrationPage = new RegistrationPage();
-  const employeeName1 = 'Test 2 Patient';
-  const employeeName2 = 'Employee Test 1';
-
+  const employeeReference1 = 'EM.TE.1'; // Test 2 Patient
+  const employeeReference2 = 'EM.TE.2'; // Employee Test 1
 
   before(() => helpers.navigate(path));
 
   it(`should update data for employee`, async () => {
-    await registrationPage.editEmployeeName(employeeName1);
+    await registrationPage.editEmployee(employeeReference1);
 
     await registrationPage.setService('Administration');
     await registrationPage.setFonction('Infirmier');
@@ -30,7 +29,7 @@ describe('Update Employees', () => {
   });
 
   it(`blocks validation when the value is already taken when the field must be Unique`, async () => {
-    await registrationPage.editEmployeeName(employeeName2);
+    await registrationPage.editEmployee(employeeReference2);
     await registrationPage.setHospitalNumber(110);
 
     await registrationPage.createEmployee();

--- a/test/end-to-end/payrollProcess/payroll_process.page.js
+++ b/test/end-to-end/payrollProcess/payroll_process.page.js
@@ -5,10 +5,8 @@
 
 const grid = require('../shared/GridUtils');
 
-/* loading grid actions */
-const GA = require('../shared/GridAction');
-const GU = require('../shared/GridUtils');
 const FU = require('../shared/FormUtils');
+const GridRow = require('../shared/GridRow');
 const components = require('../shared/components');
 
 class PayrollProcessPage {
@@ -24,9 +22,10 @@ class PayrollProcessPage {
     await grid.expectRowCount(this.gridId, number, message);
   }
 
-  async editPayrollRubric(label) {
-    const { rowIndex } = await GU.getGridIndexesMatchingText(this.gridId, label);
-    await GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'config', this.gridId);
+  async editPayrollRubric(reference) {
+    const row = new GridRow(reference);
+    await row.dropdown().click();
+    await row.method('config').click();
 
     await components.currencyInput.set(120, 'TPR');
     await components.currencyInput.set(150, 'PRI');
@@ -38,9 +37,10 @@ class PayrollProcessPage {
     await components.notification.hasSuccess();
   }
 
-  async errorEditPayrollRubric(label) {
-    const { rowIndex } = await GU.getGridIndexesMatchingText(this.gridId, label);
-    await GA.clickOnMethod(rowIndex, this.actionLinkColumn, 'config', this.gridId);
+  async errorEditPayrollRubric(reference) {
+    const row = new GridRow(reference);
+    await row.dropdown().click();
+    await row.method('config').click();
 
     await FU.buttons.submit();
     await components.notification.hasDanger();

--- a/test/end-to-end/payrollProcess/payroll_process.page.js
+++ b/test/end-to-end/payrollProcess/payroll_process.page.js
@@ -1,6 +1,3 @@
-/* global element, by */
-/* eslint  */
-
 /**
  * This class is represents a Payroll Process Page in term of structure and
  * behaviour so it is a Payroll Process Page object
@@ -17,7 +14,6 @@ const components = require('../shared/components');
 class PayrollProcessPage {
   constructor() {
     this.gridId = 'multipayroll-grid';
-    this.multipayrollGrid = element(by.id(this.gridId));
     this.actionLinkColumn = 5;
   }
 

--- a/test/end-to-end/payrollProcess/payroll_process.spec.js
+++ b/test/end-to-end/payrollProcess/payroll_process.spec.js
@@ -20,7 +20,7 @@ describe('Payroll Process Management', () => {
     currency    : 2,
   };
 
-  const employeeName = 'TEST 2 PATIENT';
+  const employeeRef = 'EM.TE.1'; // TEST 2 PATIENT
 
   const gridId = 'multipayroll-grid';
 
@@ -31,7 +31,7 @@ describe('Payroll Process Management', () => {
     await Page.getEmployeeCount(employeeCount, `The number of Defined employee should be ${employeeCount}`);
   });
 
-  it(`Should configure multiple employees for Payment`, async () => {
+  it(`should configure multiple employees for payment`, async () => {
     await GU.selectRow(gridId, 0);
 
     await element(by.css('[data-action="open-menu"]')).click();
@@ -41,10 +41,10 @@ describe('Payroll Process Management', () => {
   });
 
   it(`Configure and edit Rubrics Payroll values`, async () => {
-    await Page.editPayrollRubric(employeeName);
+    await Page.editPayrollRubric(employeeRef);
   });
 
-  it(`Should set multiple employees On Waiting List of Payroll`, async () => {
+  it(`should set multiple employees on waiting list of payroll`, async () => {
     await element(by.css('[data-method="search"]')).click();
 
     await components.payrollStatusSelect.set(['configuré']);

--- a/test/end-to-end/staffingIndice/staffing-indice.spec.js
+++ b/test/end-to-end/staffingIndice/staffing-indice.spec.js
@@ -27,7 +27,7 @@ describe('Staffing indice Management Tests', () => {
 
   const gridId = 'staffing-indice-grid';
   const actionLinkCol = 6;
-  it('creates a new Staffing indice', async () => {
+  it('creates a new staffing indice', async () => {
     await FU.buttons.create();
     await components.employeeSelect.set(indice.employee);
     await components.gradeSelect.set(indice.grade);
@@ -39,7 +39,7 @@ describe('Staffing indice Management Tests', () => {
     await components.notification.hasSuccess();
   });
 
-  it('should edit a Staffing indice', async () => {
+  it('should edit a staffing indice', async () => {
     await GA.clickOnMethod(2, actionLinkCol, 'edit-record', gridId);
     await components.inpuText.set('function_indice', 200);
     // submit the page to the server
@@ -59,7 +59,7 @@ describe('Staffing indice Management Tests', () => {
     await components.notification.hasSuccess();
   });
 
-  it('should delete the Staffing indice', async () => {
+  it('should delete the staffing indice', async () => {
     // click the edit button
     await GA.clickOnMethod(3, actionLinkCol, 'delete-record', gridId);
     await FU.buttons.submit();


### PR DESCRIPTION
This PR refactors a lot of the employee registry and search modal, and adds in a link between the multiple payroll and the employee registry.

Below is a screenshot of multiple payroll, showing the following improvements:
  1. There is a link to the employee
  2. There is a reference column for the employee
  3. There is a header with the employee reference on the dropdown.
  4. The $$ columns are now right-aligned.
  5. The actions dropdown is right-aligned.
![image](https://user-images.githubusercontent.com/896472/80703723-37641c00-8adb-11ea-9b49-79be173a41c7.png)

There is a demonstration of the link working:
![SWf7VZvrO3](https://user-images.githubusercontent.com/896472/80704090-dee14e80-8adb-11ea-842b-c400b69aca48.gif)

Finally, I've cleaned up the employee search modal by using proper HTML and removing extraneous imports/code.

Closes #4350.
Closes #4351.
