### PR TITLE
fix required MySQL version in documentation

### DIFF
--- a/docs/en/for-developers/installing-bhima.md
+++ b/docs/en/for-developers/installing-bhima.md
@@ -10,7 +10,7 @@ This guide will get you up and running with bhima locally. Please note that bhim
 
 Before you begin the installation process, please make sure you have all the bhima dependencies installed locally. We only test on Linux, so your best bet is to use a Linux flavor you are familiar with. Please make sure you have recent version of:
 
-1. [MySQL](http://dev.mysql.com/downloads/) \(5.6 or newer\)
+1. [MySQL](http://dev.mysql.com/downloads/) \(5.6 or 5.7\)
 2. [Redis](https://redis.io)
 3. [curl](https://curl.haxx.se/)
 4. [NodeJS](https://nodejs.org/en/) \(we recommend using [node version manager](https://github.com/creationix/nvm) on linux. Note that we only test on stable and edge\).

--- a/docs/fr/for-developers/installing-bhima.md
+++ b/docs/fr/for-developers/installing-bhima.md
@@ -10,7 +10,7 @@ Ce guide vous permettra de vous familiariser avec bhima localement. Veuillez not
 
 Avant de commencer le processus d'installation, assurez-vous que toutes les dépendances bhima sont installées localement. Nous ne testons que sous Linux. Il est donc préférable d’utiliser une version de Linux que vous connaissez bien. Assurez-vous d'avoir la version récente de:
 
-1. [MySQL](http://dev.mysql.com/downloads/) \(5.6 ou plus récent \)
+1. [MySQL](http://dev.mysql.com/downloads/) \(5.6 ou 5.7\)
 2. [Redis](https://redis.io)
 3. [curl](https://curl.haxx.se/)
 4. [NodeJS](https://nodejs.org/en/) \(nous vous recommandons d’utiliser le [gestionnaire de version de node](https://github.com/creationix/nvm) sous Linux. Notez que nous ne testons que sur des versions stables. et bord \).


### PR DESCRIPTION
bhima does not run with MySQL 8 (#4393), so lets fix the docs

-----
[View rendered docs/en/for-developers/installing-bhima.md](https://github.com/individual-it/bhima/blob/fixMysqlVersioninDocs/docs/en/for-developers/installing-bhima.md)
[View rendered docs/fr/for-developers/installing-bhima.md](https://github.com/individual-it/bhima/blob/fixMysqlVersioninDocs/docs/fr/for-developers/installing-bhima.md)