### PR TITLE
Automatically update stock lot expiration dates in bhima_test

### DIFF
--- a/test/data.sql
+++ b/test/data.sql
@@ -2987,11 +2987,11 @@ SET @multivitamine = HUID('f6556e72-9d05-4799-8cbd-0a03b1810185');
 
 -- stock lots
 INSERT INTO `lot` (`uuid`, `label`, `initial_quantity`, `quantity`, `unit_cost`, `expiration_date`, `inventory_uuid`, `origin_uuid`, `delay`, `entry_date`) VALUES
-  (HUID('064ab1d9-5246-4402-ae8a-958fcdb07b35'), 'VITAMINE-A', 100, 100, 1.2000, '2019-04-30', @multivitamine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
-  (HUID('5a0e06c2-6ca7-4633-8b17-92e2a59db44c'), 'VITAMINE-B', 20, 20, 0.5000, '2020-04-30', @multivitamine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
-  (HUID('6f80748b-1d94-4247-804e-d4be99e827d2'), 'QUININE-B', 200, 200, 0.8000, '2018-04-30', @quinine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
-  (HUID('ae735e99-8faf-417b-aa63-9b404fca99ac'), 'QUININE-A', 100, 100, 1.2000, '2018-04-30', @quinine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
-  (HUID('ef24cf1a-d5b9-4846-b70c-520e601c1ea6'), 'QUININE-C', 50, 50, 2.0000, '2017-04-30',   @quinine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25');
+  (HUID('064ab1d9-5246-4402-ae8a-958fcdb07b35'), 'VITAMINE-A', 100, 100, 1.2000, date_add(CURRENT_DATE, INTERVAL 2 YEAR), @multivitamine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
+  (HUID('5a0e06c2-6ca7-4633-8b17-92e2a59db44c'), 'VITAMINE-B', 20, 20, 0.5000, date_add(CURRENT_DATE, INTERVAL 2 YEAR), @multivitamine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
+  (HUID('6f80748b-1d94-4247-804e-d4be99e827d2'), 'QUININE-B', 200, 200, 0.8000, date_add(CURRENT_DATE, INTERVAL 1 MONTH),  @quinine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
+  (HUID('ae735e99-8faf-417b-aa63-9b404fca99ac'), 'QUININE-A', 100, 100, 1.2000, '2017-04-30', @quinine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
+  (HUID('ef24cf1a-d5b9-4846-b70c-520e601c1ea6'), 'QUININE-C', 50, 50, 2.0000, date_add(CURRENT_DATE, INTERVAL 2 YEAR), @quinine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25');
 
 -- stock lots movements
 INSERT INTO `stock_movement` (`uuid`, `lot_uuid`, `document_uuid`, `depot_uuid`, `entity_uuid`, `flux_id`, `date`, `quantity`, `unit_cost`, `is_exit`, `period_id`, `user_id`) VALUES

--- a/test/end-to-end/stock/stock.lots.spec.js
+++ b/test/end-to-end/stock/stock.lots.spec.js
@@ -82,7 +82,7 @@ function StockLotsRegistryTests() {
   it('find lots by expiration date', async () => {
     await modal.setdateInterval('01/01/2017', '31/12/2017', 'expiration-date');
     await modal.submit();
-    await GU.expectRowCount(gridId, 1 + depotGroupingRow);
+    await GU.expectRowCount(gridId, depotGroupingRow - 1); // 1 expired in this date range
   });
 
   it('find inventories by group', async () => {

--- a/test/end-to-end/stock/stock.z3.inventory-adjustment-lots.spec.js
+++ b/test/end-to-end/stock/stock.z3.inventory-adjustment-lots.spec.js
@@ -37,7 +37,7 @@ function StockLotsRegistryTests() {
   it('find only lots setted during the adjustment process', async () => {
     const quinine = {
       label : 'Quinine Bichlorhydrate, sirop, 100mg base/5ml, 100ml, flacon, Unité',
-      lot : 'QUININE-C',
+      lot : 'QUININE-B',
       quantity : '17',
     };
     const vitamine = {

--- a/test/integration/stock/stock.js
+++ b/test/integration/stock/stock.js
@@ -187,7 +187,7 @@ describe('(/stock/) The Stock HTTP API', () => {
     () => agent.get(`/stock/inventories/depots`)
       .query({ limit : 1000, includeEmptyLot : 0, is_expired : 1 })
       .then(res => {
-        helpers.api.listed(res, 5);
+        helpers.api.listed(res, 3);
       })
       .catch(helpers.handler));
 
@@ -195,7 +195,7 @@ describe('(/stock/) The Stock HTTP API', () => {
     () => agent.get(`/stock/inventories/depots`)
       .query({ limit : 1000, includeEmptyLot : 0, is_expired : 0 })
       .then(res => {
-        helpers.api.listed(res, 1);
+        helpers.api.listed(res, 5);
       })
       .catch(helpers.handler));
 


### PR DESCRIPTION
This update updates the stock lots as follows:
- Most stock lots expire 2 years from the date the database is loaded (by: yarn build:db)
- Quinine lot QUININE-A expired: 2017-04-30
- Quinine lot QUININE-B expires 1 month in the future

Based on the changes made to the lot expiration dates, all but one of the lots should not be expired no matter when bhima_test tests are run.

Suggestions for Testing:
- Run 'yarn build:db' with the updates in the pull request
- Run bhima (yarn dev)
- In the browser, go to Stock > Stock Lots, you should see 5 items.  Only one will be expired (in red).
- When you change the search filter to select expired/unexpired, you should see appropriate list changes
- When you implement a search filter date range of 1/1/2017 thru 31/12/2017, you should see only the one expired item (in red).

Several of the end-to-end and integration tests needed to be updated, as expected.   Updates were made, but in some cases it was not clear why the necessary changes were needed.    However, when I ran the BHIMA interactively (yarn dev), the behavior in the  stock lot registry and associated filtering worked as expected.
