### PR TITLE
fix(stock): credit supplier on entry from purchase

### DIFF
--- a/client/src/i18n/en/enterprise.json
+++ b/client/src/i18n/en/enterprise.json
@@ -32,7 +32,9 @@
       "ENABLE_AUTO_EMAIL_REPORT_HELP_TEXT" : "Enabling this option allows users to configure schedules to automatically send reports to a list of email addresses.",
       "ENABLE_INDEX_PAYMENT_SYSTEM" : "Enabling index payment system",
       "ENABLE_DAILY_CONSUMPTION_LABEL" : "Enable CMM calculation based on days of consumption",
-      "ENABLE_DAILY_CONSUMPTION_HELP_TEXT" : "The CMM (Average Monthly Consumption) is calculated taking into account the quantities consumed over the number of days on which there was consumption"
+      "ENABLE_DAILY_CONSUMPTION_HELP_TEXT" : "The CMM (Average Monthly Consumption) is calculated taking into account the quantities consumed over the number of days on which there was consumption",
+      "ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY" : "Enable Automatic Crediting of Supplier on Stock Entry",
+      "ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY_HELP_TEXT" : "Automatically adds the transactions to credit the supplier for the value of stock received in a depot when entering stock from a purchase order.  This is only triggered if the automatic stock accounting is set as well."
     }
   }
 }

--- a/client/src/i18n/fr/enterprise.json
+++ b/client/src/i18n/fr/enterprise.json
@@ -32,7 +32,9 @@
       "ENABLE_AUTO_EMAIL_REPORT_HELP_TEXT" : "L'activation de cette option permet aux utilisateurs de configurer des planifications pour envoyer automatiquement des rapports à une liste d'adresses électroniques.",
       "ENABLE_INDEX_PAYMENT_SYSTEM" : "Activer le systeme de payement par indice",
       "ENABLE_DAILY_CONSUMPTION_LABEL" : "Activer le calcul du CMM sur base des jours de consommation",
-      "ENABLE_DAILY_CONSUMPTION_HELP_TEXT" : "La Consommation Moyenne Mensuelle (CMM) est calculée en tenant compte des quantités consommées sur le nombre de jours où il y a eu des consommation"
+      "ENABLE_DAILY_CONSUMPTION_HELP_TEXT" : "La Consommation Moyenne Mensuelle (CMM) est calculée en tenant compte des quantités consommées sur le nombre de jours où il y a eu des consommation",
+      "ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY" : "Activer le crédit automatique du fournisseur lors de l'entrée de stock",
+      "ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY_HELP_TEXT" : "Ajoute automatiquement les transactions pour créditer le fournisseur de la valeur du stock reçu dans un dépôt lors de l'entrée du stock à partir d'une commande d'achat. Ceci n'est déclenché que si la comptabilité de stock automatique est également définie."
     }
   }
 }

--- a/client/src/modules/enterprises/enterprises.html
+++ b/client/src/modules/enterprises/enterprises.html
@@ -249,6 +249,14 @@
               </div>
 
               <bh-yes-no-radios
+                label="ENTERPRISE.SETTINGS.ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY"
+                value="EnterpriseCtrl.enterprise.settings.enable_supplier_credit"
+                name="enable_supplier_credit"
+                help-text="ENTERPRISE.SETTINGS.ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY_HELP_TEXT"
+                on-change-callback="EnterpriseCtrl.enableSupplierCredit(value)">
+              </bh-yes-no-radios>
+
+              <bh-yes-no-radios
                 label="ENTERPRISE.SETTINGS.ENABLE_PRICE_LOCK_LABEL"
                 value="EnterpriseCtrl.enterprise.settings.enable_price_lock"
                 name="enable_price_lock"

--- a/client/src/modules/enterprises/enterprises.js
+++ b/client/src/modules/enterprises/enterprises.js
@@ -228,6 +228,7 @@ function EnterpriseController(Enterprises, util, Notify, Projects, Modal, Scroll
   vm.enableAutoEmailReportSetting = proxy('enable_auto_email_report');
   vm.enableIndexPaymentSetting = proxy('enable_index_payment_system');
   vm.enableDailyConsumptionSetting = proxy('enable_daily_consumption');
+  vm.enableSupplierCredit = proxy('enable_supplier_credit');
   vm.setMonthAverage = function setMonthAverage() {
     $touched = true;
   };

--- a/server/controllers/admin/enterprises.js
+++ b/server/controllers/admin/enterprises.js
@@ -23,7 +23,7 @@ exports.list = function list(req, res, next) {
     sql = `
       SELECT id, name, abbr, email, po_box, phone, address,
         BUID(location_id) AS location_id, logo, currency_id,
-        gain_account_id, loss_account_id, enable_price_lock, enable_prepayments,
+        gain_account_id, loss_account_id, enable_price_lock, enable_prepayments, enable_supplier_credit,
         enable_delete_records, enable_password_validation, enable_balance_on_invoice_receipt,
         enable_barcodes, enable_auto_stock_accounting, enable_auto_purchase_order_confirmation,
         enable_auto_email_report, enable_index_payment_system, enable_daily_consumption,
@@ -56,6 +56,7 @@ exports.list = function list(req, res, next) {
             'enable_daily_consumption',
             'month_average_consumption',
             'default_min_months_security_stock',
+            'enable_supplier_credit',
           ];
 
           row.settings = _.pick(row, settings);

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -109,6 +109,10 @@ async function createStock(req, res, next) {
         period_id : periodId,
       };
 
+      if (params.entity_uuid) {
+        createMovementObject.entity_uuid = db.bid(params.entity_uuid);
+      }
+
       // adding a lot insertion query into the transaction
       transaction.addQuery(createLotQuery, [createLotObject]);
 

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -743,10 +743,19 @@ CREATE TABLE  `stock_movement_status` (
  * @author: mbayopanda
  * @date: 2020-09-07
  * @description: Add the importance level column in the inventory table
- *    the importance value can be : 
+ *    the importance value can be :
  *    NULL -> The inventory doesn't need a particular focus for dashboards
- *    1 -> LOW 
- *    2 -> MID 
+ *    1 -> LOW
+ *    2 -> MID
  *    3 -> HIGH
  */
 ALTER TABLE inventory ADD COLUMN `importance` SMALLINT(5) NULL COMMENT 'Inventory level of importance : 1 -> LOW, 2 -> MID, 3 -> HIGH';
+
+
+/*
+ * @author: jniles
+ * @date: 2020-09-10
+ * @description: add enterprise setting for crediting supplier's invoice on stock
+ * entry from purchase.
+ */
+ALTER TABLE `enterprise_setting` ADD COLUMN `enable_supplier_credit` TINYINT(1) NOT NULL DEFAULT 0;

--- a/server/models/procedures/stock.sql
+++ b/server/models/procedures/stock.sql
@@ -65,6 +65,7 @@ BEGIN
   DECLARE v_item_description TEXT;
 
   DECLARE sm_flux_id INT(11);
+  DECLARE es_enable_supplier_credit TINYINT(1) DEFAULT 0;
   DECLARE FROM_PURCHASE_FLUX_ID INT(11) DEFAULT 1;
 
   -- transaction type
@@ -130,9 +131,17 @@ BEGIN
   -- get the flux id
   SET sm_flux_id = (SELECT flux_id FROM stock_movement WHERE document_uuid = documentUuid AND is_exit = isExit LIMIT 1);
 
+  -- check if enable_supplier_credit is set for this enterprise
+  SET es_enable_supplier_credit = (
+    SELECT enable_supplier_credit FROM enterprise_setting AS es
+      JOIN enterprise AS e ON e.id = es.enterprise_id
+      JOIN project AS p ON e.id = p.enterprise_id
+    WHERE p.id = projectId
+  );
+
   -- if this is from a purchase, grap the supplier's account as the account to credit in the voucher, not
   -- the COGS account
-  IF (sm_flux_id = FROM_PURCHASE_FLUX_ID) THEN
+  IF (sm_flux_id = FROM_PURCHASE_FLUX_ID AND es_enable_supplier_credit = 1) THEN
     SET voucher_item_account_credit = (
       SELECT creditor_group.account_id FROM purchase
         JOIN supplier ON purchase.supplier_uuid = supplier.uuid
@@ -165,7 +174,7 @@ BEGIN
     if (v_is_exit = 1) THEN
       SET voucher_item_account_debit = v_cogs_account;
       SET voucher_item_account_credit = v_stock_account;
-    ELSEIF (sm_flux_id = FROM_PURCHASE_FLUX_ID) THEN
+    ELSEIF (sm_flux_id = FROM_PURCHASE_FLUX_ID AND es_enable_supplier_credit = 1) THEN
       -- we already set the credit account above for the purchase case
       SET voucher_item_account_debit = v_stock_account;
     ELSE

--- a/server/models/procedures/stock.sql
+++ b/server/models/procedures/stock.sql
@@ -64,6 +64,9 @@ BEGIN
   DECLARE v_is_exit TINYINT(1);
   DECLARE v_item_description TEXT;
 
+  DECLARE sm_flux_id INT(11);
+  DECLARE FROM_PURCHASE_FLUX_ID INT(11) DEFAULT 1;
+
   -- transaction type
   DECLARE STOCK_EXIT_TYPE SMALLINT(5) DEFAULT 13;
   DECLARE STOCK_ENTRY_TYPE SMALLINT(5) DEFAULT 14;
@@ -124,6 +127,23 @@ BEGIN
     SET voucher_type_id = STOCK_ENTRY_TYPE;
   END IF;
 
+  -- get the flux id
+  SET sm_flux_id = (SELECT flux_id FROM stock_movement WHERE document_uuid = documentUuid AND is_exit = isExit LIMIT 1);
+
+  -- if this is from a purchase, grap the supplier's account as the account to credit in the voucher, not
+  -- the COGS account
+  IF (sm_flux_id = FROM_PURCHASE_FLUX_ID) THEN
+    SET voucher_item_account_credit = (
+      SELECT creditor_group.account_id FROM purchase
+        JOIN supplier ON purchase.supplier_uuid = supplier.uuid
+        JOIN creditor ON supplier.creditor_uuid = creditor.uuid
+        JOIN creditor_group ON creditor_group.uuid = creditor.group_uuid
+      WHERE purchase.uuid IN (
+        SELECT entity_uuid FROM stock_movement WHERE document_uuid = documentUuid AND is_exit = isExit
+      )
+    );
+  END IF;
+
   -- insert into voucher
   INSERT INTO voucher (uuid, date, project_id, currency_id, user_id, type_id, description, amount) VALUES (
     voucher_uuid, voucher_date, voucher_project_id, voucher_currency_id, voucher_user_id,
@@ -145,6 +165,9 @@ BEGIN
     if (v_is_exit = 1) THEN
       SET voucher_item_account_debit = v_cogs_account;
       SET voucher_item_account_credit = v_stock_account;
+    ELSEIF (sm_flux_id = FROM_PURCHASE_FLUX_ID) THEN
+      -- we already set the credit account above for the purchase case
+      SET voucher_item_account_debit = v_stock_account;
     ELSE
       SET voucher_item_account_debit = v_stock_account;
       SET voucher_item_account_credit = v_cogs_account;
@@ -384,11 +407,11 @@ CREATE PROCEDURE `computeStockQuantity` (
 
     SET _qtt = IFNULL(_qtt, 0);
 
-    SELECT in_quantity, out_quantity 
+    SELECT in_quantity, out_quantity
     INTO _in_qtt, _out_qtt
     FROM temp_stock_movement m
     WHERE DATE(m.date) =DATE(_start_date) AND m.depot_uuid = @depot_uuid;
-  
+
     DELETE FROM temp_stock_movement WHERE DATE(`date`) <=_start_date AND `depot_uuid` = @depot_uuid;
 
     -- check if this date already exist in stock_movement_status for the inventory

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -580,6 +580,7 @@ CREATE TABLE `enterprise_setting` (
   `month_average_consumption` SMALLINT(5) NOT NULL DEFAULT 6,
   `default_min_months_security_stock` SMALLINT(5) NOT NULL DEFAULT 2,
   `enable_daily_consumption` TINYINT(1) NOT NULL DEFAULT 0,
+  `enable_supplier_credit` TINYINT(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`enterprise_id`),
   CONSTRAINT `enterprise_setting__enterprise` FOREIGN KEY (`enterprise_id`) REFERENCES `enterprise` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1667,7 +1667,7 @@ CREATE TABLE `supplier` (
   `fax`             VARCHAR(45) DEFAULT NULL,
   `note`            TEXT,
   `phone`           VARCHAR(15) DEFAULT NULL,
-  `INTernational`   TINYINT(1) NOT NULL DEFAULT 0,
+  `international`   TINYINT(1) NOT NULL DEFAULT 0,
   `locked`          TINYINT(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`uuid`),
   UNIQUE KEY `supplier_1` (`display_name`),
@@ -1960,7 +1960,7 @@ CREATE TABLE `stock_movement` (
   `document_uuid`   BINARY(16) NOT NULL,
   `depot_uuid`      BINARY(16) NOT NULL,
   `lot_uuid`        BINARY(16) NOT NULL,
-  `entity_uuid`     BINARY(16) NULL,
+  `entity_uuid`     BINARY(16) NULL, -- holds the patient_uuid, destination depot_uuid, service_uuid, or purchase_order uuid
   `description`     TEXT NULL,
   `flux_id`         INT(11) NOT NULL,
   `date`            DATETIME NOT NULL,


### PR DESCRIPTION
This commit fixes the stock management accounting to credit the supplier's account when stock is received in the depot from a purchase order.

Importantly, this feature is configurable, so that it doesn't affect enterprises that do OHADA accounting and wish to pass these writings manually.

Fixes a bug our friends in Vanga are facing in production.

Partially addresses #4081.

This will definitely collide with https://github.com/IMA-WorldHealth/bhima/pull/4898.