### PR TITLE
Prevent selection of expired lots by the user in Stock-Exit (except for Loss)

### DIFF
--- a/client/src/i18n/en/errors.json
+++ b/client/src/i18n/en/errors.json
@@ -18,6 +18,7 @@
     "OVERPAID_INVOICE" : "You have overpaid the invoices.",
     "ER_DUP_KEY" : "A key collided in a unique database field.  Please retry your action.  If the problem persists, contact the developers.",
     "ER_DUP_ENTRY" : "You have duplicated a value in a unique field!  Please make sure that the necessary values are unique.",
+    "ER_EXPIRED_STOCK_LOTS" : "Some stock lots are expired",
     "ER_BAD_FIELD_ERROR" : "Column does not exist in database.",
     "ER_ROW_IS_REFERENCED" : "Cannot delete entity because entity is used in another table.",
     "ER_ROW_IS_REFERENCED_2" : "Cannot delete entity because entity is used in another table.",

--- a/client/src/i18n/fr/errors.json
+++ b/client/src/i18n/fr/errors.json
@@ -18,6 +18,7 @@
     "OVERPAID_INVOICE" : "Vous avez payé trop aux factures.",
     "ER_DUP_KEY" : "Il ya déjà un enregistrement avec cette clé. Veuillez réessayer votre action. Si le problème persiste, contactez les développeurs.",
     "ER_DUP_ENTRY" : "Vous avez dupliqué une valeur dans un champ unique! Assurez-vous que les valeurs nécessaires sont uniques.",
+    "ER_EXPIRED_STOCK_LOTS" : "Certains lots de stock sont expirés",
     "ER_BAD_FIELD_ERROR" : "Vous avez entré un champ qui ne peut pas être stocké dans la base de données.",
     "ER_ROW_IS_REFERENCED" : "Vous ne pouvez pas supprimer cet enregistrement, car il est référencé par un autre enregistrement dans la base de données.",
     "ER_ROW_IS_REFERENCED_2" : "Vous ne pouvez pas supprimer cet enregistrement, car il est référencé par un autre enregistrement dans la base de données.",

--- a/test/end-to-end/stock/stock.exit.spec.js
+++ b/test/end-to-end/stock/stock.exit.spec.js
@@ -31,7 +31,7 @@ function StockExiTests() {
     await page.addRows(2);
 
     // first item
-    await page.setItem(0, 'Quinine', 'QUININE-A', 20);
+    await page.setItem(0, 'Quinine', 'QUININE-C', 20);
 
     // second item
     await page.setItem(1, 'Vitamines', 'VITAMINE-A', 10);
@@ -85,7 +85,7 @@ function StockExiTests() {
     await page.addRows(1);
 
     // first item
-    await page.setItem(0, 'Quinine', 'QUININE-C', 45);
+    await page.setItem(0, 'Quinine', 'QUININE-C', 20);
 
     // submit
     await page.submit();

--- a/test/end-to-end/stock/stock.lots.spec.js
+++ b/test/end-to-end/stock/stock.lots.spec.js
@@ -82,7 +82,7 @@ function StockLotsRegistryTests() {
   it('find lots by expiration date', async () => {
     await modal.setdateInterval('01/01/2017', '31/12/2017', 'expiration-date');
     await modal.submit();
-    await GU.expectRowCount(gridId, depotGroupingRow - 1); // 1 expired in this date range
+    await GU.expectRowCount(gridId, 1 + depotGroupingRow);
   });
 
   it('find inventories by group', async () => {

--- a/test/end-to-end/stock/stock.lots.spec.js
+++ b/test/end-to-end/stock/stock.lots.spec.js
@@ -57,7 +57,7 @@ function StockLotsRegistryTests() {
   it('find lots in depot principal', async () => {
     await modal.setDepot('Depot Principal');
     await modal.submit();
-    await GU.expectRowCount(gridId, 17 + depotGroupingRow);
+    await GU.expectRowCount(gridId, 18 + depotGroupingRow);
   });
 
   it('find lots by inventory', async () => {

--- a/test/end-to-end/stock/stock.z2.inventory-adjustment-inventories.spec.js
+++ b/test/end-to-end/stock/stock.z2.inventory-adjustment-inventories.spec.js
@@ -22,10 +22,10 @@ function StockInventoriesRegistryTests() {
   const gridId = 'stock-inventory-grid';
   const GROUPING_ROW = 1;
 
-  it('find 2 inventory in Depot Principal plus one line for the Grouping', async () => {
+  it('find 3 inventory in Depot Principal plus one line for the Grouping', async () => {
     await modal.setDepot('Depot Principal');
     await modal.submit();
-    await GU.expectRowCount(gridId, 2 + GROUPING_ROW);
+    await GU.expectRowCount(gridId, 3 + GROUPING_ROW);
     await filters.resetFilters();
   });
 

--- a/test/end-to-end/stock/stock.z3.inventory-adjustment-lots.spec.js
+++ b/test/end-to-end/stock/stock.z3.inventory-adjustment-lots.spec.js
@@ -23,7 +23,7 @@ function StockLotsRegistryTests() {
   });
 
   const gridId = 'stock-lots-grid';
-  const LOT_FOR_ALLTIME = 2;
+  const LOT_FOR_ALLTIME = 3;
   const GROUPING_ROW = 1;
 
   it(`finds ${LOT_FOR_ALLTIME} lots for all time`, async () => {
@@ -37,7 +37,7 @@ function StockLotsRegistryTests() {
   it('find only lots setted during the adjustment process', async () => {
     const quinine = {
       label : 'Quinine Bichlorhydrate, sirop, 100mg base/5ml, 100ml, flacon, Unité',
-      lot : 'QUININE-B',
+      lot : 'QUININE-A',
       quantity : '17',
     };
     const vitamine = {

--- a/test/end-to-end/stock/stock.z3.inventory-adjustment-lots.spec.js
+++ b/test/end-to-end/stock/stock.z3.inventory-adjustment-lots.spec.js
@@ -23,7 +23,7 @@ function StockLotsRegistryTests() {
   });
 
   const gridId = 'stock-lots-grid';
-  const LOT_FOR_ALLTIME = 2;
+  const LOT_FOR_ALLTIME = 3;
   const GROUPING_ROW = 1;
 
   it(`finds ${LOT_FOR_ALLTIME} lots for all time`, async () => {
@@ -37,7 +37,7 @@ function StockLotsRegistryTests() {
   it('find only lots setted during the adjustment process', async () => {
     const quinine = {
       label : 'Quinine Bichlorhydrate, sirop, 100mg base/5ml, 100ml, flacon, Unité',
-      lot : 'QUININE-C',
+      lot : 'QUININE-A',
       quantity : '17',
     };
     const vitamine = {


### PR DESCRIPTION
For Stock-Exit to Patient, Service, or Depot, once the user has selected the inventory item, the drop-down menu to select the lot/batch will not show expired lots.  We also have a secondary check in the main submit function in the hopefully improbable case that expired lots come in via Invoices(Patient) or Requisitions(Service/Depot).

Suggested testing procedure using Bhima_test
 - ~Update the expiration date for Stock Lots for Quinine to make sure that one of the lots is not expired~.  <br>[This is no longer necessary due to the automatic updating of bhima_test data in PR https://github.com/IMA-WorldHealth/bhima/pull/4812]
 - Do Stock/Stock Exit, select Patient, Depot, or Service
 - Select the stock item for Quinine
 - Verify that only the unexpired lots are present in the Lots/Batches drop-down menu
 - Try the same procedure with Loss, the drop-down should show all the available lots including the expired ones.

Verify the French/English translations for the new error message:  ER_EXPIRED_STOCK_LOTS
This error message will be displayed as an error message (in red) at the top of the Stock Exit page when expired lots are found.

Note: There is no easy way to test for the error detection in the main submit button.  However if you modify `client/src/modules/stock/exit/exit.js` line 242 to be a copy of line 240 (temporarily in your local test sandbox), you should be able to test this by selecting an expired item (eg, in Patient) and then trying to Submit. You should see this error message in red at the top of the screen and the submit should fail.