### PR TITLE
feat(reports): optionally rm cash clients in Annual Clients Report

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -60,7 +60,9 @@
       "TITLE" : "Annual Clients Report",
       "DESCRIPTION": "This report displays all the debtor groups, their account balances at the beginning of the fiscal year, the debits and credits to their accounts, and their ending balances.",
       "HIDE_LOCKED_CLIENTS" : "Hide Locked Clients",
-      "HIDE_LOCKED_CLIENTS_HELP_TEXT" : "Selecting yes will filter out all locked clients from the report.  By default, the value is no."
+      "HIDE_LOCKED_CLIENTS_HELP_TEXT" : "Selecting yes will filter out all locked clients from the report.  By default, the value is no.",
+      "INCLUDE_CASH_CLIENTS" : "Include Cash Clients",
+      "INCLUDE_CASH_CLIENTS_HELP_TEXT" : "Selecting this option will add in cash debtor groups.  By default only non-cash clients (conventions) are queried."
     },
     "CLOSING_BALANCE": "Closing Balance",
     "COMPARE_INVOICED_RECEIVED": {

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -142,7 +142,7 @@
       "EXCLUDE_INVENTORIES_ZERO_VALUE": "Exclure les inventaires dont la valeur en stock est nulle"
 
     },
-    
+
     "STOCK_CONSUMPTION_GRAPH_REPORT" : {
       "TITLE" : "Rapport graphique de la consommation de stock",
       "DESCRIPTION" : "Ce rapport montre graphiquement la consommation de stock durant une période pour un depot ou un inventaire"
@@ -208,7 +208,9 @@
       "TITLE" : "Rapport Annuel des Clients",
       "DESCRIPTION" : "Ce rapport affiche tous les groupes de débiteurs, leurs soldes de compte au début de l'exercice, les soldes actuels et leurs soldes de clôture.",
       "HIDE_LOCKED_CLIENTS" : "Masquer les clients verrouillés",
-      "HIDE_LOCKED_CLIENTS_HELP_TEXT" : "Si vous sélectionnez oui, tous les clients verrouillés seront filtrés dans le rapport. Par défaut, la valeur est non."
+      "HIDE_LOCKED_CLIENTS_HELP_TEXT" : "Si vous sélectionnez oui, tous les clients verrouillés seront filtrés dans le rapport. Par défaut, la valeur est non.",
+      "INCLUDE_CASH_CLIENTS" : "Inclure les payant cash",
+      "INCLUDE_CASH_CLIENTS_HELP_TEXT" : "La sélection de cette option ajoutera des groupes de débiteurs en espèces. Par défaut, seules les conventions sont interrogées."
     },
     "UNPAID_INVOICE_PAYMENTS_REPORT": {
       "TITLE": "Rapport de Factures Non-Payées",

--- a/client/src/modules/reports/generate/annual-clients-report/annual-clients-report.html
+++ b/client/src/modules/reports/generate/annual-clients-report/annual-clients-report.html
@@ -42,6 +42,14 @@
             on-change-callback="ReportConfigCtrl.onHideLockedClientsToggle(value)">
           </bh-yes-no-radios>
 
+          <bh-yes-no-radios
+            label="REPORT.CLIENTS.INCLUDE_CASH_CLIENTS"
+            value="ReportConfigCtrl.reportDetails.includeCashClients"
+            name="includeCashClients"
+            help-text="REPORT.CLIENTS.INCLUDE_CASH_CLIENTS_HELP_TEXT"
+            on-change-callback="ReportConfigCtrl.onIncludeCashClientsToggle(value)">
+          </bh-yes-no-radios>
+
           <!--preview-->
           <bh-loading-button loading-state="ConfigForm.$loading">
             <span translate>REPORT.UTIL.PREVIEW</span>
@@ -59,5 +67,4 @@
       on-select-report="ReportConfigCtrl.onSelectCronReport(report)">
     </bh-cron-email-report>
   </div>
-</div>
 </div>

--- a/client/src/modules/reports/generate/annual-clients-report/annual-clients-report.js
+++ b/client/src/modules/reports/generate/annual-clients-report/annual-clients-report.js
@@ -16,19 +16,20 @@ AnnualClientsReportController.$inject = [
  */
 function AnnualClientsReportController($state, $sce, Notify, AppCache, SavedReports, reportData, Session) {
   const vm = this;
-  const cache = new AppCache('configure_clients');
+  const cache = new AppCache('AnnualClientsReport');
   const reportUrl = 'reports/finance/annual-clients-report';
 
   vm.reportDetails = {
     currencyId : Session.enterprise.currency_id,
     hideLockedClients : 0,
+    includeCashClients : 0,
   };
 
   checkCachedConfiguration();
 
   // update the fiscal year on selection
-  vm.onSelectFiscal = fiscal => {
-    vm.reportDetails.fiscalId = fiscal.id;
+  vm.onSelectFiscal = fiscalYear => {
+    vm.reportDetails.fiscalId = fiscalYear.id;
   };
 
   vm.onSelectCronReport = report => {
@@ -41,6 +42,10 @@ function AnnualClientsReportController($state, $sce, Notify, AppCache, SavedRepo
 
   vm.onHideLockedClientsToggle = hideLockedClients => {
     vm.reportDetails.hideLockedClients = hideLockedClients;
+  };
+
+  vm.onIncludeCashClientsToggle = includeCashClients => {
+    Object.assign(vm.reportDetails, { includeCashClients });
   };
 
   vm.requestSaveAs = function requestSaveAs() {


### PR DESCRIPTION
Adds the ability to filter out cash clients from the annual debtor groups report.  By default, cash clients are included and only
conventions are shown.

Here is what it looks like:
![bE5rO7esU9](https://user-images.githubusercontent.com/896472/85535086-c8520200-b609-11ea-9834-b88f285a6cb9.gif)


Closes #4635.