### PR TITLE
fix(stock): movement search flux displayValues

### DIFF
--- a/client/src/js/components/bhFluxSelect.js
+++ b/client/src/js/components/bhFluxSelect.js
@@ -15,7 +15,7 @@ FluxSelectController.$inject = [
 ];
 
 /**
- * Flux Selection Component
+ * @function FluxSelectController
  *
  * @description
  * Provides a ui-select of the flux options from the database.
@@ -27,13 +27,18 @@ function FluxSelectController(Flux, Notify) {
     // label to display
     $ctrl.label = $ctrl.label || 'STOCK.FLUX';
 
-    // init the model
-    $ctrl.selectedFlux = $ctrl.fluxIds || [];
+    // initialize the model
+    $ctrl.selectedFlux = [];
 
     // load all Flux
     Flux.read()
       .then(flux => {
         $ctrl.fluxes = Flux.addI18nLabelToItems(flux);
+
+        if ($ctrl.fluxIds) {
+          $ctrl.selectedFlux = $ctrl.fluxes.filter(f => $ctrl.fluxIds.includes(f.id));
+        }
+
 
         // sort the array in alphabetical order
         $ctrl.fluxes.sort((a, b) => a.plainText.localeCompare(b.plainText));

--- a/client/src/modules/stock/movements/modals/search.modal.js
+++ b/client/src/modules/stock/movements/modals/search.modal.js
@@ -2,11 +2,11 @@ angular.module('bhima.controllers')
   .controller('SearchMovementsModalController', SearchMovementsModalController);
 
 SearchMovementsModalController.$inject = [
-  'data', 'NotifyService', '$uibModalInstance', 'FluxService', '$translate',
+  'data', 'NotifyService', '$uibModalInstance',
   'PeriodService', 'Store', 'util', 'StockService',
 ];
 
-function SearchMovementsModalController(data, Notify, Instance, Flux, $translate, Periods, Store, util, Stock) {
+function SearchMovementsModalController(data, Notify, Instance, Periods, Store, util, Stock) {
   const vm = this;
   const displayValues = {};
   const changes = new Store({ identifier : 'key' });
@@ -24,20 +24,6 @@ function SearchMovementsModalController(data, Notify, Instance, Flux, $translate
   // keep track of the initial search queries to make sure we properly restore
   // default display values
   const initialSearchQueries = angular.copy(vm.searchQueries);
-
-  // load flux
-  Flux.read()
-    .then(handleFluxes)
-    .catch(Notify.handleError);
-
-  function handleFluxes(rows) {
-    vm.fluxes = rows.map(handleFlux);
-  }
-
-  function handleFlux(row) {
-    row.label = $translate.instant(row.label);
-    return row;
-  }
 
   // default filter period - directly write to changes list
   vm.onSelectPeriod = function onSelectPeriod(period) {
@@ -70,19 +56,17 @@ function SearchMovementsModalController(data, Notify, Instance, Flux, $translate
   };
 
   // custom filter flux_id - assign the value to the searchQueries object
-  vm.onFluxChange = function onFluxChange(_flux) {
-    let typeText = '/';
-    vm.searchQueries.flux_id = _flux;
+  vm.onFluxChange = function onFluxChange(fluxes) {
+    const searchValue = fluxes.map(f => f.id);
 
-    _flux.forEach(fluxIds => {
-      vm.fluxes.forEach(flux => {
-        if (fluxIds === flux.id) {
-          typeText += String(flux.label).concat(' / ');
-        }
-      });
-    });
+    // concats with a comma, replaces last comma
+    const displayValue = fluxes
+      .reduce((aggstr, flux) => aggstr.concat(flux.plainText, ', '), '')
+      .replace(/, $/i, '')
+      .trim();
 
-    displayValues.flux_id = typeText;
+    vm.searchQueries.flux_id = searchValue;
+    displayValues.flux_id = displayValue;
   };
 
   // custom filter user

--- a/client/src/modules/templates/bhFluxSelect.tmpl.html
+++ b/client/src/modules/templates/bhFluxSelect.tmpl.html
@@ -17,7 +17,8 @@
       <ui-select-match placeholder="{{ 'STOCK.FLUX' | translate }}">
         <span>{{ $item.plainText }}</span>
       </ui-select-match>
-      <ui-select-choices ui-select-focus-patch repeat="flux.id as flux in $ctrl.fluxes | filter: { plainText: $select.search }">
+
+      <ui-select-choices ui-select-focus-patch repeat="flux as flux in $ctrl.fluxes | filter: { plainText: $select.search }">
         <span ng-bind-html="flux.plainText | highlight:$select.search"></span>
       </ui-select-choices>
     </ui-select>


### PR DESCRIPTION
Fixes the display values of the stock movement registry's flux ids so that they render better and are saved between page reloads.

Closes #4316.

![FicgkMFeYM](https://user-images.githubusercontent.com/896472/81801360-3637e380-950c-11ea-8fb6-a78b5c26714e.gif)