### PR TITLE
bh-depot-select : do not send empty search text parameter

### DIFF
--- a/client/src/js/components/bhDepotSelect/bhDepotSelect.js
+++ b/client/src/js/components/bhDepotSelect/bhDepotSelect.js
@@ -39,6 +39,10 @@ function DepotSelectController(Depots, Notify) {
   };
 
   $ctrl.searchByName = text => {
+    if (!text) {
+      return null;
+    }
+
     const options = {
       text : (text || '').toLowerCase(),
       exception : $ctrl.exception,


### PR DESCRIPTION
Fix the issue #4557

Close #4557 