### PR TITLE
refactor(patients): improve stock movement table

### DIFF
--- a/client/src/i18n/en/patient_records.json
+++ b/client/src/i18n/en/patient_records.json
@@ -65,12 +65,13 @@
       "OLD_CASES":"Old Cases",
       "HOSPITALIZED":"Hospitalized",
       "AMBULATORY":"Ambulatory",
-      "PREGNANT":"Pregnants",
+      "PREGNANT":"Pregnant Women",
       "REFERRED":"Referred",
       "INSIDE_HEALTH_ZONE":"Within Health Zone",
       "OUTSIDE_HEALTH_ZONE":"Outside Health Zone"
     },
     "STOCK_MOVEMENTS_TO_PATIENT" : "Stock movements distributed to the patient",
+    "VIEW_ALL_MOVEMENTS_TO_PATIENT" : "View All {{numMovements}} Distributions to Patient",
     "TRANSFER":{
       "TITLE":"Transfer",
       "NEW_DESTINATION_DESCRIPTION":"Please select the new destination (ward, room and bed) of the patient",

--- a/client/src/i18n/fr/patient_records.json
+++ b/client/src/i18n/fr/patient_records.json
@@ -71,6 +71,7 @@
       "OUTSIDE_HEALTH_ZONE":"Hors zone de santé"
     },
     "STOCK_MOVEMENTS_TO_PATIENT" : "Mouvements de stock distribués au patient",
+    "VIEW_ALL_MOVEMENTS_TO_PATIENT" : "Voir les {{numMovements}} mouvements du patient",
     "TRANSFER":{
       "TITLE":"Transfert",
       "NEW_DESTINATION_DESCRIPTION":"Veuillez séléctionner la nouvelle destination (pavillon, chambre et lit) du patient",

--- a/client/src/less/bhima-bootstrap.less
+++ b/client/src/less/bhima-bootstrap.less
@@ -552,3 +552,9 @@ div.ui-grid-cell .form-group.has-error input.ng-invalid {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+
+.text-overflow {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/client/src/modules/patients/record/bh-patient-financial-activity.html
+++ b/client/src/modules/patients/record/bh-patient-financial-activity.html
@@ -80,56 +80,58 @@
           </dd>
         </dl>
 
-        <hr/>
-        <h5 style="margin-top:0;">
-          <i class="fa fa-medkit" aria-hidden="true"></i>
-          <strong>
-            <a href ui-sref="stockMovements({
-              filters : [
-                { key : 'entity_uuid', value : $ctrl.patientUuid, displayValue: $ctrl.data.patient.display_name },
-                { key : 'period', value : 'allTime' }
-              ]
-            })">
-            <span translate>PATIENT_RECORDS.STOCK_MOVEMENTS_TO_PATIENT</span>
-            <span ng-if="!$ctrl.noStockMovement">
-              ({{$ctrl.dataMovement.length}})
-            </span>
-            </a>
-          </strong>
+        <h5 style="margin-top:0;" translate>
+          PATIENT_RECORDS.STOCK_MOVEMENTS_TO_PATIENT
         </h5>
 
-        <div class="col-sm-6 col-xs-12">
-          <table class="table table-responsive table-bordered table-condensed">
-            <thead>
-              <tr>
-                <td translate>FORM.LABELS.NR</td>
-                <td translate>FORM.LABELS.REFERENCE</td>
-                <td translate>FORM.LABELS.INVENTORY</td>                
-                <td translate>FORM.LABELS.DATE</td>
-                <td translate>FORM.LABELS.VALUE</td>
-              </tr>
-            </thead>
-            <tbody>
-              <tr ng-repeat="dataMovement in $ctrl.dataMovement">
-                <td>{{ $index + 1 }}</td>
-                <td><strong> {{ dataMovement.reference_text }} </strong></th>
-                <td>{{dataMovement.inventory_name}}</td>
-                <td> {{ dataMovement.date | date : "dd/MM/yyyy HH:mm:ss" }} </td>
-                <td><strong> {{ dataMovement.value | currency:$ctrl.enterpriseCurrencyId }} </strong></th>
-                
-              </tr>
-              <tr  ng-if="!$ctrl.noStockMovement">
-                <td colspan="5" class="text-right">
-                  <span translate>FORM.LABELS.TOTAL</span> : 
-                  <span>{{$ctrl.dataMovementTotalValue | currency:$ctrl.enterpriseCurrencyId}}</span>
-                </td>
-              </tr>
-              <tr ng-if="$ctrl.noStockMovement">
-                <td colspan="5" translate>TABLE.COLUMNS.EMPTY</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <table class="table table-responsive table-condensed">
+          <thead>
+            <tr>
+              <th translate>FORM.LABELS.REFERENCE</th>
+              <th style="max-width:20%;" translate>FORM.LABELS.DEPOT</th>
+              <th style="max-width:45%;" translate>FORM.LABELS.INVENTORY</th>
+              <th translate>FORM.LABELS.DATE</th>
+              <th translate>FORM.LABELS.VALUE</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr ng-repeat="movement in $ctrl.dataMovement">
+              <th>
+                <bh-receipt value="movement.document_uuid" type="stockExitPatientReceipt" display-value="movement.reference_text" >
+                </bh-receipt>
+              </th>
+              <td>{{ movement.depot_name }}</td>
+              <td>{{ movement.inventory_name}}</td>
+              <td>{{ movement.date | date : "dd/MM/yyyy HH:mm:ss" }}</td>
+              <th class="text-right">{{ movement.value | currency:$ctrl.enterpriseCurrencyId }}</th>
+            </tr>
+
+            <tr ng-if="$ctrl.noStockMovement">
+              <td colspan="5" translate>TABLE.COLUMNS.EMPTY</td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr ng-if="!$ctrl.noStockMovement">
+              <th colspan="3">
+                <a href ui-sref="stockMovements({
+                  filters : [
+                    { key : 'entity_uuid', value : $ctrl.patientUuid, displayValue: $ctrl.data.patient.display_name, cacheable: false },
+                    { key : 'period', value : 'allTime' }
+                  ]
+                })">
+                  <i class="fa fa-link"></i>
+                  <span translate translate-values="{'numMovements':$ctrl.dataMovement.length}">
+                    PATIENT_RECORDS.VIEW_ALL_MOVEMENTS_TO_PATIENT
+                  </span>
+                </a>
+              </th>
+              <th colspan="2" class="text-right">
+                <span translate>FORM.LABELS.TOTAL</span>:
+                <span>{{$ctrl.dataMovementTotalValue | currency:$ctrl.enterpriseCurrencyId}}</span>
+              </th>
+            </tr>
+          </tfoot>
+        </table>
       </div>
 
       <!-- patient's records -->

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -263,7 +263,6 @@ function lookupPatientPriceList(patientUuid) {
     .then(([row]) => row && row.price_list_uuid);
 }
 
-
 /**
  * @method updatePatientDebCred
  *
@@ -545,7 +544,6 @@ function read(req, res, next) {
     .done();
 }
 
-
 function invoicingFees(req, res, next) {
   const uid = db.bid(req.params.uuid);
 
@@ -700,19 +698,18 @@ function getStockMovements(req, res, next) {
 function stockMovementByPatient(patientUuid) {
   const sql = `
       SELECT DISTINCT BUID(sm.document_uuid) AS document_uuid,
-      BUID(sm.depot_uuid) as depot_uuid,
-      sm.unit_cost,
-      (sm.quantity * sm.unit_cost) as value,
+      BUID(sm.depot_uuid) AS depot_uuid, d.text as depot_name,
+      sm.unit_cost, (sm.quantity * sm.unit_cost) AS value,
       sm.date, map.text AS reference_text,
       i.text AS inventory_name
     FROM stock_movement AS sm
-    JOIN depot AS d ON d.uuid = sm.depot_uuid
-    JOIN patient AS p ON p.uuid = sm.entity_uuid
-    JOIN lot l ON l.uuid = sm.lot_uuid
-    JOIN inventory i ON i.uuid = l.inventory_uuid
-    JOIN document_map AS map ON map.uuid = sm.document_uuid
+      JOIN depot AS d ON d.uuid = sm.depot_uuid
+      JOIN patient AS p ON p.uuid = sm.entity_uuid
+      JOIN lot AS l ON l.uuid = sm.lot_uuid
+      JOIN inventory i ON i.uuid = l.inventory_uuid
+      JOIN document_map AS map ON map.uuid = sm.document_uuid
     WHERE sm.entity_uuid = ?
-    ORDER BY sm.date desc
+    ORDER BY sm.date DESC
   `;
 
   return db.exec(sql, [db.bid(patientUuid)]);


### PR DESCRIPTION
Improves the "stock movements" section of the `bhPatientFinancialActivity` component by removing borders, adding in the
depot name, and allowing users to click on the stock movement and see the receipt.

This is what it looks like now:
![image](https://user-images.githubusercontent.com/896472/85886024-3569c100-b7dd-11ea-862a-ec85b2ed5513.png)

And here is what it looks like in action:
![V6wehaT7qT](https://user-images.githubusercontent.com/896472/85918418-89ff5180-b85a-11ea-8d1f-74a59590b80d.gif)

