### PR TITLE
fix: allow multiple debtor invoice selections

### DIFF
--- a/client/src/modules/cash/cash.routes.js
+++ b/client/src/modules/cash/cash.routes.js
@@ -46,7 +46,7 @@ angular.module('bhima.routes')
           debtor_uuid : { value : undefined },
           invoices    : { value : [] },
         },
-        onEnter : ['$state', '$uibModal', debtorInvoicesModal],
+        onEnter : ['$state', '$uibModal', '$transition$', debtorInvoicesModal],
         onExit  : ['$uibModalStack', closeModal],
       })
 
@@ -79,7 +79,6 @@ function scanCashBarcodeModal($state, Modal) {
     controller  : 'CashBarcodeScannerModalController as BarcodeModalCtrl',
     templateUrl : 'modules/templates/barcode-scanner-modal.html',
     size        : 'lg',
-    backdrop    : 'static',
     keyboard    : true,
   }).result
     .catch(() => {
@@ -91,12 +90,12 @@ function scanCashBarcodeModal($state, Modal) {
     });
 }
 
-function debtorInvoicesModal($state, Modal) {
+function debtorInvoicesModal($state, Modal, $transition) {
   Modal.open({
     templateUrl : 'modules/cash/modals/invoice-modal.html',
     controller  : 'CashInvoiceModalController as CashInvoiceModalCtrl',
-    animation   : false,
     keyboard    : true,
+    resolve : { params : () => $transition.params('to') },
   }).result.finally(() => {
     $state.go('^.window', { id : $state.params.id });
   });

--- a/client/src/modules/cash/modals/invoice-modal.ctrl.js
+++ b/client/src/modules/cash/modals/invoice-modal.ctrl.js
@@ -2,8 +2,8 @@ angular.module('bhima.controllers')
   .controller('CashInvoiceModalController', CashInvoiceModalController);
 
 CashInvoiceModalController.$inject = [
-  'DebtorService', 'SessionService', '$timeout', 'NotifyService', '$state',
-  '$rootScope', '$uibModalInstance',
+  'DebtorService', 'SessionService', '$timeout', 'NotifyService',
+  '$rootScope', '$uibModalInstance', 'params',
 ];
 
 /**
@@ -13,13 +13,13 @@ CashInvoiceModalController.$inject = [
  * This controller is responsible for retrieving a list of debtor invoices from the server,
  * and allowing selection of any number of invoices.
  */
-function CashInvoiceModalController(Debtors, Session, $timeout, Notify, $state, $rootScope, Instance) {
-  var vm = this;
+function CashInvoiceModalController(Debtors, Session, $timeout, Notify, $rootScope, Instance, params) {
+  const vm = this;
 
-  var debtorId = $state.params.debtor_uuid;
-  var invoices = $state.params.invoices;
+  const debtorId = params.debtor_uuid;
+  // const { invoices } = params;
 
-  vm.$params = $state.params;
+  vm.$params = params;
 
   // defaults to value
   vm.missingId = !angular.isDefined(debtorId);
@@ -33,12 +33,12 @@ function CashInvoiceModalController(Debtors, Session, $timeout, Notify, $state, 
     multiSelect       : true,
     fastWatch         : true,
     flatEntityAccess  : true,
-    onRegisterApi     : onRegisterApi,
+    onRegisterApi,
     enableColumnMenus : false,
     columnDefs        : [
-      { name: 'reference' },
-      { name: 'balance', cellFilter: 'currency:' + Session.enterprise.currencyId},
-      { name: 'date', cellFilter: 'date' },
+      { name : 'reference' },
+      { name : 'balance', cellFilter : `currency:${Session.enterprise.currencyId}` },
+      { name : 'date', cellFilter : 'date' },
     ],
     minRowsToShow : 10,
   };
@@ -66,11 +66,11 @@ function CashInvoiceModalController(Debtors, Session, $timeout, Notify, $state, 
   function selectPreviouslySelectedInvoices() {
     if (!vm.gridApi) { return; }
 
-    var rows = vm.gridApi.grid.rows;
+    const { rows } = vm.gridApi.grid;
 
     // loop through each invoice id passed in and reselect those that have
     // previously been selected
-    rows.forEach(function (row) {
+    rows.forEach((row) => {
       if (invoices.indexOf(row.entity.uuid) > -1) {
         vm.gridApi.selection.selectRow(row.entity);
       }
@@ -85,15 +85,15 @@ function CashInvoiceModalController(Debtors, Session, $timeout, Notify, $state, 
 
     // load debtor invoices
     Debtors.invoices(debtorId, { balanced : 0 })
-      .then(function (invoices) {
+      .then((invoices) => {
         vm.gridOptions.data = invoices;
 
         // requires timeout to bind angular ids to each row before selecting them.
-        $timeout(function () {
+        $timeout(() => {
           selectPreviouslySelectedInvoices();
         }, 0, false);
       })
-      .catch(function (error) {
+      .catch((error) => {
         vm.hasError = true;
         Notify.handleError(error);
       })
@@ -107,7 +107,7 @@ function CashInvoiceModalController(Debtors, Session, $timeout, Notify, $state, 
 
   // resolve the modal with the selected invoices to add to the cash payment bills
   function submit() {
-    var invoices;
+    let invoices;
 
     // we start in a neutral state
     vm.loading = false;
@@ -116,7 +116,7 @@ function CashInvoiceModalController(Debtors, Session, $timeout, Notify, $state, 
     // retrieve the outstanding patient invoices from the ui grid
     invoices = vm.getSelectedRows();
 
-    $rootScope.$broadcast('cash:configure', { invoices: invoices });
+    $rootScope.$broadcast('cash:configure', { invoices });
 
     return Instance.close();
   }


### PR DESCRIPTION
This commit fixes the cash invoice selection modal by using `$transition` instead of `$state` params.  For some reason, selecting the `$state` multiple times does not work.

It's bug that is hitting our production systems.  We should do a quick check to make sure this isn't affecting more modals.  It's a tricky bug since it works the first time (and so, passes tests) but doesn't work after that.