### PR TITLE
test different versions of node

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,9 +2,19 @@ image:
   - Ubuntu1604
   - Ubuntu1804
 
-stack: node 12, mysql, redis
+stack: mysql, redis
+
+environment:
+  DB_PASS: Password12!
+  DB_HOST: localhost
+  DB_USER: root
+  DB_NAME: bhima_test
+  matrix:
+    - nodejs_version: "14"
+    - nodejs_version: "12"
 
 install:
+  - sh: nvm install $nodejs_version
   - bash ./sh/setup-ci-env.sh
   - bash ./sh/appveyor.sh
   - yarn
@@ -14,12 +24,6 @@ build: off
 services:
   - mysql
   - redis
-
-environment:
-  DB_PASS: Password12!
-  DB_HOST: localhost
-  DB_USER: root
-  DB_NAME: bhima_test
 
 test_script:
   - yarn build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,21 +14,36 @@ env:
 
 matrix:
   include:
-    - env: TEST_TYPE=e2e
+    - node_js: lts/erbium
+      env: TEST_TYPE=e2e
       services:
         - mysql
         - redis
-    - env: TEST_TYPE=e2e
+    - node_js: node
+      env: TEST_TYPE=e2e
+      services:
+        - mysql
+        - redis
+    - node_js: lts/erbium
+      env: TEST_TYPE=e2e
       services:
         - redis
       addons:
         mariadb: '10.5'
-    - env:
+    - node_js: lts/erbium
+      env:
         TEST_TYPE=installation
       services:
         - mysql
         - redis
-    - env:
+    - node_js: node
+      env:
+        TEST_TYPE=installation
+      services:
+        - mysql
+        - redis
+    - node_js: lts/erbium
+      env:
         TEST_TYPE=installation
       addons:
         mariadb: '10.5'
@@ -40,8 +55,6 @@ before_install:
   - sudo ./sh/travis.sh
 
 language: node_js
-node_js:
-  - lts/erbium
 
 before_script:
   - sh -c "if [ '$TEST_TYPE' = 'e2e' ]; then yarn build; fi"


### PR DESCRIPTION
fixes #2090

because MySQL <5.7 seems not to be supported (#4457) this adds only matrix entries for different node versions