### PR TITLE
fix(stock): do not show icon for stock out

### DIFF
--- a/client/src/modules/stock/inventories/registry.js
+++ b/client/src/modules/stock/inventories/registry.js
@@ -198,7 +198,7 @@ function StockInventoriesController(
     item.alert = item.hasExpiredLots;
     item.warning = !item.hasExpiredLots && (item.hasNearExpireLots || item.hasRiskyLots);
 
-    item.isSoldOut = item.status === bhConstants.stockStatus.IS_STOCK_OUT;
+    item.hasStockOut = item.status === bhConstants.stockStatus.IS_STOCK_OUT;
     item.isInStock = item.status === bhConstants.stockStatus.IS_IN_STOCK;
     item.hasSecurityWarning = item.status === bhConstants.stockStatus.HAS_SECURITY_WARNING;
     item.hasMinimumWarning = item.status === bhConstants.stockStatus.HAS_MINIMUM_WARNING;

--- a/client/src/modules/stock/inventories/templates/status.cell.html
+++ b/client/src/modules/stock/inventories/templates/status.cell.html
@@ -1,21 +1,21 @@
 <div class="ui-grid-cell-contents" translate>
-    <div ng-if="row.entity.isSoldOut" class="label label-danger" translate>
-        STOCK.STATUS.STOCK_OUT
+    <div ng-if="row.entity.hasStockOut" class="label label-danger" translate>
+      STOCK.STATUS.STOCK_OUT
     </div>
 
     <div ng-if="row.entity.isInStock" class="label label-success" translate>
-        STOCK.STATUS.IN_STOCK
+      STOCK.STATUS.IN_STOCK
     </div>
 
     <div ng-if="row.entity.hasSecurityWarning" class="label label-warning" translate>
-        STOCK.STATUS.SECURITY
+      STOCK.STATUS.SECURITY
     </div>
 
     <div ng-if="row.entity.hasMinimumWarning" class="label label-info" translate>
-        STOCK.STATUS.MINIMUM
+      STOCK.STATUS.MINIMUM
     </div>
 
     <div ng-if="row.entity.hasOverageWarning" class="label label-primary" translate>
-        STOCK.STATUS.OVER_MAX
+      STOCK.STATUS.OVER_MAX
     </div>
 </div>

--- a/client/src/modules/stock/inventories/templates/warning.cell.html
+++ b/client/src/modules/stock/inventories/templates/warning.cell.html
@@ -1,12 +1,11 @@
 <div ng-if="!row.groupHeader" class="ui-grid-cell-contents text-center" translate>
-  <span 
-    uib-tooltip-template="'warningLotsMessage.html'" 
+  <span
+    ng-if="!row.entity.hasStockOut"
+    uib-tooltip-template="'warningLotsMessage.html'"
     tooltip-append-to-body="true"
     tooltip-placement="right">
     <i ng-if="row.entity.noAlert"  class="fa fa-check text-success"></i>
-
     <i ng-if="row.entity.alert" class="fa fa-exclamation-triangle text-danger"></i>
-
     <i ng-if="row.entity.warning" class="fa fa-exclamation-circle text-warning"></i>
   </span>
 </div>


### PR DESCRIPTION
This commit changes the display value of the icon to no longer show a green check mark when there is a stock out.

Closes #4943.

This is what it looks like:
![image](https://user-images.githubusercontent.com/896472/94152388-65c00a80-fe73-11ea-929e-5c96bc2147e2.png)
