### PR TITLE
Swapped inventory/lot labels on expiration warning block

### DIFF
--- a/client/src/js/components/bhStockExpired/bhStockExpired.html
+++ b/client/src/js/components/bhStockExpired/bhStockExpired.html
@@ -19,8 +19,8 @@ class="table table-condensed table-bordered">
 </thead>
 <tbody>
   <tr>
-    <th translate>FORM.LABELS.LOT</th>
     <th translate>FORM.LABELS.INVENTORY</th>
+    <th translate>FORM.LABELS.LOT</th>
   </tr>
   <tr ng-repeat = "inventory in $ctrl.expiredInventories | limitTo : 5">
     <td>{{inventory.text}} ({{inventory.expiration_date}})</td>


### PR DESCRIPTION
In the warning block for expired stock (in the Stock Lots registry) from PR https://github.com/IMA-WorldHealth/bhima/pull/4810, 
we missed that the label for Inventory vs Lot needed to be swapped.  This PR fixes that.
