### PR TITLE
Fix: Spacing and Overflows on Stock Reports

### DIFF
--- a/server/controllers/stock/reports/monthly_consumption.report.handlebars
+++ b/server/controllers/stock/reports/monthly_consumption.report.handlebars
@@ -1,27 +1,21 @@
 {{> head title="REPORT.MONTHLY_CONSUMPTION.TITLE" }}
 
-<body>
-
-  <div class="container">
+<body class="container-fluid">
   {{> header}}
 
   <!-- body  -->
   <div class="row">
     <div class="col-xs-12">
       <!-- page title  -->
-      <h2 class="text-center text-uppercase">
-        {{translate 'REPORT.MONTHLY_CONSUMPTION.TITLE'}}
-      </h2>
-
-      <h3 class="text-center">
-        {{ fiscalYear }} : {{ translate params.periodFromKey }} - {{ translate params.periodToKey }} 
-      </h3>
+      <h4 class="text-center text-uppercase">{{translate 'REPORT.MONTHLY_CONSUMPTION.TITLE'}}</h4>
 
       <h4 class="text-center">
-        {{ depot }}
+        {{ fiscalYear }} : {{ translate params.periodFromKey }} - {{ translate params.periodToKey }}
+        <br />
+        {{depot}}
       </h4>
 
-      <table class="table-striped table-condensed table-report table-bordered">
+      <table class="table table-striped table-condensed table-report table-bordered">
         <thead>
           <tr style="background-color:#ddd;">
             <th class="text-center" style="width: 3%;"> {{translate 'FORM.LABELS.NR'}}</th>
@@ -34,30 +28,24 @@
         </thead>
 
         <tbody>
-        {{#if dataDisplay}}
-          {{#each inventories}}
-            <tr>
-              <td class="text-center"> {{ add @index 1}} </td>
-              <td> {{ inventory_text }} </td>
-              {{#each monthlyConsumption}}
-                <td class="text-right">
-                    {{#if quantity}} 
-                      <strong> {{ quantity }} </strong>
-                    {{/if}}                  
-                </td>
-              {{/each}}
-              <td class="text-right"> <strong> {{ total }} </strong> </td>
-            </tr>
-          {{/each}}
+        {{#each inventories}}
+          <tr>
+            <td class="text-center">{{ add @index 1}}</td>
+            <td>{{ inventory_text }}</td>
+            {{#each monthlyConsumption}}
+              <td class="text-right">
+                {{#if quantity}}{{ quantity }}{{/if}}
+              </td>
+            {{/each}}
+            <td class="text-right"> <strong> {{ total }} </strong> </td>
+          </tr>
         {{else}}
           <tr>
-            <th class="text-center" colspan="{{ spanColumn }}"> <strong> {{translate 'STOCK.NO_DATA'}} </strong> </th>
+            <th class="text-center" colspan="{{ spanColumn }}"> {{translate 'STOCK.NO_DATA'}} </th>
           </tr>
-        {{/if}}
+        {{/each}}
         </tbody>
       </table>
     </div>
-  </div>
-
   </div>
 </body>

--- a/server/controllers/stock/reports/purchaseOrderAnalysis/index.js
+++ b/server/controllers/stock/reports/purchaseOrderAnalysis/index.js
@@ -10,7 +10,7 @@ exports.report = report;
 const DEFAULT_PARAMS = {
   csvKey : 'inventoriesOrdered',
   filename : 'REPORTS.PURCHASE_ORDER_ANALYSIS.TITLE',
-  orientation : 'landscape',
+  orientation : 'portrait',
 };
 
 /**

--- a/server/controllers/stock/reports/purchaseOrderAnalysis/report.handlebars
+++ b/server/controllers/stock/reports/purchaseOrderAnalysis/report.handlebars
@@ -1,145 +1,142 @@
 <!doctype html>
 <html>
-  {{> head title="{{translate 'REPORT.PURCHASE_ORDER_ANALYSIS.TITLE' }}" }}
-  <body style="font: 6px;">
-    <div style="margin-right: 2%; margin-left: 2%;">
-      {{> header}}
+  {{> head title="REPORT.PURCHASE_ORDER_ANALYSIS.TITLE" }}
 
-      <!-- body -->
-      <div class="row">
-        <div class="col-xs-12">
-          <!-- page title  -->
-          <h3 class="text-center text-bold text-uppercase">{{translate 'REPORT.PURCHASE_ORDER_ANALYSIS.TITLE'}}</h3>
-          <br>
-          <br>
-          <table style="width: 90%; margin-right: auto; margin-left: auto" class="table table-condensed table-report table-bordered">
-            <tr>
-              <td width="15%" class="text-uppercase">
-                {{translate 'FORM.LABELS.REFERENCE'}}
-              </td>
-              <td width="85%" colspan="2"><strong>{{ purchase.reference }} </td>
-            </tr>
-            <tr>
-              <td width="15%" class="text-uppercase">
-                 {{translate 'FORM.LABELS.SUPPLIER'}}
-              </td>
-              <td width="85%" colspan="2"> <strong>{{ purchase.supplier }}</strong> </td>
-            </tr>
-            <tr>
-              <td width="15%" class="text-uppercase">
-                {{translate 'FORM.LABELS.DATE'}}
-              </td>
-              <td width="85%" colspan="2"> <strong><em> {{date purchase.date "DD/MM/YYYY"}} </em></strong> </td>
-            </tr>
-            <tr>
-              <td width="13%" class="text-uppercase">
-                {{translate 'FORM.LABELS.STATUS'}}
-              </td>
-              <td style="color:white; text-align:center; background-color: {{ purchase.statusDisplay.color }}" width="2%"> {{ purchase.statusDisplay.icon }} </td>
-              <td width="80%"> <strong> {{translate purchase.status}} </strong> </td>
-            </tr>
-          </table>
+  <body style="font: 6px;" class="container-fluid">
+    {{> header}}
 
-          {{#if this.hideDetails }}
+    <!-- body -->
+    <div class="row">
+      <div class="col-xs-12">
+        <!-- page title  -->
+        <h3 class="text-center text-bold text-uppercase">{{translate 'REPORT.PURCHASE_ORDER_ANALYSIS.TITLE'}}</h3>
+        <br>
+        <table style="width: 90%; margin-right: auto; margin-left: auto" class="table table-condensed table-report table-bordered">
+          <tr>
+            <td width="15%" class="text-uppercase">
+              {{translate 'FORM.LABELS.REFERENCE'}}
+            </td>
+            <td width="85%" colspan="2"><strong>{{ purchase.reference }} </td>
+          </tr>
+          <tr>
+            <td width="15%" class="text-uppercase">
+               {{translate 'FORM.LABELS.SUPPLIER'}}
+            </td>
+            <td width="85%" colspan="2"> <strong>{{ purchase.supplier }}</strong> </td>
+          </tr>
+          <tr>
+            <td width="15%" class="text-uppercase">
+              {{translate 'FORM.LABELS.DATE'}}
+            </td>
+            <td width="85%" colspan="2"> <strong><em> {{date purchase.date "DD/MM/YYYY"}} </em></strong> </td>
+          </tr>
+          <tr>
+            <td width="13%" class="text-uppercase">
+              {{translate 'FORM.LABELS.STATUS'}}
+            </td>
+            <td style="color:white; text-align:center; background-color: {{ purchase.statusDisplay.color }}" width="2%"> {{ purchase.statusDisplay.icon }} </td>
+            <td width="80%"> <strong> {{translate purchase.status}} </strong> </td>
+          </tr>
+        </table>
+
+        {{#if this.hideDetails }}
+        <br>
+        <table style="width: 90%; margin-right: auto; margin-left: auto" class="table table-striped table-condensed table-report table-bordered">
+          <thead>
+            <th width="6%" class="text-uppercase"> {{translate 'FORM.LABELS.CODE'}} </th>
+            <th width="20%" class="text-uppercase"> {{translate 'FORM.LABELS.INVENTORY'}} </th>
+            <th width="12%" class="text-uppercase"> {{translate 'FORM.LABELS.QUANTITY_ORDERED'}} </th>
+            <th width="12%" class="text-uppercase"> {{translate 'FORM.LABELS.QUANTITY_ENTRY'}} </th>
+            <th width="15%" class="text-uppercase"> {{translate 'FORM.LABELS.QUANTITY_DIFFERENCE'}} </th>
+            <th width="17%" class="text-uppercase" colspan="2"> {{translate 'FORM.LABELS.STATUS'}} </th>
+            <th width="18%" class="text-uppercase"> {{translate 'FORM.LABELS.LAST_ENTRY_DATE'}} </th>
+          </thead>
+          <tbody>
+            {{#each this.inventoriesOrdered}}
+              <tr>
+                <td><strong> {{ code }} </strong></td>
+                <td><strong> {{ inventory_text }} </strong> </td>
+                <td class="text-right">{{ quantity_ordered }}</td>
+                <td class="text-right">{{ quantity_inStock }}</td>
+                <td class="text-right"><strong>{{ quantity_difference }}</strong></td>
+                <td width="2%" style="color:white; text-align:center; background-color: {{ status.color }}">
+                  <strong> {{ status.icon }} </strong>
+                </td>
+                <td> <strong> {{translate status.text}} </strong> </td>
+                <td>{{date last_entry_date "DD/MM/YYYY HH:mm"}} </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+        {{/if}}
+
+        {{#if this.displayDetails }}
+        {{#each this.inventoriesOrdered}}
           <br>
           <br>
           <table style="width: 90%; margin-right: auto; margin-left: auto" class="table table-striped table-condensed table-report table-bordered">
-            <thead>
-              <th width="6%" class="text-uppercase"> {{translate 'FORM.LABELS.CODE'}} </th>
-              <th width="20%" class="text-uppercase"> {{translate 'FORM.LABELS.INVENTORY'}} </th>
-              <th width="12%" class="text-uppercase"> {{translate 'FORM.LABELS.QUANTITY_ORDERED'}} </th>
-              <th width="12%" class="text-uppercase"> {{translate 'FORM.LABELS.QUANTITY_ENTRY'}} </th>
-              <th width="15%" class="text-uppercase"> {{translate 'FORM.LABELS.QUANTITY_DIFFERENCE'}} </th>
-              <th width="17%" class="text-uppercase" colspan="2"> {{translate 'FORM.LABELS.STATUS'}} </th>
-              <th width="18%" class="text-uppercase"> {{translate 'FORM.LABELS.LAST_ENTRY_DATE'}} </th>
-            </thead>
-            <tbody>
-              {{#each this.inventoriesOrdered}}
-                <tr>
-                  <td><strong> {{ code }} </strong></td>
-                  <td><strong> {{ inventory_text }} </strong> </td>
-                  <td class="text-right">{{ quantity_ordered }}</td>
-                  <td class="text-right">{{ quantity_inStock }}</td>
-                  <td class="text-right"><strong>{{ quantity_difference }}</strong></td>
-                  <td width="2%" style="color:white; text-align:center; background-color: {{ status.color }}">
-                    <strong> {{ status.icon }} </strong>
-                  </td>
-                  <td> <strong> {{translate status.text}} </strong> </td>
-                  <td>{{date last_entry_date "DD/MM/YYYY HH:mm"}} </td>
+
+              <tr>
+                <td width="15%" class="text-uppercase"> {{translate 'FORM.LABELS.CODE'}}  </td>
+                <td colspan="7" width="85%"><strong> {{ code }} </strong></td>
+              </tr>
+              <tr>
+                <td width="15%" class="text-uppercase"> {{translate 'FORM.LABELS.INVENTORY'}}  </td>
+                <td colspan="7" width="85%"><strong> {{ inventory_text }} </strong></td>
+              </tr>
+              <tr class="text-capitalize text-bold">
+                <td></td>
+                <td width="14%">{{translate 'STOCK.MOVEMENT'}}</td>
+                <td width="14%">{{translate 'FORM.LABELS.DATE'}}</td>
+                <td width="14%">{{translate 'FORM.LABELS.DEPOT'}}</td>
+                <td width="14%">{{translate 'STOCK.LOT'}}</td>
+                <td width="14%">{{translate 'STOCK.EXPIRATION_DATE'}}</td>
+                <td width="15%" colspan="2">{{translate 'FORM.LABELS.QUANTITY_ENTRY'}}</td>
+              </tr>
+              {{#each detailled}}
+                <tr class="text-uppercase text-bold">
+                  <td></td>
+                  <td> {{ stock_movement_reference }} </td>
+                  <td> {{ date entry_date "DD/MM/YYYY HH:mm"}} </td>
+                  <td> {{ depotText }} </td>
+                  <td> {{ lotLabel }} </td>
+                  <td> {{ date expiration_date "DD/MM/YYYY"}} </td>
+                  <td colspan="2"> {{ quantity }} </td>
                 </tr>
               {{/each}}
-            </tbody>
+              <tr>
+                <td colspan="8"></td>
+              </tr>
+              <tr>
+                <td class="text-capitalize text-right text-bold" colspan="6">
+                  {{translate 'FORM.LABELS.TOTAL'}}
+                </td>
+                <td class="text-bold" colspan="2"> {{ quantity_inStock }} </td>
+              </tr>
+              <tr>
+                <td class="text-capitalize text-right text-bold" colspan="6">
+                  {{translate 'FORM.LABELS.QUANTITY_ORDERED'}}
+                </td>
+                <td class="text-bold" colspan="2"> {{ quantity_ordered }} </td>
+              </tr>
+              <tr>
+                <td class="text-capitalize text-right text-bold" colspan="6">
+                  {{translate 'FORM.LABELS.QUANTITY_DIFFERENCE'}}
+                </td>
+                <td class="text-bold" colspan="2"> {{ quantity_difference }} </td>
+              </tr>
+              <tr>
+                <td class="text-capitalize text-right text-bold" colspan="6">
+                  {{translate 'FORM.LABELS.STATUS'}}
+                </td>
+                <td width="0.5%" style="color:white; text-align:center; background-color: {{ status.color }}">
+                  <strong> {{ status.icon }} </strong>
+                </td>
+                <td class="text-bold"> {{translate status.text}} </td>
+              </tr>
           </table>
-          {{/if}}
-
-          {{#if this.displayDetails }}
-          {{#each this.inventoriesOrdered}}
-            <br>
-            <br>
-            <table style="width: 90%; margin-right: auto; margin-left: auto" class="table table-striped table-condensed table-report table-bordered">
-
-                <tr>
-                  <td width="15%" class="text-uppercase"> {{translate 'FORM.LABELS.CODE'}}  </td>
-                  <td colspan="7" width="85%"><strong> {{ code }} </strong></td>
-                </tr>
-                <tr>
-                  <td width="15%" class="text-uppercase"> {{translate 'FORM.LABELS.INVENTORY'}}  </td>
-                  <td colspan="7" width="85%"><strong> {{ inventory_text }} </strong></td>
-                </tr>
-                <tr class="text-capitalize text-bold">
-                  <td></td>
-                  <td width="14%">{{translate 'STOCK.MOVEMENT'}}</td>
-                  <td width="14%">{{translate 'FORM.LABELS.DATE'}}</td>
-                  <td width="14%">{{translate 'FORM.LABELS.DEPOT'}}</td>
-                  <td width="14%">{{translate 'STOCK.LOT'}}</td>
-                  <td width="14%">{{translate 'STOCK.EXPIRATION_DATE'}}</td>
-                  <td width="15%" colspan="2">{{translate 'FORM.LABELS.QUANTITY_ENTRY'}}</td>
-                </tr>
-                {{#each detailled}}
-                  <tr class="text-uppercase text-bold">
-                    <td></td>
-                    <td> {{ stock_movement_reference }} </td>
-                    <td> {{ date entry_date "DD/MM/YYYY HH:mm"}} </td>
-                    <td> {{ depotText }} </td>
-                    <td> {{ lotLabel }} </td>
-                    <td> {{ date expiration_date "DD/MM/YYYY"}} </td>
-                    <td colspan="2"> {{ quantity }} </td>
-                  </tr>
-                {{/each}}
-                <tr>
-                  <td colspan="8"></td>
-                </tr>
-                <tr>
-                  <td class="text-capitalize text-right text-bold" colspan="6">
-                    {{translate 'FORM.LABELS.TOTAL'}}
-                  </td>
-                  <td class="text-bold" colspan="2"> {{ quantity_inStock }} </td>
-                </tr>
-                <tr>
-                  <td class="text-capitalize text-right text-bold" colspan="6">
-                    {{translate 'FORM.LABELS.QUANTITY_ORDERED'}}
-                  </td>
-                  <td class="text-bold" colspan="2"> {{ quantity_ordered }} </td>
-                </tr>
-                <tr>
-                  <td class="text-capitalize text-right text-bold" colspan="6">
-                    {{translate 'FORM.LABELS.QUANTITY_DIFFERENCE'}}
-                  </td>
-                  <td class="text-bold" colspan="2"> {{ quantity_difference }} </td>
-                </tr>
-                <tr>
-                  <td class="text-capitalize text-right text-bold" colspan="6">
-                    {{translate 'FORM.LABELS.STATUS'}}
-                  </td>
-                  <td width="0.5%" style="color:white; text-align:center; background-color: {{ status.color }}">
-                    <strong> {{ status.icon }} </strong>
-                  </td>
-                  <td class="text-bold"> {{translate status.text}} </td>
-                </tr>
-            </table>
-          {{/each}}
-          {{/if}}
-        </div>
+        {{/each}}
+        {{/if}}
       </div>
     </div>
   </body>

--- a/server/controllers/stock/reports/stock/inventory_report.js
+++ b/server/controllers/stock/reports/stock/inventory_report.js
@@ -18,12 +18,14 @@ async function stockInventoryReport(req, res, next) {
     filename : 'TREE.STOCK_INVENTORY_REPORT',
   });
 
-  const filters = shared.formatFilters(req.query);
-
   // set up the report with report manager
   try {
     const options = req.query.params ? JSON.parse(req.query.params) : {};
     const report = new ReportManager(STOCK_INVENTORY_REPORT_TEMPLATE, req.session, optionReport);
+
+    delete req.query.label;
+
+    const filters = shared.formatFilters(req.query);
 
     const [inventory, depot, rows] = await Promise.all([
       await db.one('SELECT code, text FROM inventory WHERE uuid = ?;', [db.bid(options.inventory_uuid)]),

--- a/server/controllers/stock/reports/stock/monthly_consumption.js
+++ b/server/controllers/stock/reports/stock/monthly_consumption.js
@@ -11,8 +11,7 @@ exports.report = report;
 const DEFAULT_PARAMS = {
   csvKey : 'monthlyConsumption',
   filename : 'TREE.MONTHLY_CONSUMPTION',
-  orientation : 'landscape',
-  footerRight : '[page] / [toPage]',
+  orientation : 'portrait',
 };
 
 /**
@@ -47,8 +46,8 @@ async function report(req, res, next) {
     JOIN inventory AS iv ON iv.uuid = sc.inventory_uuid
     JOIN period AS p ON p.id = sc.period_id
     JOIN fiscal_year AS f ON f.id = p.fiscal_year_id
-    JOIN depot AS d ON d.uuid = sc.depot_uuid  
-    WHERE sc.period_id >= ? AND sc.period_id <= ? AND d.uuid = ? ORDER BY iv.text ASC;  
+    JOIN depot AS d ON d.uuid = sc.depot_uuid
+    WHERE sc.period_id >= ? AND sc.period_id <= ? AND d.uuid = ? ORDER BY iv.text ASC;
   `;
 
   const sqlAggregat = `
@@ -80,10 +79,9 @@ async function report(req, res, next) {
       data.depot = params.depot_text;
       data.inventories = inventories;
 
-      data.dataDisplay = inventories.length ? 1 : 0;
       data.spanColumn = data.periods.length + 3;
 
-      if (data.dataDisplay) {
+      if (inventories.length > 0) {
         data.inventories.forEach(item => {
           item.monthlyConsumption = [];
           item.total = 0;

--- a/server/controllers/stock/reports/stock_entry.report.handlebars
+++ b/server/controllers/stock/reports/stock_entry.report.handlebars
@@ -1,8 +1,6 @@
 {{> head title="REPORT.STOCK.ENTRY_REPORT" }}
 
-<body>
-
-  <div class="container">
+<body class="container-fluid">
   {{> header}}
 
   <!-- body  -->
@@ -10,17 +8,13 @@
     <div class="col-xs-12">
 
       <!-- page title  -->
-      <h2 class="text-center">
+      <h3 class="text-center">
         {{translate 'REPORT.STOCK.ENTRY_REPORT'}}
-      </h2>
+      </h3>
 
-      <h1 class="text-center">
-        {{ depotName }}
-      </h1>
+      <h2 class="text-center"> {{ depotName }} </h2>
 
-      <h4 class="text-center">
-        {{date dateFrom}} - {{date dateTo}}
-      </h4>
+      <h5 class="text-center"> {{date dateFrom}} - {{date dateTo}} </h5>
 
       <br/>
 
@@ -210,7 +204,5 @@
         </table>
       {{/if}}
     </div>
-  </div>
-
   </div>
 </body>

--- a/server/controllers/stock/reports/stock_exit.report.handlebars
+++ b/server/controllers/stock/reports/stock_exit.report.handlebars
@@ -1,8 +1,6 @@
 {{> head title="REPORT.STOCK.EXIT_REPORT" }}
 
-<body>
-
-  <div class="container">
+<body class="container-fluid">
   {{> header}}
 
   <!-- body  -->
@@ -211,7 +209,5 @@
       <p>*<em>{{translate 'STOCK.STOCK_COST_DESCRIPTION'}}</em></p>
       <p>*<em>{{translate 'STOCK.STOCK_UNIT_COST_ROUNDED'}}</em></p>
     </div>
-  </div>
-
   </div>
 </body>

--- a/server/controllers/stock/reports/stock_inventory.report.handlebars
+++ b/server/controllers/stock/reports/stock_inventory.report.handlebars
@@ -1,10 +1,8 @@
 {{> head title="TREE.STOCK_INVENTORY" }}
 
-<body>
+<body class="container-fluid">
 
-  <div class="container">
-    {{> header}}
-
+  {{> header}}
 
   <!-- body  -->
   <div class="row">
@@ -28,7 +26,6 @@
 
       <!-- filters  -->
       {{> filterbar filters=filters }}
-
 
       <!-- list of data  -->
       <table class="table table-condensed table-report">
@@ -92,7 +89,5 @@
         </tfoot>
       </table>
     </div>
-  </div>
-
   </div>
 </body>


### PR DESCRIPTION
This PR goes through and cleans up a lot of the font sizing, whitespace, and overflow issues on the stock reports.  It changes the default orientation of certain reports from landscape to portrait, and makes sure that there is no trailing whitespace on the margins,

Closes #2480.