### PR TITLE
chore(ci): add job names to Travis

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,12 @@ environment:
     - nodejs_version: "14"
     - nodejs_version: "12"
 
+matrix:
+  fast_finish: true
+
+skip_branch_with_pr: true
+clone_depth: 5
+
 install:
   - mysql --version
   - sh: nvm install $nodejs_version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,15 @@ os: linux
 jdk:
   - oraclejdk8
 
-# Use google chrome v74.  According to the angular team, v74 is
-# the last version that works correctly with protractor.
-# See: https://github.com/angular/protractor/commit/d77731c270f5118518d0a57cee4aee97ff29a023
 env:
   global:
     - DBUS_SESSION_BUS_ADDRESS=/dev/null
-    - CHROME_REVISION=706915
-    - CHROMEDRIVER_VERSION="79.0.3945.36"
-    - CORAL_REUSE_BROWSER=1
 
 matrix:
+  fast_finish: true
   include:
     - node_js: lts/erbium
+      name: "[E2E] MySQL 5.7 on Node LTS"
       env:
         - TEST_TYPE=e2e
         - DB=MYSQL
@@ -24,6 +20,7 @@ matrix:
         - mysql
         - redis
     - node_js: node
+      name: "[E2E] MySQL 5.7 on Node Current"
       env:
         - TEST_TYPE=e2e
         - DB=MYSQL
@@ -32,6 +29,7 @@ matrix:
         - mysql
         - redis
     - node_js: node
+      name: "[E2E] MySQL 8 on Node Current"
       env:
         - TEST_TYPE=e2e
         - DB=MYSQL
@@ -40,6 +38,7 @@ matrix:
         - mysql
         - redis
     - node_js: lts/erbium
+      name: "[E2E] MariaDB 10.5 on Node LTS"
       env:
         - TEST_TYPE=e2e
         - DB=MARIADB
@@ -49,6 +48,7 @@ matrix:
       addons:
         mariadb: '10.5'
     - node_js: lts/erbium
+      name: "[Installation] MySQL 5.7 on Node LTS"
       env:
         - TEST_TYPE=installation
         - DB=MYSQL
@@ -57,6 +57,7 @@ matrix:
         - mysql
         - redis
     - node_js: node
+      name: "[Installation] MySQL 5.7 on Node Current"
       env:
         - TEST_TYPE=installation
         - DB=MYSQL
@@ -65,6 +66,7 @@ matrix:
         - mysql
         - redis
     - node_js: node
+      name: "[Installation] MySQL 8 on Node Current"
       env:
         - TEST_TYPE=installation
         - DB=MYSQL
@@ -73,6 +75,7 @@ matrix:
         - mysql
         - redis
     - node_js: lts/erbium
+      name: "[Installation] MariaDB 10.5 on Node LTS"
       env:
         - TEST_TYPE=installation
         - DB=MARIADB
@@ -91,12 +94,11 @@ language: node_js
 
 before_script:
   - sh -c "if [ '$TEST_TYPE' = 'e2e' ]; then yarn build; fi"
-  - sh -c "if [ '$TEST_TYPE' = 'e2e' ]; then yarn webdriver-manager update --versions.chrome=$CHROMEDRIVER_VERSION --gecko false; fi"
+  - sh -c "if [ '$TEST_TYPE' = 'e2e' ]; then yarn webdriver-manager update --gecko false; fi"
 
 script:
   - sh -c "if [ '$TEST_TYPE' = 'e2e' ]; then yarn test:ends; fi"
   - sh -c "if [ '$TEST_TYPE' = 'installation' ]; then ./sh/install-tests.sh; fi"
-
 
 git:
   depth: 3
@@ -108,5 +110,5 @@ cache:
 
 branches:
   except:
-    # do not build any branches that have *.tmp in their name
+    # do not build any branches that end in *.tmp in their name
     - /.*\.tmp$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ jdk:
 
 env:
   global:
-    - DBUS_SESSION_BUS_ADDRESS=/dev/null
+    - CHROME_REVISION=706915
+    - CHROMEDRIVER_VERSION="79.0.3945.36"
 
 matrix:
   fast_finish: true
@@ -94,7 +95,7 @@ language: node_js
 
 before_script:
   - sh -c "if [ '$TEST_TYPE' = 'e2e' ]; then yarn build; fi"
-  - sh -c "if [ '$TEST_TYPE' = 'e2e' ]; then yarn webdriver-manager update --gecko false; fi"
+  - sh -c "if [ '$TEST_TYPE' = 'e2e' ]; then yarn webdriver-manager update --versions.standalone=3.141.59 --versions.chrome=${CHROMEDRIVER_VERSION} --gecko false; fi"
 
 script:
   - sh -c "if [ '$TEST_TYPE' = 'e2e' ]; then yarn test:ends; fi"

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -36,6 +36,9 @@ const config = {
   // this will log the user in to begin with
   onPrepare : () => {
     return q.fcall(async () => {
+
+      await browser.driver.manage().window().maximize();
+
       await browser.get('http://localhost:8080/#!/login');
 
       // Turns off ng-animate animations for all elements in the
@@ -52,10 +55,8 @@ const config = {
 };
 
 // configuration for running on SauceLabs via Travis
-if (process.env.TRAVIS_BUILD_NUMBER) {
+if (process.env.CI) {
   // SauceLabs credentials
-  config.sauceUser = process.env.SAUCE_USERNAME;
-  config.sauceKey = process.env.SAUCE_ACCESS_KEY;
   // report directory on the server(ubuntu)
   process.env.REPORT_DIR = '/opt/reports/';
 
@@ -69,7 +70,7 @@ if (process.env.TRAVIS_BUILD_NUMBER) {
     'tunnel-identifier' : process.env.TRAVIS_JOB_NUMBER,
     build               : process.env.TRAVIS_BUILD_NUMBER,
     chromeOptions : {
-      args : ['--headless', '--disable-gpu', '--window-size=1280,1024'],
+      args : ['--headless', '--disable-gpu', '--window-size=1920,1080'],
     },
   }];
 

--- a/sh/integration-tests.sh
+++ b/sh/integration-tests.sh
@@ -7,7 +7,7 @@ set -a
 source .env.development
 set +a
 
-./sh/build-database.sh
+./sh/build-database.sh || { echo 'failed to build DB' ; exit 1; }
 
 echo "[test]"
 

--- a/sh/travis.sh
+++ b/sh/travis.sh
@@ -21,7 +21,6 @@ mysql -h $DB_HOST -u root -e "FLUSH PRIVILEGES;"
 
 if [ "$TEST_TYPE" = 'e2e' ]
 then
-
   echo "Downloading chrome revision: $CHROME_REVISION"
   echo "Download URL: https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/$CHROME_REVISION/chrome-linux.zip"
 


### PR DESCRIPTION
Adds job names to the Travis CI to give use better insight into what tests failed.  Also adds `fast_finish` and `clone depth` to the appveyor configuration.

Basically, changes this:
![image](https://user-images.githubusercontent.com/896472/85953621-a938d480-b969-11ea-97f5-c471d3a63636.png)

To this:
![image](https://user-images.githubusercontent.com/896472/85953627-b05fe280-b969-11ea-88a4-0829f1feb02f.png)
