### PR TITLE
fix(cash): bug fixes in search modal

### DIFF
--- a/client/src/modules/cash/payments/templates/search.modal.html
+++ b/client/src/modules/cash/payments/templates/search.modal.html
@@ -58,9 +58,10 @@
 
           <!-- cashbox -->
           <bh-cashbox-select
-            cashbox-id = "$ctrl.searchQueries.cashbox_id"
-            name = "cashbox_id"
-            on-select-callback = "$ctrl.onSelectCashbox(cashbox)">
+            cashbox-id="$ctrl.searchQueries.cashbox_id"
+            name="cashbox_id"
+            restrict-to-user="false"
+            on-select-callback="$ctrl.onSelectCashbox(cashbox)">
             <bh-clear on-clear="$ctrl.clear('cashbox_id')"></bh-clear>
           </bh-cashbox-select>
 

--- a/client/src/modules/cash/payments/templates/search.modal.js
+++ b/client/src/modules/cash/payments/templates/search.modal.js
@@ -20,7 +20,7 @@ function SearchCashPaymentModalController(Notify, Instance, filters, Store, Peri
 
   const searchQueryOptions = [
     'is_caution', 'reference', 'cashbox_id', 'user_id', 'reference_patient',
-    'currency_id', 'reversed', 'debtor_group_uuid', 'description',
+    'currency_id', 'reversed', 'debtor_group_uuid', 'description', 'project_id',
   ];
 
   vm.searchQueries = {};


### PR DESCRIPTION
Fixes two bugs in the cash payments search modal:
  1) The project is now restored when you close and reopen the modal.
  2) The cashbox selection works.

Closes #4490.
Closes #4491.

![cKXlySkqGr](https://user-images.githubusercontent.com/896472/81705430-ef43e280-9466-11ea-872e-d89f8f87201e.gif)
