### PR TITLE
docs: improve mysql documentation with docker

### DIFF
--- a/docs/en/for-developers/installing-bhima.md
+++ b/docs/en/for-developers/installing-bhima.md
@@ -141,9 +141,23 @@ sudo service mysql restart
 ```
 
 To start a MySQL server using docker you can use:
-`docker run --name mysql5.7 -p 3306:3306 -e MYSQL_ROOT_PASSWORD=MyPassword -d mysql:5.7 --sql-mode='STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION'`
-this will start a MySQL server that listens on port 3306 (the default MySQL port) on your localhost.
-Additionally, you have to set `DB_HOST` in the `.env` file to `127.0.0.1`, leaving it to `localhost` will make the `mysql` command trying to connect via socket, what is not possible when using docker.
+
+```bash
+# in this example, we use mysql8
+
+docker run --name mysql8 -p 3306:3306 \
+  -e MYSQL_ROOT_PASSWORD=MyPassword \
+  -d mysql:8 \
+  --sql-mode='STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION' \
+  --default-authentication-plugin=mysql_native_password \
+  --character-set-server=utf8mb4 \
+  --collation-server=utf8mb4_unicode_ci
+
+# give it a few seconds, and MySQL will be started and listening on port 3306
+```
+
+
+This will start a MySQL server that listens on port 3306 (the default MySQL port) on your localhost.  Additionally, you have to set `DB_HOST` in the `.env` file to `127.0.0.1`, leaving it to `localhost` will make the `mysql` command trying to connect via socket, what is not possible when using docker.
 
 If you have already a MySQL server running on port 3306 of your localhost, start docker without the port-forwarding (`-p 3306:3306`), use `docker inspect mysql5.7` to find the IP of the container and use that IP in the `.env` file as `DB_HOST`.
 

--- a/docs/fr/for-developers/installing-bhima.md
+++ b/docs/fr/for-developers/installing-bhima.md
@@ -117,12 +117,30 @@ _NOTE: BHIMA s'exécute dans _`sql_mode = 'STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRAC
 #Pour configurer MySQL avec ce paramètre, exécutez les commandes suivantes:
 sudo nano /etc/mysql/mysql.conf.d/mysqld.cnf
 
-#Under dans la section [mysqld], ajoutez le texte suivant:
-sql-mode = "STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION"
+# dans la section [mysqld], ajoutez le texte suivant:
+sql-mode="STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION"
 
-# save and quit, puis redémarrez mysql avec la commande suivante:
+# sauvegarder, puis redémarrez mysql avec la commande suivante:
 sudo service mysql redémarrer
 ```
+
+Tu peux aussi utiliser docker avec mysql.  Le command pour le lancer est:
+```bash
+
+#demarrer docker sur port 3306
+
+docker run --name mysql8 -p 3306:3306 \
+  -e MYSQL_ROOT_PASSWORD=MyPassword \
+  -d mysql:8 \
+  --sql-mode='STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION' \
+  --default-authentication-plugin=mysql_native_password \
+  --character-set-server=utf8mb4 \
+  --collation-server=utf8mb4_unicode_ci
+
+```
+
+Il faut changer le fichier `.env` pour mettre `DB_HOST` a `127.0.0.1`.
+
 
 La structure de la base de données est contenue dans les fichiers `server/models/*. Sql`. Vous pouvez les exécuter un par un dans l'ordre ci-dessous ou simplement lancer `yarn build: db`.
 


### PR DESCRIPTION
Improves the documentation for how to use mysql with docker.  Notably, I discuss how to ensure that you are running in the correct collation and with the mysql authentication plugin restored so node can connect to it.  Also adds a French section addressing this.





-----
[View rendered docs/en/for-developers/installing-bhima.md](https://github.com/jniles/bhima/blob/docs-improve-docker-configuration/docs/en/for-developers/installing-bhima.md)
[View rendered docs/fr/for-developers/installing-bhima.md](https://github.com/jniles/bhima/blob/docs-improve-docker-configuration/docs/fr/for-developers/installing-bhima.md)