### PR TITLE
fix: improve UI of stock exits

### DIFF
--- a/client/src/js/components/bhStockExpired/bhStockExpired.html
+++ b/client/src/js/components/bhStockExpired/bhStockExpired.html
@@ -1,49 +1,48 @@
-<div class="row">
-  <bh-grid-loading-indicator
-  loading-state="$ctrl.loading">
-</bh-grid-loading-indicator>
+<div>
+  <bh-grid-loading-indicator loading-state="$ctrl.loading">
+  </bh-grid-loading-indicator>
 
+  <table
+    ng-show="$ctrl.expiredInventories.length > 0"
+    class="table table-condensed table-bordered">
+    <thead>
+      <tr>
+        <th colspan="2">
+          <span class="text-danger"
+            translate-values="{ total : $ctrl.expiredInventories.length }"
+            translate="{{ 'STOCK.STOCK_EXPIRED_WARNING' }}">
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th translate>FORM.LABELS.INVENTORY</th>
+        <th translate>FORM.LABELS.LOT</th>
+      </tr>
+      <tr ng-repeat="inventory in $ctrl.expiredInventories | limitTo : 5">
+        <td>{{inventory.text}} (<u translate-attr="{'title' : inventory.expiration_date_raw}">{{inventory.expiration_date}}</u>)</td>
+        <td class="lot-width">{{inventory.label}}</td>
+      </tr>
 
-<table
-ng-show = "$ctrl.expiredInventories.length > 0"
-class="table table-condensed table-bordered">
-<thead>
-  <tr>
-    <th colspan="2">
-      <span class="text-danger"
-        translate-values="{ total : $ctrl.expiredInventories.length }"
-        translate="{{ 'STOCK.STOCK_EXPIRED_WARNING' }}">
-      </span>
-    </th>
-  </tr>
-</thead>
-<tbody>
-  <tr>
-    <th translate>FORM.LABELS.INVENTORY</th>
-    <th translate>FORM.LABELS.LOT</th>
-  </tr>
-  <tr ng-repeat = "inventory in $ctrl.expiredInventories | limitTo : 5">
-    <td>{{inventory.text}} ({{inventory.expiration_date}})</td>
-    <td class="lot-width">{{inventory.label}}</td>
-  </tr>
+      <tr>
+        <td colspan="2">
+          <span class="text-danger"
+            ng-show="($ctrl.expiredInventories.length - 5) > 0"
+            translate-values="{ left : ($ctrl.expiredInventories.length - 5)}"
+            translate="{{ 'STOCK.AND_MORE' }}">
+          </span>
 
-  <tr>
-    <td colspan="2">
-      <span class="text-danger"
-        ng-show="($ctrl.expiredInventories.length - 5) > 0"
-        translate-values="{ left : ($ctrl.expiredInventories.length - 5)}"
-        translate="{{ 'STOCK.AND_MORE' }}">
-      </span>
-
-    <a ui-sref= "stockLots({ filters : [
-      { key : 'period', value : 'allTime'},
-      { key : 'depot_uuid', value : $ctrl.depot.uuid, displayValue: $ctrl.depot.text, cacheable:false },
-      { key : 'includeEmptyLot', value : 0 },
-      { key : 'is_expired', value : 1, cacheable:false }
-      ]})" translate>FORM.LABELS.SEE_ALL</a>
-    </td>
-  </tr>
-</tbody>
-</table>
+          <a ui-sref="stockLots({ filters : [
+            { key : 'period', value : 'allTime'},
+            { key : 'depot_uuid', value : $ctrl.depot.uuid, displayValue: $ctrl.depot.text, cacheable:false },
+            { key : 'includeEmptyLot', value : 0 },
+            { key : 'is_expired', value : 1, cacheable:false }
+            ]})" translate>
+            FORM.LABELS.SEE_ALL
+          </a>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
-

--- a/client/src/js/components/bhStockExpired/bhStockExpired.js
+++ b/client/src/js/components/bhStockExpired/bhStockExpired.js
@@ -2,7 +2,6 @@ angular.module('bhima.components')
   .component('bhStockExpired', {
     templateUrl : 'js/components/bhStockExpired/bhStockExpired.html',
     controller  : bhStockExpiredController,
-    transclude  : true,
     bindings    : {
       depotUuid : '<',
       date : '<?',
@@ -10,53 +9,64 @@ angular.module('bhima.components')
   });
 
 bhStockExpiredController.$inject = [
-  'StockService', 'moment', 'NotifyService', 'DepotService',
+  'StockService', 'moment', 'NotifyService', 'DepotService', '$filter',
 ];
 
 /**
  * Stock Expired component
  */
-function bhStockExpiredController(Stock, moment, Notify, Depot) {
+function bhStockExpiredController(Stock, moment, Notify, Depot, $filter) {
   const $ctrl = this;
+
   $ctrl.loading = false;
   $ctrl.expiredInventories = [];
 
+  const $date = $filter('date');
+
   $ctrl.$onInit = () => {
-    expired();
+    fetchExpiredStock();
     getDepot();
   };
 
   $ctrl.$onChanges = () => {
-    expired();
+    fetchExpiredStock();
     getDepot();
   };
 
   function getDepot() {
     if (!$ctrl.depotUuid) return;
-    Depot.read($ctrl.depotUuid).then(depot => {
-      $ctrl.depot = depot;
-    });
+    Depot.read($ctrl.depotUuid)
+      .then(depot => {
+        $ctrl.depot = depot;
+      });
   }
 
   /**
-   * @function expred
-   * get expired inventories for a depot
+   * @function fetchExpiredStock()
+   *
+   * @description
+   * Gets expired inventories for a depot
    */
-  function expired() {
-    const dateTo = $ctrl.date || new Date();
+  function fetchExpiredStock() {
     if (!$ctrl.depotUuid) return;
+    const dateTo = $ctrl.date || new Date();
     $ctrl.loading = true;
+
     Stock.inventories.read(null, {
       is_expired : 1,
       depot_uuid : $ctrl.depotUuid,
       includeEmptyLot : 0,
       dateTo,
-    }).then(inventories => {
-      inventories.forEach(inventory => {
-        inventory.expiration_date = moment(inventory.expiration_date).fromNow();
-      });
-      $ctrl.expiredInventories = inventories;
-    }).catch(Notify.handleError)
+    })
+      .then(inventories => {
+        inventories.forEach(inventory => {
+          inventory.expiration_date_raw = $date(inventory.expiration_date);
+          inventory.expiration_date = moment(inventory.expiration_date).fromNow();
+        });
+
+        $ctrl.expiredInventories = inventories;
+      })
+      .catch(Notify.handleError)
       .finally(() => {
         $ctrl.loading = false;
       });

--- a/client/src/js/components/bhStockSoldOut/bhStockSoldOut.html
+++ b/client/src/js/components/bhStockSoldOut/bhStockSoldOut.html
@@ -1,45 +1,41 @@
-<div class="row">
-  <bh-grid-loading-indicator
-  loading-state="$ctrl.loading"
-  error-state="$ctrl.hasError">
-</bh-grid-loading-indicator>
+<div>
+  <bh-grid-loading-indicator loading-state="$ctrl.loading" error-state="$ctrl.hasError">
+  </bh-grid-loading-indicator>
 
+  <table
+    class="table table-condensed table-bordered"
+    ng-show="$ctrl.soldOutInventories.length > 0">
+    <thead>
+      <tr>
+        <th>
+          <span class="text-danger"
+            translate-values="{ total : $ctrl.soldOutInventories.length }"
+            translate="{{ 'STOCK.STOCK_OUT_WARNING' }}">
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr ng-repeat = "inventory in $ctrl.soldOutInventories | limitTo : 5">
+        <td>{{inventory.text}} (<u translate-attr="{ 'title' : inventory.stock_out_date_raw }">{{inventory.stock_out_date}}</u>)</td>
+      </tr>
 
-<table
-ng-show = "$ctrl.soldOutInventories.length > 0"
-class="table table-condensed table-bordered">
-<thead>
-  <tr>
-    <th>
-      <span class="text-danger"
-        translate-values="{ total : $ctrl.soldOutInventories.length }"
-        translate="{{ 'STOCK.STOCK_OUT_WARNING' }}">
-      </span>
-    </th>
-  </tr>
-</thead>
-<tbody>
-  <tr ng-repeat = "inventory in $ctrl.soldOutInventories | limitTo : 5">
-    <td>{{inventory.text}} ({{inventory.stock_out_date}})</td>
-  </tr>
+      <tr>
+        <td>
+          <span class="text-danger"
+            ng-show="($ctrl.soldOutInventories.length - 5) > 0"
+            translate-values="{ left : ($ctrl.soldOutInventories.length - 5)}"
+            translate="{{ 'STOCK.AND_MORE' }}">
+          </span>
 
-  <tr>
-    <td>
-      <span class="text-danger"
-        ng-show="($ctrl.soldOutInventories.length - 5) > 0"
-        translate-values="{ left : ($ctrl.soldOutInventories.length - 5)}"
-        translate="{{ 'STOCK.AND_MORE' }}">
-      </span>
-
-    <a ui-sref= "stockInventories({ filters : [
-      { key : 'period', value : 'allTime'},
-      { key : 'includeEmptyLot', value : 1 },
-      { key : 'depot_uuid', value : $ctrl.depot.uuid, displayValue: $ctrl.depot.text, cacheable:false },
-      { key : 'status', value : 'stock_out', displayValue: 'STOCK.STATUS.STOCK_OUT', cacheable:false }
-      ]})" translate>FORM.LABELS.SEE_ALL</a>
-    </td>
-  </tr>
-</tbody>
-</table>
+        <a ui-sref= "stockInventories({ filters : [
+          { key : 'period', value : 'allTime'},
+          { key : 'includeEmptyLot', value : 1 },
+          { key : 'depot_uuid', value : $ctrl.depot.uuid, displayValue: $ctrl.depot.text, cacheable:false },
+          { key : 'status', value : 'stock_out', displayValue: 'STOCK.STATUS.STOCK_OUT', cacheable:false }
+          ]})" translate>FORM.LABELS.SEE_ALL</a>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
-

--- a/client/src/modules/stock/exit/exit.html
+++ b/client/src/modules/stock/exit/exit.html
@@ -56,7 +56,7 @@
 
       <!-- date and note -->
       <div class="row">
-        <div class="col-xs-8 col-md-4">
+        <div class="col-xs-8 col-md-5">
           <!-- date -->
           <bh-date-editor
             date-value="StockCtrl.movement.date"
@@ -90,15 +90,12 @@
         </div>
 
         <div class="col-xs-6 col-md-3 panel-default">
-          <bh-stock-sold-out
-            depot-uuid="StockCtrl.depot.uuid"
-            date="StockCtrl.movement.date">
+          <bh-stock-sold-out depot-uuid="StockCtrl.depot.uuid" date="StockCtrl.movement.date">
           </bh-stock-sold-out>
         </div>
-        <div class="col-xs-10 col-md-5 panel-default">
-          <bh-stock-expired
-            depot-uuid="StockCtrl.depot.uuid"
-            date="StockCtrl.movement.date">
+
+        <div class="col-xs-6 col-md-4 panel-default">
+          <bh-stock-expired depot-uuid="StockCtrl.depot.uuid" date="StockCtrl.movement.date">
           </bh-stock-expired>
         </div>
       </div>
@@ -115,7 +112,6 @@
         </div>
       </div>
 
-      <!-- add and recovery -->
       <div class="row" style="padding-bottom : 5px;">
         <div class="col-xs-12">
 
@@ -132,27 +128,17 @@
             <!-- Other Actions -->
             <div class="grid-toolbar-item">
               <div uib-dropdown dropdown-append-to-body data-action="grid-lots-tools">
-                  <a class="btn btn-default" uib-dropdown-toggle>
-                    </span> <span class="hidden-xs" translate>FORM.BUTTONS.ACTIONS</span> <span class="caret"></span>
-                  </a>
-                  <ul uib-dropdown-menu role="menu" class="dropdown-menu-right">
-                    <li role="menuitem">
-                      <a href ng-click="StockCtrl.exportGrid()">
-                        <i class="fa fa-file-excel-o"></i> <span translate>FORM.BUTTONS.EXPORT</span>
-                      </a>
-                    </li>
-                    <!-- TODO: Cache Selected Lots
-                      <li role="menuitem">
-                        <a href
-                          ng-class="{'bg-ima-blue' : StockCtrl.hasCacheAvailable }"
-                          ng-click="StockCtrl.readCache()"
-                          ng-disabled="!StockCtrl.hasCacheAvailable">
-                          <i class="fa fa-recycle"></i> <span translate>FORM.BUTTONS.RECOVER_ITEMS</span>
-                        </a>
-                      </li>
-                    -->
-                  </ul>
-                </div>
+                <a class="btn btn-default" uib-dropdown-toggle>
+                  </span> <span class="hidden-xs" translate>FORM.BUTTONS.ACTIONS</span> <span class="caret"></span>
+                </a>
+                <ul uib-dropdown-menu role="menu" class="dropdown-menu-right">
+                  <li role="menuitem">
+                    <a href ng-click="StockCtrl.exportGrid()">
+                      <i class="fa fa-file-excel-o"></i> <span translate>FORM.BUTTONS.EXPORT</span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>

--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -127,6 +127,7 @@ function StockExitController(
         cellTemplate : 'modules/stock/exit/templates/expiration.tmpl.html',
       },
       {
+        displayName : '',
         field : 'actions',
         width : 25,
         cellTemplate : 'modules/stock/exit/templates/actions.tmpl.html',


### PR DESCRIPTION
Improves the user interface of stock exits by addressing three concerns:
  1. The components for bhStockOut and bhStockExpired both now fit into the available space.
  2. The columns now add up to 12 on both the large and medium display sizes.
  3. The dates now show the raw date on hover with the mouse in case a user wants further details.

Finally, it fixes a bug with the bhStockSoldOut where the template wasn't loading correctly.


Here is what it looks like:
![image](https://user-images.githubusercontent.com/896472/94161305-71b0ca00-fe7d-11ea-998a-fd27260283c0.png)
