### PR TITLE
fix(csp): adds font and blob src to whitelist

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -40,7 +40,14 @@ exports.configure = function configure(app) {
   debug('configuring middleware.');
 
   // helmet guards
-  app.use(helmet({ contentSecurityPolicy : { directives : { defaultSrc : ['\'self\'', '\'unsafe-inline\''] } } }));
+  app.use(helmet({
+    contentSecurityPolicy : {
+      directives : {
+        defaultSrc : ['\'self\'', '\'unsafe-inline\'', 'blob:'],
+        fontSrc : ['\'self\'', '\'https://fonts.gstatic.com\''],
+      },
+    },
+  }));
 
   app.use(bodyParser.json({ limit : '8mb' }));
   app.use(bodyParser.urlencoded({ extended : false }));


### PR DESCRIPTION
Adds font and blob sources to the CSP whitelist.  Previously rendered PDFs did not display in the browser.