### PR TITLE
fix: listen on appveyor PR

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
   "continuous-integration/travis-ci/push",
-  "continuous-integration/appveyor/branch"
+  "continuous-integration/appveyor/pr"
 ]
 
 delete_merged_branches = true


### PR DESCRIPTION
Configures bors to listen on the appveyor PR status, not the branch status.  This brings it in line with github checks.