### PR TITLE
Add SemaphoreCI for testing instead of AppVeyor

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,7 +23,7 @@ blocks:
           value: bhima
         - name: DB_HOST
           value: 127.0.0.1
-        - name: DB_PASSWORD
+        - name: DB_PASS
           value: 6a50c5ed121ac12b35b96cbb59b5
         - name: DB_PORT
           value: '3306'
@@ -34,7 +34,7 @@ blocks:
       jobs:
         - name: Run Test Matrix
           commands:
-            - 'sem-service start mysql $MYSQL_VERSION --username=$DB_USER --password=$DB_PASSWORD --db=$DB_NAME --sql-mode="STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION"'
+            - 'sem-service start mysql $MYSQL_VERSION --username=$DB_USER --password=$DB_PASS --db=$DB_NAME --sql-mode="STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION"'
             - nvm install $NODEJS_VERSION
             - checkout
             - 'echo "Testing node:$NODEJS_VERSION on mysql:$MYSQL_VERSION"'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,7 +28,7 @@ blocks:
         - name: DB_PORT
           value: '3306'
         - name: DB_NAME
-          value: bhima-semaphore
+          value: semaphoreci
         - name: PORT
           value: '8080'
       jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,54 @@
+version: v1.0
+name: Integration Tests
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Update Dependencies
+    task:
+      jobs:
+        - name: Update Dependencies
+          commands:
+            - sudo apt-get -y update && sudo apt-get install mysql-client redis-tools
+            - sudo apt autoremove -y && sudo apt autoclean -y
+            - echo "done"
+  - name: Testing Matrix
+    task:
+      prologue:
+        commands:
+          - sem-service start redis
+      env_vars:
+        - name: DB_USER
+          value: bhima
+        - name: DB_HOST
+          value: 127.0.0.1
+        - name: DB_PASSWORD
+          value: 6a50c5ed121ac12b35b96cbb59b5
+        - name: DB_PORT
+          value: '3306'
+        - name: DB_NAME
+          value: bhima-semaphore
+        - name: PORT
+          value: '8080'
+      jobs:
+        - name: Run Test Matrix
+          commands:
+            - 'sem-service start mysql $MYSQL_VERSION --username=$DB_USER --password=$DB_PASSWORD --db=$DB_NAME --sql-mode="STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION"'
+            - nvm install $NODEJS_VERSION
+            - checkout
+            - 'echo "Testing node:$NODEJS_VERSION on mysql:$MYSQL_VERSION"'
+            - yarn
+            - 'yarn build:db'
+            - yarn build
+            - 'yarn test:server-unit'
+            - echo "done."
+          matrix:
+            - env_var: MYSQL_VERSION
+              values:
+                - '5.7'
+                - '8'
+            - env_var: NODEJS_VERSION
+              values:
+                - '12'
+                - '14'

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
   "continuous-integration/travis-ci/push",
-  "continuous-integration/appveyor/branch"
+  "continuous-integration/semaphoreci"
 ]
 
 delete_merged_branches = true

--- a/sh/build-database.sh
+++ b/sh/build-database.sh
@@ -21,6 +21,8 @@ if [ "$1" == "debug" ]; then
     fout=/dev/tty
 fi
 
+echo "Building database: $DB_USER,$DB_PASS,$DB_HOST,$DB_NAME'"
+
 # build the test database
 mysql -u $DB_USER -p$DB_PASS -h$DB_HOST -e "DROP DATABASE IF EXISTS $DB_NAME ;" || { echo 'failed to drop DB' ; exit 1; }
 mysql -u $DB_USER -p$DB_PASS -h$DB_HOST -e "CREATE DATABASE $DB_NAME CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" || { echo 'failed to create DB' ; exit 1; }


### PR DESCRIPTION
Well, I've bit the bullet and am working again on testing with a different service.  My rationale for moving away from AppVeyor is the following:

 1. We ran into multiple issues with AppVeyor and environmental variables resulting from AppVeyor confusing my personal account and the Github org account.
 2. AppVeyor did not support parallel builds.
 3. AppVeyor is built for windows and it was kind of cludgey getting the linux builds working correctly.
 4. They do not support deleting accounts.  You can't do it.  You have to open a support ticket.  This is a red flag I was not aware of when installing it.

Things that I have learned since moving:
  1. Semaphore CI is blazingly fast.  I'm super happy with it.
  2. The configuration files are intuitive and their web GUI is really nice.