### PR TITLE
Depot permission for distribution

### DIFF
--- a/client/src/i18n/en/depot.json
+++ b/client/src/i18n/en/depot.json
@@ -25,6 +25,7 @@
     "UPDATED" : "Depot updated successfully",
     "WAREHOUSE" : "Warehouse",
     "WAREHOUSE_INFO" : "This depot can distribute to other depots",
+    "ALLOWED_DESTINATION_DEPOTS":"Allowed destination depots",
     "MODAL" : {
       "SELECTION" : "Depot Selection",
       "TYPE_DEPOT_NAME" : "Type the depot's name",

--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -184,7 +184,9 @@
     "ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY" : "Enable Automatic Crediting of Supplier on Stock Entry",
     "ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY_HELP_TEXT" : "Automatically adds the transactions to credit the supplier for the value of stock received in a depot when entering stock from a purchase order.  This is only triggered if the automatic stock accounting is set as well.",
     "ORDER_BY_CREATED_AT" : "Sort lots movements by their true creation date",
-    "ORDER_BY_CREATED_AT_HELP_TEXT" : "This option allows you to sort lot movements by their true creation date in the system"
+    "ORDER_BY_CREATED_AT_HELP_TEXT" : "This option allows you to sort lot movements by their true creation date in the system",
+    "ENABLE_STRICT_DEPOT_DISTRIBUTION" : "Activate the restriction of distribution depots",
+    "ENABLE_STRICT_DEPOT_DISTRIBUTION_HELP_TEXT" : "Limit the list of distribution depots for depots"
   },
   "STOCK_FLUX" : {
     "FROM_PURCHASE"    : "From Purchase Order",

--- a/client/src/i18n/fr/depot.json
+++ b/client/src/i18n/fr/depot.json
@@ -25,6 +25,7 @@
     "UPDATED" : "Dépôt mise à jour avec succès",
     "WAREHOUSE" : "Entrepôts",
     "WAREHOUSE_INFO" : "Ce dépôt est en mesure d'approvisionner d'autres dépôts",
+    "ALLOWED_DESTINATION_DEPOTS":"Les dépôts de destination autorisés",
     "MODAL" : {
       "SELECTION" : "Sélection du dépôt",
       "TYPE_DEPOT_NAME" : "Saisir le nom du depot",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -188,7 +188,9 @@
     "ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY" : "Activer le crédit automatique du fournisseur lors de l'entrée de stock",
     "ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY_HELP_TEXT" : "Ajoute automatiquement les transactions pour créditer le fournisseur de la valeur du stock reçu dans un dépôt lors de l'entrée du stock à partir d'une commande d'achat. Ceci n'est déclenché que si la comptabilité de stock automatique est également définie.",
     "ORDER_BY_CREATED_AT" : "Ordonner les mouvements de lots par leurs dates de création",
-    "ORDER_BY_CREATED_AT_HELP_TEXT" : "Cette option permet d'ordonner les movements de lots par leurs dates réelles de création dans le système"
+    "ORDER_BY_CREATED_AT_HELP_TEXT" : "Cette option permet d'ordonner les movements de lots par leurs dates réelles de création dans le système",
+    "ENABLE_STRICT_DEPOT_DISTRIBUTION" : "Activer la restriction des depots de distribution",
+    "ENABLE_STRICT_DEPOT_DISTRIBUTION_HELP_TEXT" : "Limiter la liste des depots de distribution pour les depots"
   },
   "STOCK_FLUX" : {
     "FROM_PURCHASE"    : "Commande d'achat",

--- a/client/src/js/components/bhDepotSelect/bhDepotSelect.js
+++ b/client/src/js/components/bhDepotSelect/bhDepotSelect.js
@@ -25,6 +25,7 @@ function DepotSelectController(Depots, Notify) {
     $ctrl.label = $ctrl.label || 'FORM.LABELS.DEPOT';
 
     if ($ctrl.depotUuid) {
+      if ($ctrl.depotUuid === '0') { return; }
       Depots.read($ctrl.depotUuid)
         .then(depot => {
           $ctrl.depotText = depot.text;

--- a/client/src/js/components/bhDepotSelectSearch/bhDepotSelect.js
+++ b/client/src/js/components/bhDepotSelectSearch/bhDepotSelect.js
@@ -1,4 +1,3 @@
-
 angular.module('bhima.components')
   .component('bhDepotSearchSelect', {
     templateUrl : 'js/components/bhDepotSelectSearch/bhDepotSelectSearch.html',
@@ -79,7 +78,7 @@ function DepotSearchSelectController(Depots, uuidService) {
   };
 
   function loadSelected(depotsUuids) {
-    if (!(depotsUuids.length > 0)) return;
+    if (!depotsUuids || !(depotsUuids.length > 0)) return;
     Depots.read(null, { uuids : depotsUuids }).then(depots => {
       $ctrl.depotsSected = depots;
     });

--- a/client/src/js/components/bhDepotSelectSearch/bhDepotSelectSearch.html
+++ b/client/src/js/components/bhDepotSelectSearch/bhDepotSelectSearch.html
@@ -6,7 +6,6 @@
         <span class="text-primary">{{depot.text}}</span>
         <i class="fa fa-close text-danger link" ng-click="$ctrl.remove(depot.uuid)" id="{{depot.uuid}}"></i>
       </span>
-      
     </span>
   </div>
 

--- a/client/src/modules/depots/depots.js
+++ b/client/src/modules/depots/depots.js
@@ -155,7 +155,6 @@ function DepotManagementController(
         });
 
         vm.gridOptions.data = FormatTreeData.formatStore(depotsData);
-
       })
       .catch(Notify.handleError)
       .finally(() => {
@@ -164,12 +163,12 @@ function DepotManagementController(
   }
 
   // switch to delete warning mode
-  function deleteDepot(depot) {
+  function deleteDepot(uuid) {
     ModalService.confirm('FORM.DIALOGS.CONFIRM_DELETE')
       .then(bool => {
         if (!bool) { return; }
 
-        Depots.delete(depot.uuid)
+        Depots.delete(uuid)
           .then(() => {
             Notify.success('DEPOT.DELETED');
             load();
@@ -179,8 +178,8 @@ function DepotManagementController(
   }
 
   // update an existing depot
-  function editDepot(depotObject) {
-    $state.go('depots.edit', { depot : depotObject });
+  function editDepot(uuid) {
+    $state.go('depots.edit', { uuid });
   }
 
   // create a new depot

--- a/client/src/modules/depots/depots.routes.js
+++ b/client/src/modules/depots/depots.routes.js
@@ -20,7 +20,7 @@ angular.module('bhima.routes')
       .state('depots.edit', {
         url : '/edit',
         params : {
-          depot : { value : {} },
+          uuid : { value : null },
           isCreateState : { value : false },
         },
         onEnter : ['$uibModal', '$transition$', depotModal],

--- a/client/src/modules/depots/depots.service.js
+++ b/client/src/modules/depots/depots.service.js
@@ -49,6 +49,7 @@ function DepotService(Api, Modal) {
     delete depot.location;
     delete depot.users;
     delete depot.parent;
+    delete depot.distribution_depots;
   };
 
   return service;

--- a/client/src/modules/depots/modals/depot.modal.html
+++ b/client/src/modules/depots/modals/depot.modal.html
@@ -139,6 +139,18 @@
       </div>
     </div>
 
+    <div ng-if="DepotModalCtrl.enable_strict_depot_distribution">
+      <label class="control-label" translate>DEPOT.ALLOWED_DESTINATION_DEPOTS</label>
+      <p ng-if="!DepotModalCtrl.depot.allowed_distribution_depots.length"><i translate>DEPOT.NO_DEPOT</i></p>
+      <bh-depot-search-select
+        label="STOCK.DEPOT"
+        id="distribution_depots"
+        depots-uuids = "DepotModalCtrl.depot.allowed_distribution_depots"
+        on-change="DepotModalCtrl.onDistributionDepotChange(depots)"
+        form-name="DepotForm">
+      </bh-depot-search-select>
+    </div>
+
   </div>
 
   <div class="modal-footer">

--- a/client/src/modules/depots/templates/action.tmpl.html
+++ b/client/src/modules/depots/templates/action.tmpl.html
@@ -8,7 +8,7 @@
     <li class="bh-dropdown-header">{{row.entity.text}}</li>
 
     <li>
-      <a data-method="edit-record" ng-click="grid.appScope.editDepot(row.entity)" href>
+      <a data-method="edit-record" ng-click="grid.appScope.editDepot(row.entity.uuid)" href>
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
       </a>
     </li>
@@ -32,7 +32,7 @@
 
     <li class="divider"></li>
     <li>
-      <a data-method="delete-record" ng-click="grid.appScope.deleteDepot(row.entity)" href>
+      <a data-method="delete-record" ng-click="grid.appScope.deleteDepot(row.entity.uuid)" href>
         <span class="text-danger">
           <i class="fa fa-trash"></i> <span translate>DEPOT.DELETE</span>
         </span>

--- a/client/src/modules/stock/settings/stock-settings.html
+++ b/client/src/modules/stock/settings/stock-settings.html
@@ -80,6 +80,14 @@
             help-text="SETTINGS.ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY_HELP_TEXT"
             on-change-callback="StockSettingsCtrl.enableSupplierCredit(value)">
           </bh-yes-no-radios>
+
+          <bh-yes-no-radios
+            label="SETTINGS.ENABLE_STRICT_DEPOT_DISTRIBUTION"
+            help-text="SETTINGS.ENABLE_STRICT_DEPOT_DISTRIBUTION_HELP_TEXT"
+            value="StockSettingsCtrl.settings.enable_strict_depot_distribution"
+            name="enable_strict_depot_distribution"
+            on-change-callback="StockSettingsCtrl.enableStrictDepotDistribution(value)">
+          </bh-yes-no-radios>
         </div>
 
         <div class="panel-footer" id="submission">

--- a/client/src/modules/stock/settings/stock-settings.js
+++ b/client/src/modules/stock/settings/stock-settings.js
@@ -92,6 +92,7 @@ function StockSettingsController(
   vm.enableDailyConsumption = proxy('enable_daily_consumption');
   vm.enableStrictDepotPermission = proxy('enable_strict_depot_permission');
   vm.enableSupplierCredit = proxy('enable_supplier_credit');
+  vm.enableStrictDepotDistribution = proxy('enable_strict_depot_distribution');
   vm.setMonthAverage = function setMonthAverage() {
     $touched = true;
   };

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -7,14 +7,15 @@
  *
  * @requires q
  * @requires lodash
+ * @requires debug
  * @requires lib/db
  * @requires lib/errors/Unauthorized
  */
 
 const _ = require('lodash');
 const q = require('q');
-const db = require('../lib/db');
 const debug = require('debug')('app');
+const db = require('../lib/db');
 const Unauthorized = require('../lib/errors/Unauthorized');
 
 // POST /auth/login
@@ -234,7 +235,6 @@ async function loadSessionInformation(user) {
 
   return session;
 }
-
 
 /**
  * @method reload

--- a/server/controllers/stock/setting/index.js
+++ b/server/controllers/stock/setting/index.js
@@ -23,7 +23,7 @@ exports.list = function list(req, res, next) {
     SELECT month_average_consumption, default_min_months_security_stock,
       enable_auto_purchase_order_confirmation, enable_auto_stock_accounting,
       enable_daily_consumption, enable_strict_depot_permission,
-      enable_supplier_credit
+      enable_supplier_credit, enable_strict_depot_distribution
     FROM stock_setting
     WHERE enterprise_id = ? LIMIT 1;
     `;

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -56,3 +56,21 @@ ALTER TABLE enterprise_setting DROP COLUMN enable_supplier_credit;
  */
  ALTER TABLE `depot` ADD COLUMN `parent_uuid` BINARY(16) NULL;
  ALTER TABLE `depot` ADD INDEX `parent_uuid` (`parent_uuid`);
+
+ /*
+  * @author: mbayopanda
+  * @date: 2020-10-05
+  * @desc: Adding new column enable_strict_depot_distribution in stock settings
+  */
+ALTER TABLE stock_setting ADD COLUMN `enable_strict_depot_distribution` TINYINT(1) NOT NULL DEFAULT 0;
+
+/*
+  * @author: mbayopanda
+  * @date: 2020-10-05
+  * @desc: Adding a new table depot_distribution_permission
+  */
+DROP TABLE IF EXISTS `depot_distribution_permission`;
+CREATE TABLE `depot_distribution_permission` (
+  `depot_uuid` BINARY(16) NOT NULL,
+  `distribution_depot_uuid` BINARY(16) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -467,6 +467,12 @@ CREATE TABLE `depot` (
   INDEX `parent_uuid` (`parent_uuid`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
+DROP TABLE IF EXISTS `depot_distribution_permission`;
+CREATE TABLE `depot_distribution_permission` (
+  `depot_uuid` BINARY(16) NOT NULL,
+  `distribution_depot_uuid` BINARY(16) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
+
 
 DROP TABLE IF EXISTS discount;
 CREATE TABLE discount (
@@ -1861,6 +1867,7 @@ CREATE TABLE `stock_setting` (
   `enable_daily_consumption` TINYINT(1) NOT NULL DEFAULT 0,
   `enable_strict_depot_permission` TINYINT(1) NOT NULL DEFAULT 0,
   `enable_supplier_credit` TINYINT(1) NOT NULL DEFAULT 0,
+  `enable_strict_depot_distribution` TINYINT(1) NOT NULL DEFAULT 0,
   CONSTRAINT `stock_setting__enterprise` FOREIGN KEY (`enterprise_id`) REFERENCES `enterprise` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 

--- a/test/end-to-end/depots/depots.page.js
+++ b/test/end-to-end/depots/depots.page.js
@@ -61,6 +61,15 @@ class DepotPage {
     await components.notification.hasSuccess();
   }
 
+  // create depot with distribution restriction
+  async createDepotWithDistributionRestriction(name) {
+    await FU.buttons.create();
+    await FU.input('DepotModalCtrl.depot.text', name);
+
+    await FU.buttons.submit();
+    await components.notification.hasSuccess();
+  }
+
   /**
    * block creation without the depot name
    */

--- a/test/end-to-end/depots/depots.page.js
+++ b/test/end-to-end/depots/depots.page.js
@@ -61,15 +61,6 @@ class DepotPage {
     await components.notification.hasSuccess();
   }
 
-  // create depot with distribution restriction
-  async createDepotWithDistributionRestriction(name) {
-    await FU.buttons.create();
-    await FU.input('DepotModalCtrl.depot.text', name);
-
-    await FU.buttons.submit();
-    await components.notification.hasSuccess();
-  }
-
   /**
    * block creation without the depot name
    */

--- a/test/end-to-end/depots/depots.spec.js
+++ b/test/end-to-end/depots/depots.spec.js
@@ -13,6 +13,7 @@ describe('Depots Management', () => {
    * The implementation of the E2E test of the assignment of a Depot
    * to a user is added in the E2E test of the Depot and not in the
    * user test because the E2E test on the users runs after the Depot test.
+   * @todo Add tests for distribution depots which require enterprise settings enabled
    */
   const userPage = new UserPage();
 

--- a/test/integration/stock/stockSettings.js
+++ b/test/integration/stock/stockSettings.js
@@ -18,7 +18,7 @@ describe('(/stock/setting) Stock Settings API', () => {
     'month_average_consumption', 'default_min_months_security_stock',
     'enable_auto_purchase_order_confirmation', 'enable_auto_stock_accounting',
     'enable_daily_consumption', 'enable_strict_depot_permission',
-    'enable_supplier_credit',
+    'enable_supplier_credit', 'enable_strict_depot_distribution',
   ];
 
   it('GET /stock/setting/:id returns the stock settings for the default Enterprise and checks a value', () => {


### PR DESCRIPTION
This PR add feature of specifying distribution depots : 
<img width="606" alt="Capture d’écran 2020-10-06 à 16 41 09" src="https://user-images.githubusercontent.com/5445251/95224716-efb48f80-07f2-11eb-8496-7a81ee379089.png">

Enable or not this feature in the stock settings page
<img width="903" alt="Capture d’écran 2020-10-06 à 16 44 09" src="https://user-images.githubusercontent.com/5445251/95224968-30140d80-07f3-11eb-9451-a620501607dd.png">

If the feature is enable, the depot to select in the stock exit page for distribution are restricted to distribution depots defined for the current depot