### PR TITLE
4687: feat add expired flag to lots in stock

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,7 +1,6 @@
 # Server Config
 PORT=8080
 
-
 # database configuration
 DB_HOST='localhost'
 DB_USER='bhima'

--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -1,5 +1,4 @@
-{
-  "STOCK" : {
+{ "STOCK" : {
     "ALERT"           : "Alert",
     "ADJUSTMENT"      : "Adjustment",
     "ADJUSTMENT_TYPE" : "Adjustment Type",
@@ -21,6 +20,7 @@
     "DOCUMENT"        : "Document",
     "DONATION"        : "Donation",
     "EMPTY"           : "You do not have any stock in your depot",
+    "EXPIRED"         : "Expired",
     "ENTRY"           : "Stock Entry",
     "ENTRY_DATE"      : "Entry Date",
     "ENTRY_DOCUMENT"  : "Entry Document",
@@ -161,7 +161,9 @@
     "UNIT_COST"       : "Unit cost",
     "ANTERIOR_DATE_QUANTITY_MESSAGE" : "You have chosen a past date. Only the lots available on the chosen date will be visible as well as the quantity on this date",
     "STOCK_COST_DESCRIPTION" : "Monetary values are based on the cost of purchasing inventory, not the selling price",
-    "STOCK_UNIT_COST_ROUNDED" : "The unit cost is rounded with two decimals"
+    "STOCK_UNIT_COST_ROUNDED" : "The unit cost is rounded with two decimals",
+    "TOGGLE_EXPIRED_STOCK" : "Show expired lots?",
+    "TOGGLE_EXPIRED_STOCK_HELP_TEXT" : "This will add a filter on lots that are expired."
   },
   "SETTINGS" : {
     "ORDER_BY_CREATED_AT" : "Sort lots movements by their true creation date",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -21,6 +21,7 @@
     "DOCUMENT"        : "Document",
     "DONATION"        : "Donation",
     "EMPTY"           : "Vous n'avez aucun stock dans votre dépôt",
+    "EXPIRED"         : "Expiré",
     "ENTRY"           : "Entrée de stock",
     "ENTRY_DATE"      : "Date d'entrée",
     "ENTRY_DOCUMENT"  : "Document d'entrée",
@@ -161,7 +162,9 @@
     "UNIT_COST"       : "Coût unitaire",
     "ANTERIOR_DATE_QUANTITY_MESSAGE" : "Vous avez choisi une date anterieur, seul les lots disponibles à la date choisie seront visibles ainsi que la quantité à cette date",
     "STOCK_COST_DESCRIPTION" : "Les valeurs monetaires sont basées sur le coût d'achat de stock et non sur le prix de vente",
-    "STOCK_UNIT_COST_ROUNDED" : "Le cout unitaire est arrondi avec deux decimales"
+    "STOCK_UNIT_COST_ROUNDED" : "Le cout unitaire est arrondi avec deux decimales",
+    "TOGGLE_EXPIRED_STOCK" : "Afficher le stock expiré?",
+    "TOGGLE_EXPIRED_STOCK_HELP_TEXT" : "Cela ajoutera un filtre sur les lots arrivés à expiration."
   },
   "SETTINGS" : {
     "ORDER_BY_CREATED_AT" : "Ordonner les mouvements de lots par leurs dates de création",

--- a/client/src/modules/stock/StockFilterer.service.js
+++ b/client/src/modules/stock/StockFilterer.service.js
@@ -30,6 +30,7 @@ function StockFiltererService(Filters, AppCache, Periods, $httpParamSerializer, 
     { key : 'patientReference', label : 'FORM.LABELS.REFERENCE_PATIENT' },
     { key : 'requestor_uuid', label : 'REQUISITION.RECEIVER' },
     { key : 'service_uuid', label : 'STOCK.SERVICE' },
+    { key : 'is_expired', label : 'STOCK.EXPIRED' },
     {
       key : 'dateFrom', label : 'FORM.LABELS.DATE', comparitor : '>', valueFilter : 'date',
     },

--- a/client/src/modules/stock/lots/modals/search.modal.html
+++ b/client/src/modules/stock/lots/modals/search.modal.html
@@ -69,6 +69,15 @@
             mode="clean">
           </bh-date-interval>
 
+          <bh-yes-no-radios
+            label="STOCK.TOGGLE_EXPIRED_STOCK"
+            value="$ctrl.searchQueries.is_expired"
+            name="is_expired"
+            help-text="STOCK.TOGGLE_EXPIRED_STOCK_HELP_TEXT"
+            on-change-callback="$ctrl.onToggleExpired(value)">
+            <bh-clear on-clear="$ctrl.clear('is_expired')"></bh-clear>
+          </bh-yes-no-radios>
+
           <!-- include exhausted lots  -->
           <div class="checkbox">
             <label>

--- a/client/src/modules/stock/lots/modals/search.modal.js
+++ b/client/src/modules/stock/lots/modals/search.modal.js
@@ -18,11 +18,15 @@ function SearchLotsModalController(data, util, Store, Instance, Periods, Stock, 
   const searchQueryOptions = [
     'depot_uuid', 'inventory_uuid', 'group_uuid', 'label', 'entry_date_from',
     'entry_date_to', 'expiration_date_from', 'expiration_date_to', 'includeEmptyLot',
+    'is_expired',
   ];
 
   // displayValues will be an id:displayValue pair
   const displayValues = {};
   const lastDisplayValues = Stock.filter.lot.getDisplayValueMap();
+
+  // assign already defined custom filters to searchQueries object
+  vm.searchQueries = util.maskObjectFromKeys(data, searchQueryOptions);
 
   // default filter period - directly write to changes list
   vm.onSelectPeriod = function onSelectPeriod(period) {
@@ -50,8 +54,10 @@ function SearchLotsModalController(data, util, Store, Instance, Periods, Stock, 
     displayValues.includeEmptyLot = vm.searchQueries.includeEmptyLot;
   };
 
-  // assign already defined custom filters to searchQueries object
-  vm.searchQueries = util.maskObjectFromKeys(data, searchQueryOptions);
+  // toggle expired stock
+  vm.onToggleExpired = function onToggleExpired(bool) {
+    vm.searchQueries.is_expired = bool;
+  };
 
   if (data.limit) {
     vm.defaultQueries.limit = data.limit;

--- a/test/integration/stock/stock.js
+++ b/test/integration/stock/stock.js
@@ -74,7 +74,6 @@ describe('(/stock/) The Stock HTTP API', () => {
       .catch(helpers.handler),
   );
 
-
   // list all movement relatives to 'Service Administration'
   it(
     `GET /stock/lots/movements?service_uuid=...
@@ -184,14 +183,29 @@ describe('(/stock/) The Stock HTTP API', () => {
       .catch(helpers.handler),
   );
 
-  it(
-    `/stock/inventories/depots Get Inventories in Stock By Depot`,
-    () => agent.get(`/stock/inventories/depots?depot_uuid=${shared.depotPrincipalUuid}&limit=1000&includeEmptyLot=0`)
-      .then((res) => {
-        helpers.api.listed(res, 4);
+  it(`GET /stock/inventories/depots filters on expired lots`,
+    () => agent.get(`/stock/inventories/depots`)
+      .query({ limit : 1000, includeEmptyLot : 0, is_expired : 1 })
+      .then(res => {
+        helpers.api.listed(res, 5);
+      })
+      .catch(helpers.handler));
 
-        // This is the test of automatically calculated key values
-        /*
+  it(`GET /stock/inventories/depots filters on non-expired lots`,
+    () => agent.get(`/stock/inventories/depots`)
+      .query({ limit : 1000, includeEmptyLot : 0, is_expired : 0 })
+      .then(res => {
+        helpers.api.listed(res, 1);
+      })
+      .catch(helpers.handler));
+
+  it(`GET /stock/inventories/depots Get Inventories in Stock By Depot`, () => agent.get(`/stock/inventories/depots`)
+    .query({ depot_uuid : shared.depotPrincipalUuid, limit : 1000, includeEmptyLot : 0 })
+    .then((res) => {
+      helpers.api.listed(res, 4);
+
+      // This is the test of automatically calculated key values
+      /*
         expect(res.body[1].quantity).to.be.equal(155);
         expect(res.body[1].avg_consumption).to.be.equal(10);
         expect(res.body[1].S_SEC).to.be.equal(10);
@@ -207,21 +221,20 @@ describe('(/stock/) The Stock HTTP API', () => {
         expect(res.body[2].S_MONTH).to.be.equal(3);
         */
 
-        expect(res.body[1].quantity).to.be.equal(150);
-        expect(res.body[1].avg_consumption).to.be.equal(10);
-        expect(res.body[1].S_SEC).to.be.equal(10);
-        expect(res.body[1].S_MIN).to.be.equal(20);
-        expect(res.body[1].S_MAX).to.be.equal(20);
-        expect(res.body[1].S_MONTH).to.be.equal(15);
+      expect(res.body[1].quantity).to.be.equal(150);
+      expect(res.body[1].avg_consumption).to.be.equal(10);
+      expect(res.body[1].S_SEC).to.be.equal(10);
+      expect(res.body[1].S_MIN).to.be.equal(20);
+      expect(res.body[1].S_MAX).to.be.equal(20);
+      expect(res.body[1].S_MONTH).to.be.equal(15);
 
-        expect(res.body[2].quantity).to.be.equal(180300);
-        expect(res.body[2].avg_consumption).to.be.equal(49916.67);
-        expect(res.body[2].S_SEC).to.be.equal(49916.67);
-        expect(res.body[2].S_MIN).to.be.equal(99833.34);
-        expect(res.body[2].S_MAX).to.be.equal(99833.34);
-        expect(res.body[2].S_MONTH).to.be.equal(3);
+      expect(res.body[2].quantity).to.be.equal(180300);
+      expect(res.body[2].avg_consumption).to.be.equal(49916.67);
+      expect(res.body[2].S_SEC).to.be.equal(49916.67);
+      expect(res.body[2].S_MIN).to.be.equal(99833.34);
+      expect(res.body[2].S_MAX).to.be.equal(99833.34);
+      expect(res.body[2].S_MONTH).to.be.equal(3);
 
-      })
-      .catch(helpers.handler),
-  );
+    })
+    .catch(helpers.handler));
 });


### PR DESCRIPTION
This PR adds a filter on the lots registry to filter on expired stock.  See below for it in action.
![LgtxJK8Set](https://user-images.githubusercontent.com/896472/87653113-faf4a380-c74c-11ea-91f4-b9e2dba47555.gif)

Importantly, the "expiration" flag is set on the server time, not the client time.  Therefore, stock items will be marked as expired if their expiration dates are in the past according to the server.

Closes #4687 