### PR TITLE
fix(stock): activate cancel button on depot modal

### DIFF
--- a/client/src/js/directives/bhChangeDepot.js
+++ b/client/src/js/directives/bhChangeDepot.js
@@ -41,7 +41,8 @@ function bhChangeDepotController(Depots, AppCache, Notify) {
       }
 
       function changeDepot() {
-        // if requirement is true the modal cannot be canceled
+        // if requirement is true the modal will use History.back() to
+        // cancel the modal.
         const requirement = !cache.depotUuid;
 
         return Depots.openSelectionModal($ctrl.currentDepot, requirement)

--- a/client/src/modules/depots/depots.service.js
+++ b/client/src/modules/depots/depots.service.js
@@ -24,22 +24,19 @@ function DepotService(Api, Modal) {
    *
    * @param isDepotRequired helps to keep the modal displayed as long as no depot was submitted
    */
-  service.openSelectionModal = function openSelectionModal(depot, isDepotRequired) {
-    service.isDepotRequired = isDepotRequired || false;
+  service.openSelectionModal = function openSelectionModal(depot, isDepotRequired = false) {
+    service.isDepotRequired = isDepotRequired;
     return Modal.open({
       controller : 'SelectDepotModalController as $ctrl',
       templateUrl : 'modules/stock/depot-selection.modal.html',
       resolve : {
-        depot : function injectDepot() { return depot; },
+        depot : () => depot,
       },
-      backdrop : 'static',
-      keyboard : false,
     }).result;
   };
 
   service.searchByName = function searchByName(options = {}) {
     const target = baseUrl.concat('search/name');
-
     return service.$http.get(target, { params : options })
       .then(service.util.unwrapHttpResponse);
   };

--- a/client/src/modules/stock/depot-selection.ctrl.js
+++ b/client/src/modules/stock/depot-selection.ctrl.js
@@ -2,13 +2,13 @@ angular.module('bhima.controllers')
   .controller('SelectDepotModalController', SelectDepotModalController);
 
 SelectDepotModalController.$inject = [
-  '$uibModalInstance', 'DepotService', 'NotifyService', 'depot',
+  '$uibModalInstance', 'DepotService', 'NotifyService', 'depot', '$window',
 ];
 
 /**
  * This modal selects a depot from the list of all depots.
  */
-function SelectDepotModalController(Instance, Depots, Notify, depot) {
+function SelectDepotModalController(Instance, Depots, Notify, depot, $window) {
   const vm = this;
   const LIMIT = 10;
 
@@ -16,7 +16,9 @@ function SelectDepotModalController(Instance, Depots, Notify, depot) {
   vm.depot = depot;
   vm.selectDepot = selectDepot;
   vm.hasSelectedDepot = hasSelectedDepot;
+
   vm.isDepotRequired = Depots.isDepotRequired;
+
   vm.loading = false;
   vm.limit = LIMIT;
   vm.showAllDepots = showAllDepots;
@@ -24,8 +26,18 @@ function SelectDepotModalController(Instance, Depots, Notify, depot) {
   // this is a toggle for a one-time message shown to the user if they do not have a cached depot.
   vm.hasNoDefaultDepot = !angular.isDefined(depot);
 
-  vm.submit = function submit() { Instance.close(vm.depot); };
-  vm.cancel = function cancel() { Instance.dismiss(); };
+  vm.submit = function submit() { return Instance.close(vm.depot); };
+
+  // the cancel button has two behaviors, depending on if we have a cached depot or not.
+  // If we do not have a cached depot and we didn't pass a depot in, we use history.back()
+  // to navigate back to wherever the user came from.  Otherwise, we simply close the modal.
+  vm.cancel = () => {
+    if (vm.hasNoDefaultDepot && vm.isDepotRequired) {
+      $window.history.back();
+    }
+
+    Instance.dismiss();
+  };
 
   // loads a new set of depots from the server.
   function startup() {
@@ -48,10 +60,10 @@ function SelectDepotModalController(Instance, Depots, Notify, depot) {
   }
 
   // fired when a user selects a depot from a list
-  function selectDepot(uuid) {
-    vm.depot = vm.depots.filter((d) => {
-      return d.uuid === uuid;
-    }).pop();
+  function selectDepot(depotUuid) {
+    vm.depot = vm.depots
+      .filter(({ uuid }) => uuid === depotUuid)
+      .pop();
   }
 
   function toggleLoadingIndicator() {

--- a/client/src/modules/stock/depot-selection.modal.html
+++ b/client/src/modules/stock/depot-selection.modal.html
@@ -50,8 +50,8 @@
       </li>
     </ul>
 
-    <a href ng-click="$ctrl.showAllDepots()" ng-if="$ctrl.depots.length > $ctrl.limit && !$ctrl.showAll" 
-      class="text-right text-primary pull-right" 
+    <a href ng-click="$ctrl.showAllDepots()" ng-if="$ctrl.depots.length > $ctrl.limit && !$ctrl.showAll"
+      class="text-right text-primary pull-right"
       translate-values="{ number : $ctrl.totalOtherDepots }"
       translate>DEPOT.MODAL.AND_MORE_DEPOTS
     </a>
@@ -64,8 +64,6 @@
     type="button"
     class="btn btn-default"
     ng-click="$ctrl.cancel()"
-
-    ng-disabled="$ctrl.isDepotRequired"
     translate>
     FORM.BUTTONS.CANCEL
   </button>

--- a/client/src/modules/stock/requisition/registry.html
+++ b/client/src/modules/stock/requisition/registry.html
@@ -2,7 +2,7 @@
   <div class="bhima-title">
     <ol class="headercrumb">
       <li class="static" translate>TREE.STOCK</li>
-      <li class="title" translate>REQUISITION.STOCK_REQUISITION</li>
+      <li class="static" translate>REQUISITION.STOCK_REQUISITION</li>
       <li class="title" ng-if="StockCtrl.depot.uuid">
         <span>{{ StockCtrl.depot.text }}</span>
       </li>

--- a/client/src/modules/stock/requisition/registry.js
+++ b/client/src/modules/stock/requisition/registry.js
@@ -22,7 +22,6 @@ function StockRequisitionController(
   const stockRequisitionFilters = Stock.filter.requisition;
   vm.status = [];
 
-
   // grid columns
   const columns = [
     {
@@ -83,7 +82,7 @@ function StockRequisitionController(
 
   const gridFooterTemplate = `
     <div style="padding-left: 10px;">
-      <b>{{ grid.appScope.countGridRows() }}</b> 
+      <b>{{ grid.appScope.countGridRows() }}</b>
       <span translate>TABLE.AGGREGATES.ROWS</span>
     </div>
   `;


### PR DESCRIPTION
Ensures that the "cancel" button works on the depot selection modal.
This means that users can always cancel an operation and it will not
leave them in an undefined state.  If there is no default depot, it
returns them to the previous state.  If there is a defined depot, it
returns them to the current module.

Partially addresses #4776.

Here is what it looks like in action:

![n1WcBYTwqQ](https://user-images.githubusercontent.com/896472/89405385-5fcf6800-d713-11ea-995a-74bfd324a5b8.gif)
