### PR TITLE
chore: use bhFilterToggle on Entry from Transfer

### DIFF
--- a/client/src/js/components/bhFilterToggle.js
+++ b/client/src/js/components/bhFilterToggle.js
@@ -7,7 +7,6 @@ angular.module('bhima.components')
     },
   });
 
-
 /**
  * @component bhFilterToggle
  *

--- a/client/src/modules/patients/visits/registry.js
+++ b/client/src/modules/patients/visits/registry.js
@@ -128,6 +128,7 @@ function AdmissionRegistryController(
     vm.uiGridOptions.enableFiltering = !vm.uiGridOptions.enableFiltering;
     vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
   }
+
   const columnConfig = new Columns(vm.uiGridOptions, cacheKey);
   const state = new GridState(vm.uiGridOptions, cacheKey);
 

--- a/client/src/modules/stock/entry/modals/findTransfer.modal.html
+++ b/client/src/modules/stock/entry/modals/findTransfer.modal.html
@@ -1,29 +1,24 @@
-<form 
+<form
   name="FindForm"
   ng-submit="$ctrl.submit(FindForm)"
   novalidate>
 
   <div class="modal-header space-between">
     <div class="headercrumb">
-      <i class="fa fa-search"></i> 
-      <span translate>FORM.LABELS.SEARCH</span> 
+      <i class="fa fa-search"></i>
+      <span translate>FORM.LABELS.SEARCH</span>
       <span translate>STOCK.ENTRY_TRANSFER</span>
     </div>
 
     <div class="toolbar text-right">
-      <div class="toolbar-item">
-        <button type="button"
-          ng-click="$ctrl.toggleFilter()"
-          class="btn btn-sm btn-default"
-          ng-class="{ 'btn-info' : $ctrl.filterEnabled }">
-          <span class="fa fa-filter"></span>
-        </button>
-      </div>
+      <bh-filter-toggle
+        on-toggle="$ctrl.toggleInlineFilter()">
+      </bh-filter-toggle>
 
       <div class="toolbar-item">
         <button type="button"
           ng-click="$ctrl.toggleReceived()"
-          class="btn btn-sm btn-default"
+          class="btn btn-default"
           ng-class="{ 'btn-info' : $ctrl.filterReceived }">
           <span class="fa fa-eye"></span>
           <span translate>STOCK.TRANSFER_RECEIVED</span>
@@ -56,7 +51,7 @@
       FORM.BUTTONS.CLOSE
     </button>
 
-    <button class="btn btn-primary" type="submit" data-method="submit" translate>
+    <button class="btn btn-primary" type="submit" data-method="submit" ng-disabled="$ctrl.loading" translate>
       FORM.BUTTONS.SUBMIT
     </button>
   </div>

--- a/client/src/modules/stock/entry/modals/findTransfer.modal.js
+++ b/client/src/modules/stock/entry/modals/findTransfer.modal.js
@@ -8,49 +8,39 @@ StockFindTransferModalController.$inject = [
 
 function StockFindTransferModalController(
   Instance, StockService, Notify,
-  uiGridConstants, Filtering, Receipts, data, bhConstants
+  uiGridConstants, Filtering, Receipts, data, bhConstants,
 ) {
-  var vm = this;
-  var filtering;
-  var columns;
+  const vm = this;
 
-  vm.filterEnabled = false;
+  let selectedRow;
+
   vm.filterReceived = false;
-
   vm.gridOptions = { appScopeProvider : vm };
 
-  filtering = new Filtering(vm.gridOptions);
+  const filtering = new Filtering(vm.gridOptions);
 
-  columns = [
-    {
-      field : 'status',
-      displayName : 'FORM.LABELS.STATUS',
-      headerCellFilter : 'translate',
-      cellTemplate : 'modules/stock/entry/modals/templates/transfer.status.tmpl.html',
-    },
-
-    {
-      field : 'date',
-      cellFilter       : 'date:"'.concat(bhConstants.dates.format, '"'),
-      filter : { condition : filtering.filterByDate },
-      displayName : 'TABLE.COLUMNS.DATE',
-      headerCellFilter : 'translate',
-      sort : { priority : 0, direction : 'desc' },
-    },
-
-    {
-      field : 'document_reference',
-      displayName : 'FORM.LABELS.REFERENCE',
-      headerCellFilter : 'translate',
-      cellTemplate : 'modules/stock/entry/modals/templates/document_reference.tmpl.html',
-    },
-
-    {
-      field : 'depot_name',
-      displayName : 'FORM.LABELS.ORIGIN',
-      headerCellFilter : 'translate',
-    },
-  ];
+  const columns = [{
+    field : 'status',
+    displayName : 'FORM.LABELS.STATUS',
+    headerCellFilter : 'translate',
+    cellTemplate : 'modules/stock/entry/modals/templates/transfer.status.tmpl.html',
+  }, {
+    field : 'date',
+    cellFilter : `date:"${bhConstants.dates.format}"`,
+    filter : { condition : filtering.filterByDate },
+    displayName : 'TABLE.COLUMNS.DATE',
+    headerCellFilter : 'translate',
+    sort : { priority : 0, direction : 'desc' },
+  }, {
+    field : 'document_reference',
+    displayName : 'FORM.LABELS.REFERENCE',
+    headerCellFilter : 'translate',
+    cellTemplate : 'modules/stock/entry/modals/templates/document_reference.tmpl.html',
+  }, {
+    field : 'depot_name',
+    displayName : 'FORM.LABELS.ORIGIN',
+    headerCellFilter : 'translate',
+  }];
 
   vm.gridOptions.columnDefs = columns;
   vm.gridOptions.multiSelect = false;
@@ -64,7 +54,7 @@ function StockFindTransferModalController(
   vm.submit = submit;
   vm.cancel = cancel;
   vm.showReceipt = showReceipt;
-  vm.toggleFilter = toggleFilter;
+  vm.toggleInlineFilter = toggleInlineFilter;
   vm.toggleReceived = toggleReceived;
 
   vm.hasError = false;
@@ -75,13 +65,12 @@ function StockFindTransferModalController(
   }
 
   function rowSelectionCallback(row) {
-    vm.selectedRow = row.entity;
+    selectedRow = row.entity;
   }
 
   /** toggle filter */
-  function toggleFilter() {
-    vm.filterEnabled = !vm.filterEnabled;
-    vm.gridOptions.enableFiltering = vm.filterEnabled;
+  function toggleInlineFilter() {
+    vm.gridOptions.enableFiltering = !vm.gridOptions.enableFiltering;
     vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
   }
 
@@ -103,16 +92,16 @@ function StockFindTransferModalController(
     StockService.transfers.read(null, {
       depot_uuid : data.depot_uuid,
     })
-      .then(function fillGrid(transfers) {
+      .then((transfers) => {
         vm.allTransfers = transfers;
         vm.pendingTransfers = transfers.filter(transferNotReceived);
         vm.gridOptions.data = vm.pendingTransfers;
       })
-      .catch(function handleError(err) {
+      .catch((err) => {
         vm.hasError = true;
         Notify.errorHandler(err);
       })
-      .finally(function handleLoading() {
+      .finally(() => {
         vm.loading = false;
       });
   }
@@ -127,12 +116,12 @@ function StockFindTransferModalController(
 
   // submit
   function submit() {
-    if (!vm.selectedRow) { return 0; }
+    if (!selectedRow) { return 0; }
     return StockService.movements.read(null, {
-      document_uuid : vm.selectedRow.document_uuid,
+      document_uuid : selectedRow.document_uuid,
       is_exit : 1,
     })
-      .then(function close(transfers) {
+      .then((transfers) => {
         Instance.close(transfers);
       })
       .catch(Notify.errorHandler);
@@ -144,5 +133,4 @@ function StockFindTransferModalController(
   }
 
   load();
-
 }

--- a/client/src/modules/stock/entry/modals/templates/transfer.status.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/transfer.status.tmpl.html
@@ -5,6 +5,6 @@
   </div>
 
   <div class="bg-success" ng-hide="row.entity.countedReceived > 0">
-      <span translate>STOCK.TRANSFER_AVAILABLE</span>
+    <span translate>STOCK.TRANSFER_AVAILABLE</span>
   </div>
 </div>

--- a/server/controllers/stock/reports/stock/entry/entryFromTransfer.js
+++ b/server/controllers/stock/reports/stock/entry/entryFromTransfer.js
@@ -9,7 +9,7 @@ const ENTRY_FROM_DEPOT_ID = 2;
  */
 function fetch(depotUuid, dateFrom, dateTo, showDetails) {
   const sql = `
-    SELECT 
+    SELECT
       i.code, i.text, iu.text AS unit_text, BUID(m.document_uuid) AS document_uuid,
       SUM(m.quantity) as quantity, m.date, m.description,
       u.display_name AS user_display_name,
@@ -17,12 +17,12 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     FROM stock_movement m
       JOIN lot l ON l.uuid = m.lot_uuid
       JOIN inventory i ON i.uuid = l.inventory_uuid
-      JOIN inventory_unit iu ON iu.id = i.unit_id 
+      JOIN inventory_unit iu ON iu.id = i.unit_id
       JOIN depot d ON d.uuid = m.depot_uuid
       JOIN depot dd ON dd.uuid = m.entity_uuid
       JOIN user u ON u.id = m.user_id
       LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
-    WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${ENTRY_FROM_DEPOT_ID} AND d.uuid = ? 
+    WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${ENTRY_FROM_DEPOT_ID} AND d.uuid = ?
       AND (DATE(m.date) BETWEEN DATE(?) AND DATE(?))
     GROUP BY i.uuid`;
 


### PR DESCRIPTION
This commit makes the findTransfer modal use the `bhFilterToggle` component for filtering.  It also disables the submit button until data is loaded and removes an unnecessary binding.