### PR TITLE
Implemented enterprise and depot-specific min months security stock parameter

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -724,6 +724,10 @@ growl-notification.fading.ng-leave.ng-leave-active {
   max-width : calc(100% - 50px);
 }
 
+.form-warning {
+  color : #ff0000 !important;
+}
+
 /* 'Card' Utility class */
 .text-float-util {
   text-align : right;
@@ -885,16 +889,16 @@ a[disabled] {
 }
 
 .at-risk {
-  background-color: #ffff6686 !important; 
+  background-color: #ffff6686 !important;
 }
 
 .at-risk-of-expiring {
-  background-color: #ff880191 !important; 
+  background-color: #ff880191 !important;
 }
 
 .out-of-stock {
   /* text-decoration : line-through; */
-  background-color: #cc00ff8f !important; 
+  background-color: #cc00ff8f !important;
 }
 
 .dropdown-menu {

--- a/client/src/i18n/en/enterprise.json
+++ b/client/src/i18n/en/enterprise.json
@@ -11,6 +11,7 @@
     "UPDATE_LOGO":"Update the enterprise logo",
     "SETTINGS" : {
       "TITLE" : "Enterprise Settings",
+      "DEFAULT_MIN_MONTHS_SECURITY_STOCK": "Default minimum number of months of security stock for depots",
       "ENABLE_PRICE_LOCK_LABEL" : "Lock Price Changes for Patient Invoicing",
       "ENABLE_PRICE_LOCK_HELP_TEXT" : "Enable to prohibit users from modifying the prices of inventory items in the Patient Invoice module.",
       "ENABLE_PREPAYMENTS_LABEL" : "Enable Cash Prepayments",

--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -539,6 +539,7 @@
             "MEMBERSHIP_FEE": "Membership fees",
             "MENU": "Menu",
             "MIDDLE_NAME": "Middle Name",
+            "MIN_MONTHS_SECURITY_STOCK": "Minimum number of months of security stock",
             "MONTH_CUMUL" : "Accumulated Monthly",
             "MONTH_ECART" : "Monthly Difference",
             "MONTH_IMPOT" : "Monthly Impot",

--- a/client/src/i18n/fr/enterprise.json
+++ b/client/src/i18n/fr/enterprise.json
@@ -11,6 +11,7 @@
     "UPDATE_LOGO":"Mettre à jour le logo",
     "SETTINGS" : {
       "TITLE" : "Parametres de l'Enterprise",
+      "DEFAULT_MIN_MONTHS_SECURITY_STOCK": "Nombre minimum de mois par défaut de stock de sécurité pour les dépôts",
       "ENABLE_PRICE_LOCK_LABEL" : "Verrouiller les changements de prix pour la facturation des patients",
       "ENABLE_PRICE_LOCK_HELP_TEXT" : "L'activation de cette fonctionnalité empêchera les utilisateurs de modifier les prix des articles en stock dans le module Facturation de Patients.",
       "ENABLE_PREPAYMENTS_LABEL" : "Activer les Cautions",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -543,6 +543,7 @@
             "MEMBERSHIP_FEE": "Cotisations",
             "MENU": "Menu",
             "MIDDLE_NAME": "Post-nom",
+            "MIN_MONTHS_SECURITY_STOCK": "Nombre minimum de mois de stock de sécurité",
             "MONTH_CUMUL" : "Cumul Mensuel",
             "MONTH_ECART" : "Ecart Mensuel",
             "MONTH_IMPOT" : "Impot Mensuel",

--- a/client/src/modules/depots/modals/depot.modal.html
+++ b/client/src/modules/depots/modals/depot.modal.html
@@ -119,6 +119,18 @@
       </div>
     </div>
 
+    <div class="form-group">
+      <label class="control-label" translate>
+        FORM.LABELS.MIN_MONTHS_SECURITY_STOCK
+      </label>
+      <input name="min_months_security_stock" class="form-control" ng-model="DepotModalCtrl.depot.min_months_security_stock"
+        type="number" min="1" autocomplete="off" required bh-integer>
+      <div class="help-block form-warning" ng-show="DepotForm.$submitted"
+           ng-messages="DepotForm.min_months_security_stock.$error">
+        <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+      </div>
+    </div>
+
   </div>
 
   <div class="modal-footer">

--- a/client/src/modules/depots/modals/depot.modal.html
+++ b/client/src/modules/depots/modals/depot.modal.html
@@ -119,13 +119,13 @@
       </div>
     </div>
 
-    <div class="form-group">
+    <div class="form-group" ng-class="{ 'has-error' : DepotForm.$submitted && DepotForm.min_months_security_stock.$invalid }">
       <label class="control-label" translate>
         FORM.LABELS.MIN_MONTHS_SECURITY_STOCK
       </label>
       <input name="min_months_security_stock" class="form-control" ng-model="DepotModalCtrl.depot.min_months_security_stock"
         type="number" min="1" autocomplete="off" required bh-integer>
-      <div class="help-block form-warning" ng-show="DepotForm.$submitted"
+      <div class="help-block" ng-show="DepotForm.$submitted"
            ng-messages="DepotForm.min_months_security_stock.$error">
         <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
       </div>

--- a/client/src/modules/depots/modals/depot.modal.js
+++ b/client/src/modules/depots/modals/depot.modal.js
@@ -2,10 +2,10 @@ angular.module('bhima.controllers')
   .controller('DepotModalController', DepotModalController);
 
 DepotModalController.$inject = [
-  '$state', 'DepotService', 'NotifyService',
+  '$state', 'DepotService', 'NotifyService', 'SessionService',
 ];
 
-function DepotModalController($state, Depots, Notify) {
+function DepotModalController($state, Depots, Notify, Session) {
   const vm = this;
 
   vm.depot = $state.params.depot;
@@ -13,6 +13,11 @@ function DepotModalController($state, Depots, Notify) {
 
   // make sure hasLocation is set
   vm.hasLocation = vm.depot.location_uuid ? 1 : 0;
+
+  // If creating, insert the default min_months_security_stock
+  if (vm.isCreating) {
+    vm.depot.min_months_security_stock = Session.enterprise.settings.default_min_months_security_stock;
+  }
 
   // exposed methods
   vm.submit = submit;

--- a/client/src/modules/enterprises/enterprises.html
+++ b/client/src/modules/enterprises/enterprises.html
@@ -236,6 +236,17 @@
                   <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
                 </div>
               </div>
+              <div class="form-group" ng-class="{ 'has-error' : EnterpriseForm.$submitted && EnterpriseForm.default_min_months_security_stock.$invalid }">
+                <label class="control-label" translate>
+                  ENTERPRISE.SETTINGS.DEFAULT_MIN_MONTHS_SECURITY_STOCK
+                </label>
+                <input type="number" class="form-control" autocomplete="off"
+                  name="default_min_months_security_stock" ng-model="EnterpriseCtrl.enterprise.settings.default_min_months_security_stock"
+                  ng-change="EnterpriseCtrl.setDefaultMinMonthsSecurityStock(value)" min="1" bh-integer>
+                <div class="help-block" ng-messages="EnterpriseForm.default_min_months_security_stock.$error" ng-show="EnterpriseForm.$submitted">
+                  <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+                </div>
+              </div>
 
               <bh-yes-no-radios
                 label="ENTERPRISE.SETTINGS.ENABLE_PRICE_LOCK_LABEL"

--- a/client/src/modules/enterprises/enterprises.js
+++ b/client/src/modules/enterprises/enterprises.js
@@ -231,6 +231,9 @@ function EnterpriseController(Enterprises, util, Notify, Projects, Modal, Scroll
   vm.setMonthAverage = function setMonthAverage() {
     $touched = true;
   };
+  vm.setDefaultMinMonthsSecurityStock = function setDefaultMinMonthsSecurityStock() {
+    $touched = true;
+  };
 
   startup();
 }

--- a/server/controllers/admin/enterprises.js
+++ b/server/controllers/admin/enterprises.js
@@ -26,8 +26,8 @@ exports.list = function list(req, res, next) {
         gain_account_id, loss_account_id, enable_price_lock, enable_prepayments,
         enable_delete_records, enable_password_validation, enable_balance_on_invoice_receipt,
         enable_barcodes, enable_auto_stock_accounting, enable_auto_purchase_order_confirmation,
-        enable_auto_email_report, enable_index_payment_system,
-        month_average_consumption, enable_daily_consumption
+        enable_auto_email_report, enable_index_payment_system, enable_daily_consumption,
+        month_average_consumption, default_min_months_security_stock
       FROM enterprise LEFT JOIN enterprise_setting
         ON enterprise.id = enterprise_setting.enterprise_id
       ;`;
@@ -53,8 +53,9 @@ exports.list = function list(req, res, next) {
             'enable_auto_purchase_order_confirmation',
             'enable_auto_email_report',
             'enable_index_payment_system',
-            'month_average_consumption',
             'enable_daily_consumption',
+            'month_average_consumption',
+            'default_min_months_security_stock',
           ];
 
           row.settings = _.pick(row, settings);

--- a/server/controllers/inventory/depots/index.js
+++ b/server/controllers/inventory/depots/index.js
@@ -89,7 +89,8 @@ function update(req, res, next) {
       const sql = `
         SELECT BUID(uuid) as uuid, text, enterprise_id, is_warehouse,
           allow_entry_purchase, allow_entry_donation, allow_entry_integration, allow_entry_transfer,
-          allow_exit_debtor, allow_exit_service, allow_exit_transfer, allow_exit_loss
+          allow_exit_debtor, allow_exit_service, allow_exit_transfer, allow_exit_loss,
+          min_months_security_stock
         FROM depot WHERE uuid = ?`;
       return db.exec(sql, [uid]);
     })
@@ -127,6 +128,7 @@ function list(req, res, next) {
       d.allow_entry_purchase, d.allow_entry_donation, d.allow_entry_integration,
       d.allow_entry_transfer, d.allow_exit_debtor, d.allow_exit_service,
       d.allow_exit_transfer, d.allow_exit_loss, BUID(d.location_uuid) AS location_uuid,
+      d.min_months_security_stock,
       v.name as village_name, s.name as sector_name, p.name as province_name, c.name as country_name
     FROM depot d
     LEFT JOIN village v ON v.uuid = d.location_uuid
@@ -240,7 +242,8 @@ function detail(req, res, next) {
     SELECT
       BUID(d.uuid) as uuid, d.text, d.is_warehouse,
       allow_entry_purchase, allow_entry_donation, allow_entry_integration, allow_entry_transfer,
-      allow_exit_debtor, allow_exit_service, allow_exit_transfer, allow_exit_loss
+      allow_exit_debtor, allow_exit_service, allow_exit_transfer, allow_exit_loss,
+      min_months_security_stock
     FROM depot AS d
     WHERE d.enterprise_id = ? AND d.uuid = ? `;
 
@@ -252,7 +255,7 @@ function detail(req, res, next) {
 
   db.one(query, [req.session.enterprise.id, uid, req.session.user.id])
     .then((row) => {
-    // return the json
+      // return the json
       res.status(200).json(row);
     })
     .catch(next)

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -707,3 +707,11 @@ CREATE TABLE `lot_tag` (
   FOREIGN KEY (`lot_uuid`) REFERENCES `lot` (`uuid`),
   FOREIGN KEY (`tag_uuid`) REFERENCES `tags` (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
+
+/*
+ * @author: jmcameron
+ * @date: 2020-08-28
+ * @description: add min_months_security_stock to enterprise and depot tables
+ */
+ALTER TABLE `depot` ADD COLUMN `min_months_security_stock` SMALLINT(5) NOT NULL DEFAULT 2;
+ALTER TABLE `enterprise_setting` ADD COLUMN `min_months_security_stock` SMALLINT(5) NOT NULL DEFAULT 2;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -460,6 +460,7 @@ CREATE TABLE `depot` (
   `allow_exit_transfer` TINYINT(1) UNSIGNED NOT NULL DEFAULT 0,
   `allow_exit_loss` TINYINT(1) UNSIGNED NOT NULL DEFAULT 0,
   `location_uuid` BINARY(16) NULL,
+  `min_months_security_stock` SMALLINT(5) NOT NULL DEFAULT 2,
   PRIMARY KEY (`uuid`),
   UNIQUE KEY `depot_1` (`text`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
@@ -577,6 +578,7 @@ CREATE TABLE `enterprise_setting` (
   `enable_auto_email_report` TINYINT(1) NOT NULL DEFAULT 0,
   `enable_index_payment_system` TINYINT(1) NOT NULL DEFAULT 0,
   `month_average_consumption` SMALLINT(5) NOT NULL DEFAULT 6,
+  `default_min_months_security_stock` SMALLINT(5) NOT NULL DEFAULT 2,
   `enable_daily_consumption` TINYINT(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`enterprise_id`),
   CONSTRAINT `enterprise_setting__enterprise` FOREIGN KEY (`enterprise_id`) REFERENCES `enterprise` (`id`)

--- a/test/data.sql
+++ b/test/data.sql
@@ -2973,8 +2973,8 @@ SET @depot_uuid = HUID("f9caeb16-1684-43c5-a6c4-47dbac1df296");
 SET @second_depot_uuid = HUID("d4bb1452-e4fa-4742-a281-814140246877");
 
 INSERT INTO `depot` VALUES
-  (@depot_uuid, 'Depot Principal', 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, NULL),
-  (@second_depot_uuid, 'Depot Secondaire', 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL);
+  (@depot_uuid, 'Depot Principal', 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 2),
+  (@second_depot_uuid, 'Depot Secondaire', 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3);
 
 -- Set Depot Management By User
 INSERT INTO depot_permission (user_id, depot_uuid) VALUES
@@ -2987,11 +2987,11 @@ SET @multivitamine = HUID('f6556e72-9d05-4799-8cbd-0a03b1810185');
 
 -- stock lots
 INSERT INTO `lot` (`uuid`, `label`, `initial_quantity`, `quantity`, `unit_cost`, `expiration_date`, `inventory_uuid`, `origin_uuid`, `delay`, `entry_date`) VALUES
-  (HUID('064ab1d9-5246-4402-ae8a-958fcdb07b35'), 'VITAMINE-A', 100, 100, 1.2000, date_add(CURRENT_DATE, INTERVAL 2 YEAR), @multivitamine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
-  (HUID('5a0e06c2-6ca7-4633-8b17-92e2a59db44c'), 'VITAMINE-B', 20, 20, 0.5000, date_add(CURRENT_DATE, INTERVAL 2 YEAR), @multivitamine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
-  (HUID('6f80748b-1d94-4247-804e-d4be99e827d2'), 'QUININE-B', 200, 200, 0.8000, date_add(CURRENT_DATE, INTERVAL 1 MONTH),  @quinine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
+  (HUID('064ab1d9-5246-4402-ae8a-958fcdb07b35'), 'VITAMINE-A', 100, 100, 1.2000, DATE_ADD(CURRENT_DATE, INTERVAL 2 YEAR), @multivitamine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
+  (HUID('5a0e06c2-6ca7-4633-8b17-92e2a59db44c'), 'VITAMINE-B', 20, 20, 0.5000, DATE_ADD(CURRENT_DATE, INTERVAL 2 YEAR), @multivitamine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
+  (HUID('6f80748b-1d94-4247-804e-d4be99e827d2'), 'QUININE-B', 200, 200, 0.8000, DATE_ADD(CURRENT_DATE, INTERVAL 1 MONTH),  @quinine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
   (HUID('ae735e99-8faf-417b-aa63-9b404fca99ac'), 'QUININE-A', 100, 100, 1.2000, '2017-04-30', @quinine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25'),
-  (HUID('ef24cf1a-d5b9-4846-b70c-520e601c1ea6'), 'QUININE-C', 50, 50, 2.0000, date_add(CURRENT_DATE, INTERVAL 2 YEAR), @quinine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25');
+  (HUID('ef24cf1a-d5b9-4846-b70c-520e601c1ea6'), 'QUININE-C', 50, 50, 2.0000, DATE_ADD(CURRENT_DATE, INTERVAL 2 YEAR), @quinine, HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588'), 0, '2017-02-02 11:09:25');
 
 -- stock lots movements
 INSERT INTO `stock_movement` (`uuid`, `lot_uuid`, `document_uuid`, `depot_uuid`, `entity_uuid`, `flux_id`, `date`, `quantity`, `unit_cost`, `is_exit`, `period_id`, `user_id`) VALUES
@@ -3005,10 +3005,14 @@ INSERT INTO `stock_movement` (`uuid`, `lot_uuid`, `document_uuid`, `depot_uuid`,
 -- This segment was added to simulate the distribution of drugs to patients as well as the loss of stock
 INSERT INTO `stock_movement` (`uuid`, `document_uuid`, `depot_uuid`, `lot_uuid`, `entity_uuid`, `description`, `flux_id`, `date`, `quantity`, `unit_cost`, `is_exit`, `user_id`, `invoice_uuid`, `created_at`, `period_id`) VALUES
   (0xB8E73617428B49FDB256DE9C0DFAB743, 0xECE15AAFA73B4A3C880B828CBEB11FE2, 0xF9CAEB16168443C5A6C447DBAC1DF296, 0x6F80748B1D944247804ED4BE99E827D2, NULL, 'Perte de stock', 11, '2019-10-28 13:01:15', 180, 0.8000, 1, 1, NULL, '2019-10-28 13:02:07', 201910),
-  (0xAD36BEC6350A4E1E8961782468FDAADB, 0xA4F26E8C74F84CD29A908CFDB9352A72, 0xF9CAEB16168443C5A6C447DBAC1DF296, 0xAE735E998FAF417BAA639B404FCA99AC, 0xB1816006555845F993A0C222B5EFA6CB, 'Distribution vers un service', 10, '2019-10-28 13:03:03', 80, 1.2000, 1, 1, NULL, '2019-10-28 13:03:35', 201910);
+  (0xAD36BEC6350A4E1E8961782468FDAADB, 0xA4F26E8C74F84CD29A908CFDB9352A72, 0xF9CAEB16168443C5A6C447DBAC1DF296, 0xAE735E998FAF417BAA639B404FCA99AC, 0xB1816006555845F993A0C222B5EFA6CB, 'Distribution vers un service', 10, '2019-10-28 13:03:03', 80, 1.2000, 1, 1, NULL, '2019-10-28 13:03:35', 201910),
+  (0x00068A69CBF54B10960234E913B6EE2C, 0xB88D7A6CCA094F0689C03738DC55C3CC, 0xF9CAEB16168443C5A6C447DBAC1DF296, 0x064AB1D952464402AE8A958FCDB07B35, 0x274C51AEEFCC423898C6F402BFB39866, 'Distribution to Test 2 Patient', 9, DATE_ADD(CURRENT_DATE, INTERVAL -1 WEEK),  10, 1.2000, 1, 1, NULL, DATE_ADD(CURRENT_DATE, INTERVAL -1 WEEK), DATE_FORMAT(DATE_ADD(CURRENT_DATE, INTERVAL -1 WEEK), '%Y%m')),
+  (0xA45397EC170B43D7A246947BFE40EE81, 0x63C5CBB248CE452B97FF0D6BD6B9120B, 0xF9CAEB16168443C5A6C447DBAC1DF296, 0x6F80748B1D944247804ED4BE99E827D2, 0xD1D7F856D41444008B948BA9445A2BC0, 'Distribution to the patient Employee Test 1', 9, DATE_ADD(CURRENT_DATE, INTERVAL -2 WEEK), 5, 0.8000, 1, 1, NULL, DATE_ADD(CURRENT_DATE, INTERVAL -2 WEEK), DATE_FORMAT(DATE_ADD(CURRENT_DATE, INTERVAL -2 WEEK), '%Y%m'));
 
 INSERT INTO `stock_consumption` (`inventory_uuid`, `depot_uuid`, `period_id`, `quantity`) VALUES
-  (0x43F3DECBFCE9426E940ABC2150E62186, 0xF9CAEB16168443C5A6C447DBAC1DF296, 201910, 80);
+  (0x43F3DECBFCE9426E940ABC2150E62186, 0xF9CAEB16168443C5A6C447DBAC1DF296, 201910, 80),
+  (0x43F3DECBFCE9426E940ABC2150E62186, 0xF9CAEB16168443C5A6C447DBAC1DF296, DATE_FORMAT(DATE_ADD(CURRENT_DATE, INTERVAL -1 WEEK), '%Y%m'),  10),
+  (0xF6556E729D0547998CBD0A03B1810185, 0xF9CAEB16168443C5A6C447DBAC1DF296, DATE_FORMAT(DATE_ADD(CURRENT_DATE, INTERVAL -1 WEEK), '%Y%m'),  5);
 
 -- Rubric Payroll
 INSERT INTO `rubric_payroll` (`id`, `label`, `abbr`, `is_employee`, `is_percent`, `is_discount`, `is_tax`, `is_social_care`, `is_defined_employee`, `is_membership_fee`, `debtor_account_id`, `expense_account_id`, `is_ipr`, `is_associated_employee`, `value`) VALUES

--- a/test/end-to-end/cash/registry.spec.js
+++ b/test/end-to-end/cash/registry.spec.js
@@ -26,7 +26,7 @@ function CashPaymentsRegistryTests() {
     await filters.resetFilters();
   });
 
-  it('finds only two payment for today', async () => {
+  it('finds only two payments for today', async () => {
     const DEFAULT_PAYMENTS_FOR_TODAY = 2;
     await modal.switchToDefaultFilterTab();
     await modal.setPeriod('today');

--- a/test/end-to-end/stock/stock.exit.spec.js
+++ b/test/end-to-end/stock/stock.exit.spec.js
@@ -65,7 +65,7 @@ function StockExiTests() {
     await page.addRows(2);
 
     // first item
-    await page.setItem(0, 'Quinine', 'QUININE-B', 14);
+    await page.setItem(0, 'Quinine', 'QUININE-B', 8);
 
     // second item
     await page.setItem(1, 'Vitamines', 'VITAMINE-B', 5);

--- a/test/end-to-end/stock/stock.lots.spec.js
+++ b/test/end-to-end/stock/stock.lots.spec.js
@@ -57,7 +57,7 @@ function StockLotsRegistryTests() {
   it('find lots in depot principal', async () => {
     await modal.setDepot('Depot Principal');
     await modal.submit();
-    await GU.expectRowCount(gridId, 18 + depotGroupingRow);
+    await GU.expectRowCount(gridId, 17 + depotGroupingRow);
   });
 
   it('find lots by inventory', async () => {
@@ -70,7 +70,7 @@ function StockLotsRegistryTests() {
   it('find lot by name', async () => {
     await modal.setLotLabel('VITAMINE-A');
     await modal.submit();
-    await GU.expectRowCount(gridId, 3 + depotGroupingRow);
+    await GU.expectRowCount(gridId, 1 + depotGroupingRow);
   });
 
   it('find lots by entry date', async () => {
@@ -88,7 +88,7 @@ function StockLotsRegistryTests() {
   it('find inventories by group', async () => {
     await components.inventoryGroupSelect.set(inventoryGroup);
     await FU.modal.submit();
-    await GU.expectRowCount(gridId, 10);
+    await GU.expectRowCount(gridId, 9);
     await filters.resetFilters();
   });
 }

--- a/test/end-to-end/stock/stock.movements.spec.js
+++ b/test/end-to-end/stock/stock.movements.spec.js
@@ -30,7 +30,7 @@ function StockMovementsRegistryTests() {
     await modal.switchToDefaultFilterTab();
     await modal.setPeriod('allTime');
     await modal.submit();
-    await GU.expectRowCount(gridId, 16 + (2 * depotGroupingRow));
+    await GU.expectRowCount(gridId, 18 + (2 * depotGroupingRow));
   });
 
   it('find entry movements ', async () => {
@@ -46,7 +46,7 @@ function StockMovementsRegistryTests() {
     await modal.setEntryExit(1);
     await modal.switchToDefaultFilterTab();
     await modal.submit();
-    await GU.expectRowCount(gridId, 10 + depotGroupingRow);
+    await GU.expectRowCount(gridId, 12 + depotGroupingRow);
   });
 
   it('find movements by depot', async () => {
@@ -70,7 +70,7 @@ function StockMovementsRegistryTests() {
   it('find movements by lot name', async () => {
     await modal.setLotLabel('VITAMINE-A');
     await FU.modal.submit();
-    await GU.expectRowCount(gridId, 4 + depotGroupingRow);
+    await GU.expectRowCount(gridId, 5 + depotGroupingRow);
   });
 
   it('find by lots reasons for purchase order', async () => {
@@ -83,7 +83,7 @@ function StockMovementsRegistryTests() {
     // to patient
     await modal.setMovementReason(['Vers un patient']);
     await modal.submit();
-    await GU.expectRowCount(gridId, 3 + depotGroupingRow);
+    await GU.expectRowCount(gridId, 5 + depotGroupingRow);
   });
 
   it('find by lots reasons for distribution to depot', async () => {
@@ -113,7 +113,7 @@ function StockMovementsRegistryTests() {
   it('find movements by reference', async () => {
     await modal.setReference(REFERENCE);
     await modal.submit();
-    await GU.expectRowCount(gridId, 1 + depotGroupingRow);
+    await GU.expectRowCount(gridId, 2 + depotGroupingRow);
   });
 }
 

--- a/test/end-to-end/stock/stock.z2.inventory-adjustment-inventories.spec.js
+++ b/test/end-to-end/stock/stock.z2.inventory-adjustment-inventories.spec.js
@@ -25,7 +25,7 @@ function StockInventoriesRegistryTests() {
   it('find 3 inventory in Depot Principal plus one line for the Grouping', async () => {
     await modal.setDepot('Depot Principal');
     await modal.submit();
-    await GU.expectRowCount(gridId, 3 + GROUPING_ROW);
+    await GU.expectRowCount(gridId, 2 + GROUPING_ROW);
     await filters.resetFilters();
   });
 

--- a/test/end-to-end/stock/stock.z3.inventory-adjustment-lots.spec.js
+++ b/test/end-to-end/stock/stock.z3.inventory-adjustment-lots.spec.js
@@ -23,7 +23,7 @@ function StockLotsRegistryTests() {
   });
 
   const gridId = 'stock-lots-grid';
-  const LOT_FOR_ALLTIME = 3;
+  const LOT_FOR_ALLTIME = 2;
   const GROUPING_ROW = 1;
 
   it(`finds ${LOT_FOR_ALLTIME} lots for all time`, async () => {
@@ -37,12 +37,12 @@ function StockLotsRegistryTests() {
   it('find only lots setted during the adjustment process', async () => {
     const quinine = {
       label : 'Quinine Bichlorhydrate, sirop, 100mg base/5ml, 100ml, flacon, Unité',
-      lot : 'QUININE-A',
+      lot : 'QUININE-B',
       quantity : '17',
     };
     const vitamine = {
       label : 'Vitamines B1+B6+B12, 100+50+0.5mg/2ml, Amp, Unité',
-      lot : 'VITAMINE-A',
+      lot : 'VITAMINE-B',
       quantity : '23',
     };
     await modal.setDepot('Depot Principal');

--- a/test/integration/stock/shared.js
+++ b/test/integration/stock/shared.js
@@ -156,7 +156,7 @@ const movementDepot = {
 };
 
 const depotPrincipalUuid = 'F9CAEB16168443C5A6C447DBAC1DF296';
-const depotPrincipalMvt = 26; // 10 initial plus 3 distributions + 10 imported
+const depotPrincipalMvt = 28; // 10 initial plus 3 distributions + 10 imported
 const lotQuinineUuid = 'ae735e99-8faf-417b-aa63-9b404fca99ac';
 
 const depotSecondaireUuid = 'D4BB1452E4FA4742A281814140246877';

--- a/test/integration/stock/stock.js
+++ b/test/integration/stock/stock.js
@@ -38,7 +38,7 @@ describe('(/stock/) The Stock HTTP API', () => {
   // list all movement relatives to 'Depot Principal'
   it(
     `GET /stock/lots/movements?depot_uuid=...
-    returns movements for Depot Principal (13: 10 IN + 3 OUT)`,
+    returns movements for Depot Principal`,
     async () => {
       const res = await agent.get(`/stock/lots/movements?depot_uuid=${shared.depotPrincipalUuid}`);
       helpers.api.listed(res, shared.depotPrincipalMvt);
@@ -47,10 +47,10 @@ describe('(/stock/) The Stock HTTP API', () => {
 
   // list all movement relatives to patient 'PA.TPA.2'
   it(
-    `GET /stock/lots/movements?patientReference=PA.TPA.2 returns two movements for patient PA.TPA.2`,
+    `GET /stock/lots/movements?patientReference=PA.TPA.2 returns three movements for patient PA.TPA.2`,
     async () => {
       const res = await agent.get('/stock/lots/movements').query({ patientReference : 'PA.TPA.2' });
-      helpers.api.listed(res, 3);
+      helpers.api.listed(res, 4);
     },
   );
 
@@ -67,17 +67,17 @@ describe('(/stock/) The Stock HTTP API', () => {
   // list all stock exit relatives to 'Depot Principal'
   it(
     `GET /stock/lots/movements?is_exit=1&depot_uuid=...
-    returns exits for Depot Principal (3 OUT)`,
+    returns exits for Depot Principal (5 OUT)`,
     async () => {
       const res = await agent.get(`/stock/lots/movements?is_exit=1&depot_uuid=${shared.depotPrincipalUuid}`);
-      helpers.api.listed(res, 6);
+      helpers.api.listed(res, 8);
     },
   );
 
   // (report) render all stock exit
   it(
     `GET /reports/stock/lots?renderer=json
-    returns exits for all depots (10 OUT)`,
+    returns exits for all depots (12 OUT)`,
     async () => {
       const res = await agent.get(`/reports/stock/lots?renderer=json`);
       expect(res.body.rows.length).to.equal(22);
@@ -87,7 +87,7 @@ describe('(/stock/) The Stock HTTP API', () => {
   // (report) render all stock exit relatives to 'Depot Principal'
   it(
     `GET /reports/stock/lots?renderer=json
-    returns exits for Depot principal(10 OUT)`,
+    returns exits for Depot principal(12 OUT)`,
     async () => {
       const res = await agent.get(`/reports/stock/lots?renderer=json&depot_uuid=${shared.depotPrincipalUuid}`);
       expect(res.body.rows.length).to.equal(20);
@@ -136,7 +136,7 @@ describe('(/stock/) The Stock HTTP API', () => {
 
   it(`GET /stock/lots/movements filters on user`, async () => {
     const res = await agent.get('/stock/lots/movements').query({ user_id : 1 });
-    helpers.api.listed(res, 28);
+    helpers.api.listed(res, 30);
   });
 
   // returns quantity of QUININE-A in 'Depot Principal'
@@ -170,12 +170,12 @@ describe('(/stock/) The Stock HTTP API', () => {
 
     helpers.api.listed(res, 4);
 
-    expect(res.body[1].quantity).to.equal(150);
-    expect(res.body[1].avg_consumption).to.equal(10);
-    expect(res.body[1].S_SEC).to.equal(10);
-    expect(res.body[1].S_MIN).to.equal(20);
-    expect(res.body[1].S_MAX).to.equal(20);
-    expect(res.body[1].S_MONTH).to.equal(15);
+    expect(res.body[1].quantity).to.equal(140);
+    expect(res.body[1].avg_consumption).to.equal(8);
+    expect(res.body[1].S_SEC).to.equal(8);
+    expect(res.body[1].S_MIN).to.equal(16);
+    expect(res.body[1].S_MAX).to.equal(16);
+    expect(res.body[1].S_MONTH).to.equal(17);
 
     expect(res.body[2].quantity).to.equal(180300);
     expect(res.body[2].avg_consumption).to.equal(49916.67);


### PR DESCRIPTION
This PR:

- Adds a default Minimum Months of Security Stock ("Safety Stock") to the Enterprise settings
- Adds a minimum months of security stock parameter for depots
- Updates CMM/stock security calculations to use the depot-specific Months of Security Stock parameter
- Adds a 2 stock exits for patients to Bhima_test so that CMM can be calculated

Suggested testing procedure (MMSS = Min Months of Security Stock):
  - Use bhima_test
  - Do:  yarn build:db   (there are new stock exits)
  - Go to Stock > Depot Management
    - Edit each depot and verify that MMSS is:
      - Depot Principal: 2
      - Depot Secondaire: 3
    - Start to create a depot
      - Notice that MMSS defaults to 2
      - Enter name of depot, delete the value of MMSS, try to submit. 
        It should fail with warning that MMSS is required.
      - Exit without creating the depot
  - Go to Administration > Enterprise settings
    - Change default MMSS to 3
    - Select another page
    - Edit enterprise settings again, and verify default MMSS changed to 3
  - Go back to Stock > Depot Management
    - Create a depot, notice that MMSS dfaults to 3
    - Change the MMSS to 1
    - Complete creating the depot
    - Edit it again to verify the MMSS is 1
  - Verify that the MMSS value is being used in stock calculations
    - Go to Stock > Report > Inventories, click Preview
      - Recall that MMSS for the Principal depot defaults to 2
      - Note that the MIN column (near right end) are:
        - Quinine: 20
        - Vitamins: 10
    - Edit the Principal Depot, change MMSS to 1
    - Go to Stock > Report > Inventories, click Preview
      - Note that the MIN column (near right end) are changed:
        - Quinine: 10
        - Vitamins: 5

