### PR TITLE
Expose database port in env

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,6 +2,7 @@
 PORT=8080
 
 # database configuration
+DB_PORT=3306
 DB_HOST='localhost'
 DB_USER='bhima'
 DB_PASS='HISCongo2013'

--- a/server/lib/db/index.js
+++ b/server/lib/db/index.js
@@ -26,6 +26,7 @@ const NotFound = require('../errors/NotFound');
 class DatabaseConnector {
   constructor() {
     const params = {
+      port     : process.env.DB_PORT,
       host     : process.env.DB_HOST,
       user     : process.env.DB_USER,
       password : process.env.DB_PASS,


### PR DESCRIPTION
Exposing the database port in the environnement file for using bhima with MAMP or other system which doesn't run MySQL database on 3306