### PR TITLE
catch MySQL exception and rethrow with error in case of incorrect value

### DIFF
--- a/server/controllers/admin/functions.js
+++ b/server/controllers/admin/functions.js
@@ -77,19 +77,9 @@ function update(req, res, next) {
 
 // DELETE /function/:id
 function del(req, res, next) {
-  const sql = `DELETE FROM fonction WHERE id = ?;`;
-
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a function with id ${req.params.id}`);
-      }
-
-      res.status(204).json();
-    })
-    .catch(next)
-    .done();
+  db.delete(
+    'fonction', 'id', req.params.id, res, next, `Could not find a function with id ${req.params.id}`,
+  );
 }
 
 // get list of function

--- a/server/controllers/admin/holidays.js
+++ b/server/controllers/admin/holidays.js
@@ -132,19 +132,9 @@ async function update(req, res, next) {
 
 // DELETE /Holiday/:id
 function del(req, res, next) {
-  const sql = `DELETE FROM holiday WHERE id = ?;`;
-
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a Holiday with id ${req.params.id}`);
-      }
-
-      res.sendStatus(204);
-    })
-    .catch(next)
-    .done();
+  db.delete(
+    'holiday', 'id', req.params.id, res, next, `Could not find a Holiday with id ${req.params.id}`,
+  );
 }
 
 // get list of Holiday

--- a/server/controllers/admin/iprTax.js
+++ b/server/controllers/admin/iprTax.js
@@ -83,19 +83,7 @@ function update(req, res, next) {
 
 // DELETE /IprTax/:id
 function del(req, res, next) {
-  const sql = `DELETE FROM taxe_ipr WHERE id = ?;`;
-
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a IprTax with id ${req.params.id}`);
-      }
-
-      res.status(204).json();
-    })
-    .catch(next)
-    .done();
+  db.delete('taxe_ipr', 'id', req.params.id, res, next, `Could not find a IprTax with id ${req.params.id}`);
 }
 
 
@@ -187,19 +175,10 @@ function updateConfig(req, res, next) {
 
 // DELETE /IprTaxConfig/:id
 function deleteConfig(req, res, next) {
-  const sql = `DELETE FROM taxe_ipr_configuration WHERE id = ?;`;
-
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a IprTax Configuration with id ${req.params.id}`);
-      }
-
-      res.status(204).json();
-    })
-    .catch(next)
-    .done();
+  db.delete(
+    'taxe_ipr_configuration', 'id', req.params.id, res, next,
+    `Could not find a IprTax Configuration with id ${req.params.id}`,
+  );
 }
 
 // get list of IprTax

--- a/server/controllers/admin/offdays.js
+++ b/server/controllers/admin/offdays.js
@@ -78,19 +78,9 @@ function update(req, res, next) {
 
 // DELETE /Offday/:id
 function del(req, res, next) {
-  const sql = `DELETE FROM offday WHERE id = ?;`;
-
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a Offday with id ${req.params.id}`);
-      }
-
-      res.status(204).json();
-    })
-    .catch(next)
-    .done();
+  db.delete(
+    'offday', 'id', req.params.id, res, next, `Could not find a Offday with id ${req.params.id}`,
+  );
 }
 
 // get list of Offday

--- a/server/controllers/admin/projects.js
+++ b/server/controllers/admin/projects.js
@@ -141,17 +141,5 @@ exports.update = async function update(req, res, next) {
  * Deletes a project.
  */
 exports.delete = function del(req, res, next) {
-  const sql = `DELETE FROM project WHERE id = ?;`;
-
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-      // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`No project found by id ${req.params.id}.`);
-      }
-
-      res.sendStatus(204);
-    })
-    .catch(next)
-    .done();
+  db.delete('project', 'id', req.params.id, res, next, `No project found by id ${req.params.id}.`);
 };

--- a/server/controllers/admin/services.js
+++ b/server/controllers/admin/services.js
@@ -141,18 +141,7 @@ function update(req, res, next) {
  * Remove a service in the database.
  */
 function remove(req, res, next) {
-  const sql = 'DELETE FROM service WHERE id = ?;';
-
-  db.exec(sql, [req.params.id])
-    .then((result) => {
-      if (!result.affectedRows) {
-        throw new NotFound(`Could not find a service with id ${req.params.id}.`);
-      }
-
-      res.sendStatus(204);
-    })
-    .catch(next)
-    .done();
+  db.delete('service', 'id', req.params.id, res, next, `Could not find a service with id ${req.params.id}`);
 }
 
 /**

--- a/server/controllers/finance/cashboxes/currencies.js
+++ b/server/controllers/finance/cashboxes/currencies.js
@@ -120,6 +120,13 @@ function update(req, res, next) {
 
       res.status(200).json(rows[0]);
     })
+    .catch((e) => {
+      if (e.code === 'ER_TRUNCATED_WRONG_VALUE') {
+        res.status(200).json({});
+      } else {
+        throw e;
+      }
+    })
     .catch(next)
     .done();
 }

--- a/server/controllers/finance/cashboxes/index.js
+++ b/server/controllers/finance/cashboxes/index.js
@@ -193,18 +193,9 @@ function update(req, res, next) {
  * This method removes the cashbox from the system.
  */
 function remove(req, res, next) {
-  const sql = 'DELETE FROM cash_box WHERE id = ?';
-
-  db.exec(sql, [req.params.id])
-    .then((rows) => {
-      if (!rows.affectedRows) {
-        throw new NotFound(`Could not find a cash box with id ${req.params.id}.`);
-      }
-
-      res.sendStatus(204);
-    })
-    .catch(next)
-    .done();
+  db.delete(
+    'cash_box', 'id', req.params.id, res, next, `Could not find a cash box with id ${req.params.id}`,
+  );
 }
 
 /**

--- a/server/controllers/payroll/accounts/index.js
+++ b/server/controllers/payroll/accounts/index.js
@@ -81,19 +81,10 @@ function update(req, res, next) {
 
 // DELETE /ACCOUNT_CONFIG /:ID
 function del(req, res, next) {
-  const sql = `DELETE FROM config_accounting WHERE id = ?;`;
-
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a Account Configuration with id ${req.params.id}`);
-      }
-
-      res.status(204).json();
-    })
-    .catch(next)
-    .done();
+  db.delete(
+    'config_accounting', 'id', req.params.id, res, next,
+    `Could not find a Account Configuration with id ${req.params.id}`,
+  );
 }
 
 // get list of Account

--- a/server/controllers/payroll/configuration/index.js
+++ b/server/controllers/payroll/configuration/index.js
@@ -83,19 +83,10 @@ function update(req, res, next) {
 
 // DELETE /PAYROLL_CONFIG /:ID
 function del(req, res, next) {
-  const sql = `DELETE FROM payroll_configuration WHERE id = ?;`;
-
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a Payroll configuration with id ${req.params.id}`);
-      }
-
-      res.status(204).json();
-    })
-    .catch(next)
-    .done();
+  db.delete(
+    'payroll_configuration', 'id', req.params.id, res, next,
+    `Could not find a Payroll configuration with id ${req.params.id}`,
+  );
 }
 
 function paiementStatus(req, res, next) {

--- a/server/controllers/payroll/employeeConfig/index.js
+++ b/server/controllers/payroll/employeeConfig/index.js
@@ -80,19 +80,10 @@ function update(req, res, next) {
 
 // DELETE /EMPLOYEE_CONFIG/:ID
 function del(req, res, next) {
-  const sql = `DELETE FROM config_employee WHERE id = ?;`;
-
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a Employee configuration with id ${req.params.id}`);
-      }
-
-      res.status(204).json();
-    })
-    .catch(next)
-    .done();
+  db.delete(
+    'config_employee', 'id', req.params.id, res, next,
+    `Could not find a Employee configuration with id ${req.params.id}`,
+  );
 }
 
 

--- a/server/controllers/payroll/rubricConfig/index.js
+++ b/server/controllers/payroll/rubricConfig/index.js
@@ -77,19 +77,9 @@ function update(req, res, next) {
 
 // DELETE /RubricConfig/:id
 function del(req, res, next) {
-  const sql = `DELETE FROM config_rubric WHERE id = ?;`;
-
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a RubricConfig with id ${req.params.id}`);
-      }
-
-      res.status(204).json();
-    })
-    .catch(next)
-    .done();
+  db.delete(
+    'config_rubric', 'id', req.params.id, res, next, `Could not find a RubricConfig with id ${req.params.id}`,
+  );
 }
 
 /**

--- a/server/controllers/payroll/rubrics/index.js
+++ b/server/controllers/payroll/rubrics/index.js
@@ -106,19 +106,7 @@ function update(req, res, next) {
 
 // DELETE /Rubric/:id
 function del(req, res, next) {
-  const sql = `DELETE FROM rubric_payroll WHERE id = ?;`;
-
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a Rubric with id ${req.params.id}`);
-      }
-
-      res.status(204).json();
-    })
-    .catch(next)
-    .done();
+  db.delete('rubric_payroll', 'id', req.params.id, res, next, `Could not find a Rubric with id ${req.params.id}`);
 }
 
 // get list of Rubric

--- a/server/controllers/payroll/weekendConfig/index.js
+++ b/server/controllers/payroll/weekendConfig/index.js
@@ -100,19 +100,9 @@ function update(req, res, next) {
 
 // DELETE /WEEKEND_CONFIG /:ID
 function del(req, res, next) {
-  const sql = `DELETE FROM weekend_config WHERE id = ?;`;
-
-  db.exec(sql, [req.params.id])
-    .then((row) => {
-    // if nothing happened, let the client know via a 404 error
-      if (row.affectedRows === 0) {
-        throw new NotFound(`Could not find a Weekend configuration with id ${req.params.id}`);
-      }
-
-      res.status(204).json();
-    })
-    .catch(next)
-    .done();
+  db.delete(
+    'weekend_config', 'id', req.params.id, res, next, `Could not find a Weekend configuration with id ${req.params.id}`,
+  );
 }
 
 /**

--- a/test/integration/accountConfig.js
+++ b/test/integration/accountConfig.js
@@ -47,6 +47,14 @@ describe('(/payroll/account_configuration) The /payroll/account_configuration  A
       .catch(helpers.handler);
   });
 
+  it('GET /ACCOUNT_CONFIG/:ID will send back a 404 if the Account Configuration is a string', () => {
+    return agent.get('/account_config/str')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
   it('PUT /ACCOUNT_CONFIG  should update an existing Account Configuration', () => {
     return agent.put('/account_config/'.concat(accountConfig.id))
       .send(accountConfigUpdate)
@@ -67,6 +75,14 @@ describe('(/payroll/account_configuration) The /payroll/account_configuration  A
 
   it('DELETE /ACCOUNT_CONFIG/:ID will send back a 404 if the Account Configuration does not exist', () => {
     return agent.delete('/account_config/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /ACCOUNT_CONFIG/:ID will send back a 404 if the Account Configuration is a string', () => {
+    return agent.delete('/account_config/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })

--- a/test/integration/cashboxes.js
+++ b/test/integration/cashboxes.js
@@ -145,8 +145,20 @@ describe('(/cashboxes) The Cashboxes API endpoint', () => {
 
   // why does this route exit?! Why should this not fail???
   // see https://github.com/IMA-WorldHealth/bhima/commit/3b943808be5d59579db95edfd2e0bb4482fac07c
+  // server/controllers/finance/cashboxes/currencies.js lines 132-136
   it('PUT /cashboxes/:id/currencies/<undefined currency> should successfully return nothing', () => {
     return agent.put(`/cashboxes/${BOX.id}/currencies/123456789`)
+      .send({ transfer_account_id : 197 })
+      .then(res => {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body).to.be.empty;
+      })
+      .catch(helpers.handler);
+  });
+
+  it('PUT /cashboxes/:id/currencies/<invalid value> should successfully return nothing', () => {
+    return agent.put(`/cashboxes/${BOX.id}/currencies/str`)
       .send({ transfer_account_id : 197 })
       .then(res => {
         expect(res).to.have.status(200);
@@ -185,6 +197,14 @@ describe('(/cashboxes) The Cashboxes API endpoint', () => {
 
   it('DELETE /cashboxes/:id should return a 404 for an unknown cashbox id', () => {
     return agent.delete('/cashboxes/123456789')
+      .then(res => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /cashboxes/:id should return a 404 it the cashbox id is a string', () => {
+    return agent.delete('/cashboxes/str')
       .then(res => {
         helpers.api.errored(res, 404);
       })

--- a/test/integration/creditorGroups.js
+++ b/test/integration/creditorGroups.js
@@ -47,6 +47,14 @@ describe('(/creditors/groups) Creditor Groups', () => {
       .catch(helpers.handler);
   });
 
+  it('GET /creditors/groups/:uuid should not be found for invalid uuid', () => {
+    return agent.get('/creditors/groups/str')
+      .then(res => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
   it('PUT /creditors/groups  should update an existing creditor group', () => {
     return agent.put(`/creditors/groups/${creditorGroup.uuid}`)
       .send({ name : 'Creditor Group Update' })

--- a/test/integration/currencies.js
+++ b/test/integration/currencies.js
@@ -34,4 +34,12 @@ describe('(/currencies) currencies API routes', () => {
       })
       .catch(helpers.handler);
   });
+
+  it('GET /currencies/:id should return an error for an invalid id', () => {
+    return agent.get('/currencies/str')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
 });

--- a/test/integration/employeeConfig.js
+++ b/test/integration/employeeConfig.js
@@ -83,6 +83,14 @@ describe('(/payroll/account_configuration) The /payroll/employee_configuration  
       .catch(helpers.handler);
   });
 
+  it('DELETE /EMPLOYEE_CONFIG/:ID will send back a 404 if the Employee Configuration id is a string', () => {
+    return agent.delete('/employee_config/str')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
   it('DELETE /EMPLOYEE_CONFIG/:ID should delete an Employee Configuration ', () => {
     return agent.delete('/employee_config/'.concat(employeeConfig.id))
       .then((res) => {

--- a/test/integration/enterprises.js
+++ b/test/integration/enterprises.js
@@ -153,6 +153,14 @@ describe('(/enterprises) Enterprises API', () => {
       .catch(helpers.handler);
   });
 
+  it('GET /enterprises/:id returns a 404 error it the enterprises id is a string', () => {
+    return agent.get('/enterprises/str')
+      .then(res => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
   it('POST /enterprises/:id/logo should upload a new enterprise logo', () => {
     return agent
       .post(`/enterprises/${enterprise.id}/logo`)

--- a/test/integration/exchange.js
+++ b/test/integration/exchange.js
@@ -70,7 +70,7 @@ describe('(/exchange) The /exchange API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('PUT /exchange should update an unknown exchange rate', () => {
+  it('PUT /exchange will send back a 404 if the exchange rate does not exist', () => {
     return agent.put('/exchange/123456789')
       .send({ rate : 1000000 })
       .then((res) => {
@@ -81,12 +81,30 @@ describe('(/exchange) The /exchange API endpoint', () => {
       .catch(helpers.handler);
   });
 
+  it('PUT /exchange will send back a 404 if the exchange rate is a string', () => {
+    return agent.put('/exchange/str')
+      .send({ rate : 1000000 })
+      .then((res) => {
 
-  it('DELETE /exchange/:id will send back a 404 if the exchage rate does not exist', () => {
+        // make sure the API conforms to app standards
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /exchange/:id will send back a 404 if the exchange rate does not exist', () => {
     return agent.delete('/exchange/123456789')
       .then((res) => {
 
         // make sure the API conforms to app standards
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /exchange/:id will send back a 404 if the exchange rate id is a string', () => {
+    return agent.delete('/exchange/str')
+      .then((res) => {
         helpers.api.errored(res, 404);
       })
       .catch(helpers.handler);

--- a/test/integration/feesCenters.js
+++ b/test/integration/feesCenters.js
@@ -70,24 +70,64 @@ describe('(/fee_center) The /fee_center  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /FEE_CENTER/:ID should not be found for unknown id', () => {
+  it('GET /FEE_CENTER/:ID result should be empty for an unknown id', () => {
     return agent.get('/fee_center/123456789')
       .then((res) => {
         const response = res.body;
-
+        expect(res).to.have.status(200);
         expect(response.feeCenter.length).to.equal(0);
         expect(response.references.length).to.equal(0);
       })
       .catch(helpers.handler);
   });
 
-  it('PUT /FEE_CENTER  should update the Label for an existing Fee Center ', () => {
+  it('GET /FEE_CENTER/:ID result should be empty if the fee center id is a string', () => {
+    return agent.get('/fee_center/str')
+      .then((res) => {
+        const response = res.body;
+        expect(res).to.have.status(200);
+        expect(response.feeCenter.length).to.equal(0);
+        expect(response.references.length).to.equal(0);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /FEE_CENTER/:ID result should be empty when the id is a string', () => {
+    return agent.get('/fee_center/str')
+      .then((res) => {
+        const response = res.body;
+        expect(res).to.have.status(200);
+        expect(response.feeCenter.length).to.equal(0);
+        expect(response.references.length).to.equal(0);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('PUT /FEE_CENTER/:ID should update the Label for an existing Fee Center ', () => {
     return agent.put('/fee_center/'.concat(feeCenterId))
       .send(feeCenterUpt1)
       .then((res) => {
         const response = res.body;
         expect(res).to.have.status(200);
         expect(response.feeCenter[0].label).to.equal('Update Test');
+      })
+      .catch(helpers.handler);
+  });
+
+  it('PUT /FEE_CENTER/:ID should return 400 for an non-existing Fee Center ', () => {
+    return agent.put('/fee_center/4321')
+      .send(feeCenterUpt2)
+      .then((res) => {
+        helpers.api.errored(res, 400);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('PUT /FEE_CENTER should return 400 if the Fee Center id is a string ', () => {
+    return agent.put('/fee_center/str')
+      .send(feeCenterUpt2)
+      .then((res) => {
+        helpers.api.errored(res, 400);
       })
       .catch(helpers.handler);
   });
@@ -100,7 +140,7 @@ describe('(/fee_center) The /fee_center  API endpoint', () => {
         expect(res).to.have.status(200);
         expect(response.feeCenter[0].is_principal).to.equal(feeCenterUpt2.is_principal);
         expect(response.references[0].account_reference_id).to.equal(
-          feeCenterUpt2.reference_fee_center[0].account_reference_id
+          feeCenterUpt2.reference_fee_center[0].account_reference_id,
         );
         expect(response.references[0].is_cost).to.equal(feeCenterUpt2.reference_fee_center[0].is_cost);
       })

--- a/test/integration/functions.js
+++ b/test/integration/functions.js
@@ -36,8 +36,16 @@ describe('(/functions) The /functions  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /functions/:id should not be found for unknown id', () => {
+  it('GET /functions/:id will send back a 404 for an unknown id', () => {
     return agent.get('/functions/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /functions/:id will send back a 404 if the functions id is a string', () => {
+    return agent.get('/functions/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })
@@ -66,6 +74,14 @@ describe('(/functions) The /functions  API endpoint', () => {
 
   it('DELETE /functions/:id will send back a 404 if the Function does not exist', () => {
     return agent.delete('/functions/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /functions/:id will send back a 404 if the Function id is a string', () => {
+    return agent.delete('/functions/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })

--- a/test/integration/grades.js
+++ b/test/integration/grades.js
@@ -39,8 +39,16 @@ describe('(/grades) API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /grades/:uuid should not be found for unknown uuid', () => {
+  it('GET /grades/:uuid will send back a 404 if the graded id does not exist', () => {
     return agent.get('/grades/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /grades/:uuid will send back a 404 if the graded id is a string', () => {
+    return agent.get('/grades/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })
@@ -68,6 +76,14 @@ describe('(/grades) API endpoint', () => {
   });
 
   it('DELETE /grades/:uuid will send back a 404 if the grade does not exist', () => {
+    return agent.delete('/grades/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /grades/:uuid will send back a 404 if the grade id is a string', () => {
     return agent.delete('/grades/123456789')
       .then((res) => {
         helpers.api.errored(res, 404);

--- a/test/integration/holidays.js
+++ b/test/integration/holidays.js
@@ -38,8 +38,16 @@ describe('(/holidays) The /holidays  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /HOLIDAYS/:ID should not be found for unknown id', () => {
+  it('GET /HOLIDAYS/:ID will send back a 404 if the holidays id does not exist', () => {
     return agent.get('/holidays/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /HOLIDAYS/:ID will send back a 404 if the holidays id is a string', () => {
+    return agent.get('/holidays/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })
@@ -64,8 +72,16 @@ describe('(/holidays) The /holidays  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('DELETE /HOLIDAYS/:ID will send back a 404 if the Holiday does not exist', () => {
+  it('DELETE /HOLIDAYS/:ID will send back a 404 if the Holidays id does not exist', () => {
     return agent.delete('/holidays/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /HOLIDAYS/:ID will send back a 404 if the Holidays id is a string', () => {
+    return agent.delete('/holidays/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })

--- a/test/integration/offdays.js
+++ b/test/integration/offdays.js
@@ -37,8 +37,16 @@ describe('(/offdays) The /offdays  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /OFFDAYS/:ID should not be found for unknown id', () => {
+  it('GET /OFFDAYS/:ID will send back a 404 if the offdays id does not exist', () => {
     return agent.get('/offdays/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /OFFDAYS/:ID will send back a 404 if the offdays id is a string', () => {
+    return agent.get('/offdays/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })
@@ -63,8 +71,16 @@ describe('(/offdays) The /offdays  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('DELETE /OFFDAYS/:ID will send back a 404 if the Offday does not exist', () => {
+  it('DELETE /OFFDAYS/:ID will send back a 404 if the Offday id does not exist', () => {
     return agent.delete('/offdays/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /OFFDAYS/:ID will send back a 404 if the Offday id is a string', () => {
+    return agent.delete('/offdays/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })

--- a/test/integration/patientInvoice.js
+++ b/test/integration/patientInvoice.js
@@ -47,8 +47,16 @@ describe('(/invoices) Patient Invoices', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /invoices/:uuid returns 404 for an invalid patient invoice', () => {
+  it('GET /invoices/:uuid will send back a 404 if the patient invoices id does not exist', () => {
     return agent.get('/invoices/123456789')
+      .then(res => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /invoices/:uuid will send back a 404 if the patient invoices id is a string', () => {
+    return agent.get('/invoices/str')
       .then(res => {
         helpers.api.errored(res, 404);
       })

--- a/test/integration/payrollConfig.js
+++ b/test/integration/payrollConfig.js
@@ -37,7 +37,7 @@ describe('(/payroll) The /payroll  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('POST /PAYROLL_CONFIG should create a new Account Configuration', () => {
+  it('POST /PAYROLL_CONFIG should create a new Payroll Configuration', () => {
     return agent.post('/payroll_config')
       .send(payrollConfig)
       .then((res) => {
@@ -55,7 +55,7 @@ describe('(/payroll) The /payroll  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('PUT /PAYROLL_CONFIG  should update an existing Account Configuration', () => {
+  it('PUT /PAYROLL_CONFIG  should update an existing Payroll Configuration', () => {
     return agent.put('/payroll_config/'.concat(payrollConfig.id))
       .send(PayrollConfigUpdate)
       .then((res) => {
@@ -65,7 +65,7 @@ describe('(/payroll) The /payroll  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /PAYROLL_CONFIG/:ID returns a single Account Configuration', () => {
+  it('GET /PAYROLL_CONFIG/:ID returns a single Payroll Configuration', () => {
     return agent.get('/payroll_config/'.concat(payrollConfig.id))
       .then((res) => {
         expect(res).to.have.status(200);
@@ -73,7 +73,7 @@ describe('(/payroll) The /payroll  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('DELETE /PAYROLL_CONFIG/:ID will send back a 404 if the Account Configuration does not exist', () => {
+  it('DELETE /PAYROLL_CONFIG/:ID will send back a 404 if the Payroll Configuration does not exist', () => {
     return agent.delete('/payroll_config/123456789')
       .then((res) => {
         helpers.api.errored(res, 404);
@@ -81,7 +81,15 @@ describe('(/payroll) The /payroll  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('DELETE /PAYROLL_CONFIG/:ID should delete an Account Configuration ', () => {
+  it('DELETE /PAYROLL_CONFIG/:ID will send back a 404 if the Payroll Configuration is a string', () => {
+    return agent.delete('/payroll_config/str')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /PAYROLL_CONFIG/:ID should delete an Payroll Configuration ', () => {
     return agent.delete('/payroll_config/'.concat(payrollConfig.id))
       .then((res) => {
         helpers.api.deleted(res);

--- a/test/integration/projects.js
+++ b/test/integration/projects.js
@@ -36,8 +36,16 @@ describe('(/projects) The projects API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /projects/:id should not be found for unknown id', () => {
+  it('GET /projects/:id will send back a 404 if the projects id does not exist', () => {
     return agent.get('/projects/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /projects/:id will send back a 404 if the projects id is a string', () => {
+    return agent.get('/projects/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })
@@ -107,8 +115,16 @@ describe('(/projects) The projects API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('DELETE /projects/:id will send back a 404 if the prjects does not exist', () => {
+  it('DELETE /projects/:id will send back a 404 if the projects id does not exist', () => {
     return agent.delete('/projects/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /projects/:id will send back a 404 if the projects id is a string', () => {
+    return agent.delete('/projects/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })

--- a/test/integration/purchase.js
+++ b/test/integration/purchase.js
@@ -82,12 +82,17 @@ describe('(/purchases) Purchases', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /purchases/:uuid returns 404 for an invalid purchase order', () => {
+  it('GET /purchases/:uuid will send back a 404 if the purchases id does not exist', () => {
     return agent.get('/purchases/123456789')
       .then(res => helpers.api.errored(res, 404))
       .catch(helpers.handler);
   });
 
+  it('GET /purchases/:uuid will send back a 404 if the purchases id is a string', () => {
+    return agent.get('/purchases/str')
+      .then(res => helpers.api.errored(res, 404))
+      .catch(helpers.handler);
+  });
 
   it('PUT /purchases/:uuid unable to update an unknown purchase order', () => {
     return agent.put('/purchases/invalid')

--- a/test/integration/rubrics.js
+++ b/test/integration/rubrics.js
@@ -59,8 +59,16 @@ describe('(/payroll/rubrics) The /payroll/rubrics  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /RUBRICS/:ID should not be found for unknown id', () => {
+  it('GET /RUBRICS/:ID send back a 404 if the rubrics id does not exist', () => {
     return agent.get('/rubrics/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /RUBRICS/:ID send back a 404 if the rubrics id is a string', () => {
+    return agent.get('/rubrics/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })
@@ -85,8 +93,16 @@ describe('(/payroll/rubrics) The /payroll/rubrics  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('DELETE /RUBRICS/:ID will send back a 404 if the Rubric does not exist', () => {
+  it('DELETE /RUBRICS/:ID will send back a 404 if the Rubric id does not exist', () => {
     return agent.delete('/rubrics/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /RUBRICS/:ID will send back a 404 if the Rubric id is a string', () => {
+    return agent.delete('/rubrics/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })
@@ -121,8 +137,16 @@ describe('(/payroll/rubrics) The /payroll/rubrics  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /RUBRIC_CONFIG/:ID should not be found for unknown id', () => {
+  it('GET /RUBRIC_CONFIG/:ID will send back a 404 if the Rubric Configuration id does not exist', () => {
     return agent.get('/rubric_config/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /RUBRIC_CONFIG/:ID will send back a 404 if the Rubric Configuration id is a string', () => {
+    return agent.get('/rubric_config/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })
@@ -147,8 +171,16 @@ describe('(/payroll/rubrics) The /payroll/rubrics  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('DELETE /RUBRIC_CONFIG/:ID will send back a 404 if the Rubric Configuration does not exist', () => {
+  it('DELETE /RUBRIC_CONFIG/:ID will send back a 404 if the Rubric Configuration id does not exist', () => {
     return agent.delete('/rubric_config/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /RUBRIC_CONFIG/:ID will send back a 404 if the Rubric Configuration id is a string', () => {
+    return agent.delete('/rubric_config/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })

--- a/test/integration/services.js
+++ b/test/integration/services.js
@@ -74,8 +74,16 @@ describe('(/services) The Service API', () => {
       .catch(helpers.handler);
   });
 
-  it('DELETE /services/:id should return a 404 for unknown service', () => {
+  it('DELETE /services/:id will send back a 404 if the services id does not exist', () => {
     return agent.delete('/services/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /services/:id will send back a 404 if the services id is a string', () => {
+    return agent.delete('/services/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })

--- a/test/integration/suppliers.js
+++ b/test/integration/suppliers.js
@@ -67,7 +67,7 @@ describe('(/suppliers) The supplier API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /suppliers/:id should return a 404 error for unknown id', () => {
+  it('GET /suppliers/:id will send back a 404 if the suppliers id does not exist', () => {
     return agent.get('/suppliers/123456789')
       .then((res) => {
         helpers.api.errored(res, 404);
@@ -75,6 +75,13 @@ describe('(/suppliers) The supplier API endpoint', () => {
       .catch(helpers.handler);
   });
 
+  it('GET /suppliers/:id will send back a 404 if the suppliers id is a string', () => {
+    return agent.get('/suppliers/str')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
 
   it('GET /suppliers/?locked=0 returns a complete list of unlocked supplier', () => {
     return agent.get('/suppliers?locked=0')

--- a/test/integration/taxIpr.js
+++ b/test/integration/taxIpr.js
@@ -52,8 +52,16 @@ describe('(/ipr_tax) The /ipr_tax  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /IPRTAX/:ID should not be found for unknown id', () => {
+  it('GET /IPRTAX/:ID will send back a 404 if the Ipr tax id does not exist', () => {
     return agent.get('/iprTax/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /IPRTAX/:ID will send back a 404 if the Ipr tax id is a string', () => {
+    return agent.get('/iprTax/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })
@@ -96,7 +104,7 @@ describe('(/ipr_tax) The /ipr_tax  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /IPRTAXCONFIG/:ID should not be found for unknown id', () => {
+  it('GET /IPRTAXCONFIG/:ID will send back a 404 if the Ipr tax Configuration id does not exist', () => {
     return agent.get('/iprTaxConfig/123456789')
       .then((res) => {
         helpers.api.errored(res, 404);
@@ -104,7 +112,15 @@ describe('(/ipr_tax) The /ipr_tax  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('PUT /IPRTAXCONFIG  should update an existing scale of Ipr tax Confuguration', () => {
+  it('GET /IPRTAXCONFIG/:ID will send back a 404 if the Ipr tax Configuration id is a string', () => {
+    return agent.get('/iprTaxConfig/str')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('PUT /IPRTAXCONFIG  should update an existing scale of Ipr tax Configuration', () => {
     return agent.put('/iprTaxConfig/'.concat(iprTaxConfig.id))
       .send({ rate : 15 })
       .then((res) => {
@@ -122,8 +138,16 @@ describe('(/ipr_tax) The /ipr_tax  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('DELETE /IPRTAXCONFIG/:ID will send back a 404 if the Ipr Tax does not exist', () => {
+  it('DELETE /IPRTAXCONFIG/:ID will send back a 404 if the Ipr Tax Configuration id does not exist', () => {
     return agent.delete('/iprTaxConfig/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /IPRTAXCONFIG/:ID will send back a 404 if the Ipr Tax Configuration id is a string', () => {
+    return agent.delete('/iprTaxConfig/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })
@@ -138,8 +162,16 @@ describe('(/ipr_tax) The /ipr_tax  API endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('DELETE /IPRTAX/:ID will send back a 404 if the Ipr Tax does not exist', () => {
+  it('DELETE /IPRTAX/:ID will send back a 404 if the Ipr Tax id does not exist', () => {
     return agent.delete('/iprTax/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /IPRTAX/:ID will send back a 404 if the Ipr Tax id is a string', () => {
+    return agent.delete('/iprTax/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })

--- a/test/integration/vouchers.js
+++ b/test/integration/vouchers.js
@@ -232,8 +232,16 @@ describe('(/vouchers) The vouchers HTTP endpoint', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /vouchers/:uuid returns a NOT FOUND (404) when unknown {uuid}', () => {
+  it('GET /vouchers/:uuid will send back a 404 if the vouchers uuid does not exist', () => {
     return agent.get('/vouchers/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /vouchers/:uuid will send back a 404 if the vouchers uuid is a string', () => {
+    return agent.get('/vouchers/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })

--- a/test/integration/weekEndConfig.js
+++ b/test/integration/weekEndConfig.js
@@ -41,8 +41,16 @@ describe('(/payroll/weekend_configuration) The /payroll/weekend_configuration  A
   });
 
 
-  it('GET /WEEKEND__CONFIG/:ID should not be found for unknown id', () => {
+  it('GET /WEEKEND__CONFIG/:ID will send back a 404 if the WeekEnd Configuration id does not exist', () => {
     return agent.get('/weekend_config/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('GET /WEEKEND__CONFIG/:ID will send back a 404 if the WeekEnd Configuration id is a string', () => {
+    return agent.get('/weekend_config/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })
@@ -69,6 +77,14 @@ describe('(/payroll/weekend_configuration) The /payroll/weekend_configuration  A
 
   it('DELETE /WEEKEND__CONFIG/:ID will send back a 404 if the WeekEnd Configuration does not exist', () => {
     return agent.delete('/weekend_config/123456789')
+      .then((res) => {
+        helpers.api.errored(res, 404);
+      })
+      .catch(helpers.handler);
+  });
+
+  it('DELETE /WEEKEND__CONFIG/:ID will send back a 404 if the WeekEnd Configuration is a string', () => {
+    return agent.delete('/weekend_config/str')
       .then((res) => {
         helpers.api.errored(res, 404);
       })


### PR DESCRIPTION
these changes make sure the HTTP return codes are the same on MySQL 5.7 & 8, when trying to request, update or delete a row but sending an invalid id type.

fixes #4501

Only tests have been added to endpoints where the tests have been changed in #4473, so endpoints or actions that have been untested before are still untested and might still react different on different versions on MySQL