### PR TITLE
refactor: remove `event` table

### DIFF
--- a/server/controllers/admin/entities/index.js
+++ b/server/controllers/admin/entities/index.js
@@ -17,8 +17,8 @@ exports.create = create;
 
 function list(req, res, next) {
   const query = `
-    SELECT 
-      BUID(e.uuid) AS uuid, e.display_name, e.gender, e.email, e.phone, e.address, 
+    SELECT
+      BUID(e.uuid) AS uuid, e.display_name, e.gender, e.email, e.phone, e.address,
       e.reference, et.id AS entity_type_id, et.label, et.translation_key
     FROM entity e
     JOIN entity_type et ON et.id = e.entity_type_id
@@ -92,8 +92,8 @@ function create(req, res, next) {
  */
 function fetchEntity(uuid) {
   const query = `
-    SELECT 
-      BUID(e.uuid) AS uuid, e.display_name, e.gender, e.email, e.phone, e.address, 
+    SELECT
+      BUID(e.uuid) AS uuid, e.display_name, e.gender, e.email, e.phone, e.address,
       e.reference, et.id AS entity_type_id, et.label, et.translation_key
     FROM entity e
     JOIN entity_type et ON et.id = e.entity_type_id

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -12,3 +12,9 @@ UPDATE `unit` SET `path` = '/reports/stock_sheet', `url` = '/modules/reports/sto
 @date: 2020-05-26
 */
 ALTER TABLE enterprise_setting MODIFY `enable_auto_stock_accounting` TINYINT(1) NOT NULL DEFAULT 1;
+
+/**
+@author: jniles
+@date: 2020-05-27
+*/
+DROP TABLE IF EXISTS `event`;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -588,21 +588,6 @@ CREATE TABLE `entity_map` (
   PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
-DROP TABLE IF EXISTS `event`;
-CREATE TABLE `event` (
-  `timestamp`   TIMESTAMP NOT NULL,
-  `user_id`     SMALLINT(5) UNSIGNED NOT NULL,
-  `channel`     VARCHAR(25) NOT NULL,
-  `entity`      VARCHAR(25) NOT NULL,
-  `type`        VARCHAR(25) NOT NULL,
-  `data`        TEXT NOT NULL, -- TODO, this should be JSON in newer MySQL
-  KEY `user_id` (`user_id`),
-  FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON UPDATE CASCADE,
-  INDEX event_channel (channel),
-  INDEX event_entity (entity),
-  INDEX event_type (type)
-) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
-
 DROP TABLE IF EXISTS `exchange_rate`;
 CREATE TABLE `exchange_rate` (
   `id`    MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
We've never used the event table.  This removes it from the schema.

Closes #4526.