### PR TITLE
docs: add notes on AMC in stock exit

### DIFF
--- a/docs/en/glossary.md
+++ b/docs/en/glossary.md
@@ -1,0 +1,17 @@
+# Glossary
+
+## A
+
+##### Average Monthly Consumption (AMC)
+The average monthly consumption is a measure of the consumption of a drug or medication by patients or hospital services.  Importantly, the AMC does _not_ include the loss of drugs due to expiry, theft, or other losses.  The AMC may be defined for the entire institution or by pharmacy in the institution.
+
+## I
+
+##### Integration
+Integration is a method of increasing or decreasing the quantity in stock of a particular stock lot.  It's used to perform adjustments to the stock in a depot/pharmacy after an inventory is performed and quantities need to be adjusted to match the real quantity in stock.
+
+
+## S
+
+##### Service
+A service is a department in the hospital.  Services can be assigned invoices, consume medications, contain staff, and have both profit and loss centers.   They are useful for understanding where in the hospital financial activities are taking place.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -10,6 +10,7 @@ This manual is split into chapters:
 4. [Inventory and Stock Management](./stock-management)
 5. Reporting and Statistics
 6. [Developer Reference](./for-developers)
+7. [Glossary](./glossary.md)
 
 # About
 

--- a/docs/en/stock-management/movement.exit.md
+++ b/docs/en/stock-management/movement.exit.md
@@ -1,3 +1,30 @@
-&raquo; [Home](../index.md) / [Inventory Management](./index.md) /  [stocks movements](./movement.md) / Stock Exit
+&raquo; [Home](../index.md) / [Inventory Management](./index.md) / [Stock Movements](./movement.md) / Stock Exit
 
 # Stock Exit
+
+Any outflows of stock from a depot is a stock exit in BHIMA.  The available options are:
+
+1. Exit to Patient *
+2. Exit to a Service *
+3. Transfer to a Depot
+4. Exit to record a Loss
+
+The stock exits marked with an asterisk are _consumptions_ and influence the [average monthly consumption (AMC)](#average-monthly-consumption).  All other types of exits are not considered in the AMC calculation.
+
+Note that stock exits to a patient, service, or recording a loss effectively remove stock items from the enterprise.  The only way to replenish stock after an exit is made is to perform a stock adjustment.
+
+# Average Monthly Consumption (AMC)
+
+The Average Monthly Consumption (AMC) in BHIMA is _currently_ defined as follows:
+
+```sh
+AMC = SUM(quantity consumed) / COUNT(days with a stock consumption event)
+```
+
+Technically, this is not a complete metric.  This is being tracked in [#4346](https://github.com/IMA-WorldHealth/bhima/issues/4346).  We are working towards implementing the following:
+
+```sh
+AMC = SUM(quantity consumed) / COUNT(days with stock on hand)
+```
+
+However, for highly used medications, both calculations should approach the same value.

--- a/docs/en/stock-management/movement.md
+++ b/docs/en/stock-management/movement.md
@@ -13,10 +13,11 @@ Thanks to BHIMA it is possible to carry out stock movements such as:
 - [Stock exits](./movement.exit.md)
   - To a patient
   - To a service
-  - To another deposit
+  - To another depot
   - As a stock loss
 - [Stock adjustments](./movement.adjustment.md): When the physical quantities differ from the quantities in BHIMA, it is possible to adjust either positively or negatively the quantity of stocks concerned.
 
-<div class = "bs-callout bs-callout-info">
-It should be noted that any movement of stocks (inflows, outflows, adjustments) is recorded in the inventory movement register. This allows you to have the history of stock movements at any time.
+<div class="bs-callout bs-callout-info">
+  It should be noted that any movement of stocks (inflows, outflows, adjustments) is recorded in the stock
+  movement registry. This allows you to have the history of stock movements at any time.
 </div>


### PR DESCRIPTION
Added some more formal documentation on stock exits in English and notes on the AMC calculation.  This documentation will be updated when we have all components of the stock management working correctly.

-----
[View rendered docs/en/stock-management/movement.exit.md](https://github.com/jniles/bhima/blob/docs-add-notes-on-AMC-for-stock-movements/docs/en/stock-management/movement.exit.md)
[View rendered docs/en/stock-management/movement.md](https://github.com/jniles/bhima/blob/docs-add-notes-on-AMC-for-stock-movements/docs/en/stock-management/movement.md)