### PR TITLE
Added 'temp' directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ nbproject/
 # Ignore test files
 sh/build-database-test.sh
 
+# Ignore local temporary files
+temp/
+
 # ignore documentation bad files
 docs/_site/
 docs/.sass-cache/


### PR DESCRIPTION
Allow developers to create a local 'temp' directory for development files, etc, that git will ignore.
