### PR TITLE
Fixed New Requistions modal cancel

### DIFF
--- a/client/src/modules/stock/requisition/modals/action.modal.js
+++ b/client/src/modules/stock/requisition/modals/action.modal.js
@@ -56,8 +56,8 @@ function ActionRequisitionModalController(
   vm.addItem = addItem;
   vm.removeItem = removeItem;
   vm.configureItem = configureItem;
-  vm.cancel = Modal.close;
   vm.autoSuggestInventories = autoSuggestInventories;
+  vm.cancel = cancel;
 
   vm.onSelectDepot = depot => {
     vm.model.depot_uuid = depot.uuid;
@@ -168,6 +168,10 @@ function ActionRequisitionModalController(
     item._initialised = true;
     item.inventory_uuid = item.inventory.uuid;
     item.quantity = 0;
+  }
+
+  function cancel() {
+    Modal.dismiss('cancel');
   }
 
   startup();


### PR DESCRIPTION
When in: Stock > Requisitions
a list of requisitions is shown.  When you click on the "New Requisition" or "Other Requistion" a new modal pops up for creating the requisition.  If you click on the [Cancel] button, this fix prevents the parent "Requisition Registry" from reloading.

Testing:
Before checking out this code and trying it, first try this with 'master'.  The reload is barely noticeable with Bhima_test.  You may want to try one of larger datasets to make this lack of a reload more obvious.

Then try it with this PR fix to verify there is no data reload.

NOTE: This is likely an issue for other modals to create a new item for a list/grid.