### PR TITLE
Add Enterprise flag for automatic confirmation of purchase orders.  Fixes #4725

### DIFF
--- a/client/src/i18n/en/enterprise.json
+++ b/client/src/i18n/en/enterprise.json
@@ -23,6 +23,8 @@
       "ENABLE_PREPAYMENT_INVOICE_HELP_TEXT" : "Enable to see the balance and the paid amount on an invoice",
       "ENABLE_BARCODES_LABEL" : "Enables barcodes throughout the application",
       "ENABLE_BARCODES_HELP_TEXT" : "Enable to place barcodes on most printed records and enable options to scan barcodes for document inputs.",
+      "ENABLE_AUTO_PURCHASE_ORDER_CONFIRMATION_LABEL" : "Enable automatic confirmation of purchase orders",
+      "ENABLE_AUTO_PURCHASE_ORDER_CONFIRMATION_HELP_TEXT" : "Enable automatic confirmation of purchase orders when they are created without requiring manual confirmation",
       "ENABLE_AUTO_STOCK_ACCOUNTING_LABEL" : "Enables realtime stock accounting",
       "ENABLE_AUTO_STOCK_ACCOUNTING_HELP_TEXT" : "Enabling this feature will write stock movement transactions into the posting journal in real time. It requires all inventory accounts to be correctly configured.",
       "ENABLE_AUTO_EMAIL_REPORT_LABEL" : "Enable sending automatic reports by email",

--- a/client/src/i18n/fr/enterprise.json
+++ b/client/src/i18n/fr/enterprise.json
@@ -23,6 +23,8 @@
       "ENABLE_PREPAYMENT_INVOICE_HELP_TEXT" : "L'activation de cette option permet de voir les montants payés ainsi que le solde pour une facture",
       "ENABLE_BARCODES_LABEL" : "Activer les codes à barres dans l'application",
       "ENABLE_BARCODES_HELP_TEXT" : "L'activation de cette fonction placera des codes à barres sur la plupart des enregistrements imprimés et activera les options permettant de numériser des codes à barres pour les entrées de document.",
+      "ENABLE_AUTO_PURCHASE_ORDER_CONFIRMATION_LABEL" : "Activer la confirmation automatique des commandes d'achat",
+      "ENABLE_AUTO_PURCHASE_ORDER_CONFIRMATION_HELP_TEXT" : "Activer la confirmation automatique des bons de commande lorsqu'ils sont créés sans nécessiter de confirmation manuelle.",
       "ENABLE_AUTO_STOCK_ACCOUNTING_LABEL" : "Activer la comptabilisation de stock en temps réel",
       "ENABLE_AUTO_STOCK_ACCOUNTING_HELP_TEXT" : "L'activation de cette option va écrire automatiquement et en temps réel dans le journal toutes les transactions liées aux mouvements de stock. Les comptes des inventaires et groupes d'inventaire doivent être bien configurés au préalable",
       "ENABLE_AUTO_EMAIL_REPORT_LABEL" : "Activer l'envoie des rapports automatiques par email",

--- a/client/src/modules/enterprises/enterprises.html
+++ b/client/src/modules/enterprises/enterprises.html
@@ -284,6 +284,14 @@
               </bh-yes-no-radios>
 
               <bh-yes-no-radios
+                label="ENTERPRISE.SETTINGS.ENABLE_AUTO_PURCHASE_ORDER_CONFIRMATION_LABEL"
+                value="EnterpriseCtrl.enterprise.settings.enable_auto_purchase_order_confirmation"
+                name="enable_auto_purchase_order_confirmation"
+                help-text="ENTERPRISE.SETTINGS.ENABLE_AUTO_PURCHASE_ORDER_CONFIRMATION_HELP_TEXT"
+                on-change-callback="EnterpriseCtrl.enableAutoPurchaseOrderConfirmationSetting(value)">
+              </bh-yes-no-radios>
+
+              <bh-yes-no-radios
                 label="ENTERPRISE.SETTINGS.ENABLE_DAILY_CONSUMPTION_LABEL"
                 value="EnterpriseCtrl.enterprise.settings.enable_daily_consumption"
                 name="enable_daily_consumption"

--- a/client/src/modules/enterprises/enterprises.js
+++ b/client/src/modules/enterprises/enterprises.js
@@ -225,6 +225,7 @@ function EnterpriseController(Enterprises, util, Notify, Projects, Modal, Scroll
   vm.enableBalanceOnInvoiceReceipSetting = proxy('enable_balance_on_invoice_receipt');
   vm.enableBarcodesSetting = proxy('enable_barcodes');
   vm.enableAutoStockAccountingSetting = proxy('enable_auto_stock_accounting');
+  vm.enableAutoPurchaseOrderConfirmationSetting = proxy('enable_auto_purchase_order_confirmation');
   vm.enableAutoEmailReportSetting = proxy('enable_auto_email_report');
   vm.enableIndexPaymentSetting = proxy('enable_index_payment_system');
   vm.enableDailyConsumptionSetting = proxy('enable_daily_consumption');

--- a/server/controllers/admin/enterprises.js
+++ b/server/controllers/admin/enterprises.js
@@ -25,7 +25,7 @@ exports.list = function list(req, res, next) {
         BUID(location_id) AS location_id, logo, currency_id,
         gain_account_id, loss_account_id, enable_price_lock, enable_prepayments,
         enable_delete_records, enable_password_validation, enable_balance_on_invoice_receipt,
-        enable_barcodes, enable_auto_stock_accounting,
+        enable_barcodes, enable_auto_stock_accounting, enable_auto_purchase_order_confirmation,
         enable_auto_email_report, enable_index_payment_system,
         month_average_consumption, enable_daily_consumption
       FROM enterprise LEFT JOIN enterprise_setting
@@ -50,6 +50,7 @@ exports.list = function list(req, res, next) {
             'enable_balance_on_invoice_receipt',
             'enable_barcodes',
             'enable_auto_stock_accounting',
+            'enable_auto_purchase_order_confirmation',
             'enable_auto_email_report',
             'enable_index_payment_system',
             'month_average_consumption',

--- a/server/controllers/finance/purchases.js
+++ b/server/controllers/finance/purchases.js
@@ -24,6 +24,10 @@ const identifiers = require('../../config/identifiers');
 const FilterParser = require('../../lib/filter');
 const util = require('../../lib/util');
 
+// See the schema for purchase_status and the value of
+// PURCHASES.STATUS.CONFIRMED in the bhima.sql data
+const PURCHASE_STATUS_CONFIRMED_ID = 2;
+
 const entityIdentifier = identifiers.PURCHASE_ORDER.key;
 
 // create a new purchase order
@@ -166,6 +170,10 @@ function create(req, res, next) {
   data.user_id = req.session.user.id;
   data.project_id = req.session.project.id;
   data.currency_id = req.session.enterprise.currency_id;
+
+  if (req.session.enterprise.settings.enable_auto_purchase_order_confirmation) {
+    data.status_id = PURCHASE_STATUS_CONFIRMED_ID;
+  }
 
   const sql = 'INSERT INTO purchase SET ?';
 

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -98,4 +98,4 @@ ALTER TABLE `village` DROP INDEX `village_1`;
 Add flag for automatic confirmation of purchase orders to the enterprise settings
 */
 
-ALTER TABLE `enterprise_setting` ADD COLUMN `enable_auto_stock_accounting` TINYINT(1) NOT NULL DEFAULT 1;
+ALTER TABLE `enterprise_setting` ADD COLUMN `enable_auto_purchase_order_confirmation` TINYINT(1) NOT NULL DEFAULT 1;

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -90,3 +90,12 @@ ALTER TABLE `province` DROP INDEX `province_1`;
 ALTER TABLE `sector` DROP INDEX `sector_1`;
 
 ALTER TABLE `village` DROP INDEX `village_1`;
+
+
+/*
+@author jmcameron
+@description
+Add flag for automatic confirmation of purchase orders to the enterprise settings
+*/
+
+ALTER TABLE `enterprise_setting` ADD COLUMN `enable_auto_stock_accounting` TINYINT(1) NOT NULL DEFAULT 1;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -572,6 +572,7 @@ CREATE TABLE `enterprise_setting` (
   `enable_balance_on_invoice_receipt` TINYINT(1) NOT NULL DEFAULT 0,
   `enable_barcodes` TINYINT(1) NOT NULL DEFAULT 1,
   `enable_auto_stock_accounting` TINYINT(1) NOT NULL DEFAULT 1,
+  `enable_auto_purchase_order_confirmation` TINYINT(1) NOT NULL DEFAULT 0,
   `enable_auto_email_report` TINYINT(1) NOT NULL DEFAULT 0,
   `enable_index_payment_system` TINYINT(1) NOT NULL DEFAULT 0,
   `month_average_consumption` SMALLINT(5) NOT NULL DEFAULT 6,

--- a/test/data.sql
+++ b/test/data.sql
@@ -9,8 +9,8 @@ SET NAMES 'utf8';
 INSERT INTO `enterprise` VALUES
   (1, 'Test Enterprise', 'TE', '243 81 504 0540', 'enterprise@test.org', HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, 2, 103, NULL, NULL);
 
-INSERT INTO `enterprise_setting` (enterprise_id, enable_price_lock, enable_password_validation, enable_delete_records, enable_auto_email_report, enable_auto_stock_accounting) VALUES
-  (1, 0, 1, 1, 1, 0);
+INSERT INTO `enterprise_setting` (enterprise_id, enable_price_lock, enable_password_validation, enable_delete_records, enable_auto_email_report, enable_auto_stock_accounting, enable_auto_purchase_order_confirmation) VALUES
+  (1, 0, 1, 1, 1, 0, 0);
 
 -- Project
 INSERT INTO `project` VALUES


### PR DESCRIPTION
Testing procedure:
 * Verify that the new Enterprise settings "Enable automatic confirmation of purchase orders" flag works
 * Verify that restarting Bhima keeps the previous setting (eg, that the setting is being properly stored in the DB).
 * Set to default enterprise setting, confirm = NO
 * Add a purchase order, verify that the PO is NOT confirmed
 * Change the enterprise setting, confirm = YES
 * Add a purchase order, verify that the PO is confirmed

Translation:
   * Check the French translation (make sure Google Translate did okay)!
