### PR TITLE
feat(patients): detect duplicate patients

### DIFF
--- a/client/src/i18n/en/cash.json
+++ b/client/src/i18n/en/cash.json
@@ -26,7 +26,7 @@
       "NO_OTHER_PROJECT_CASHBOXES" : "No cashboxes found registered to other projects.",
 	  "NO_OTHER_PROJECT_CASHBOXES_ACCESS" : "No cashboxes found registered to other projects that you have access rights to.",
     "NO_CURRENT_PROJECT_CASHBOXES" : "No cashboxes found registered to the current project.",
-    "NO_CASHBOXE" : "No cashboxes found registered in the system. Contact the administrator to create one.",
+    "NO_CASHBOXES" : "No cashboxes found registered in the system. Contact the administrator to create one.",
 	  "NO_CURRENT_PROJECT_CASHBOXES_ACCESS" : "No cashboxes in your project that you have access rights to"
     },
     "TITLE":"Cash Window",

--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -642,6 +642,7 @@
             "REFERENCE_GROUP": "Reference Group",
             "REFERENCE_PATIENT": "Patient Reference",
             "REFERENCE": "Reference",
+            "REFERENCES": "References",
             "REGISTER_EMPLOYEE_PATIENT": "Save as an employee",
             "REGISTRATION_NUMBER": "Registration number",
             "RELIGION": "Religion",

--- a/client/src/i18n/en/patient_reg.json
+++ b/client/src/i18n/en/patient_reg.json
@@ -10,6 +10,8 @@
     "PAGE_TITLE": "Patient Registration",
     "PATIENT_DETAILS": "Patient Details",
     "REMOVE_PREVIOUS_ASSIGNMENT" : "Remove all patient groups already assigned to these patients.",
-    "SUCCESS": "Patient Registered Successfully"
+    "SUCCESS": "Patient Registered Successfully",
+    "FIND_DUPLICATE_PATIENTS" : "Find Duplicate Patients",
+    "NO_DUPLICATES_DETECTED" : "No duplicates detected in the database."
   }
 }

--- a/client/src/i18n/fr/cash.json
+++ b/client/src/i18n/fr/cash.json
@@ -30,7 +30,7 @@
       "NO_OTHER_PROJECT_CASHBOXES" : "Il n'y a aucune caisses enregistrer pour les autres projets.",
 	  "NO_OTHER_PROJECT_CASHBOXES_ACCESS" : "Il n'existe aucune caisses des autres projets dont vous avez le droit d'accès .",
       "NO_CURRENT_PROJECT_CASHBOXES" : "Il n'y a aucune caisses enregistrer pour votre projet.",
-      "NO_CASHBOXE" : "Il n'y a aucune caisse enregistrée dans le système, veillez contacter l'administrateur pour en créer.",
+      "NO_CASHBOXES" : "Il n'y a aucune caisse enregistrée dans le système, veillez contacter l'administrateur pour en créer.",
 	  "NO_CURRENT_PROJECT_CASHBOXES_ACCESS" : "Il n'y a aucune caisses dans votre projet dont vous avez le droit d'accès."
     },
     "TITLE":"Caisse Auxilliaire",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -643,6 +643,7 @@
             "REFERENCE_GROUP": "Groupe de référence",
             "REFERENCE_PATIENT": "Référence Patient",
             "REFERENCE": "Référence",
+            "REFERENCES": "Références",
             "REGISTER_EMPLOYEE_PATIENT": "Enregistrer comme un employé",
             "REGISTRATION_NUMBER": "Matricule",
             "RELIGION": "Religion",

--- a/client/src/i18n/fr/patient_reg.json
+++ b/client/src/i18n/fr/patient_reg.json
@@ -10,6 +10,8 @@
     "PAGE_TITLE": "Enregistrement des Patients",
     "PATIENT_DETAILS": "Détails Patient",
     "REMOVE_PREVIOUS_ASSIGNMENT" : "Supprimer tous les groupes déjà assignés à ces patients",
-    "SUCCESS": "Patient enregistré avec succès"
+    "SUCCESS": "Patient enregistré avec succès",
+    "FIND_DUPLICATE_PATIENTS" : "Trouver des patients en double",
+    "NO_DUPLICATES_DETECTED" : "Aucun doublon détecté dans la base de données."
   }
 }

--- a/client/src/modules/cash/modals/select-cashbox-modal.html
+++ b/client/src/modules/cash/modals/select-cashbox-modal.html
@@ -6,11 +6,10 @@
 </div>
 
 <div class="modal-body" data-cashbox-modal>
-
-  <p class ="text-danger" ng-if="!$ctrl.hasCashboxes" translate>
-    CASH.SELECTION.NO_CASHBOXE
+  <p class="text-danger" ng-if="!$ctrl.hasCashboxes" translate>
+    CASH.SELECTION.NO_CASHBOXES
   </p>
-  
+
   <label class="control-label" translate>CASH.SELECTION.CURRENT_PROJECT_CASHBOXES</label>
 
   <!-- list of cashboxes -->
@@ -42,7 +41,7 @@
   </p>
 
 
-  
+
 
   <label class="control-label" translate>CASH.SELECTION.OTHER_PROJECT_CASHBOXES</label>
   <ul ng-if="$ctrl.hasOtherProjectCashboxes" class="list-group">

--- a/client/src/modules/patients/patients.service.js
+++ b/client/src/modules/patients/patients.service.js
@@ -23,7 +23,7 @@ PatientService.$inject = [
  */
 function PatientService(
   Session, $uibModal, Documents, Visits, Filters, AppCache, Periods, Api,
-  $httpParamSerializer, Languages, bhConstants, HttpCache
+  $httpParamSerializer, Languages, bhConstants, HttpCache,
 ) {
   const baseUrl = '/patients/';
   const service = new Api(baseUrl);
@@ -42,6 +42,7 @@ function PatientService(
   service.openSearchModal = openSearchModal;
   service.searchByName = searchByName;
   service.merge = merge;
+  service.findDuplicatePatients = findDuplicatePatients;
   service.countEmployees = countEmployees;
 
   service.getFinancialActivity = getFinancialActivity;
@@ -53,6 +54,7 @@ function PatientService(
   service.balance = balance;
   service.download = download;
   service.openReturningPatientModal = openReturningPatientModal;
+  service.openFindDuplicatePatientsModal = openFindDuplicatePatientsModal;
 
   /**
    * @method merge
@@ -66,6 +68,25 @@ function PatientService(
     const path = `/patients/merge`;
     return service.$http.post(path, params)
       .then(service.util.unwrapHttpResponse);
+  }
+
+  /**
+   * @method findDuplicatePatients()
+   *
+   * @description
+   * Queries the server to look up patients which may be duplicates for
+   * merging.
+   */
+  function findDuplicatePatients(params) {
+    return service.$http.get(`${baseUrl}merge/duplicates`, { params })
+      .then(service.util.unwrapHttpResponse);
+  }
+
+  function openFindDuplicatePatientsModal() {
+    return $uibModal.open({
+      templateUrl : 'modules/patients/registry/modals/findDuplicatePatients.modal.html',
+      controller : 'FindDuplicatePatientsModalController as ModalCtrl',
+    }).result;
   }
 
   /**
@@ -237,6 +258,7 @@ function PatientService(
 
   patientFilters.registerCustomFilters([
     { key : 'uuid', label : 'FORM.LABELS.NAME' },
+    { key : 'uuids', label : 'FORM.LABELS.REFERENCES' },
     { key : 'display_name', label : 'FORM.LABELS.NAME' },
     { key : 'sex', label : 'FORM.LABELS.GENDER' },
     { key : 'hospital_no', label : 'FORM.LABELS.HOSPITAL_NO' },
@@ -317,7 +339,7 @@ function PatientService(
       backdrop : 'static',
       controller : 'PatientRegistryModalController as $ctrl',
       resolve : {
-        filters : function paramsProvider() { return params; },
+        filters : () => params,
       },
     }).result;
   }

--- a/client/src/modules/patients/registry/modals/findDuplicatePatients.modal.html
+++ b/client/src/modules/patients/registry/modals/findDuplicatePatients.modal.html
@@ -1,0 +1,38 @@
+<bh-modal-notify error="ModalCtrl.errorValue"></bh-modal-notify>
+
+<div class="modal-header">
+  <ol class="headercrumb">
+    <li class="static" translate>TREE.HOSPITAL</li>
+    <li class="static" translate>PATIENT_REGISTRY.TITLE</li>
+    <li class="title" translate>PATIENT_REG.FIND_DUPLICATE_PATIENTS</li>
+  </ol>
+</div>
+
+<div class="modal-body">
+  <p class="text-success" ng-if="ModalCtrl.hasNoDuplicates" translate>
+    PATIENT_REG.NO_DUPLICATES_DETECTED
+  </p>
+
+  <div
+    id="duplicate-patients-grid"
+    style="height: 40vh; margin-bottom: 1em;"
+    ui-grid="ModalCtrl.uiGridOptions"
+    ui-grid-auto-resize
+    ui-grid-selection>
+    <bh-grid-loading-indicator
+      loading-state="ModalCtrl.loading"
+      empty-state="ModalCtrl.uiGridOptions.data.length === 0"
+      error-state="ModalCtrl.hasError">
+    </bh-grid-loading-indicator>
+  </div>
+</div>
+
+<div class="modal-footer">
+  <button data-method="cancel" type="button" class="btn btn-default" ng-click="ModalCtrl.dismiss()">
+    <span translate>FORM.BUTTONS.CANCEL</span>
+  </button>
+
+  <button type="submit" class="btn btn-primary" ng-click="ModalCtrl.submit()">
+    <span translate>FORM.BUTTONS.SUBMIT</span>
+  </button>
+</div>

--- a/client/src/modules/patients/registry/modals/findDuplicatePatients.modal.js
+++ b/client/src/modules/patients/registry/modals/findDuplicatePatients.modal.js
@@ -1,0 +1,99 @@
+angular.module('bhima.controllers')
+  .controller('FindDuplicatePatientsModalController', FindDuplicatePatientsModalController);
+
+FindDuplicatePatientsModalController.$inject = [
+  'PatientService', '$uibModalInstance',
+];
+
+function FindDuplicatePatientsModalController(Patients, Instance) {
+  const vm = this;
+  vm.submit = submit;
+  vm.dismiss = () => Instance.close();
+
+  function handleError(err) {
+    vm.errorValue = err;
+    vm.hasError = true;
+  }
+
+  vm.uiGridOptions = {
+    appScopeProvider : vm,
+    enableFiltering : false,
+    enableSorting : true,
+    fastWatch : true,
+    flatEntityAccess : true,
+    enableSelectionBatchEvent : false,
+    onRegisterApi,
+  };
+
+  function parseOtherPatientsField(others) {
+    const patients = others.split(',');
+    return patients.map(patient => patient.split(':'));
+  }
+
+  function lookupDuplicates() {
+    vm.loading = true;
+    const options = { sensitivity : 2, limit : 25 };
+
+    // clear errors if they exist.
+    delete vm.hasError;
+    delete vm.errorValue;
+
+    Patients.findDuplicatePatients(options)
+      .then(data => {
+        vm.uiGridOptions.data = data;
+        vm.hasNoDuplicates = data.length === 0;
+      })
+      .catch(handleError)
+      .finally(() => {
+        vm.loading = false;
+      });
+  }
+
+  vm.uiGridOptions.columnDefs = [{
+    field : 'num_patients',
+    displayName : 'TABLE.COLUMNS.TOTAL',
+    headerCellFilter : 'translate',
+  }, {
+    field : 'display_name',
+    displayName : 'TABLE.COLUMNS.NAME',
+    headerCellFilter : 'translate',
+  }];
+
+  function onRegisterApi(gridApi) {
+    vm.gridApi = gridApi;
+    vm.gridApi.selection.on.rowSelectionChanged(null, rowSelectionCallback);
+  }
+
+  // called whenever the selection changes in the ui-grid
+  function rowSelectionCallback() {
+    const selected = vm.gridApi.selection.getSelectedRows();
+    vm.hasSelectedRows = selected.length > 0;
+  }
+
+  function submit() {
+    const selected = vm.gridApi.selection.getSelectedRows();
+
+    const parsed = selected.map(row => parseOtherPatientsField(row.others));
+
+    const { uuids, names } = parsed.reduce((agg, patients) => {
+      agg.uuids.push(...patients.map(v => v[0]));
+      agg.names.push(...patients.map(v => v[1]));
+      return agg;
+    }, { uuids : [], names : [] });
+
+    // display the references in a predicatable order
+    const displayValues = names.sort().join(',');
+
+    const filters = [
+      { key : 'period', value : 'allTime' },
+      { key : 'limit', value : '10000', cacheable : false },
+      {
+        key : 'uuids', value : uuids, displayValue : displayValues, cacheable : false,
+      },
+    ];
+
+    return Instance.close(filters);
+  }
+
+  lookupDuplicates();
+}

--- a/client/src/modules/patients/registry/registry.html
+++ b/client/src/modules/patients/registry/registry.html
@@ -39,13 +39,18 @@
                   <i class="fa fa-compress"></i> <span translate>FORM.LABELS.MERGE_PATIENTS</span>
               </a>
             </li>
+            <li role="menuitem">
+              <a href data-method="find-duplicate-patients" ng-click="PatientRegistryCtrl.openFindDuplicatePatientsModal()">
+                  <i class="fa fa-group"></i> <span translate>PATIENT_REG.FIND_DUPLICATE_PATIENTS</span>
+              </a>
+            </li>
 
             <li role="separator" class="divider"></li>
             <li role="menuitem">
-                <a href data-method="change-patient-group" ng-click="PatientRegistryCtrl.changePatientGroup()">
-                  <i class="fa fa-edit"></i> <span translate>FORM.LABELS.CHANGE_PATIENT_GROUP</span>
-                </a>
-              </li>
+              <a href data-method="change-patient-group" ng-click="PatientRegistryCtrl.changePatientGroup()">
+                <i class="fa fa-edit"></i> <span translate>FORM.LABELS.CHANGE_PATIENT_GROUP</span>
+              </a>
+            </li>
             <li role="separator" class="divider"></li>
             <li role="menuitem">
               <a ng-href="/reports/medical/patients/?{{ PatientRegistryCtrl.download('pdf') }}" download="{{ 'PATIENT_REGISTRY.TITLE' | translate }}">

--- a/client/src/modules/patients/registry/registry.js
+++ b/client/src/modules/patients/registry/registry.js
@@ -33,6 +33,7 @@ function PatientRegistryController(
   vm.toggleInlineFilter = toggleInlineFilter;
   vm.openBarcodeScanner = openBarcodeScanner;
   vm.mergePatients = mergePatients;
+  vm.openFindDuplicatePatientsModal = openFindDuplicatePatientsModal;
 
   // track if module is making a HTTP request for patients
   vm.loading = false;
@@ -197,11 +198,28 @@ function PatientRegistryController(
     Patients.openSearchModal(filtersSnapshot)
       .then((changes) => {
         Patients.filters.replaceFilters(changes);
-
         Patients.cacheFilters();
         vm.latestViewFilters = Patients.filters.formatView();
         return load(Patients.filters.formatHTTP(true));
       });
+  }
+
+  /**
+   * @function openFindDuplicatePatientsModal
+   *
+   * @description
+   * Opens the modal to locate duplicate patients.  This is essentially a search
+   * modal and returns filters to the registry to filter the registry on duplciate
+   * patients.  If the modal is dismissed, nothing happens.
+   */
+  function openFindDuplicatePatientsModal() {
+    Patients.openFindDuplicatePatientsModal()
+      .then((changes) => {
+        Patients.filters.replaceFilters(changes);
+        vm.latestViewFilters = Patients.filters.formatView();
+        return load(Patients.filters.formatHTTP(true));
+      })
+      .catch(angular.noop);
   }
 
   // remove a filter with from the filter object, save the filters and reload

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -493,6 +493,7 @@ exports.configure = function configure(app) {
 
   // patients merge routes
   app.get('/patients/merge/count_employees', patients.merge.countEmployees);
+  app.get('/patients/merge/duplicates', patients.merge.getDuplicatePatients);
   app.post('/patients/merge', patients.merge.mergePatients);
 
   // Patients API

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -491,10 +491,8 @@ exports.configure = function configure(app) {
   app.get('/patients/visits', patients.visits.list);
   app.get('/patients/visits/:uuid', patients.visits.detail);
 
-  // patients merge routes
-  app.get('/patients/merge/count_employees', patients.merge.countEmployees);
-  app.get('/patients/merge/duplicates', patients.merge.getDuplicatePatients);
-  app.post('/patients/merge', patients.merge.mergePatients);
+  // patient merge routes
+  app.use('/patients/merge', patients.merge.router);
 
   // Patients API
   app.get('/patients', patients.read);

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -8,7 +8,6 @@
  * This module is responsible for handling all crud operations relatives to patients
  * and define all patient API functions.
  *
- * @requires q
  * @requires lodash
  * @requires lib/db
  * @requires lib/util
@@ -699,7 +698,7 @@ function getStockMovements(req, res, next) {
 
 function stockMovementByPatient(patientUuid) {
   const sql = `
-      SELECT DISTINCT BUID(sm.document_uuid) AS document_uuid, 
+      SELECT DISTINCT BUID(sm.document_uuid) AS document_uuid,
       BUID(sm.depot_uuid) as depot_uuid,
       sm.unit_cost,
       (sm.quantity * sm.unit_cost) as value,
@@ -724,12 +723,12 @@ function stockConsumedPerPatient(patientUuid) {
     iv.text AS inventory_text, sm.quantity, sm.unit_cost,
     l.label AS lotLabel, un.text AS inventoryUnit
     FROM stock_movement AS sm
-    JOIN lot AS l ON l.uuid = sm.lot_uuid
-    JOIN inventory AS iv ON iv.uuid = l.inventory_uuid
-    JOIN inventory_unit AS un ON un.id = iv.unit_id
-    JOIN depot AS d ON d.uuid = sm.depot_uuid
-    JOIN patient AS p ON p.uuid = sm.entity_uuid
-    JOIN document_map AS map ON map.uuid = sm.document_uuid
+      JOIN lot AS l ON l.uuid = sm.lot_uuid
+      JOIN inventory AS iv ON iv.uuid = l.inventory_uuid
+      JOIN inventory_unit AS un ON un.id = iv.unit_id
+      JOIN depot AS d ON d.uuid = sm.depot_uuid
+      JOIN patient AS p ON p.uuid = sm.entity_uuid
+      JOIN document_map AS map ON map.uuid = sm.document_uuid
     WHERE sm.entity_uuid = ?
     ORDER BY sm.date, sm.reference desc, iv.text asc;
   `;

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -45,8 +45,8 @@ const merge = require('./merge');
 exports.groups = groups;
 exports.documents = documents;
 exports.visits = visits;
-exports.pictures = pictures;
 exports.merge = merge;
+exports.pictures = pictures;
 exports.stockMovementByPatient = stockMovementByPatient;
 exports.stockConsumedPerPatient = stockConsumedPerPatient;
 
@@ -436,7 +436,9 @@ function searchByName(req, res, next) {
  */
 function find(options) {
   // ensure epected options are parsed appropriately as binary
-  db.convert(options, ['patient_group_uuid', 'debtor_group_uuid', 'debtor_uuid', 'uuid']);
+  db.convert(options, [
+    'patient_group_uuid', 'debtor_group_uuid', 'debtor_uuid', 'uuid', 'uuids',
+  ]);
 
   const filters = new FilterParser(options, {
     tableAlias : 'p',
@@ -452,6 +454,7 @@ function find(options) {
   filters.equals('health_area');
   filters.equals('project_id');
   filters.equals('uuid');
+  filters.equals('uuids', 'uuid', 'p', true);
 
   // filters for location
   const originNameSql = `(originVillage.name LIKE ?) OR (originSector.name LIKE ?) OR (originProvince.name LIKE ?)`;
@@ -471,10 +474,8 @@ function find(options) {
   filters.equals('sex');
   filters.equals('hospital_no');
   filters.equals('user_id');
+  filters.equals('reference', 'text', 'em');
 
-  filters.custom('reference', 'em.text = ?');
-
-  // @TODO Support ordering query (reference support for limit)?
   filters.setOrder('ORDER BY p.registration_date DESC');
 
   // applies filters and limits to defined sql, get parameters in correct order

--- a/server/controllers/medical/patients/merge.js
+++ b/server/controllers/medical/patients/merge.js
@@ -11,10 +11,12 @@
  * - remove the patient to remove
  * - remove the debtor relate to patient to remove
  */
+const debug = require('debug')('bhima:patients:merge');
 const db = require('../../../lib/db');
 
 exports.mergePatients = mergePatients;
 exports.countEmployees = countEmployees;
+exports.getDuplicatePatients = getDuplicatePatients;
 
 function countEmployees(req, res, next) {
   const query = `
@@ -29,12 +31,38 @@ function countEmployees(req, res, next) {
     .done();
 }
 
-function mergePatients(req, res, next) {
-  const params = req.body;
-  const glb = {};
+async function getDuplicatePatients(req, res, next) {
+  const sensitivity = req.params.sensitivity || 2;
+  const duplicateSQL = `
+    SELECT COUNT(p.uuid) AS num_patients, p.display_name, GROUP_CONCAT(CONCAT(BUID(p.uuid), ':', em.text)) AS others,
+    FROM patient p LEFT JOIN entity_map em ON p.uuid = em.uuid
+    GROUP BY LOWER(p.display_name) HAVING COUNT(p.uuid) > ?
+    ORDER BY COUNT(p.uuid) DESC
+    LIMIT 10;
+  `;
 
-  const selectedPatientUuid = db.bid(params.selected);
-  const otherPatientUuids = params.other.map(uuid => db.bid(uuid));
+  try {
+    const patients = await db.exec(duplicateSQL, [sensitivity]);
+    res.status(200).json(patients);
+  } catch (e) {
+    next(e);
+  }
+}
+
+/**
+ * @function mergePatients
+ *
+ * @description
+ * Receives a POST request from the client with "selected" and "other" as the two options
+ * and merges all "other" patients into the "selected" patient.
+ */
+async function mergePatients(req, res, next) {
+  const { selected, other } = req.body;
+
+  debug(`#mergePatients(): merging ${other.length + 1} patients together.`);
+
+  const selectedPatientUuid = db.bid(selected);
+  const otherPatientUuids = other.map(uuid => db.bid(uuid));
 
   const getSelectedDebtorUuid = `SELECT debtor_uuid FROM patient WHERE uuid = ?`;
   const getOtherDebtorUuids = `SELECT debtor_uuid FROM patient WHERE uuid IN (?)`;
@@ -80,37 +108,42 @@ function mergePatients(req, res, next) {
     DELETE FROM patient WHERE uuid IN (?);
   `;
 
-  db.one(getSelectedDebtorUuid, [selectedPatientUuid])
-    .then(row => {
-      glb.selectedDebtorUuid = row.debtor_uuid;
-      return db.exec(getOtherDebtorUuids, otherPatientUuids);
-    })
-    .then(rows => {
-      glb.otherDebtorUuids = rows.map(row => row.debtor_uuid);
+  try {
+    const patient = await db.one(getSelectedDebtorUuid, [selectedPatientUuid]);
+    const debtorUuid = patient.debtor_uuid;
 
-      const transaction = db.transaction();
+    debug(`#mergePatient(): keeping "${patient.display_name}" (${debtorUuid}).`);
 
-      transaction.addQuery(replaceDebtorInJournal, [glb.selectedDebtorUuid, [glb.otherDebtorUuids]]);
-      transaction.addQuery(replaceDebtorInLedger, [glb.selectedDebtorUuid, [glb.otherDebtorUuids]]);
+    const rows = await db.exec(getOtherDebtorUuids, otherPatientUuids);
+    const otherDebtorUuids = rows.map(row => row.debtor_uuid);
+    const otherDebtorNames = rows
+      .map(row => `${row.display_name} (${row.debtor_uuid})`)
+      .join(',');
 
-      transaction.addQuery(replaceDebtorInCash, [glb.selectedDebtorUuid, [glb.otherDebtorUuids]]);
-      transaction.addQuery(replaceDebtorInDebtorGroupHistory, [glb.selectedDebtorUuid, [glb.otherDebtorUuids]]);
-      transaction.addQuery(replaceDebtorInInvoice, [glb.selectedDebtorUuid, [glb.otherDebtorUuids]]);
-      transaction.addQuery(replaceDebtorInPatient, [glb.selectedDebtorUuid, [glb.otherDebtorUuids]]);
+    debug(`#mergePatient(): removing ${otherDebtorNames}.`);
 
-      transaction.addQuery(replacePatientInEmployee, [selectedPatientUuid, [otherPatientUuids]]);
-      transaction.addQuery(replacePatientInPatientAssignment, [selectedPatientUuid, [otherPatientUuids]]);
-      transaction.addQuery(replacePatientInPatientDocument, [selectedPatientUuid, [otherPatientUuids]]);
-      transaction.addQuery(replacePatientInPatientHospitalization, [selectedPatientUuid, [otherPatientUuids]]);
-      transaction.addQuery(replacePatientInPatientVisit, [selectedPatientUuid, [otherPatientUuids]]);
+    const transaction = db.transaction()
+      .addQuery(replaceDebtorInJournal, [debtorUuid, [otherDebtorUuids]])
+      .addQuery(replaceDebtorInLedger, [debtorUuid, [otherDebtorUuids]])
 
-      transaction.addQuery(removeOtherPatients, [otherPatientUuids]);
-      transaction.addQuery(removeOtherDebtors, [glb.otherDebtorUuids]);
-      return transaction.execute();
-    })
-    .then(() => {
-      res.sendStatus(204);
-    })
-    .catch(next)
-    .done();
+      .addQuery(replaceDebtorInCash, [debtorUuid, [otherDebtorUuids]])
+      .addQuery(replaceDebtorInDebtorGroupHistory, [debtorUuid, [otherDebtorUuids]])
+      .addQuery(replaceDebtorInInvoice, [debtorUuid, [otherDebtorUuids]])
+      .addQuery(replaceDebtorInPatient, [debtorUuid, [otherDebtorUuids]])
+
+      .addQuery(replacePatientInEmployee, [selectedPatientUuid, [otherPatientUuids]])
+      .addQuery(replacePatientInPatientAssignment, [selectedPatientUuid, [otherPatientUuids]])
+      .addQuery(replacePatientInPatientDocument, [selectedPatientUuid, [otherPatientUuids]])
+      .addQuery(replacePatientInPatientHospitalization, [selectedPatientUuid, [otherPatientUuids]])
+      .addQuery(replacePatientInPatientVisit, [selectedPatientUuid, [otherPatientUuids]])
+
+      .addQuery(removeOtherPatients, [otherPatientUuids])
+      .addQuery(removeOtherDebtors, [otherDebtorUuids]);
+
+    await transaction.execute();
+    debug(`#mergePatient(): Merged patients successfully.`);
+    res.sendStatus(204);
+  } catch (e) {
+    next(e);
+  }
 }

--- a/server/lib/filter.js
+++ b/server/lib/filter.js
@@ -149,7 +149,6 @@ class FilterParser {
         preparedStatement = `${tableString}${columnAlias} = ${valueString}`;
       }
 
-
       this._addFilter(preparedStatement, this._filters[filterKey]);
       delete this._filters[filterKey];
     }

--- a/test/integration/patients.js
+++ b/test/integration/patients.js
@@ -191,6 +191,19 @@ describe('(/patients) Patients', () => {
     });
   });
 
+  it('GET /patients/merge/duplicates returns duplicate patients', () => {
+    return agent.get('/patients/merge/duplicates')
+      .then((res) => {
+        helpers.api.listed(res, 0);
+        return agent.get('/patients/merge/duplicates')
+          .query({ sensitivity : 0 });
+      })
+      .then((res) => {
+        helpers.api.listed(res, 0);
+      })
+      .catch(helpers.handler);
+  });
+
   it('GET /patients returns a list of patients', () => {
     return agent.get('/patients')
       .then((res) => {


### PR DESCRIPTION
This PR adds the functionality to detect duplicate patients in the database using the naive algorithm proposed in #1578 (essentially `LOWER(display_name)`).  The idea is that users will be able to use this to detect duplicate patients in their database and merge their histories.

Multiple patients are allowed to be selected at once.  We could change this if we think it is too confusing.  I've also included the ability to change the sensitivity and limits, but these are currently hard-coded.  I'm not convinced it is actually necessary.  We could add this functionality later if that feeling changes.

Here is what it looks like with the Vanga database.
![FXDTX2af0V](https://user-images.githubusercontent.com/896472/84267797-937c8000-ab1e-11ea-86d9-c164e7b5cc09.gif)
