### PR TITLE
Fix stock movements grouping

### DIFF
--- a/docs/cloud-init.yml
+++ b/docs/cloud-init.yml
@@ -75,7 +75,7 @@ write_files:
       collation-server=utf8mb4_unicode_ci
       init-connect='SET NAMES utf8mb4'
       character-set-server=utf8mb4
-      sql-mode="STRICT_ALL_TABLES"
+      sql-mode="STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION"
 
   - path: /tmp/bhima.service
     content: |

--- a/server/controllers/finance/fiscal.js
+++ b/server/controllers/finance/fiscal.js
@@ -75,7 +75,6 @@ function lookupFiscalYear(id) {
   return db.one(sql, [id], id, 'fiscal year');
 }
 
-
 function getFiscalYearByPeriodId(periodId) {
   const sql = `
     SELECT id, enterprise_id, number_of_months, label, start_date, end_date,
@@ -88,7 +87,6 @@ function getFiscalYearByPeriodId(periodId) {
 
   return db.one(sql, periodId);
 }
-
 
 /**
  * @method list

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -285,7 +285,7 @@ async function getLotsMovements(depotUuid, params) {
   }
 
   if (params.groupByDocument === 1) {
-    finalClause = 'GROUP BY document_uuid';
+    finalClause = 'GROUP BY document_uuid, is_exit';
     delete params.groupByDocument;
   }
 
@@ -348,7 +348,7 @@ async function getMovements(depotUuid, params) {
   LEFT JOIN service AS serv ON serv.uuid = m.entity_uuid
   `;
 
-  const finalClause = 'GROUP BY document_uuid';
+  const finalClause = 'GROUP BY document_uuid, is_exit';
   const orderBy = 'ORDER BY d.text, m.date';
   const movements = await getLots(sql, params, finalClause, orderBy);
   return movements;

--- a/test/end-to-end/stock/stock.exit.page.js
+++ b/test/end-to-end/stock/stock.exit.page.js
@@ -97,7 +97,7 @@ function StockExitPage() {
   /**
    * @method setItem
    */
-  page.setItem = async function setInventory(rowNumber, code, lot, quantity) {
+  page.setItem = async function setItem(rowNumber, code, lot, quantity) {
     // inventory code column
     const itemCell = await GU.getCell(gridId, rowNumber, 1);
 
@@ -126,7 +126,6 @@ function StockExitPage() {
    */
   page.setLot = async (rowNumber, lot) => {
     const lotCell = await GU.getCell(gridId, rowNumber, 3);
-
     await FU.uiSelectAppended('row.entity.lot', lot, lotCell);
   };
 

--- a/test/end-to-end/stock/stock.inventories.spec.js
+++ b/test/end-to-end/stock/stock.inventories.spec.js
@@ -57,19 +57,19 @@ function StockInventoriesRegistryTests() {
     await filters.resetFilters();
   });
 
-  it('find 2 inventory by state (security reached)', async () => {
+  it('find 3 inventory by state (security reached)', async () => {
     await FU.radio('$ctrl.searchQueries.status', 2);
     await FU.modal.submit();
-    await GU.expectRowCount(gridId, 2);
+    await GU.expectRowCount(gridId, 3);
 
     await filters.resetFilters();
   });
 
-  it('find 2 inventories  by state plus one line for grouping (minimum reached)', async () => {
+  it('find 0 inventories  by state plus one line for grouping (minimum reached)', async () => {
     await FU.radio('$ctrl.searchQueries.status', 3);
     await FU.modal.submit();
 
-    await GU.expectRowCount(gridId, 2);
+    await GU.expectRowCount(gridId, 0);
     await filters.resetFilters();
   });
 

--- a/test/end-to-end/stock/stock.lots.spec.js
+++ b/test/end-to-end/stock/stock.lots.spec.js
@@ -66,7 +66,6 @@ function StockLotsRegistryTests() {
     await GU.expectRowCount(gridId, 4 + (2 * depotGroupingRow));
   });
 
-
   it('find lot by name', async () => {
     await modal.setLotLabel('VITAMINE-A');
     await modal.submit();

--- a/test/end-to-end/stock/stock.movements.spec.js
+++ b/test/end-to-end/stock/stock.movements.spec.js
@@ -30,7 +30,7 @@ function StockMovementsRegistryTests() {
     await modal.switchToDefaultFilterTab();
     await modal.setPeriod('allTime');
     await modal.submit();
-    await GU.expectRowCount(gridId, 18 + (2 * depotGroupingRow));
+    await GU.expectRowCount(gridId, 19 + (2 * depotGroupingRow));
   });
 
   it('find entry movements ', async () => {
@@ -70,7 +70,7 @@ function StockMovementsRegistryTests() {
   it('find movements by lot name', async () => {
     await modal.setLotLabel('VITAMINE-A');
     await FU.modal.submit();
-    await GU.expectRowCount(gridId, 5 + depotGroupingRow);
+    await GU.expectRowCount(gridId, 7 + depotGroupingRow);
   });
 
   it('find by lots reasons for purchase order', async () => {

--- a/test/integration/stock/stock.js
+++ b/test/integration/stock/stock.js
@@ -171,11 +171,11 @@ describe('(/stock/) The Stock HTTP API', () => {
     helpers.api.listed(res, 4);
 
     expect(res.body[1].quantity).to.equal(140);
-    expect(res.body[1].avg_consumption).to.equal(8);
-    expect(res.body[1].S_SEC).to.equal(8);
-    expect(res.body[1].S_MIN).to.equal(16);
-    expect(res.body[1].S_MAX).to.equal(16);
-    expect(res.body[1].S_MONTH).to.equal(17);
+    expect(res.body[1].avg_consumption).to.equal(15);
+    expect(res.body[1].S_SEC).to.equal(15);
+    expect(res.body[1].S_MIN).to.equal(30);
+    expect(res.body[1].S_MAX).to.equal(30);
+    expect(res.body[1].S_MONTH).to.equal(9);
 
     expect(res.body[2].quantity).to.equal(180300);
     expect(res.body[2].avg_consumption).to.equal(49916.67);


### PR DESCRIPTION
Stock movements are not uniquely identified by their document_uuid.
This is documented in #4083.  However, the tests made this assumption
because MySQL 5.7 had a stable sort on the GROUP BY.  In MySQL 8, this
is no longer stable.

To solve this issue, grouping on `document_uuid` now includes the `is_exit` column
as well.