### PR TITLE
fix(invoice): link patient via debtor_uuid

### DIFF
--- a/client/src/modules/invoices/registry/templates/action.cell.html
+++ b/client/src/modules/invoices/registry/templates/action.cell.html
@@ -23,7 +23,7 @@
 
     <!-- view linked records -->
     <li>
-      <a data-method="view-patient" href ui-sref="patientRegistry({ filters : [{ key : 'period', value : 'allTime' }, { key : 'display_name', value : row.entity.patientName }]})">
+      <a data-method="view-patient" href ui-sref="patientRegistry({ filters : [{ key : 'period', value : 'allTime' }, { key : 'debtor_uuid', value: row.entity.debtor_uuid, displayValue : row.entity.patientName, cacheable:false }]})">
         <i class="fa fa-user"></i> <span translate>REPORT.VIEW_PATIENT</span>
       </a>
     </li>


### PR DESCRIPTION
Makes the patient link from the invoice use the `debtor_uuid`.  This means that the lookup is both more performant and also more specific. Previously we picked up any number of patients in our lookup.

Closes #4414.