### PR TITLE
fix(receipts): allow stock movement lookups

### DIFF
--- a/server/config/identifiers.js
+++ b/server/config/identifiers.js
@@ -54,6 +54,7 @@ module.exports = {
   STOCK_MOVEMENT : {
     key : 'SM',
     table : 'stock_movement',
+    documentPath : '/receipts/stock/',
     redirectPath : '/#/stock/movements',
   },
   STOCK_LOT : {


### PR DESCRIPTION
This commit fixes the stock movement lookups to actually render their PDFs on click.  It also brings the reference lookups into line with the other reference lookups and streamlines the lookups.

**Before**
![KqIba0grPB](https://user-images.githubusercontent.com/896472/92488140-111b5f00-f1e6-11ea-8798-e5b70292d691.gif)



**After**
![EhoqwMyYr3](https://user-images.githubusercontent.com/896472/92488011-ec26ec00-f1e5-11ea-96de-15386c76f602.gif)

