### PR TITLE
fix(stock): hide expiration information when irrelevant

### DIFF
--- a/client/src/modules/stock/lots/registry.js
+++ b/client/src/modules/stock/lots/registry.js
@@ -134,6 +134,8 @@ function StockLotsController(
     Stock.lots.read(null, filters)
       .then((lots) => {
 
+        lots.forEach(LotsRegistry.formatLotsWithoutExpirationDate);
+
         // FIXME(@jniles): we should do this ordering on the server via an ORDER BY
         lots.sort(LotsRegistry.orderByDepot);
 

--- a/client/src/modules/stock/lots/registry.service.js
+++ b/client/src/modules/stock/lots/registry.service.js
@@ -151,6 +151,24 @@ function LotsRegistryService(uiGridConstants, Session) {
     </div>
   `;
 
+  /**
+   * @function formatLotsWithoutExpirationDate
+   *
+   * @description
+   * Removes values from lots that do not have expiration dates so they do not show up in the
+   * registry view.
+   */
+  service.formatLotsWithoutExpirationDate = (lot) => {
+    lot.hasExpirationDate = (lot.tracking_expiration === 1);
+    if (!lot.hasExpirationDate) {
+      delete lot.delay_expiration;
+      delete lot.expiration_date;
+      delete lot.lifetime;
+      delete lot.S_LOT_LIFETIME;
+      delete lot.S_RP;
+    }
+  };
+
   service.orderByDepot = (rowA, rowB) => {
     return String(rowA.depot_text).localeCompare(rowB.depot_text);
   };

--- a/client/src/modules/stock/lots/templates/in_risk_of_expiration.html
+++ b/client/src/modules/stock/lots/templates/in_risk_of_expiration.html
@@ -1,4 +1,4 @@
 <div class="ui-grid-cell-contents text-center"  ng-if="!row.groupHeader">
-  <span ng-if="row.entity.IS_IN_RISK_EXPIRATION" translate>FORM.LABELS.YES</span>
-  <span ng-if="!row.entity.IS_IN_RISK_EXPIRATION" translate>FORM.LABELS.NO</span>
+  <span ng-if="row.entity.hasExpirationDate && row.entity.IS_IN_RISK_EXPIRATION" translate>FORM.LABELS.YES</span>
+  <span ng-if="row.entity.hasExpirationDate && !row.entity.IS_IN_RISK_EXPIRATION" translate>FORM.LABELS.NO</span>
 </div>

--- a/client/src/modules/stock/lots/templates/lifetime.cell.html
+++ b/client/src/modules/stock/lots/templates/lifetime.cell.html
@@ -1,3 +1,5 @@
 <div class="ui-grid-cell-contents text-right">
-  {{ row.entity.lifetime }} <span translate>FORM.LABELS.MONTH</span>
+  <span ng-if="row.entity.hasExpirationDate">
+    {{ row.entity.lifetime }} <span translate>FORM.LABELS.MONTH</span>
+  </span>
 </div>

--- a/client/src/modules/stock/lots/templates/lot_lifetime.cell.html
+++ b/client/src/modules/stock/lots/templates/lot_lifetime.cell.html
@@ -1,3 +1,5 @@
 <div class="ui-grid-cell-contents text-right">
-  {{ row.entity.S_LOT_LIFETIME }} <span translate>FORM.LABELS.MONTH</span>
+  <span ng-if="row.entity.hasExpirationDate">
+    {{ row.entity.S_LOT_LIFETIME }} <span translate>FORM.LABELS.MONTH</span>
+  </span>
 </div>

--- a/client/src/modules/stock/lots/templates/risk.cell.html
+++ b/client/src/modules/stock/lots/templates/risk.cell.html
@@ -1,3 +1,5 @@
 <div class="ui-grid-cell-contents text-right" ng-class="{'text-danger': row.entity.S_RISK < 0, 'text-success': row.entity.S_RISK >= 0}">
-  {{ row.entity.S_RISK }} <span translate>FORM.LABELS.MONTH</span>
+  <span ng-if="row.entity.hasExpirationDate">
+    {{ row.entity.S_RISK }} <span translate>FORM.LABELS.MONTH</span>
+  </span>
 </div>


### PR DESCRIPTION
This commit hides the expiration information for those lots that do not expire.

![image](https://user-images.githubusercontent.com/896472/90515814-13484b80-e15b-11ea-9bea-7477f53e2f51.png)



Closes #4752