### PR TITLE
fix(reports): fix filename on report download

### DIFF
--- a/server/lib/ReportManager.js
+++ b/server/lib/ReportManager.js
@@ -185,7 +185,7 @@ class ReportManager {
     const renderHeaders = renderer.headers;
 
     if (fileName) {
-      renderHeaders['Content-Disposition'] = `filename=${fileName}`;
+      renderHeaders['Content-Disposition'] = `filename="${fileName}"`;
       renderHeaders.filename = fileName;
     }
 


### PR DESCRIPTION
The HTTP spec requires that the filename in the Content-Disposition header is put in quotes. See:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition