### PR TITLE
Improve stock lot highlighting in Stock Lots registry

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -881,10 +881,21 @@ a[disabled] {
 }
 
 .expired {
-  /* text-decoration : line-through; */
-  background-color: #ffb3b3 !important;
+  background-color: #ff000083 !important;
 }
 
+.at-risk {
+  background-color: #ffff6686 !important; 
+}
+
+.at-risk-of-expiring {
+  background-color: #ff880191 !important; 
+}
+
+.out-of-stock {
+  /* text-decoration : line-through; */
+  background-color: #cc00ff8f !important; 
+}
 
 .dropdown-menu {
   z-index : 9999;

--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -158,7 +158,7 @@
       "OVER_MAX"      : "Over Maximum",
       "SECURITY"      : "Security Stock Reached",
       "STOCK_OUT"      : "Stock Out",
-      "IS_IN_OF_RISK_EXPIRATION" : "At risk of expiration"
+      "IS_IN_RISK_OF_EXPIRATION" : "At risk of expiration"
     },
     "SUCCESS"         : "Successfully created a movement",
     "TO"              : "Destination",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -160,7 +160,7 @@
       "OVER_MAX"      : "Stock Max Depassé",
       "SECURITY"      : "Stock de Securité Atteint",
       "STOCK_OUT"      : "Rupture de stock",
-      "IS_IN_OF_RISK_EXPIRATION" : "A risque d'expiration"
+      "IS_IN_RISK_OF_EXPIRATION" : "A risque d'expiration"
     },
     "SUCCESS"         : "Mouvement realisé avec success",
     "TO"              : "Destination",

--- a/client/src/js/services/LotService.js
+++ b/client/src/js/services/LotService.js
@@ -19,5 +19,46 @@ function LotService(Api, $http, util) {
       .then(util.unwrapHttpResponse);
   };
 
+  /**
+  * @function computeLotWarningFlags()
+  *  @description
+  *   Takes in a Lot and attaches warning flags to the Lot.
+  *
+  *   The logic goes like this, in this order.
+  *   NOTE: Once a case is found to be true, all following cases are ignored.
+  *     1. If the stock is exhausted, warn about that.
+  *        (Recall that the user can choose to display exhausted lots in Lots Registry.)
+  *     2. If the Lot is expired, warn about that.
+  *     3. If the Lot is near expiration, warn about that.
+  *        NOTE that this assumes the CMM and that stock exits all come from this
+  *        lot exclusively.  But the CMM is based on not only on this lot, but on
+  *        an aggregate all lots of this inventory item, so there is no guarantee
+  *        that this will be correct.
+  *     4. If a Lot is at risk of running out, warn about that. Again this is
+  *        based on the aggregate CMM which may not work out exactly for this
+  *        Lot in practice.
+  *
+  * Based on this logic, only one of the warning flags should be set to true.
+  */
+  lots.computeLotWarningFlags = (lot) => {
+    lots.exhausted = false;
+    lots.expired = false;
+    lots.near_expiration = false;
+    lots.at_risk = false;
+    if (lot.quantity <= 0) {
+      lot.exhaused = true;
+    } else if (lot.lifetime < 0) {
+      // Equivalent to: lot.quantity > 0 && lot.lifetime < 0
+      lot.expired = true;
+    } else if (lot.IS_IN_RISK_EXPIRATION) {
+      // Equivalent to: lot.quantity > 0 && lot.lifetime >= 0 && lot.IS_IN_RISK_EXPIRATION
+      lot.near_expiration = true;
+    } else if (lot.S_RISK <= 0) {
+      // Equivalent to: lot.quantity > 0 && lot.lifetime >= 0 && lot.S_RISK <= 0
+      lot.at_risk = true;
+    }
+
+  };
+
   return lots;
 }

--- a/client/src/js/services/LotService.js
+++ b/client/src/js/services/LotService.js
@@ -46,7 +46,7 @@ function LotService(Api, $http, util) {
     lots.near_expiration = false;
     lots.at_risk = false;
     if (lot.quantity <= 0) {
-      lot.exhaused = true;
+      lot.exhausted = true;
     } else if (lot.lifetime < 0) {
       // Equivalent to: lot.quantity > 0 && lot.lifetime < 0
       lot.expired = true;

--- a/client/src/modules/stock/lots/registry.js
+++ b/client/src/modules/stock/lots/registry.js
@@ -2,9 +2,9 @@ angular.module('bhima.controllers')
   .controller('StockLotsController', StockLotsController);
 
 StockLotsController.$inject = [
-  'StockService', 'NotifyService', 'uiGridConstants', 'StockModalService', 'LanguageService', 'GridGroupingService',
-  'GridStateService', 'GridColumnService', '$state', '$httpParamSerializer', 'BarcodeService', 'LotsRegistryService',
-  'moment',
+  'StockService', 'NotifyService', 'uiGridConstants', 'StockModalService', 'LanguageService',
+  'GridGroupingService', 'GridStateService', 'GridColumnService', '$state', '$httpParamSerializer',
+  'BarcodeService', 'LotService', 'LotsRegistryService', 'moment',
 ];
 
 /**
@@ -12,8 +12,9 @@ StockLotsController.$inject = [
  * This module is a registry page for stock lots
  */
 function StockLotsController(
-  Stock, Notify, uiGridConstants, Modal, Languages, Grouping,
-  GridState, Columns, $state, $httpParamSerializer, Barcode, LotsRegistry, moment,
+  Stock, Notify, uiGridConstants, Modal, Languages,
+  Grouping, GridState, Columns, $state, $httpParamSerializer,
+  Barcode, LotService, LotsRegistry, moment,
 ) {
   const vm = this;
   const cacheKey = 'lot-grid';
@@ -139,6 +140,7 @@ function StockLotsController(
         lots.forEach((lot) => {
           const delay = moment(new Date(lot.expiration_date)).diff(current);
           lot.delay_expiration = moment.duration(delay).humanize(true);
+          LotService.computeLotWarningFlags(lot);
         });
 
         lots.forEach(LotsRegistry.formatLotsWithoutExpirationDate);

--- a/client/src/modules/stock/lots/registry.service.js
+++ b/client/src/modules/stock/lots/registry.service.js
@@ -124,7 +124,7 @@ function LotsRegistryService(uiGridConstants, Session) {
     },
     {
       field : 'IS_IN_RISK_EXPIRATION',
-      displayName : 'STOCK.STATUS.IS_IN_OF_RISK_EXPIRATION',
+      displayName : 'STOCK.STATUS.IS_IN_RISK_OF_EXPIRATION',
       headerCellFilter : 'translate',
       cellTemplate     : 'modules/stock/lots/templates/in_risk_of_expiration.html',
       cellClass : 'text-right',

--- a/client/src/modules/stock/lots/templates/row.expired.html
+++ b/client/src/modules/stock/lots/templates/row.expired.html
@@ -4,7 +4,9 @@
   ng-repeat="(colRenderIndex, col) in colContainer.renderedColumns track by col.uid"
   ui-grid-one-bind-id-grid="rowRenderIndex + '-' + col.uid + '-cell'"
   class="ui-grid-cell"
-  ng-class="{ 'ui-grid-row-header-cell': col.isRowHeader, 'expired': row.entity.lifetime < 0 }"
+  ng-class="{ 'ui-grid-row-header-cell': col.isRowHeader, 'at-risk-of-expiring': row.entity.near_expiration,
+              'expired': row.entity.expired, 'at-risk': row.entity.at_risk, 'out-of-stock': row.entity.exhausted,
+            }"
   data-vals="{{col.isRowHeader}}"
   role="{{col.isRowHeader ? 'rowheader' : 'gridcell'}}"
   ui-grid-cell>

--- a/server/controllers/stock/reports/stock/expiration_report.js
+++ b/server/controllers/stock/reports/stock/expiration_report.js
@@ -47,7 +47,7 @@ async function stockExpirationReport(req, res, next) {
           row.color = 'red';
           found = true;
         } else if (row.IS_IN_RISK_EXPIRATION) {
-          row.status = `STOCK.STATUS.IS_IN_OF_RISK_EXPIRATION`;
+          row.status = `STOCK.STATUS.IS_IN_RISK_OF_EXPIRATION`;
           row.color = '#f5cb42';
           found = true;
         }


### PR DESCRIPTION
Updated stock lot highlighting.   No changes to underlying lot status logic.

**My goals are:**

- Clearly mark lots that are expired.   This is an important issue for stock management.
- Mark lots that are stock-out.  Note that the Stock Lots registry hides these unless the user selects an option in the "Search" filter.
- Mark lots that are at risk of expiration so they can be used first.  
   - NOTE: We should consider how to inform the user about this when they select lots!  Perhaps the lot selection drop-down menu could be highlighted?
- Mark lots that are "at risk" (about to run out or expire).   

The currently supported highlight colors are (all for the specific lot):https://github.com/jmcameron/bhima/blob/at_risk_highlighting/client/src/modules/stock/lots/templates/row.expired.html

- **Red** (css class=expired): When the stock lot quantity is not 0 but it is expired.
- **Purple** (css class=out-of-stock): When the stock lot quantity is 0 (stock out)
- **Orange** (css class=at-risk-of-expiring): When the stock lot quantity is not 0, is not expired, but flag in the "At risk of expiration" column  is true.  (I have not been able to test this because I have not found a case where this is true.  There may be a logic issue with this.)
- **Yellow** (css class=at-risk): When the stock lot quantity is not 0, is not expired, but will run out or expire soon (the value in the "Risk" column is <= 0).

The logic for these classes is in: https://github.com/IMA-WorldHealth/bhima/blob/master/client/src/modules/stock/lots/templates/row.expired.html

Although I have attempted to make these mutually exclusive, I would not be surprised if there are logical inconsistencies.    It is quite possible that these are not mutually exclusive cases.   In that case, we need to figure out how to handle it best and update the class selection logic appropriately.     It is not clear to me why we need three columns for Risk-related items.  They do not seem to me to tell a very clear story.

I welcome suggestions on color scheme, how to improve this, etc.

Also renamed translation label  'IS_IN_OF_RISK_EXPIRATION' to 'IS_IN_RISK_OF_EXPIRATION' for readability.

**Suggestions for testing**

- Use the IMCK database.  
- Go to the Stock > Stock Lots and observe the colors of the rows and how they correspond to the descriptions above.
- In the "Search" filter, scroll to the bottom and click on the "Included Exausted  Lots" at the very end.  Click [Submit] on the pop-up Search filter dialog.  You should see stock-out items in purple.

