### PR TITLE
Add totals and consider unposted transactions

### DIFF
--- a/client/src/modules/reports/generate/collectionCapacity/collectionCapacity.config.js
+++ b/client/src/modules/reports/generate/collectionCapacity/collectionCapacity.config.js
@@ -12,7 +12,7 @@ function CollectionCapacityController($sce, Notify, SavedReports, AppCache, repo
   const reportUrl = 'reports/finance/collectionCapacity';
 
   vm.previewGenerated = false;
-  vm.reportDetails = {};
+  vm.reportDetails = { includeUnpostedValues : 0 };
 
   vm.onChangeUnpostedValues = value => {
     vm.reportDetails.includeUnpostedValues = value;

--- a/client/src/modules/reports/generate/collectionCapacity/collectionCapacity.config.js
+++ b/client/src/modules/reports/generate/collectionCapacity/collectionCapacity.config.js
@@ -14,6 +14,10 @@ function CollectionCapacityController($sce, Notify, SavedReports, AppCache, repo
   vm.previewGenerated = false;
   vm.reportDetails = {};
 
+  vm.onChangeUnpostedValues = value => {
+    vm.reportDetails.includeUnpostedValues = value;
+  };
+
   vm.clearPreview = function clearPreview() {
     vm.previewGenerated = false;
     vm.previewResult = null;

--- a/client/src/modules/reports/generate/collectionCapacity/collectionCapacity.html
+++ b/client/src/modules/reports/generate/collectionCapacity/collectionCapacity.html
@@ -29,6 +29,15 @@
               limit-min-fiscal>
             </bh-date-interval>
 
+            <bh-yes-no-radios
+              value="ReportConfigCtrl.reportDetails.includeUnpostedValues"
+              name="includeUnpostedValues"
+              on-change-callback="ReportConfigCtrl.onChangeUnpostedValues(value)"
+              name="includeUnpostedValues"
+              label="REPORT.OPTIONS.INCLUDE_UNPOSTED_RECORDS"
+              help-text="REPORT.OPTIONS.INCLUDE_UNPOSTED_RECORDS_HELP">
+            </bh-yes-no-radios>
+
             <bh-loading-button loading-state="ConfigForm.$loading">
               <span translate>REPORT.UTIL.PREVIEW</span>
             </bh-loading-button>

--- a/server/controllers/finance/reports/collection_capacity/index.js
+++ b/server/controllers/finance/reports/collection_capacity/index.js
@@ -36,6 +36,26 @@ async function report(req, res, next) {
     const INVOICE_TRANSACTION_TYPE = 11;
     const INCOME_ACCOUNT_TYPE = 4;
 
+    const formatedDateFrom = moment(dateFrom).format('YYYY-MM-DD');
+    const formatedDateTo = moment(dateTo).format('YYYY-MM-DD');
+
+    const includeUnpostedValues = qs.includeUnpostedValues ? Number(qs.includeUnpostedValues) : 0;
+    let generalTable = 'general_ledger';
+
+    if (includeUnpostedValues) {
+      generalTable = `
+      (
+        SELECT trans_id, description, trans_date, debit_equiv, credit_equiv, currency_id, debit, credit,
+          account_id, record_uuid, reference_uuid, created_at, transaction_type_id
+        FROM posting_journal WHERE DATE(trans_date) BETWEEN DATE("${formatedDateFrom}") AND DATE("${formatedDateTo}")
+        UNION ALL 
+        SELECT trans_id, description, trans_date, debit_equiv, credit_equiv, currency_id, debit, credit,
+          account_id, record_uuid, reference_uuid, created_at, transaction_type_id
+        FROM general_ledger WHERE DATE(trans_date) BETWEEN DATE("${formatedDateFrom}") AND DATE("${formatedDateTo}")
+      )
+      `;
+    }
+
     /**
      * credit to :
      * https://www.shayanderson.com/mysql/generating-a-series-of-dates-in-mysql.htm
@@ -67,7 +87,7 @@ async function report(req, res, next) {
 
     const invoices = `
       SELECT DATE(gl.trans_date) invoice_date, SUM(IFNULL(credit_equiv - debit_equiv, 0)) AS total_invoiced 
-      FROM general_ledger gl
+      FROM ${generalTable} gl
       JOIN invoice i ON i.uuid = gl.record_uuid
       JOIN account a ON a.id = gl.account_id
       WHERE gl.transaction_type_id IN (${INVOICE_TRANSACTION_TYPE})
@@ -78,7 +98,7 @@ async function report(req, res, next) {
 
     const payments = `
       SELECT DATE(gl.trans_date) trans_date, SUM(IFNULL(debit_equiv - credit_equiv, 0)) AS total_paid 
-      FROM general_ledger gl
+      FROM ${generalTable} gl
       JOIN cash c ON c.uuid = gl.record_uuid
       WHERE gl.transaction_type_id IN (${CASH_PAYMENT_TRANSACTION_TYPE}, ${CAUTION_TRANSACTION_TYPE})
         AND (DATE(gl.trans_date) >= DATE(?) AND DATE(gl.trans_date) <= DATE(?))
@@ -98,6 +118,25 @@ async function report(req, res, next) {
       ORDER BY d.date
     `;
 
+    const queryTotals = `
+      SELECT w.registrations, w.total_invoiced, w.total_paid,
+        IF(w.registrations <> 0, (IFNULL(w.total_invoiced, 0) / w.registrations), 0) avg_cost,
+        IF(w.total_invoiced <> 0, ROUND((IFNULL(w.total_paid, 0) / w.total_invoiced), 2), 0) recovery_capacity
+      FROM (
+        SELECT 
+          SUM(IFNULL(pa.registrations, 0)) registrations,
+          SUM(i.total_invoiced) total_invoiced,
+          SUM(IFNULL(p.total_paid, 0)) total_paid,
+          SUM(IF(pa.registrations <> 0, (IFNULL(i.total_invoiced, 0) / pa.registrations), 0)) avg_cost,
+          SUM(IF(i.total_invoiced <> 0, ROUND((IFNULL(p.total_paid, 0) / i.total_invoiced), 2), 0)) recovery_capacity
+        FROM (${dateRange}) d
+        LEFT JOIN (${invoices}) i ON i.invoice_date = d.date
+        LEFT JOIN (${payments}) p ON p.trans_date = d.date
+        LEFT JOIN (${patients}) pa ON pa.registration_date = d.date
+        ORDER BY d.date
+      ) w;
+  `;
+
     const queryAuxiliaryCashboxes = `
       SELECT cac.account_id AS id FROM cash_box_account_currency cac 
       JOIN cash_box cb ON cb.id = cac.cash_box_id
@@ -107,9 +146,6 @@ async function report(req, res, next) {
     const auxiliaryCashboxesAccountRows = await db.exec(queryAuxiliaryCashboxes);
     const auxiliaryCashboxesAccountIds = auxiliaryCashboxesAccountRows.map(item => item.id);
 
-    const formatedDateFrom = moment(dateFrom).format('YYYY-MM-DD');
-    const formatedDateTo = moment(dateTo).format('YYYY-MM-DD');
-
     const parameters = [
       formatedDateTo, formatedDateTo, formatedDateFrom, formatedDateTo,
       formatedDateFrom, formatedDateTo,
@@ -118,11 +154,14 @@ async function report(req, res, next) {
     ];
 
     const rows = await db.exec(query, parameters);
+    const totals = await db.one(queryTotals, parameters);
 
     const result = await rpt.render({
       dateFrom,
       dateTo,
       rows,
+      totals,
+      includeUnpostedValues,
     });
 
     res.set(result.headers).send(result.report);

--- a/server/controllers/finance/reports/collection_capacity/report.handlebars
+++ b/server/controllers/finance/reports/collection_capacity/report.handlebars
@@ -12,6 +12,7 @@
       <!-- page title  -->
       <h3 class="text-center text-uppercase">
         <strong>{{translate 'REPORT.COLLECTION_CAPACITY.TITLE'}}</strong> <br>
+        {{#if includeUnpostedValues}}<strong>({{translate 'REPORT.PROVISIONARY'}})</strong><br>{{/if}}
         <small>{{date dateFrom}} - {{date dateTo}}</small>
       </h3>
 
@@ -61,6 +62,22 @@
           </tr>
           {{/each}}
         </tbody>
+        <tfoot>
+          <tr>
+            <th>{{translate 'TABLE.COLUMNS.TOTAL'}}</th>
+            <th style="width: 10em;" class="text-right">{{totals.registrations}}</th>
+            <th class="text-right">{{debcred totals.total_invoiced metadata.enterprise.currency_id}}</th>
+            <th class="text-right">{{debcred totals.avg_cost metadata.enterprise.currency_id}}</th>
+            <th class="text-right">{{debcred totals.total_paid metadata.enterprise.currency_id}}</th>
+            <th 
+              style="width: 15em;"
+              {{#gt totals.recovery_capacity 0.71}} class="bg-success text-success text-right" {{/gt}}
+              {{#between totals.recovery_capacity 0.6 0.7}} class="bg-warning text-warning text-right" {{/between}}
+              {{#lt totals.recovery_capacity 0.6}} class="bg-danger text-danger text-right" {{/lt}}>
+              {{percentage totals.recovery_capacity}}
+            </th>
+          </tr>
+        </tfoot>
       </table>
 
     </div>


### PR DESCRIPTION
This PR : 
- Add totals in the footer of the recovery capacity table
- Add option for not posted transaction

This work is related to #4663 