### PR TITLE
fix(inventory): reverse COGS & asset accounts

### DIFF
--- a/test/data.sql
+++ b/test/data.sql
@@ -394,7 +394,7 @@ INSERT INTO cashbox_permission (user_id, cashbox_id) VALUES
   (@superUser, 2),
   (2, 1);
 
-INSERT INTO `inventory_group` (`uuid`, `name`, `code`, `sales_account`, `cogs_account`, `stock_account`, `donation_account`, `tracking_expiration`, `unique_item`) VALUES
+INSERT INTO `inventory_group` (`uuid`, `name`, `code`, `sales_account`, `stock_account`, `cogs_account`, `donation_account`, `tracking_expiration`, `unique_item`) VALUES
   (0xD81D0C1D727C11EA8241000C2997DDC0,'Anti Retro Viraux','D.ARV',242,162,201,NULL,1,0),
   (0xD81D0FEB727C11EA8241000C2997DDC0,'Tests diagnostics','D.DGT',242,162,201,NULL,1,0),
   (0xD81D12F0727C11EA8241000C2997DDC0,'Antiseptiques & Désinfectants','D.DIS',242,162,201,NULL,1,0),


### PR DESCRIPTION
Fixes the test database by reversing the cost-of-goods-sold (COGS) expense accounts and the asset accounts.  Here is the fixed version:

![image](https://user-images.githubusercontent.com/896472/89634283-098e3080-d89d-11ea-9e51-dfad02d673c7.png)


Closes #4798.