### PR TITLE
fix(reports): ensure filenames are URI encoded

### DIFF
--- a/server/lib/ReportManager.js
+++ b/server/lib/ReportManager.js
@@ -71,7 +71,7 @@ function getFileName(options, extension) {
   const fileDate = (new Date()).toLocaleDateString();
   const formattedName = `${translatedName} ${fileDate}`;
   const fileName = `${formattedName}${extension}`;
-  return fileName;
+  return encodeURIComponent(fileName);
 }
 
 


### PR DESCRIPTION
When report names are sent back to the client they must be URI encoded to be properly interpreted.