### PR TITLE
feat: improve release-it configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,19 @@
     "build:clean": "cross-env ./sh/build-init-database.sh",
     "migrate": "cross-env ./sh/setup-migration-script.sh",
     "watch": "cross-env ./node_modules/.bin/gulp watch",
-    "release": "release-it --disable-metrics"
+    "release": "release-it --disable-metrics --github.release"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/IMA-WorldHealth/bhima.git"
+  },
+  "release-it" : {
+    "git": {
+      "changelog" : "git log --invert-grep --grep=\"^chore\\|^Merge\" --pretty=format:\"* %s (%h)\" ${from}...${to}"
+    },
+    "npm" : {
+      "publish" : false
+    }
   },
   "keywords": [
     "bhima",


### PR DESCRIPTION
Filters out all our "chore" and "merge" commits generated by dependabot. It also automates github releases.  Also removes the NPM publish configuration.