### PR TITLE
fix(reports): improve Aux Cashbox Analysis

### DIFF
--- a/client/src/modules/reports/generate/analysisAuxiliaryCash/analysisAuxiliaryCash.config.js
+++ b/client/src/modules/reports/generate/analysisAuxiliaryCash/analysisAuxiliaryCash.config.js
@@ -3,24 +3,17 @@ angular.module('bhima.controllers')
 
 AnalysisAuxiliaryCashController.$inject = [
   '$sce', 'NotifyService', 'BaseReportService', 'AppCache',
-  'reportData', '$state', 'AccountService', 'FormatTreeDataService',
+  'reportData', '$state',
 ];
 
 function AnalysisAuxiliaryCashController($sce, Notify, SavedReports, AppCache,
-  reportData, $state, Accounts, FormatTreeData) {
+  reportData, $state) {
   const vm = this;
   const cache = new AppCache('analysisAuxiliaryCash');
   const reportUrl = 'reports/finance/analysis_auxiliary_cashbox';
 
   vm.previewGenerated = false;
   vm.reportDetails = {};
-
-  Accounts.read()
-    .then(elements => {
-      // bind the accounts to the controller
-      const accounts = FormatTreeData.order(elements);
-      vm.accounts = accounts;
-    });
 
   vm.onSelectFiscalYear = (fiscalYear) => {
     vm.reportDetails.fiscal_id = fiscalYear.id;

--- a/client/src/modules/reports/generate/analysisAuxiliaryCash/analysisAuxiliaryCash.html
+++ b/client/src/modules/reports/generate/analysisAuxiliaryCash/analysisAuxiliaryCash.html
@@ -31,11 +31,11 @@
               fiscal-year-id="ReportConfigCtrl.reportDetails.fiscal_id"
               period-id="ReportConfigCtrl.reportDetails.period_id"
               on-select-callback="ReportConfigCtrl.onSelectPeriod(period)">
-            </bh-period-selection>            
+            </bh-period-selection>
 
             <bh-cashbox-select
               cashbox-id="ReportConfigCtrl.reportDetails.cashboxId"
-              on-select-callback="ReportConfigCtrl.onSelectCashbox(cashbox);"
+              on-select-callback="ReportConfigCtrl.onSelectCashbox(cashbox)"
               restrict-to-user="false"
               is-auxiliary="true">
             </bh-cashbox-select>

--- a/server/controllers/finance/reports/analysis_auxiliary_cashbox/index.js
+++ b/server/controllers/finance/reports/analysis_auxiliary_cashbox/index.js
@@ -1,36 +1,35 @@
-const q = require('q');
 const _ = require('lodash');
 const moment = require('moment');
 
 const db = require('../../../../lib/db');
 const ReportManager = require('../../../../lib/ReportManager');
-const Exchange = require('../../../finance/exchange');
+const Exchange = require('../../exchange');
 
 const TEMPLATE = './server/controllers/finance/reports/analysis_auxiliary_cashbox/report.handlebars';
+
 // expose to the API
 exports.report = report;
 
 // default report parameters
 const DEFAULT_PARAMS = {
-  csvKey : 'brea_report',
-  filename : 'TREE.BREAK_EVEN_REPORT',
+  csvKey : 'transactions',
+  filename : 'REPORT.ANALYSIS_AUX_CASHBOXES.TITLE',
   orientation : 'landscape',
-  footerRight : '[page] / [toPage]',
 };
+
+const REVERSAL_TYPE_ID = 10;
 
 /**
  * @function report
  *
  * @description
- * This function renders the balance of accounts references as report.  The account_reference report provides a view
- * of the balance of account_references for a given period of fiscal year.
+ * Renders the axiliary cashbox report.
  */
-function report(req, res, next) {
+async function report(req, res, next) {
   const params = req.query;
 
   const data = {};
   data.enterprise = req.session.enterprise;
-  let reporting;
 
   const daysWeek = [
     'FORM.LABELS.WEEK_D.SUNDAY',
@@ -111,44 +110,39 @@ function report(req, res, next) {
   _.defaults(params, DEFAULT_PARAMS);
 
   try {
-    reporting = new ReportManager(TEMPLATE, req.session, params);
-  } catch (e) {
-    next(e);
-    return;
-  }
+    const reporting = new ReportManager(TEMPLATE, req.session, params);
 
-  Exchange.getExchangeRate(data.enterprise.id, params.currency_id, new Date(params.end_date))
-    .then(exchange => {
-      data.exchageRate = exchange.rate || 1;
+    const exchange = await Exchange.getExchangeRate(data.enterprise.id, params.currency_id, new Date(params.end_date));
+    data.exchangeRate = exchange.rate || 1;
 
-      const sqlCashBox = `
+    const sqlCashBox = `
         SELECT DATE(cl.trans_date) AS trans_date, SUM(cl.debit) AS debit, SUM(cl.credit) AS credit,
-        SUM(cl.debit - cl.credit) AS balance  
+        SUM(cl.debit - cl.credit) AS balance
         FROM(
           SELECT gl.debit, gl.credit, gl.trans_date, gl.account_id, gl.period_id
           FROM general_ledger AS gl
-          WHERE gl.account_id = ? AND gl.period_id = ? 
-          AND gl.transaction_type_id <> 10
+          WHERE gl.account_id = ? AND gl.period_id = ?
+          AND gl.transaction_type_id <> ${REVERSAL_TYPE_ID}
           AND gl.record_uuid NOT IN (
             SELECT rev.uuid
             FROM (
                 SELECT v.uuid FROM voucher v WHERE v.reversed = 1
-                AND DATE(v.date) >= DATE(?) AND DATE(v.date) <= DATE(?) 
+                AND DATE(v.date) >= DATE(?) AND DATE(v.date) <= DATE(?)
               UNION
                 SELECT c.uuid FROM cash c WHERE c.reversed = 1
                 AND DATE(c.date) >= DATE(?) AND DATE(c.date) <= DATE(?)
             ) AS rev
           )
-          UNION
+          UNION ALL
           SELECT pj.debit, pj.credit, pj.trans_date, pj.account_id, pj.period_id
           FROM posting_journal AS pj
-          WHERE pj.account_id = ? AND pj.period_id = ? 
-          AND pj.transaction_type_id <> 10
+          WHERE pj.account_id = ? AND pj.period_id = ?
+          AND pj.transaction_type_id <> ${REVERSAL_TYPE_ID}
           AND pj.record_uuid NOT IN (
             SELECT rev.uuid
             FROM (
                 SELECT v.uuid FROM voucher v WHERE v.reversed = 1
-                AND DATE(v.date) >= DATE(?) AND DATE(v.date) <= DATE(?) 
+                AND DATE(v.date) >= DATE(?) AND DATE(v.date) <= DATE(?)
               UNION
                 SELECT c.uuid FROM cash c WHERE c.reversed = 1
                 AND DATE(c.date) >= DATE(?) AND DATE(c.date) <= DATE(?)
@@ -159,34 +153,34 @@ function report(req, res, next) {
         ORDER BY DATE(cl.trans_date) ASC;
       `;
 
-      const sqlTransfertAccount = `
+    const sqlTransfertAccount = `
         SELECT DATE(cl.trans_date) AS trans_date, SUM(cl.debit) AS debit, SUM(cl.credit) AS credit,
-        SUM(cl.debit - cl.credit) AS balance  
+        SUM(cl.debit - cl.credit) AS balance
         FROM(
           SELECT gl.debit, gl.credit, gl.trans_date, gl.account_id, gl.period_id
           FROM general_ledger AS gl
-          WHERE gl.account_id = ? AND gl.period_id = ? 
-          AND gl.transaction_type_id <> 10
+          WHERE gl.account_id = ? AND gl.period_id = ?
+          AND gl.transaction_type_id <> ${REVERSAL_TYPE_ID}
           AND gl.record_uuid NOT IN (
             SELECT rev.uuid
             FROM (
                 SELECT v.uuid FROM voucher v WHERE v.reversed = 1
-                AND DATE(v.date) >= DATE(?) AND DATE(v.date) <= DATE(?) 
+                AND DATE(v.date) >= DATE(?) AND DATE(v.date) <= DATE(?)
               UNION
                 SELECT c.uuid FROM cash c WHERE c.reversed = 1
                 AND DATE(c.date) >= DATE(?) AND DATE(c.date) <= DATE(?)
             ) AS rev
           )
-          UNION
+          UNION ALL
           SELECT pj.debit, pj.credit, pj.trans_date, pj.account_id, pj.period_id
           FROM posting_journal AS pj
-          WHERE pj.account_id = ? AND pj.period_id = ? 
-          AND pj.transaction_type_id <> 10
+          WHERE pj.account_id = ? AND pj.period_id = ?
+          AND pj.transaction_type_id <> ${REVERSAL_TYPE_ID}
           AND pj.record_uuid NOT IN (
             SELECT rev.uuid
             FROM (
                 SELECT v.uuid FROM voucher v WHERE v.reversed = 1
-                AND DATE(v.date) >= DATE(?) AND DATE(v.date) <= DATE(?) 
+                AND DATE(v.date) >= DATE(?) AND DATE(v.date) <= DATE(?)
               UNION
                 SELECT c.uuid FROM cash c WHERE c.reversed = 1
                 AND DATE(c.date) >= DATE(?) AND DATE(c.date) <= DATE(?)
@@ -197,7 +191,7 @@ function report(req, res, next) {
         ORDER BY DATE(cl.trans_date) ASC;
       `;
 
-      const sqlPrimaryCashbox = `
+    const sqlPrimaryCashbox = `
         SELECT SUM(ledger.debit) AS debit, SUM(ledger.credit) AS credit,
         SUM(ledger.debit - ledger.credit) AS balance, ledger.account_id,
         ledger.trans_date, a.number, a.label
@@ -205,95 +199,101 @@ function report(req, res, next) {
           SELECT gll.debit, gll.credit, gll.account_id, gll.trans_date
           FROM general_ledger AS gll
           WHERE gll.trans_id IN (
-            SELECT gl.trans_id 
+            SELECT DISTINCT gl.trans_id
             FROM general_ledger AS gl
             WHERE gl.account_id = ? AND gl.period_id = ?
           ) AND (gll.account_id <> ? AND gll.account_id <> ?)
-          UNION
+          UNION ALL
           SELECT pjl.debit, pjl.credit, pjl.account_id, pjl.trans_date
           FROM posting_journal AS pjl
           WHERE pjl.trans_id IN (
-            SELECT pj.trans_id 
+            SELECT DISTINCT pj.trans_id
             FROM posting_journal AS pj
             WHERE pj.account_id = ? AND pj.period_id = ?
           ) AND (pjl.account_id <> ? AND pjl.account_id <> ?)
-          ) AS ledger 
+          ) AS ledger
           JOIN account AS a ON a.id = ledger.account_id
           GROUP BY ledger.trans_date;
       `;
 
-      const dbPromises = [
-        db.exec(sqlCashBox, cashboxParams),
-        db.exec(sqlTransfertAccount, transfertParams),
-        db.exec(sqlPrimaryCashbox, primaryParams),
-      ];
 
-      return q.all(dbPromises);
-    })
-    .spread((transactions, transferts, primaryTransferts) => {
-      transactions.forEach(item => {
-        const numDays = moment(item.trans_date).day();
-        const limiteValidationSup = data.exchageRate ? (data.exchageRate * 0.1) : 0.1;
-        const limiteValidationInf = data.exchageRate ? (data.exchageRate * -0.1) : -0.1;
+    const [transactions, transfers, primaryTransfers] = await Promise.all([
+      db.exec(sqlCashBox, cashboxParams),
+      db.exec(sqlTransfertAccount, transfertParams),
+      db.exec(sqlPrimaryCashbox, primaryParams),
+    ]);
 
-        item.transDateDays = daysWeek[numDays];
+    transactions.forEach(item => {
+      const numDays = moment(item.trans_date).day();
+      const limiteValidationSup = data.exchangeRate ? (data.exchangeRate * 0.1) : 0.1;
+      const limiteValidationInf = data.exchangeRate ? (data.exchangeRate * -0.1) : -0.1;
 
-        if (item.balance > limiteValidationInf && item.balance < limiteValidationSup) {
-          item.labelDisplay = labelDisplay.correct;
-        } else if ((item.balance > limiteValidationSup) && (item.credit !== 0)) {
-          item.labelDisplay = labelDisplay.lower;
-        } else if ((item.balance < limiteValidationSup) && (item.credit !== 0)) {
-          item.labelDisplay = labelDisplay.greater;
-        } else if (item.debit > 0 && item.credit === 0) {
-          item.labelDisplay = labelDisplay.pending;
+      item.transDateDays = daysWeek[numDays];
+
+      if (item.balance > limiteValidationInf && item.balance < limiteValidationSup) {
+        item.labelDisplay = labelDisplay.correct;
+      } else if ((item.balance > limiteValidationSup) && (item.credit !== 0)) {
+        item.labelDisplay = labelDisplay.lower;
+      } else if ((item.balance < limiteValidationSup) && (item.credit !== 0)) {
+        item.labelDisplay = labelDisplay.greater;
+      } else if (item.debit > 0 && item.credit === 0) {
+        item.labelDisplay = labelDisplay.pending;
+      }
+
+      transfers.forEach(transf => {
+        if (isSameDate(item.trans_date, transf.trans_date)) {
+          item.debit_transfert = transf.debit;
+          item.credit_transfert = transf.credit;
+          item.balance_transfert = transf.balance;
+
+          if (transf.balance > limiteValidationInf && transf.balance < limiteValidationSup) {
+            item.labelDisplayTransfert = labelDisplay.correct;
+          } else if ((transf.balance > limiteValidationSup) && (transf.credit !== 0)) {
+            item.labelDisplayTransfert = labelDisplay.lower;
+          } else if ((transf.balance < limiteValidationSup) && (transf.credit !== 0)) {
+            item.labelDisplayTransfert = labelDisplay.greater;
+          } else if (transf.debit === transf.balance) {
+            item.labelDisplayTransfert = labelDisplay.pending;
+          }
         }
-
-        transferts.forEach(transf => {
-          if (moment(item.trans_date).format('YYYY-MM-DD') === moment(transf.trans_date).format('YYYY-MM-DD')) {
-            item.debit_transfert = transf.debit;
-            item.credit_transfert = transf.credit;
-            item.balance_transfert = transf.balance;
-
-            if (transf.balance > limiteValidationInf && transf.balance < limiteValidationSup) {
-              item.labelDisplayTransfert = labelDisplay.correct;
-            } else if ((transf.balance > limiteValidationSup) && (transf.credit !== 0)) {
-              item.labelDisplayTransfert = labelDisplay.lower;
-            } else if ((transf.balance < limiteValidationSup) && (transf.credit !== 0)) {
-              item.labelDisplayTransfert = labelDisplay.greater;
-            } else if (transf.debit === transf.balance) {
-              item.labelDisplayTransfert = labelDisplay.pending;
-            }
-          }
-        });
-
-        primaryTransferts.forEach(primary => {
-          if (moment(item.trans_date).format('YYYY-MM-DD') === moment(primary.trans_date).format('YYYY-MM-DD')) {
-            item.account_target = ` ${primary.number}: ${primary.label} `;
-            item.debit_primary = primary.debit;
-            // Get the difference enter in target account And Out on transfert account
-            item.balance_primary = (primary.debit - item.debit_transfert);
-
-            if (item.balance_primary > (limiteValidationInf) && item.balance_primary < (limiteValidationSup)) {
-              item.labelDisplayPrimary = labelDisplay.correct;
-            } else if ((primary.debit > item.debit_transfert)) {
-              item.labelDisplayPrimary = labelDisplay.greater;
-            } else if ((primary.debit < item.debit_transfert)) {
-              item.labelDisplayPrimary = labelDisplay.lower;
-            } else if (primary.debit === 0 && item.debit_transfert > 0) {
-              item.labelDisplayPrimary = labelDisplay.pending;
-            }
-          }
-        });
       });
 
-      _.merge(data, { transactions });
+      primaryTransfers.forEach(primary => {
+        if (isSameDate(item.trans_date, primary.trans_date)) {
+          item.account_target = ` ${primary.number}: ${primary.label} `;
+          item.debit_primary = primary.debit;
+          // Get the difference enter in target account And Out on transfert account
+          item.balance_primary = (primary.debit - item.debit_transfert);
 
-      return reporting.render(data);
-    })
-    .then(result => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next)
-    .done();
+          if (item.balance_primary > (limiteValidationInf) && item.balance_primary < (limiteValidationSup)) {
+            item.labelDisplayPrimary = labelDisplay.correct;
+          } else if ((primary.debit > item.debit_transfert)) {
+            item.labelDisplayPrimary = labelDisplay.greater;
+          } else if ((primary.debit < item.debit_transfert)) {
+            item.labelDisplayPrimary = labelDisplay.lower;
+          } else if (primary.debit === 0 && item.debit_transfert > 0) {
+            item.labelDisplayPrimary = labelDisplay.pending;
+          }
+        }
+      });
+    });
 
+    _.merge(data, { transactions });
+
+    const result = await reporting.render(data);
+    res.set(result.headers).send(result.report);
+  } catch (e) {
+    next(e);
+  }
+}
+
+/**
+ * @function isSameDate
+ *
+ * @description
+ * Moves date logic into a nicer function
+ *
+ */
+function isSameDate(a, b) {
+  return (moment(a).format('YYYY-MM-DD') === moment(b).format('YYYY-MM-DD'));
 }

--- a/server/controllers/finance/reports/analysis_auxiliary_cashbox/report.handlebars
+++ b/server/controllers/finance/reports/analysis_auxiliary_cashbox/report.handlebars
@@ -1,91 +1,87 @@
 <!doctype html>
 <html>
   {{> head title="REPORT.ANALYSIS_AUX_CASHBOXES.TITLE" }}
-  <body>
-    <div style="margin-right: 2%; margin-left: 2%;">
-      {{> header}}
+  <body class="container">
+    {{> header}}
 
-      <!-- body -->
-      <div class="row">
-        <div class="col-xs-12">
-          <!-- page title  -->
-          <h3 class="text-center text-bold text-uppercase">{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.TITLE'}}</h3>
-          <h3 class="text-center text-bold text-uppercase">{{ report.cashboxLabel }}</h3>
-          <h4 class="text-center text-bold text-uppercase"> {{ report.periodLabel }} </h4>
+    <!-- body -->
+    <div class="row">
+      <div class="col-xs-12">
+        <!-- page title  -->
+        <h3 class="text-center text-bold text-uppercase">{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.TITLE'}}</h3>
+        <h3 class="text-center text-bold text-uppercase">{{ report.cashboxLabel }}</h3>
+        <h4 class="text-center text-bold text-uppercase">{{ report.periodLabel }}</h4>
 
-          <table style="width: 25%; float: right; margin-bottom: 1.5%">
+        <table style="width: 25%; float: right; margin-bottom: 1.5%">
+          <tr>
+            <td width="10%" style="background-color: #5cb85c; color:white; text-align:center"> ✔ </td>
+            <td width="90%">&nbsp;<strong>{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.STATUS.CORRECT'}}</strong></td>
+          </tr>
+          <tr>
+            <td width="10%" style="background-color: #777777; color:white; text-align:center"> X </td>
+            <td width="90%">&nbsp;<strong>{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.STATUS.TRANSFERT_PENDING'}}</strong></td>
+          </tr>
+          <tr>
+            <td width="10%" style="background-color: #f0ad4e; color:white; text-align:center"> ▲ </td>
+            <td width="90%">&nbsp;<strong>{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.STATUS.TRANSFERT_GREATER'}}</strong></td>
+          </tr>
+          <tr>
+            <td width="10%" style="background-color: #d9534f; color:white; text-align:center"> ▼ </td>
+            <td width="90%">&nbsp;<strong>{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.STATUS.TRANSFERT_LOWWER'}}</strong></td>
+          </tr>
+        </table>
+
+        <table class="table table-striped table-condensed table-report table-bordered">
+          <thead>
+            <th width="10%"></th>
+            <th width="35%" class="text-uppercase" colspan="4"> {{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.AUXILIARY_TRANSFERT'}} </th>
+            <th width="35%" class="text-uppercase" colspan="4">{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.TRANSFER_PRINCIPAL'}}</th>
+            <th width="20%" class="text-uppercase" colspan="3">{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.TARGET'}}</th>
+          </thead>
+          <tbody>
+          <tr>
+            <th>{{translate 'FORM.LABELS.DATE'}}</th>
+            <th width="9%">{{translate 'FORM.LABELS.DEBIT'}}</th>
+            <th width="9%">{{translate 'FORM.LABELS.CREDIT'}}</th>
+            <th width="9%">{{translate 'FORM.LABELS.BALANCE'}}</th>
+            <th width="2%"></th>
+
+            <th width="9%">{{translate 'FORM.LABELS.DEBIT'}}</th>
+            <th width="9%">{{translate 'FORM.LABELS.CREDIT'}}</th>
+            <th width="9%">{{translate 'FORM.LABELS.BALANCE'}}</th>
+            <th width="2%"></th>
+
+            <th width="21%">{{translate 'FORM.LABELS.LABEL'}}</th>
+            <th width="9%">{{translate 'FORM.LABELS.DEBIT'}}</th>
+            <th width="2%"></th>
+          </tr>
+
+          {{#each this.transactions}}
             <tr>
-              <td width="10%" style="background-color: #5cb85c; color:white; text-align:center"> ✔ </td>
-              <td width="90%">&nbsp;<strong>{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.STATUS.CORRECT'}}</strong></td>
+              <td>{{date trans_date "DD/MM/YYYY"}}, {{translate transDateDays }} </td>
+
+              <td class="text-right">{{debcred debit ../report.currencyId}}</td>
+              <td class="text-right">{{debcred credit ../report.currencyId}}</td>
+              <td class="text-right">{{debcred balance ../report.currencyId}}</td>
+              <td style="color:white; background-color: {{ labelDisplay.color }}" class="text-center">
+                {{ labelDisplay.icon }}
+              </td>
+              <td class="text-right">{{debcred debit_transfert ../report.currencyId}}</td>
+              <td class="text-right">{{debcred credit_transfert ../report.currencyId}}</td>
+              <td class="text-right">{{debcred balance_transfert ../report.currencyId}}</td>
+              <td style="color:white; background-color: {{ labelDisplayTransfert.color }}" class="text-center">
+                {{ labelDisplayTransfert.icon }}
+              </td>
+
+              <td><strong>{{ account_target }}</strong></td>
+              <td class="text-right">{{debcred debit_primary ../report.currencyId}}</td>
+              <td style="color:white; background-color: {{ labelDisplayPrimary.color }};" class="text-center">
+                {{ labelDisplayPrimary.icon }}
+              </td>
             </tr>
-            <tr>
-              <td width="10%" style="background-color: #777777; color:white; text-align:center"> X </td>
-              <td width="90%">&nbsp;<strong>{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.STATUS.TRANSFERT_PENDING'}}</strong></td>
-            </tr>
-            <tr>
-              <td width="10%" style="background-color: #f0ad4e; color:white; text-align:center"> ▲ </td>
-              <td width="90%">&nbsp;<strong>{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.STATUS.TRANSFERT_GREATER'}}</strong></td>
-            </tr>
-            <tr>
-              <td width="10%" style="background-color: #d9534f; color:white; text-align:center"> ▼ </td>
-              <td width="90%">&nbsp;<strong>{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.STATUS.TRANSFERT_LOWWER'}}</strong></td>
-            </tr>
-          </table>
-
-          <table style="width: 100%;" class="table table-striped table-condensed table-report table-bordered">
-            <thead>
-              <th width="10%"> </th>
-              <th width="35%" class="text-uppercase" colspan="4"> {{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.AUXILIARY_TRANSFERT'}} </th>
-              <th width="35%" class="text-uppercase" colspan="4">{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.TRANSFER_PRINCIPAL'}}</th>
-              <th width="20%" class="text-uppercase" colspan="3">{{translate 'REPORT.ANALYSIS_AUX_CASHBOXES.TARGET'}}</th>
-            </thead>
-            <tbody>
-            <tr>
-              <th>{{translate 'FORM.LABELS.DATE'}}</th>
-              <th width="9%">{{translate 'FORM.LABELS.DEBIT'}}</th>
-              <th width="9%">{{translate 'FORM.LABELS.CREDIT'}}</th>
-              <th width="9%">{{translate 'FORM.LABELS.BALANCE'}}</th>
-              <th width="2%"></th>
-
-              <th width="9%">{{translate 'FORM.LABELS.DEBIT'}}</th>
-              <th width="9%">{{translate 'FORM.LABELS.CREDIT'}}</th>
-              <th width="9%">{{translate 'FORM.LABELS.BALANCE'}}</th>
-              <th width="2%"></th>
-
-              <th width="21%">{{translate 'FORM.LABELS.LABEL'}}</th>
-              <th width="9%">{{translate 'FORM.LABELS.DEBIT'}}</th>
-              <th width="2%"></th>
-            </tr>
-
-            {{#each this.transactions}}
-                <tr>
-                  <td>{{date trans_date "DD/MM/YYYY"}}, {{translate transDateDays }} </td>
-
-                  <td class="text-right">{{debcred debit ../report.currencyId}}</td>
-                  <td class="text-right">{{debcred credit ../report.currencyId}}</td>
-                  <td class="text-right">{{debcred balance ../report.currencyId}}</td>
-                  <td style="color:white; background-color: {{ labelDisplay.color }}" class="text-center">
-                    {{ labelDisplay.icon }}
-                  </td>
-
-                  <td class="text-right">{{debcred debit_transfert ../report.currencyId}}</td>
-                  <td class="text-right">{{debcred credit_transfert ../report.currencyId}}</td>
-                  <td class="text-right">{{debcred balance_transfert ../report.currencyId}}</td>
-                  <td style="color:white; background-color: {{ labelDisplayTransfert.color }}" class="text-center">
-                    {{ labelDisplayTransfert.icon }}
-                  </td>
-
-                  <td><strong>{{ account_target }}</strong></td>
-                  <td class="text-right">{{debcred debit_primary ../report.currencyId}}</td>
-                  <td style="color:white; background-color: {{ labelDisplayPrimary.color }};" class="text-center">
-                    {{ labelDisplayPrimary.icon }}
-                  </td>
-                </tr>
-            {{/each}}
-            </tbody>
-          </table>
-
-        </div>
+          {{/each}}
+          </tbody>
+        </table>
       </div>
     </div>
   </body>


### PR DESCRIPTION
Various improvements to the Auxiliary Cashbox Analysis report.

 - Removes the Accounts from the client.  Not sure why we were downloading them.
 - Makes the title appropriately translated.
 - Removes comments/strings related to break even report and adds in Aux Cash Analysis text.
 - Migrates to async/await.
 - Uses UNION ALL.
 - Removes magic numbers and names the transaction type ID explicitly.
 - Spelling transferts -> transfers

Closes #4479.