### PR TITLE
feat(inventory): enforce account types on groups

### DIFF
--- a/client/src/js/components/bhAccountSelect.js
+++ b/client/src/js/components/bhAccountSelect.js
@@ -10,24 +10,27 @@ angular.module('bhima.components')
       required         : '<?',
       accountTypeId :  '<?',
       label            : '@?',
+      name             : '@?',
       excludeTitleAccounts : '@?',
     },
   });
 
 bhAccountSelectController.$inject = [
-  'AccountService', 'FormatTreeDataService', 'bhConstants', '$scope',
+  'AccountService', 'FormatTreeDataService', 'bhConstants', '$scope', '$timeout',
 ];
 
 /**
  * Account selection component
  */
-function bhAccountSelectController(Accounts, FormatTreeData, bhConstants, $scope) {
+function bhAccountSelectController(Accounts, FormatTreeData, bhConstants, $scope, $timeout) {
   const $ctrl = this;
 
   const TITLE_ACCOUNT_TYPE_ID = bhConstants.accounts.TITLE;
 
   // fired at the beginning of the account select
   $ctrl.$onInit = function $onInit() {
+    // default for form name
+    $ctrl.name = $ctrl.name || 'AccountForm';
 
     // cache the title account ID for convenience
     $ctrl.TITLE_ACCOUNT_ID = bhConstants.accounts.TITLE;
@@ -42,9 +45,17 @@ function bhAccountSelectController(Accounts, FormatTreeData, bhConstants, $scope
     $ctrl.excludeTitleAccounts = angular.isDefined($ctrl.excludeTitleAccounts)
       ? $ctrl.excludeTitleAccounts : true;
 
+    // alias the name as AccountForm
+    $timeout(aliasComponentForm);
+
     // load accounts
     return loadHttpAccounts();
   };
+
+  // this makes the HTML much more readable by reference AccountForm instead of the name
+  function aliasComponentForm() {
+    $scope.AccountForm = $scope[$ctrl.name];
+  }
 
   /**
    * @function parseAccountTypeIds
@@ -72,7 +83,7 @@ function bhAccountSelectController(Accounts, FormatTreeData, bhConstants, $scope
 
   // loads accounts from the server
   function loadHttpAccounts() {
-    const params = {};
+    const params = { hidden : 0 };
 
     if ($ctrl.accountTypeId) {
       params.detailed = 1;
@@ -80,9 +91,6 @@ function bhAccountSelectController(Accounts, FormatTreeData, bhConstants, $scope
     } else {
       params.detailed = 0;
     }
-
-    // NOTE: this will hide all "hidden" accounts
-    params.hidden = 0;
 
     // load accounts
     return Accounts.read(null, params)
@@ -99,10 +107,10 @@ function bhAccountSelectController(Accounts, FormatTreeData, bhConstants, $scope
   }
 
   // fires the onSelectCallback bound to the component boundary
-  $ctrl.onSelect = function onSelect($item) {
-    $ctrl.onSelectCallback({ account : $item });
+  $ctrl.onSelect = function onSelect(account) {
+    $ctrl.onSelectCallback({ account });
 
     // alias the AccountForm name so that we can find it via filterFormElements
-    $scope.AccountForm.$bhValue = $item.id;
+    $scope[$ctrl.name].$bhValue = account.id;
   };
 }

--- a/client/src/modules/inventory/configuration/groups/modals/actions.modal.js
+++ b/client/src/modules/inventory/configuration/groups/modals/actions.modal.js
@@ -10,6 +10,7 @@ function InventoryGroupsActionsModalController(InventoryGroups, Notify, Instance
   vm.INCOME_ACCOUNT_TYPE_ID = Constants.accounts.INCOME;
   vm.EXPENSE_ACCOUNT_TYPE_ID = Constants.accounts.EXPENSE;
   vm.ASSET_ACCOUNT_TYPE_ID = Constants.accounts.ASSET;
+  vm.EQUITY_ACCOUNT_TYPE_ID = Constants.accounts.EQUITY;
 
   // session
   vm.session = {};

--- a/client/src/modules/inventory/configuration/groups/modals/actions.modal.js
+++ b/client/src/modules/inventory/configuration/groups/modals/actions.modal.js
@@ -1,12 +1,15 @@
 angular.module('bhima.controllers')
   .controller('InventoryGroupsActionsModalController', InventoryGroupsActionsModalController);
-
 InventoryGroupsActionsModalController.$inject = [
-  'InventoryGroupService', 'NotifyService', '$uibModalInstance', 'data', 'SessionService',
+  'InventoryGroupService', 'NotifyService', '$uibModalInstance', 'data', 'SessionService', 'bhConstants',
 ];
 
-function InventoryGroupsActionsModalController(InventoryGroups, Notify, Instance, Data, Session) {
+function InventoryGroupsActionsModalController(InventoryGroups, Notify, Instance, Data, Session, Constants) {
   const vm = this;
+
+  vm.INCOME_ACCOUNT_TYPE_ID = Constants.accounts.INCOME;
+  vm.EXPENSE_ACCOUNT_TYPE_ID = Constants.accounts.EXPENSE;
+  vm.ASSET_ACCOUNT_TYPE_ID = Constants.accounts.ASSET;
 
   // session
   vm.session = {};

--- a/client/src/modules/inventory/configuration/groups/modals/actions.tmpl.html
+++ b/client/src/modules/inventory/configuration/groups/modals/actions.tmpl.html
@@ -41,6 +41,7 @@
       data-sales-account
       name="sales_account"
       account-id="$ctrl.session.sales_account"
+      account-type-id="$ctrl.INCOME_ACCOUNT_TYPE_ID"
       exclude-title-accounts="true"
       required="$ctrl.enableAutoStockAccounting"
       on-select-callback="$ctrl.onSelectSalesAccount(account)">
@@ -52,6 +53,7 @@
       data-stock-account
       name="stock_account"
       account-id="$ctrl.session.stock_account"
+      account-type-id="$ctrl.ASSET_ACCOUNT_TYPE_ID"
       exclude-title-accounts="true"
       required="$ctrl.enableAutoStockAccounting"
       on-select-callback="$ctrl.onSelectStockAccount(account)">
@@ -63,6 +65,7 @@
       data-cogs-account
       name="cogs_account"
       account-id="$ctrl.session.cogs_account"
+      account-type-id="$ctrl.EXPENSE_ACCOUNT_TYPE_ID"
       exclude-title-accounts="true"
       required="$ctrl.enableAutoStockAccounting"
       on-select-callback="$ctrl.onSelectCOGSAccount(account)">

--- a/client/src/modules/inventory/configuration/groups/modals/actions.tmpl.html
+++ b/client/src/modules/inventory/configuration/groups/modals/actions.tmpl.html
@@ -53,7 +53,7 @@
       data-stock-account
       name="stock_account"
       account-id="$ctrl.session.stock_account"
-      account-type-id="$ctrl.ASSET_ACCOUNT_TYPE_ID"
+      account-type-id="[$ctrl.ASSET_ACCOUNT_TYPE_ID, $CTRL.EQUITY_ACCOUNT_TYPE_ID]"
       exclude-title-accounts="true"
       required="$ctrl.enableAutoStockAccounting"
       on-select-callback="$ctrl.onSelectStockAccount(account)">

--- a/client/src/modules/inventory/list/modals/actions.tmpl.html
+++ b/client/src/modules/inventory/list/modals/actions.tmpl.html
@@ -113,7 +113,7 @@
       </div>
     </div>
 
-    
+
     <div class="checkbox">
       <label>
         <input type="checkbox" name="consumable" ng-true-value="1" ng-false-value="0" ng-model="$ctrl.item.consumable">

--- a/client/src/modules/templates/bhAccountSelect.tmpl.html
+++ b/client/src/modules/templates/bhAccountSelect.tmpl.html
@@ -1,4 +1,4 @@
-<div ng-form="AccountForm" bh-account-select ng-model-options="{ updateOn: 'default' }">
+<div ng-form="{{ $ctrl.name }}" bh-account-select ng-model-options="{ updateOn: 'default' }">
   <div
     class="form-group"
     ng-class="{ 'has-error' : AccountForm.$submitted && AccountForm.account_id.$invalid }">

--- a/test/data.sql
+++ b/test/data.sql
@@ -169,9 +169,9 @@ INSERT INTO `account` (`id`, `type_id`, `enterprise_id`, `number`, `label`, `par
   (152, 1, 1, 24480040, 'Mobiliers Hopital', 21, 0, '2016-10-23 16:05:34', NULL),
   (156, 1, 1, 28310010, 'Amortissement Batiments', 24, 0, '2016-10-23 16:05:34', NULL),
   (160, 6, 1, 311, 'MARCHANDISES A', 26, 0, '2016-10-23 16:05:34', NULL),
-  (161, 6, 1, 3111, 'Medicaments', 160, 0, '2016-10-23 16:05:34', NULL),
-  (162, 1, 1, 31110010, 'Medicaments en comprimes *', 161, 0, '2016-10-23 16:05:34', NULL),
-  (163, 1, 1, 31110011, 'Medicaments en Sirop *', 161, 0, '2016-10-23 16:05:34', NULL),
+  (161, 6, 1, 3111, 'Médicaments', 160, 0, '2016-10-23 16:05:34', NULL),
+  (162, 1, 1, 31110010, 'Médicaments en comprimes *', 161, 0, '2016-10-23 16:05:34', NULL),
+  (163, 1, 1, 31110011, 'Médicaments en Sirop *', 161, 0, '2016-10-23 16:05:34', NULL),
   (170, 6, 1, 4011, 'Fournisseurs', 32, 0, '2016-10-23 16:05:34', NULL),
   (171, 1, 1, 41111000, 'SNEL', 173, 0, '2016-10-23 16:05:34', NULL),
   (172, 1, 1, 41111001, 'REGIDESO', 173, 0, '2016-10-23 16:05:34', NULL),
@@ -227,9 +227,9 @@ INSERT INTO `account` (`id`, `type_id`, `enterprise_id`, `number`, `label`, `par
   (221, 6, 1, 676, 'PERTES DE CHANGE', 54, 0, '2016-10-23 16:05:34', NULL),
   (222, 5, 1, 67611010, 'Différences de change', 221, 0, '2016-10-23 16:05:34', NULL),
   (240, 6, 1, 701, 'VENTES DE MARCHANDISES', 57, 0, '2016-10-23 16:05:34', NULL),
-  (241, 6, 1, 7011, 'Vente des medicaments dans la Region Ohada', 240, 0, '2016-10-23 16:05:34', NULL),
-  (242, 4, 1, 70111010, 'Vente Medicaments en comprimes', 241, 0, '2016-10-23 16:05:34', NULL),
-  (243, 4, 1, 70111011, 'Vente Medicaments en Sirop', 241, 0, '2016-10-23 16:05:34', NULL),
+  (241, 6, 1, 7011, 'Vente des Médicaments dans la Region Ohada', 240, 0, '2016-10-23 16:05:34', NULL),
+  (242, 4, 1, 70111010, 'Vente Médicaments en comprimes', 241, 0, '2016-10-23 16:05:34', NULL),
+  (243, 4, 1, 70111011, 'Vente Médicaments en Sirop', 241, 0, '2016-10-23 16:05:34', NULL),
   (244, 6, 1, 706, 'SERVICES VENDUS', 57, 0, '2016-10-23 16:05:34', NULL),
   (245, 6, 1, 7061, 'Services vendus dans la Region ohada', 244, 0, '2016-10-23 16:05:34', NULL),
   (246, 4, 1, 70611010, 'Consultations', 245, 0, '2016-10-23 16:05:34', NULL),
@@ -3293,7 +3293,7 @@ INSERT INTO `distribution_key` (`id`, `auxiliary_fee_center_id`, `principal_fee_
 
 -- data_collector_management
 INSERT INTO `data_collector_management` (`id`, `label`, `description`, `version_number`, `color`, `is_related_patient`, `include_patient_data`) VALUES
-  (1, 'Fiche Kardex', 'Fiche de consommation Medicament', 1, '#E0FFFF', 1, 1),
+  (1, 'Fiche Kardex', 'Fiche de consommation Médicament', 1, '#E0FFFF', 1, 1),
   (3, 'Formulaire Special', NULL, 1, '#EE82EE', 0, 0);
 
 -- choices_list_management

--- a/test/end-to-end/accounts/accounts.spec.js
+++ b/test/end-to-end/accounts/accounts.spec.js
@@ -71,13 +71,13 @@ describe('Account Management', () => {
     // @todo removed to allow types to be updated - this should be reintroduced
     expect(await element(by.id('type-static')).getText()).to.equal(account.type);
     expect(
-      await element(by.model('AccountEditCtrl.account.label')).getAttribute('value')
+      await element(by.model('AccountEditCtrl.account.label')).getAttribute('value'),
     ).to.equal(account.label);
   });
 
   it('updates an account title and parent', async () => {
     await FU.input('AccountEditCtrl.account.label', 'Updated Inventory Accounts');
-    await FU.uiSelect('AccountEditCtrl.account.parent', 'Medicaments');
+    await FU.uiSelect('AccountEditCtrl.account.parent', 'Médicaments');
     await FU.modal.submit();
 
     await components.notification.hasSuccess();

--- a/test/end-to-end/inventory/configuration.spec.js
+++ b/test/end-to-end/inventory/configuration.spec.js
@@ -11,9 +11,9 @@ describe('Inventory Configuration', () => {
   const group = {
     name : 'Medicaments en Sirop for Fun',
     code : '1700',
-    sales_account : 'Caisse Principale USD',
-    stock_account : 'Medicaments en Sirop',
-    cogs_account  : 'Médicaments en Sirop',
+    sales_account : 'Vente Medicaments en comprimes',
+    stock_account : 'Medicaments en comprimes',
+    cogs_account  : 'Achats Médicaments',
     expires : 1,
     unique_item : 0,
   };
@@ -21,13 +21,13 @@ describe('Inventory Configuration', () => {
   const groupWithOnlySalesAccount = {
     name : 'Group With Only Sales Account',
     code : '1900',
-    sales_account : '77111010', // 77111010 - Interets de Prets *
+    sales_account : '70611012', // Hospitalisation
   };
 
   const updateGroup = {
     name : '[E2E] Inventory Group updated',
     code : '2500',
-    sales_account : '57110010', // Caisse principale
+    sales_account : '70611011', // Optique
   };
 
   // inventory type

--- a/test/end-to-end/inventory/configuration.spec.js
+++ b/test/end-to-end/inventory/configuration.spec.js
@@ -9,11 +9,11 @@ describe('Inventory Configuration', () => {
   before(() => helpers.navigate(url));
 
   const group = {
-    name : 'Medicaments en Sirop for Fun',
+    name : 'Médicaments en Sirop Comprimes',
     code : '1700',
-    sales_account : 'Vente Medicaments en comprimes',
-    stock_account : 'Medicaments en comprimes',
-    cogs_account  : 'Achats Médicaments',
+    sales_account : 'Vente Médicaments en comprimes',
+    stock_account : 'Médicaments en comprimes',
+    cogs_account  : 'Achat Médicaments',
     expires : 1,
     unique_item : 0,
   };


### PR DESCRIPTION
Enforce the account types for each type of account on the inventory group via the `bhAccountSelect` component.

Closes #4703.

Here is what it looks like:
![u95E40ge8u](https://user-images.githubusercontent.com/896472/89422300-0ecc6d80-d72d-11ea-8389-a2f9b2b7b391.gif)
