### PR TITLE
Hide 'Show items in stock' from purchase registry action menus if none

### DIFF
--- a/client/src/modules/purchases/list/list.js
+++ b/client/src/modules/purchases/list/list.js
@@ -213,7 +213,6 @@ function PurchaseListController(
 
   }
 
-
   // fire up the module
   startup();
 }

--- a/client/src/modules/purchases/templates/action.cell.html
+++ b/client/src/modules/purchases/templates/action.cell.html
@@ -29,7 +29,7 @@
       </a>
     </li>
 
-    <li>
+    <li ng-if="row.entity.hasStockMovement">
       <a data-method="view-stock-lot" href
         ui-sref="stockInventories({ filters : [
           { key : 'period', value : 'allTime' },


### PR DESCRIPTION
In the Purchase Registry, does not show the "Show items in stock" in the action menu for any purchase orders that have not received any stock.

Suggestions for testing:

- Use Bhima_test
- yarn dev
- In Bhima_test, there are no Purchase Orders that have received stock so we need to add one:
   - Go to Stock Entry and do the entry by purchase order.  Select the only available confirmed PO, and receive/enter its stock items.
- Go to Purchases > Purchase Registry
- Check the Action menus of the two POs.   
   - The one that has just received stock should show the "Show items in stock" 
![image](https://user-images.githubusercontent.com/62145/92963518-714d1380-f427-11ea-9579-f090d914e23a.png)
   - The second should not have it:  
![image](https://user-images.githubusercontent.com/62145/92963658-ace7dd80-f427-11ea-93e1-d982ffeb2dfa.png)


