### PR TITLE
fix(reports): stock expiration report

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -149,8 +149,8 @@
       "EXCLUDE_INVENTORIES_ZERO_VALUE": "Exclude inventories with zero stock value"
     },
     "STOCK_EXPIRATION_REPORT" : {
-      "TITLE": "Stock expiration report",
-      "DESCRIPTION": ""
+      "TITLE": "Stock Expiration Report",
+      "DESCRIPTION": "This report shows the lots that are currently in stock and are also expired or will expire prior to being consummed."
     },
     "STOCK_CONSUMPTION_GRAPH_REPORT" : {
       "TITLE" : "Stock Consumption's graph report",

--- a/client/src/js/components/bhIndicator/bhIndicator.html
+++ b/client/src/js/components/bhIndicator/bhIndicator.html
@@ -33,19 +33,19 @@
       <sup class="value-symbol" translate>{{ $ctrl.valueSymbol }}</sup>
     </div>
     <div class="description-section">
-        <div class="description" translate>
-          {{ $ctrl.description }}
-        </div>
-        <ul ng-if="$ctrl.dependencies && $ctrl.dependencies.length">
-          <li ng-repeat="deps in $ctrl.dependencies">
-            <span translate>{{ 'DASHBOARD.INDICATORS_FILES.' + deps.key }}</span>
-            <span>{{ deps.value | number }}</span>
-          </li>
-        </ul>
-        <div class="norm">
-          <span translate>DASHBOARD.NORM</span>
-          <span translate>{{ $ctrl.norm }}</span>
-        </div>
+      <div class="description" translate>
+        {{ $ctrl.description }}
+      </div>
+      <ul ng-if="$ctrl.dependencies && $ctrl.dependencies.length">
+        <li ng-repeat="deps in $ctrl.dependencies">
+          <span translate>{{ 'DASHBOARD.INDICATORS_FILES.' + deps.key }}</span>
+          <span>{{ deps.value | number }}</span>
+        </li>
+      </ul>
+      <div class="norm">
+        <span translate>DASHBOARD.NORM</span>
+        <span translate>{{ $ctrl.norm }}</span>
+      </div>
     </div>
   </div>
 </div>

--- a/client/src/modules/dashboards/finance/finance.html
+++ b/client/src/modules/dashboards/finance/finance.html
@@ -26,7 +26,7 @@
   /* Medium devices (desktops, 992px and up) */
   @media (min-width: 992px) {
     .dashboard {
-      grid-template-columns: repeat(2, 1fr); 
+      grid-template-columns: repeat(2, 1fr);
     }
   }
 </style>
@@ -37,7 +37,7 @@
         <li class="static" translate>TREE.DASHBOARDS.TITLE</li>
         <li class="title" translate>TREE.DASHBOARDS.FINANCES</li>
       </ol>
-  
+
       <div class="toolbar">
         <div class="toolbar-item">
           <bh-dashboard-filter
@@ -49,7 +49,7 @@
       </div>
     </div>
   </div>
-  
+
   <div class="flex-content">
     <div class="container">
       <h3 class="no-space" translate>DASHBOARD.INDICATORS_FILES.FINANCES_INDICATORS</h3>
@@ -202,4 +202,3 @@
       </div>
     </div>
   </div>
-  

--- a/client/src/modules/reports/generate/stock_expiration_report/stock_expiration_report.config.js
+++ b/client/src/modules/reports/generate/stock_expiration_report/stock_expiration_report.config.js
@@ -22,10 +22,6 @@ function StockExpirationReportConfigCtrl($sce, Notify, SavedReports, AppCache, r
     vm.reportDetails.depot_uuid = depot.uuid;
   };
 
-  vm.onSelectInventory = inventory => {
-    vm.reportDetails.inventory_uuid = inventory.uuid;
-  };
-
   vm.onSelectFiscalYear = year => {
     vm.reportDetails.fiscal_id = year.id;
   };

--- a/client/src/modules/reports/generate/stock_expiration_report/stock_expiration_report.html
+++ b/client/src/modules/reports/generate/stock_expiration_report/stock_expiration_report.html
@@ -24,13 +24,6 @@
 
           <form name="ConfigForm" bh-submit="ReportConfigCtrl.preview(ConfigForm)" novalidate autocomplete="off">
 
-            <bh-date-interval
-              date-from="ReportConfigCtrl.reportDetails.dateFrom"
-              date-to="ReportConfigCtrl.reportDetails.dateTo"
-              required="true"
-              limit-min-fiscal>
-            </bh-date-interval>   
-
               <!-- depot options -->
           <div class="checkbox">
             <label>
@@ -41,35 +34,15 @@
 
           <!-- select depot -->
           <div ng-if="!!ReportConfigCtrl.chooseOneDepot">
-            
+
             <!-- select depot -->
             <bh-depot-select
               depot-uuid="ReportConfigCtrl.reportDetails.depot_uuid"
               on-select-callback="ReportConfigCtrl.onSelectDepot(depot)">
               <bh-clear on-clear="ReportConfigCtrl.clear('depot_uuid')"></bh-clear>
-             </bh-depot-select>
-          </div>
-            
-              <!-- inventory options -->
-          <div class="checkbox">
-            <label>
-              <input type="checkbox" ng-model="ReportConfigCtrl.chooseOneInventory">
-              <span translate>REPORT.STOCK.ONE_INVENTORY</span>
-            </label>
+           </bh-depot-select>
           </div>
 
-          <!-- select inventory -->
-            <div ng-if="!!ReportConfigCtrl.chooseOneInventory">
-              
-              <!-- select inventory -->
-              <bh-inventory-select
-                inventory-uuid="ReportConfigCtrl.reportDetails.inventory_uuid"
-                on-select-callback="ReportConfigCtrl.onSelectInventory(inventory)"
-                only-consumable="true">
-                
-                <bh-clear on-clear="ReportConfigCtrl.clear('inventory_uuid')"></bh-clear>
-                </bh-inventory-select>
-            </div>
             <!-- preview -->
             <bh-loading-button loading-state="ConfigForm.$loading">
               <span translate>REPORT.UTIL.PREVIEW</span>

--- a/server/controllers/finance/reports/recovery_capacity/report.handlebars
+++ b/server/controllers/finance/reports/recovery_capacity/report.handlebars
@@ -52,7 +52,7 @@
             <td class="text-right">{{debcred row.total_invoiced ../metadata.enterprise.currency_id}}</td>
             <td class="text-right">{{debcred row.avg_cost ../metadata.enterprise.currency_id}}</td>
             <td class="text-right">{{debcred row.total_paid ../metadata.enterprise.currency_id}}</td>
-            <td 
+            <td
               style="width: 15em;"
               {{#gt row.recovery_capacity 0.71}} class="bg-success text-success text-right" {{/gt}}
               {{#between row.recovery_capacity 0.6 0.7}} class="bg-warning text-warning text-right" {{/between}}
@@ -69,7 +69,7 @@
             <th class="text-right">{{debcred totals.total_invoiced metadata.enterprise.currency_id}}</th>
             <th class="text-right">{{debcred totals.avg_cost metadata.enterprise.currency_id}}</th>
             <th class="text-right">{{debcred totals.total_paid metadata.enterprise.currency_id}}</th>
-            <th 
+            <th
               style="width: 15em;"
               {{#gt totals.recovery_capacity 0.71}} class="bg-success text-success text-right" {{/gt}}
               {{#between totals.recovery_capacity 0.6 0.7}} class="bg-warning text-warning text-right" {{/between}}

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -226,7 +226,7 @@ async function getLotsDepot(depotUuid, params, finalClause) {
     emptyLotToken = 'HAVING quantity > 0';
     delete params.includeEmptyLot;
   } else if (includeEmptyLot === 2) {
-    emptyLotToken = 'HAVING quantity=0';
+    emptyLotToken = 'HAVING quantity = 0';
   }
 
   const sql = `
@@ -799,7 +799,7 @@ function processMultipleLots(inventories) {
           // if we have more months of stock than the expiration date,
           // then we'll need to label these are in risk of expiration
           const numDaysOfStockLeft = numMonthsOfStockLeft * 30.5;
-          const isInRiskOfExpiration = lot.expiration_date < moment(today).add(numDaysOfStockLeft, 'days').toDate();
+          const isInRiskOfExpiration = lot.expiration_date <= moment(today).add(numDaysOfStockLeft, 'days').toDate();
           lot.IS_IN_RISK_EXPIRATION = isInRiskOfExpiration;
 
           lot.S_LOT_LIFETIME = zeroMSD || lot.lifetime < 0 ? 0 : lot.lifetime - lotLifetime;

--- a/server/controllers/stock/reports/stock/expiration_report.js
+++ b/server/controllers/stock/reports/stock/expiration_report.js
@@ -1,30 +1,28 @@
 const {
   _, db, ReportManager, pdfOptions, STOCK_EXPIRATION_REPORT_TEMPLATE,
 } = require('../common');
-const stockCore = require('../../core');
-/**
-   * @method stockEntryReport
-   *
-   * @description
-   * This method builds the stock entry report as either a JSON, PDF, or HTML
-   * file to be sent to the client.
-   *
-   * GET /reports/stock/consumption_graph
-   */
-async function stockExpirationReport(req, res, next) {
-  try {
 
-    const params = _.clone(req.query);
+const stockCore = require('../../core');
+
+/**
+ * @method stockExpirationReport
+ *
+ * @description
+ *
+ */
+async function stockExpirationReport(req, res, next) {
+
+  try {
+    const params = { includeEmptyLot : 0, ...req.query };
 
     const optionReport = _.extend(params, pdfOptions, {
-      filename : 'REPORT.STOCK_CONSUMPTION_GRAPH_REPORT.TITLE',
+      filename : 'REPORT.STOCK_EXPIRATION_REPORT.TITLE',
     });
 
     // set up the report with report manager
     const report = new ReportManager(STOCK_EXPIRATION_REPORT_TEMPLATE, req.session, optionReport);
 
-    const depotSql = 'SELECT text FROM depot WHERE uuid=?';
-    const options = req.query;
+    const options = params;
 
     if (req.session.enterprise.settings.enable_strict_depot_permission) {
       options.check_user_id = req.session.user.id;
@@ -33,53 +31,61 @@ async function stockExpirationReport(req, res, next) {
     let depot = {};
 
     if (options.depot_uuid) {
+      const depotSql = 'SELECT text FROM depot WHERE uuid = ?';
       depot = await db.one(depotSql, db.bid(options.depot_uuid));
     }
 
-    const dateFrom = new Date(options.dateFrom);
-    const dateTo = new Date(options.dateTo);
+    // clean off the label if it exists so it doesn't mess up the PDF export
+    delete options.label;
 
+    // get the lots for this depot
     const lots = await stockCore.getLotsDepot(options.depot_uuid, options);
 
-    const resultByDepot = _.groupBy(lots, 'depot_uuid');
-    const depotUuids = Object.keys(resultByDepot);
-    const result = {};
-    depotUuids.forEach(depotUuid => {
-      const depotLots = resultByDepot[depotUuid].filter(row => {
-        let found = false;
-        if (row.status === 'stock_out') {
-          row.status = `STOCK.STATUS.${row.status.toUpperCase()}`;
-          row.color = 'red';
-          found = true;
-        } else if (row.IS_IN_RISK_EXPIRATION) {
-          row.status = `STOCK.STATUS.IS_IN_RISK_OF_EXPIRATION`;
-          row.color = '#f5cb42';
-          found = true;
+    // get the lots that are "at risk"
+    const risky = lots.filter(lot => lot.IS_IN_RISK_EXPIRATION);
+
+    // make sure lots are grouped by depot.
+    const groupedByDepot = _.groupBy(risky, 'depot_uuid');
+
+    // grand totals
+    const totals = {
+      expired : { value : 0, quantity : 0 },
+      at_risk : { value : 0, quantity : 0 },
+    };
+
+    const today = new Date();
+
+    const values = _.map(groupedByDepot, (rows) => {
+      let total = 0;
+
+      rows.forEach(lot => {
+        lot.value = (lot.mvt_quantity * lot.unit_cost);
+        total += lot.value;
+
+        if (lot.expiration_date < today) {
+          lot.statusKey = 'STOCK.EXPIRED';
+          lot.classKey = 'bg-danger text-danger';
+          totals.expired.value += lot.value;
+          totals.expired.quantity += lot.mvt_quantity;
+        } else {
+          lot.statusKey = 'STOCK.STATUS.IS_IN_RISK_OF_EXPIRATION';
+          lot.classKey = 'bg-warning text-warning';
+          totals.at_risk.value += lot.value;
+          totals.at_risk.quantity += lot.mvt_quantity;
         }
-        return found;
       });
 
-      if (depotLots.length > 0) { // there are lots in this depot
-        let total = 0;
-        depotLots.forEach(lot => {
-          lot.value = lot.mvt_quantity * lot.unit_cost;
-          total += lot.value;
-        });
-
-        result[depotUuid] = {
-          rows : depotLots,
-          total,
-          depot_name : depotLots[0].depot_text,
-        };
-      }
+      return {
+        total,
+        rows,
+        depot_name : rows[0].depot_text,
+      };
     });
 
     const reportResult = await report.render({
-      dateFrom,
-      dateTo,
-      depot,
-      result,
+      depot, result : values, totals,
     });
+
     res.set(reportResult.headers).send(reportResult.report);
   } catch (error) {
     next(error);

--- a/server/controllers/stock/reports/stock_expiration_report.handlebars
+++ b/server/controllers/stock/reports/stock_expiration_report.handlebars
@@ -1,66 +1,97 @@
-{{> head title="TREE.STOCK_EXPIRATION_REPORT" }}
-
- {{> header }}
-<!-- body  -->
-<div class="container" style="font-size: 0.9em;">
+{{> head title="REPORT.STOCK_EXPIRATION_REPORT.TITLE" }}
 
 
-    <!-- body  -->
-    <div class="row">
-      <div class="col-xs-12">
+<body>
 
-    <!-- page title  -->
-        <h2 class="text-center">
-          {{translate 'REPORT.STOCK_EXPIRATION_REPORT.TITLE'}}
-        </h2>
+  {{> header }}
 
-        {{#if depot.text}}
-          <h4 class="text-center">{{depot.text}}</h4>
-        {{/if}}
-        <h4 class="text-center">
-          {{date dateFrom}} - {{date dateTo}}
-        </h4>
+  <style>
+    .card {
+      border: 1px solid #A0A0A0;
+      padding: 10px;
+    }
+    .card .title {
+      margin: 0;
+      padding: 0;
+      margin-bottom: 5px;
+    }
+    .card .value {
+      font-size: 3em;
+    }
+  </style>
+
+
+  <h2 class="text-center">
+    {{translate 'REPORT.STOCK_EXPIRATION_REPORT.TITLE'}}
+  </h2>
+
+  {{#if depot.text}}
+    <h4 class="text-center">{{depot.text}}</h4>
+  {{/if}}
+
+  <div class="row">
+    <div class="col-xs-6">
+      <div class="card" >
+        <label class="title">{{translate 'STOCK.EXPIRED'}}</label>
+        <div class="details text-right text-danger">
+          <b class="value">{{currency totals.expired.value metadata.enterprise.currency_id}}</b>
+        </div>
       </div>
-      
+    </div>
 
-    {{#each result as |line|}}
+    <div class="col-xs-6">
+      <div class="card">
+        <label class="title">{{translate 'STOCK.STATUS.IS_IN_RISK_OF_EXPIRATION'}}</label>
+        <div class="details text-right text-warning">
+          <b class="value">{{currency totals.at_risk.value metadata.enterprise.currency_id}}</b>
+        </div>
+      </div>
+    </div>
+  </div>
 
-    <h4><b>{{line.depot_name}}</b></h4>
+  {{#each result as |depot|}}
+    <h4><b>{{depot.depot_name}}</b></h4>
+
     <table class="table table-condensed table-bordered table-report">
-        <thead>
-            <tr>
-                <th>{{translate 'STOCK.INVENTORY'}}</th>
-                <th>{{translate 'STOCK.LOT'}}</th>
-                <th>{{translate 'STOCK.EXPIRATION'}}</th>
-                <th>{{translate 'STOCK.QUANTITY'}}</th>
-                <th>{{translate 'FORM.LABELS.VALUE'}}</th>
-                <th>{{translate 'STOCK.STATUS.LABEL'}}</th>
-            </tr>
-        </thead>
-        <tbody>
-
-            {{#each line.rows}}
-
-            <tr>
-                <td>{{text}}</td>
-                <td>{{label}}</td>
-                <td>{{date expiration_date}}</td>
-                <td class="text-right">{{quantity}}</td>
-                <td class="text-right">{{currency value ../enterprise.currency_id}}</td>
-                <td style="text-transform: uppercase;text-shadow: 0px 0px #001;color: {{color}};">{{translate status}}</td>
-            </tr>
-            {{/each}}
+      <thead>
         <tr>
-            <td colspan="4"><b>{{translate 'TABLE.COLUMNS.TOTAL'}}</b></td>
-            <td class="text-right">{{currency line.total ../enterprise.currency_id}}</td>
-            <td></td>
+          <th>{{translate 'STOCK.INVENTORY'}}</th>
+          <th>{{translate 'STOCK.LOT'}}</th>
+          <th>{{translate 'STOCK.EXPIRATION'}}</th>
+          <th>{{translate 'STOCK.QUANTITY'}}</th>
+          <th>{{translate 'TABLE.COLUMNS.UNIT'}}</th>
+          <th>{{translate 'REPORT.STOCK.UNIT_COST'}}</th>
+          <th>{{translate 'FORM.LABELS.VALUE'}}</th>
+          <th>{{translate 'STOCK.STATUS.LABEL'}}</th>
         </tr>
-        </tbody>
+      </thead>
 
+      <tbody>
+        {{#each depot.rows as |lot| }}
+          <tr>
+            <td>{{lot.text}}</td>
+            <td>{{lot.label}}</td>
+            <td>{{date lot.expiration_date}}</td>
+            <td class="text-right">{{lot.quantity}}</td>
+            <td>{{lot.unit_type}}</td>
+            <td>{{currency lot.unit_cost ../../metadata.enterprise.currency_id}}</td>
+            <td class="text-right">{{currency lot.value ../../metadata.enterprise.currency_id}}</td>
+            <td class="{{lot.classKey}}">{{translate lot.statusKey}}</td>
+          </tr>
+        {{/each}}
+      </tbody>
+      <tfoot>
+        <tr>
+          <th colspan="6">{{translate 'TABLE.COLUMNS.TOTAL'}}</th>
+          <th class="text-right">{{currency depot.total ../metadata.enterprise.currency_id}}</th>
+          <td></td>
+        </tr>
+      </tfoot>
     </table>
-    <br>
-    {{else}}
-    {{> emptyTable columns=6}}
-    {{/each}}
-
-</div>
+    <br />
+  {{else}}
+    <table>
+      <tbody>{{> emptyTable columns=8}}</tbody>
+    </table>
+  {{/each}}
+</body>


### PR DESCRIPTION
This commit fixes the stock expiration report by doing the following
things:
  1. Removes the date range as these don't make any sense.
  2. Uses the same color scheme as used in the other reports for warning/danger text.
  3. Adds total summaries to the top of the report.
  4. Removes the inventory select.
  5. Simplifies the queries so that less for loops are done.
  6. Fixes the currency bug so things render in the enterprise currency.
  7. Adds the column for the unit type.

Closes #4835.

Here is what it looks like now:
![image](https://user-images.githubusercontent.com/896472/93102665-977ee780-f6a3-11ea-9b6b-c7fa03d1d582.png)


----

I chose not to implement the "total value in stock" since this would be a rather expensive query and probably only makes sense if we are looking at a single depot at a time.