### PR TITLE
fix(migrate): read from .env.production

### DIFF
--- a/sh/setup-migration-script.sh
+++ b/sh/setup-migration-script.sh
@@ -14,8 +14,12 @@ set -uo pipefail
 
 echo "[migrate] Migrating BHIMA database"
 
+ENVIRONMENT=${ENVIRONMENT:-"production"}
+
+echo "[migrate] Reading from $ENVIRONMENT."
+
 set -a
-source .env.development
+source .env.$ENVIRONMENT
 set +a
 
 # Set up variables used for naming things


### PR DESCRIPTION
Defaults to reading from `.env.production` from the migration setup script.

Closes #4665.