### PR TITLE
fix: use correct CSP formulation in helmetjs

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -44,7 +44,7 @@ exports.configure = function configure(app) {
     contentSecurityPolicy : {
       directives : {
         defaultSrc : ['\'self\'', '\'unsafe-inline\'', 'blob:'],
-        fontSrc : ['\'self\'', '\'https://fonts.gstatic.com\''],
+        fontSrc : ['\'self\'', 'https://fonts.gstatic.com'],
       },
     },
   }));


### PR DESCRIPTION
Uses the correct CSP rule form for fonts in helmetjs's configuration. This eliminates the CSP errors from the console for fonts.

Closes #4800.