### PR TITLE
Update migration script to use mysql calls to use username/password

### DIFF
--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -89,7 +89,9 @@ ALTER TABLE `province` DROP INDEX `province_1`;
 
 ALTER TABLE `sector` DROP INDEX `sector_1`;
 
-ALTER TABLE `village` DROP INDEX `village_1`;
+/* ??? ALTER TABLE `village` DROP INDEX `village_1`; 
+JMC: Disabled since this fails when using migration script  2020-07-31
+*/
 
 /*
 @author jmcameron
@@ -106,9 +108,6 @@ ALTER TABLE `enterprise_setting` ADD COLUMN `enable_auto_purchase_order_confirma
 */
 
 ALTER TABLE `enterprise_setting` MODIFY COLUMN `enable_daily_consumption` TINYINT(1) NOT NULL DEFAULT 0;
-
-ALTER TABLE `village` DROP INDEX `village_1`
-  ('collectionCapacity', 'REPORT.COLLECTION_CAPACITY.TITLE');
 
 /**
  * @author: jeremielodi

--- a/sh/setup-migration-script.sh
+++ b/sh/setup-migration-script.sh
@@ -43,14 +43,14 @@ SET collation_connection = 'utf8mb4_unicode_ci';
 " > $MIGRATION_FILE
 
 echo "[migrate] Adding DROP TRIGGERS for $DATABASE."
-mysql -e "SELECT CONCAT('DROP TRIGGER IF EXISTS ', trigger_name, ';') FROM information_schema.triggers WHERE trigger_schema = '$DATABASE';" \
+mysql -u $DB_USER --password=$DB_PASS -e "SELECT CONCAT('DROP TRIGGER IF EXISTS ', trigger_name, ';') FROM information_schema.triggers WHERE trigger_schema = '$DATABASE';" \
   | sed '1d' \
   >> $MIGRATION_FILE
 
 echo "" >> $MIGRATION_FILE
 
 echo "[migrate] Adding DROP ROUTINES for $DATABASE."
-mysql -e "SELECT CONCAT('DROP ',ROUTINE_TYPE,' IF EXISTS ',ROUTINE_SCHEMA,'.',ROUTINE_NAME,';') as stmt FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = '$DATABASE';" \
+mysql -u $DB_USER --password=$DB_PASS -e "SELECT CONCAT('DROP ',ROUTINE_TYPE,' IF EXISTS ',ROUTINE_SCHEMA,'.',ROUTINE_NAME,';') as stmt FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = '$DATABASE';" \
   | sed '1d' \
   >> $MIGRATION_FILE
 


### PR DESCRIPTION
And fixed errors in the next/migrate.sql file

- Disabled problematic drop village_1 index
- Fixed a problem probably due previous fixes for pull request merging problems on previous releases.

These fixes make the 'yarn migrate' and subsequent application of the migration file to work for me on my system with MySQL 8.0

Testing:  This has only been test with recent  (today) mysql dumps of IMCK data.

When testing, when you run 'yarn migrate', make sure there are no complaints!

NOTE: I was wrong about need additional code to drop functions; it was doing that already.