### PR TITLE
fix(stock):  standardize requisition receipt

### DIFF
--- a/server/controllers/stock/requisition/requisition.js
+++ b/server/controllers/stock/requisition/requisition.js
@@ -7,10 +7,10 @@ const util = require('../../../lib/util');
 const FilterParser = require('../../../lib/filter');
 
 const SELECT_QUERY = `
-  SELECT 
+  SELECT
     BUID(sr.uuid) uuid, BUID(sr.requestor_uuid) requestor_uuid, BUID(sr.depot_uuid) depot_uuid,
     sr.requestor_type_id, sr.description, sr.date, sr.user_id,
-    u.display_name AS user_display_name, d.text AS depot_text, 
+    u.display_name AS user_display_name, d.text AS depot_text,
     s.name service_requestor, dd.text depot_requestor,
     dm.text reference, stat.title_key, stat.status_key
   FROM stock_requisition sr
@@ -31,9 +31,10 @@ async function getDetails(identifier) {
   const uuid = identifier;
   const sqlRequisition = `${SELECT_QUERY} WHERE sr.uuid = ?;`;
   const sqlRequisitionItems = `
-    SELECT BUID(i.uuid) inventory_uuid, i.code, i.text, sri.quantity
+    SELECT BUID(i.uuid) inventory_uuid, i.code, i.text, it.text as inventoryType, sri.quantity
     FROM stock_requisition_item sri
     JOIN inventory i ON i.uuid = sri.inventory_uuid
+    JOIN inventory_type it ON i.type_id = it.id
     WHERE sri.requisition_uuid = ?
   `;
   const requisition = await db.one(sqlRequisition, [uuid]);

--- a/server/controllers/stock/requisition/requisition.receipt.handlebars
+++ b/server/controllers/stock/requisition/requisition.receipt.handlebars
@@ -4,101 +4,99 @@
 <div class="container" style="font-size: 0.9em;">
 
   <header>
-    <!-- headings  -->
+      <!-- headings  -->
     <div class="row">
       {{> enterpriseDetails }}
 
       <div class="col-xs-5 text-right">
-        <h3 style="margin: 0px;">
+
+        <h3 class="text-uppercase" style="margin: 0px;">
           <span class="text-uppercase">{{translate 'REQUISITION.STOCK_REQUISITION'}}</span><br>
-          {{#if details.service_requestor}}
-            <strong>{{details.service_requestor}}</strong>
-          {{/if}}
-          {{#if details.depot_requestor}} 
-            <strong>{{details.depot_requestor}}</strong>
-          {{/if}}
-          <br>
+          <strong>{{details.reference}}</strong> <br>
         </h3>
-        <small>{{> barcode value=barcode}}</small>
+
+        <div>
+          {{translate "REPORT.PRODUCED_ON"}} <time datetime="{{metadata.timestamp}}">{{date metadata.timestamp}}</time>
+          {{translate "REPORT.BY"}} {{metadata.user.display_name}}
+
+        </div>
+        {{#if metadata.enterprise.settings.enable_barcodes}}
+          <small>{{> barcode value=barcode}}</small> <br>
+        {{/if}}
+        <br>
       </div>
     </div>
 
     <!-- client and user details  -->
     <div class="row" style="border: 1px solid #ccc; padding: 5px; margin-bottom: 15px;">
       <div class="col-xs-6">
-        <h4>{{translate 'FORM.LABELS.SUPPLIER'}}</h4>
+        <h5><u>{{translate 'FORM.LABELS.SUPPLIER'}}</u></h5>
         <span class="text-capitalize">{{translate 'STOCK.DEPOT'}}</span>: <strong>{{details.depot_text}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.REFERENCE'}}</span>: <strong>{{details.reference}}</strong> <br>
+        <span class="text-capitalize">{{translate "FORM.LABELS.NOTES"}}</span>: <strong>{{details.description}}</strong> <br>
       </div>
+
       <div class="col-xs-6">
-        <h4>{{translate 'STOCK.TO'}}</h4>
-          {{#if details.service_requestor}}
-            <span class="text-capitalize">{{translate 'FORM.LABELS.SERVICE'}}</span>: 
-            <span>{{details.service_requestor}}</span><br>
-          {{/if}}
-          {{#if details.depot_requestor}}
-            <span class="text-capitalize">{{translate 'FORM.LABELS.DEPOT'}}</span>: 
-            <span>{{details.depot_requestor}}</span><br>
-          {{/if}}
+        <h5><u>{{translate 'STOCK.TO'}}</u></h5>
+
+        {{#if details.service_requestor}}
+          <span class="text-capitalize">{{translate 'FORM.LABELS.SERVICE'}}</span>: <span>{{details.service_requestor}}</span><br>
+        {{/if}}
+
+        {{#if details.depot_requestor}}
+          <span class="text-capitalize">{{translate 'FORM.LABELS.DEPOT'}}</span>: <span>{{details.depot_requestor}}</span><br>
+        {{/if}}
+
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: <strong>{{date details.date}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.AUTHOR'}}</span>: <strong>{{details.user_display_name}}</strong> <br>
       </div>
     </div>
   </header>
 
-  {{#if details.description}}
-  <blockquote>
-    <strong>{{translate 'FORM.LABELS.NOTE'}}</strong><br>
-    {{details.description}}
-  </blockquote>
-  {{/if}}
-
   <!-- list of data  -->
   <table class="table table-condensed table-bordered table-report">
     <thead>
       <tr>
-        <th>{{translate 'STOCK.CODE'}}</th>
-        <th>{{translate 'STOCK.INVENTORY'}}</th>
-        <th class="text-right">{{translate 'STOCK.QUANTITY'}}</th>
+        <th>{{translate "STOCK.CODE"}}</th>
+        <th>{{translate "STOCK.INVENTORY"}}</th>
+        <th class="text-right">{{translate "STOCK.QUANTITY"}}</th>
+        <th>{{translate "FORM.LABELS.TYPE" }}</th>
       </tr>
     </thead>
     <tbody>
-      {{#if details.items}}
-        {{#each details.items as | item |}}
+      {{#each details.items as | item |}}
         <tr>
           <td>{{item.code}}</td>
           <td>{{item.text}}</td>
           <td class="text-right">{{item.quantity}}</td>
+          <td>{{item.inventoryType}}</td>
         </tr>
-        {{/each}}
       {{else}}
-        {{> emptyTable columns=3}}
-      {{/if}}
+        {{> emptyTable columns=4}}
+      {{/each}}
     </tbody>
   </table>
 
   <br>
 
-  <footer>
-    <div class="row">
-      <div class="col-xs-6">
-        <h4>{{translate 'STOCK.RESPONSIBLE'}}</h4>
-        <hr>
-      </div>
-
-      <div class="col-xs-6 text-center">
-        <h4>{{translate 'REQUISITION.RECEIVER'}}</h4>
-        <hr>
-        (
-          {{#if details.service_requestor}}
-            <strong>{{details.service_requestor}}</strong>
-          {{/if}}
-          {{#if details.depot_requestor}}
-            <strong>{{details.depot_requestor}}</strong>
-          {{/if}}
-        )
-      </div>
+  <div class="row">
+    <div class="col-xs-6">
+      <h4>{{translate 'STOCK.RESPONSIBLE'}}</h4>
+      <hr>
     </div>
-  </footer>
+
+    <div class="col-xs-6 text-center">
+      <h4>{{translate 'REQUISITION.RECEIVER'}}</h4>
+      <hr>
+      (
+        {{#if details.service_requestor}}
+          <strong>{{details.service_requestor}}</strong>
+        {{/if}}
+        {{#if details.depot_requestor}}
+          <strong>{{details.depot_requestor}}</strong>
+        {{/if}}
+      )
+    </div>
+  </div>
   <script>JsBarcode('.barcode').init();</script>
 </div>


### PR DESCRIPTION
Makes the requisition receipt appear a bit more standard in spacing and
layout.  Removes whitespace and adds in the inventory type column.

Closes #4421.

Here is what it looks like:

![image](https://user-images.githubusercontent.com/896472/81582321-d1fc0f00-93a7-11ea-9b31-44d9e8d50573.png)
