### PR TITLE
fix: print colors in PDFs

### DIFF
--- a/client/src/less/bhima-bootstrap.less
+++ b/client/src/less/bhima-bootstrap.less
@@ -1,4 +1,58 @@
-@import "bootstrap.less";
+// These imports customize bootstrap's LESS files found in
+// node_modules/bootstrap/less/*.less
+// See the gulpfile's build process for more information
+
+// Core variables and mixins
+@import "variables.less";
+@import "mixins.less";
+
+// Reset and dependencies
+@import "normalize.less";
+// @import "print.less"; // removed to get rid of no-color
+@import "bhima-print.less";
+@import "glyphicons.less";
+
+// Core CSS
+@import "scaffolding.less";
+@import "type.less";
+@import "code.less";
+@import "grid.less";
+@import "tables.less";
+@import "forms.less";
+@import "buttons.less";
+
+// Components
+@import "component-animations.less";
+@import "dropdowns.less";
+@import "button-groups.less";
+@import "input-groups.less";
+@import "navs.less";
+@import "navbar.less";
+@import "breadcrumbs.less";
+@import "pagination.less";
+@import "pager.less";
+@import "labels.less";
+@import "badges.less";
+@import "jumbotron.less";
+@import "thumbnails.less";
+@import "alerts.less";
+@import "progress-bars.less";
+@import "media.less";
+@import "list-group.less";
+@import "panels.less";
+@import "responsive-embed.less";
+@import "wells.less";
+@import "close.less";
+
+// Components w/ JavaScript
+@import "modals.less";
+@import "tooltip.less";
+@import "popovers.less";
+@import "carousel.less";
+
+// Utility classes
+@import "utilities.less";
+@import "responsive-utilities.less";
 
 /**
  * gutter width halfed for container padding, odd values cause overflow scroll

--- a/client/src/less/bhima-print.less
+++ b/client/src/less/bhima-print.less
@@ -1,0 +1,100 @@
+// stylelint-disable declaration-no-important, selector-no-qualifying-type
+
+/*! Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css */
+
+// ==========================================================================
+// Print styles.
+// Inlined to avoid the additional HTTP request: h5bp.com/r
+// ==========================================================================
+
+@media print {
+  *,
+  *::before,
+  *::after {
+    color: #000 !important; // Black prints faster: h5bp.com/s
+    text-shadow: none !important;
+    box-shadow: none !important;
+  }
+
+  a,
+  a:visited {
+    text-decoration: underline;
+  }
+
+  a[href]::after {
+    content: " (" attr(href) ")";
+  }
+
+  abbr[title]::after {
+    content: " (" attr(title) ")";
+  }
+
+  // Don't show links that are fragment identifiers,
+  // or use the `javascript:` pseudo protocol
+  a[href^="#"]::after,
+  a[href^="javascript:"]::after {
+    content: "";
+  }
+
+  pre,
+  blockquote {
+    border: 1px solid #999;
+    page-break-inside: avoid;
+  }
+
+  thead {
+    display: table-header-group; // h5bp.com/t
+  }
+
+  tr,
+  img {
+    page-break-inside: avoid;
+  }
+
+  img {
+    max-width: 100% !important;
+  }
+
+  p,
+  h2,
+  h3 {
+    orphans: 3;
+    widows: 3;
+  }
+
+  h2,
+  h3 {
+    page-break-after: avoid;
+  }
+
+  // Bootstrap specific changes start
+
+  // Bootstrap components
+  .navbar {
+    display: none;
+  }
+  .btn,
+  .dropup > .btn {
+    > .caret {
+      border-top-color: #000 !important;
+    }
+  }
+  .label {
+    border: 1px solid #000;
+  }
+
+  .table {
+    border-collapse: collapse !important;
+
+    td,
+    th {
+      // background-color: #fff !important;
+    }
+  }
+  .table-bordered {
+    th,
+    td {
+      border: 1px solid #ddd !important;
+    }
+  }
+}

--- a/gulpfile.js/client-css.js
+++ b/gulpfile.js/client-css.js
@@ -33,7 +33,13 @@ if (isDevelopment) {
   CSS_PATHS = CSS_PATHS.map(file => file.replace('.min.css', '.css'));
 }
 
-const LESS_CONFIG = { paths : [path.resolve(__dirname, '../node_modules/bootstrap/less/')] };
+const LESS_CONFIG = {
+  paths : [
+    path.resolve(__dirname, '../node_modules/bootstrap/less/'),
+    path.resolve(__dirname, '../client/src/less/'),
+  ],
+};
+
 const LESS_PATH = 'client/src/less/bhima-bootstrap.less';
 
 /**

--- a/server/controllers/finance/reports/analysis_auxiliary_cashbox/report.handlebars
+++ b/server/controllers/finance/reports/analysis_auxiliary_cashbox/report.handlebars
@@ -1,6 +1,6 @@
 <!doctype html>
 <html>
-  {{> head title="{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.TITLE' }}" }}
+  {{> head title="REPORT.ANALYSIS_AUX_CASHBOXES.TITLE" }}
   <body>
     <div style="margin-right: 2%; margin-left: 2%;">
       {{> header}}
@@ -21,7 +21,7 @@
             <tr>
               <td width="10%" style="background-color: #777777; color:white; text-align:center"> X </td>
               <td width="90%">&nbsp;<strong>{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.STATUS.TRANSFERT_PENDING'}}</strong></td>
-            </tr> 
+            </tr>
             <tr>
               <td width="10%" style="background-color: #f0ad4e; color:white; text-align:center"> ▲ </td>
               <td width="90%">&nbsp;<strong>{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.STATUS.TRANSFERT_GREATER'}}</strong></td>
@@ -29,7 +29,7 @@
             <tr>
               <td width="10%" style="background-color: #d9534f; color:white; text-align:center"> ▼ </td>
               <td width="90%">&nbsp;<strong>{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.STATUS.TRANSFERT_LOWWER'}}</strong></td>
-            </tr>            
+            </tr>
           </table>
 
           <table style="width: 100%;" class="table table-striped table-condensed table-report table-bordered">
@@ -60,7 +60,7 @@
             {{#each this.transactions}}
                 <tr>
                   <td>{{date trans_date "DD/MM/YYYY"}}, {{translate transDateDays }} </td>
-                  
+
                   <td class="text-right">{{debcred debit ../report.currencyId}}</td>
                   <td class="text-right">{{debcred credit ../report.currencyId}}</td>
                   <td class="text-right">{{debcred balance ../report.currencyId}}</td>
@@ -74,11 +74,11 @@
                   <td style="color:white; background-color: {{ labelDisplayTransfert.color }}" class="text-center">
                     {{ labelDisplayTransfert.icon }}
                   </td>
-                  
+
                   <td><strong>{{ account_target }}</strong></td>
                   <td class="text-right">{{debcred debit_primary ../report.currencyId}}</td>
                   <td style="color:white; background-color: {{ labelDisplayPrimary.color }};" class="text-center">
-                    {{ labelDisplayPrimary.icon }} 
+                    {{ labelDisplayPrimary.icon }}
                   </td>
                 </tr>
             {{/each}}

--- a/server/lib/template/partials/head.handlebars
+++ b/server/lib/template/partials/head.handlebars
@@ -103,6 +103,7 @@
 
     body {
       margin: 1em;
+      -webkit-print-color-adjust: exact;
     }
 
     @page {


### PR DESCRIPTION
Applies a color fix suggested by @jeremielodi, and omits bootstrap's broken `print.css`.  Instead, we've created our own `print.css` that will render the colors.  These changes should ensure that all colorschemes should print in each report without user intervention.

Also fixes the unrendered title of the cashflow report.

Closes #4382
Closes #4456

Here is what it looks like:
![q5pUWAmUbm](https://user-images.githubusercontent.com/896472/81415459-6106ee00-9140-11ea-8b2f-132a53e161c3.gif)
