### PR TITLE
feat(patients): refresh debtor group history

### DIFF
--- a/client/src/i18n/en/debtor_group.json
+++ b/client/src/i18n/en/debtor_group.json
@@ -1,7 +1,7 @@
 {
   "DEBTOR_GROUP": {
     "BACK": "Back to Debtor Groups",
-    "CHANGE" : "Debtor group changes",
+    "CHANGE" : "Changes in Debtor Group",
     "CLICK_TO_ADD" : "Click here to add a debtor group",
     "CREATE": "Create Debtor Group",
     "CREATE_ANOTHER": "Create another Debtor Group",

--- a/client/src/js/components/bhDebtorGroupHistory.js
+++ b/client/src/js/components/bhDebtorGroupHistory.js
@@ -5,13 +5,14 @@ angular.module('bhima.components')
     transclude : true,
     bindings : {
       debtorUuid : '<',
+      refresh : '<?', // set to true to refresh history
       limit : '@?',
     },
   });
 
 bhDebtorGroupHistoryController.$inject = ['DebtorGroupService', 'NotifyService'];
 /**
- * Debtor group history component
+ * Debtor Group History Component
  *
  */
 function bhDebtorGroupHistoryController(DebtorGroup, Notify) {
@@ -23,16 +24,22 @@ function bhDebtorGroupHistoryController(DebtorGroup, Notify) {
     loadHistory();
   };
 
-  $ctrl.$onChanges = () => {
-    loadHistory();
+  $ctrl.$onChanges = (changes) => {
+    if (changes.debtorUuid || changes.refresh.currentValue) {
+      loadHistory();
+    }
   };
 
   function loadHistory() {
     const parameters = { limit : $ctrl.limit };
+    $ctrl.loading = true;
     DebtorGroup.history($ctrl.debtorUuid, parameters)
       .then(groupChanges => {
         $ctrl.groupChanges = groupChanges;
       })
-      .catch(Notify.handleError);
+      .catch(Notify.handleError)
+      .finally(() => {
+        $ctrl.loading = false;
+      });
   }
 }

--- a/client/src/modules/patients/edit/edit.html
+++ b/client/src/modules/patients/edit/edit.html
@@ -81,11 +81,14 @@
                 <button
                   data-update-group-debtor
                   class="btn btn-warning btn-block"
-                  ng-click="PatientEditCtrl.updateDebtorGroup()"><span translate>FORM.BUTTONS.GROUPS_DEBTOR_UPDATE</span></button>
+                  ng-click="PatientEditCtrl.updateDebtorGroup()">
+                  <span translate>FORM.BUTTONS.GROUPS_DEBTOR_UPDATE</span>
+                </button>
               </div>
 
               <bh-debtor-group-history
                 debtor-uuid="PatientEditCtrl.medical.debtor_uuid"
+                refresh="PatientEditCtrl.refreshDebtorGroupHistory"
                 limit="5">
               </bh-debtor-group-history>
             </form>
@@ -121,7 +124,7 @@
                    <p class="form-control-static">
                       <span>{{PatientEditCtrl.medical.reference}}</span>
                    </p>
-                 
+
                  </div>
                </div>
 

--- a/client/src/modules/patients/edit/edit.js
+++ b/client/src/modules/patients/edit/edit.js
@@ -3,10 +3,10 @@ angular.module('bhima.controllers')
 
 PatientEdit.$inject = [
   '$stateParams', 'PatientService', 'util', 'moment', 'NotifyService',
-  'ScrollService', 'PatientGroupModal', 'bhConstants',
+  'ScrollService', 'PatientGroupModal', 'bhConstants', '$timeout',
 ];
 
-function PatientEdit($stateParams, Patients, util, moment, Notify, ScrollTo, GroupModal, Constants) {
+function PatientEdit($stateParams, Patients, util, moment, Notify, ScrollTo, GroupModal, Constants, $timeout) {
   const vm = this;
   const referenceId = $stateParams.uuid;
 
@@ -127,7 +127,11 @@ function PatientEdit($stateParams, Patients, util, moment, Notify, ScrollTo, Gro
   };
 
   vm.updateDebtorGroup = function updateDebtorGroup() {
-    GroupModal.updateDebtor(vm.medical, updateDebtorModel);
+    GroupModal.updateDebtor(vm.medical, updateDebtorModel)
+      .then(() => {
+        vm.refreshDebtorGroupHistory = true;
+        $timeout(() => { vm.refreshDebtorGroupHistory = false; }, 250);
+      });
   };
 
   vm.updatePatientGroups = function updatePatientGroups() {

--- a/client/src/modules/patients/groups/modal/createUpdate.html
+++ b/client/src/modules/patients/groups/modal/createUpdate.html
@@ -13,64 +13,64 @@
 
   <div class="modal-body">
     <div class="row">
-        <div class="form-group" ng-class="{ 'has-error' : patientGroupForm.$submitted && patientGroupForm.name.$invalid }">
-              <label class="control-label" translate>
-                FORM.LABELS.NAME
-              </label>
-              <input class="form-control" name="name" autocomplete="off" ng-maxlength="ModalCtrl.length100" ng-model="ModalCtrl.patientGroup.name" required>
-              <div class="help-block" ng-messages="patientGroupForm.name.$error" ng-show="patientGroupForm.$submitted">
-                <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
+      <div class="form-group" ng-class="{ 'has-error' : patientGroupForm.$submitted && patientGroupForm.name.$invalid }">
+        <label class="control-label" translate>
+          FORM.LABELS.NAME
+        </label>
+        <input class="form-control" name="name" autocomplete="off" ng-maxlength="ModalCtrl.length100" ng-model="ModalCtrl.patientGroup.name" required>
+        <div class="help-block" ng-messages="patientGroupForm.name.$error" ng-show="patientGroupForm.$submitted">
+          <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+        </div>
+      </div>
 
-            <div class="form-group" ng-class="{ 'has-error' : patientGroupForm.$submitted && patientGroupForm.priceList.$invalid }">
-              <label class="control-label" translate>
-                FORM.LABELS.PRICE_LIST
-              </label>
-              <select
-                class="form-control"
-                name="priceList"
-                ng-model="ModalCtrl.patientGroup.price_list_uuid"
-                ng-options="p.uuid as p.label for p in ModalCtrl.priceLists">
-                <option value="" disabled translate> FORM.SELECT.PRICE_LIST </option>
-              </select>
-              <div class="help-block" ng-messages="patientGroupForm.priceList.$error" ng-show="patientGroupForm.$submitted">
-                <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-              </div>
-            </div>
+      <div class="form-group" ng-class="{ 'has-error' : patientGroupForm.$submitted && patientGroupForm.priceList.$invalid }">
+        <label class="control-label" translate>
+          FORM.LABELS.PRICE_LIST
+        </label>
+        <select
+          class="form-control"
+          name="priceList"
+          ng-model="ModalCtrl.patientGroup.price_list_uuid"
+          ng-options="p.uuid as p.label for p in ModalCtrl.priceLists">
+          <option value="" disabled translate> FORM.SELECT.PRICE_LIST </option>
+        </select>
+        <div class="help-block" ng-messages="patientGroupForm.priceList.$error" ng-show="patientGroupForm.$submitted">
+          <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+        </div>
+      </div>
 
-            <div class="form-group">
-              <label class="control-label" translate>
-                FORM.LABELS.INVOICING_FEES
-              </label>
+      <div class="form-group">
+        <label class="control-label" translate>
+          FORM.LABELS.INVOICING_FEES
+        </label>
 
-              <ui-select multiple ng-model="ModalCtrl.patientGroup.invoicingFees">
-              <ui-select-match>{{$item.label}}</ui-select-match>
-              <ui-select-choices repeat="fee.id as fee in ModalCtrl.invoicingFees | filter:$select.search">
-                  {{fee.label}}
-              </ui-select-choices>
-              </ui-select>
-            </div>
+        <ui-select multiple ng-model="ModalCtrl.patientGroup.invoicingFees">
+        <ui-select-match>{{$item.label}}</ui-select-match>
+        <ui-select-choices repeat="fee.id as fee in ModalCtrl.invoicingFees | filter:$select.search">
+            {{fee.label}}
+        </ui-select-choices>
+        </ui-select>
+      </div>
 
-            <div class="form-group">
-              <label class="control-label" translate>
-                FORM.LABELS.SUBSIDIES
-              </label>
+      <div class="form-group">
+        <label class="control-label" translate>
+          FORM.LABELS.SUBSIDIES
+        </label>
 
-              <ui-select multiple ng-model="ModalCtrl.patientGroup.subsidies">
-              <ui-select-match>{{$item.label}}</ui-select-match>
-              <ui-select-choices repeat="subsidy.id as subsidy in ModalCtrl.subsidies | filter:$select.search">
-                  {{subsidy.label}}
-              </ui-select-choices>
-              </ui-select>
-            </div>
+        <ui-select multiple ng-model="ModalCtrl.patientGroup.subsidies">
+        <ui-select-match>{{$item.label}}</ui-select-match>
+        <ui-select-choices repeat="subsidy.id as subsidy in ModalCtrl.subsidies | filter:$select.search">
+            {{subsidy.label}}
+        </ui-select-choices>
+        </ui-select>
+      </div>
 
-            <div class="form-group">
-              <label class="control-label" translate>
-                FORM.LABELS.NOTES
-              </label>
-              <textarea class="form-control" ng-maxlength="ModalCtrl.maxLength" name="note" ng-model="ModalCtrl.patientGroup.note"></textarea>
-            </div>
+      <div class="form-group">
+        <label class="control-label" translate>
+          FORM.LABELS.NOTES
+        </label>
+        <textarea class="form-control" ng-maxlength="ModalCtrl.maxLength" name="note" ng-model="ModalCtrl.patientGroup.note"></textarea>
+      </div>
     </div>
   </div>
 

--- a/client/src/modules/templates/bhDebtorGroupHistory.tmpl.html
+++ b/client/src/modules/templates/bhDebtorGroupHistory.tmpl.html
@@ -2,12 +2,15 @@
   <div class="col-sm-12">
     <p><u><span translate>DEBTOR_GROUP.CHANGE</span></u></p>
     <ul class="list-unstyled">
-      <li ng-repeat="change in $ctrl.groupChanges">
+      <li ng-if="$ctrl.loading">
+        <span class="fa fa-circle-o-notch fa-spin"></span> <span translate>FORM.INFO.LOADING</span>
+      </li>
+      <li ng-repeat="change in $ctrl.groupChanges" ng-hide="$ctrl.loading">
         <i class="fa fa-clock-o"></i>
         <b>{{change.group_prev}} &#8594; {{change.group_next}}</b>
         <br/>
-        <span translate>FORM.LABELS.DATE</span> : {{change.created_at | date : 'medium'}}, 
-        <span translate>FORM.LABELS.BY</span> {{change.user}}
+        <span translate>FORM.LABELS.DATE</span> : {{change.created_at | date : 'medium'}}
+        <span style="text-transform:lowercase" translate>FORM.LABELS.BY</span> {{change.user}}
         <br/>
       </li>
     </ul>


### PR DESCRIPTION
Adds a feature to the patient edit page to instantly refresh the debtor group history after modification.  Only 15% hacky.  Also adds a loading indicator.

Closes #4481.

Here is what it looks like:
![kZr8KRtYjW](https://user-images.githubusercontent.com/896472/84388667-e3297d00-abec-11ea-8c23-af6271a1a5e1.gif)


