### PR TITLE
chore: separate stock entry and exit types ctrls

### DIFF
--- a/client/src/modules/stock/entry/entry.html
+++ b/client/src/modules/stock/entry/entry.html
@@ -36,14 +36,13 @@
 
       <!-- activator -->
       <div class="row">
-        <bh-stock-entry-exit-type
-          on-entry-exit-type-select-callback="StockCtrl.selectEntryType(type)"
+        <bh-stock-entry-type
+          on-select-callback="StockCtrl.selectEntryType(type)"
           reference="StockCtrl.reference"
           display-name="StockCtrl.displayName"
-          is-entry="true"
           depot="StockCtrl.depot"
           reset="StockCtrl.resetEntryExitTypes">
-        </bh-stock-entry-exit-type>
+        </bh-stock-entry-type>
       </div>
 
       <!-- date and note -->

--- a/client/src/modules/stock/exit/exit.html
+++ b/client/src/modules/stock/exit/exit.html
@@ -34,14 +34,13 @@
     <form name="StockExitForm" bh-submit="StockCtrl.submit(StockExitForm)" novalidate>
       <!-- destination -->
       <div class="row">
-        <bh-stock-entry-exit-type
-          on-entry-exit-type-select-callback="StockCtrl.selectExitType(type)"
+        <bh-stock-exit-type
+          on-select-callback="StockCtrl.selectExitType(type)"
           reference="StockCtrl.reference"
           display-name="StockCtrl.displayName"
-          is-entry="false"
           depot="StockCtrl.depot"
           reset="StockCtrl.resetEntryExitTypes">
-        </bh-stock-entry-exit-type>
+        </bh-stock-exit-type>
       </div>
 
       <!-- entity -->

--- a/client/src/modules/templates/bhStockEntryExitType.tmpl.html
+++ b/client/src/modules/templates/bhStockEntryExitType.tmpl.html
@@ -4,7 +4,7 @@
     id="entry-exit-type-{{type.label}}"
     class="btn-block panel panel-default segment ima-stat-card"
     ng-class="{ 'ima-stat-card-reversed' : $ctrl.isTypeSelected(type) }"
-    ng-click="$ctrl.selectEntryExitType(type)">
+    ng-click="$ctrl.selectType(type)">
       <div class="panel-body text-center text-ellipsis">
         <div class="ui lg statistic">
           <div class="value" translate>{{type.labelKey}}</div>


### PR DESCRIPTION
Separates the stock entry and exit types controllers into two different  controllers.  This simplifies the entry and exit type functionality.

Tangentially related to https://github.com/IMA-WorldHealth/bhima/issues/4744.