### PR TITLE
fix(stock): use days not lifetime for expiration

### DIFF
--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -229,7 +229,8 @@ function StockExitController(
   // configure item
   function configureItem(item) {
     item._initialised = true;
-    // get lots
+
+    // get lots for this inventory item
     Stock.lots.read(null, {
       depot_uuid : vm.depot.uuid,
       inventory_uuid : item.inventory.inventory_uuid,
@@ -237,10 +238,13 @@ function StockExitController(
       dateTo : vm.movement.date,
     })
       .then(lots => {
+        const now = new Date();
+        const isExpired = (lot) => lot.expiration_date && lot.expiration_date < now;
+
         if (vm.movement.exit_type === 'loss') {
           item.lots = lots.filter(lot => !vm.selectedLots.includes(lot.uuid));
         } else {
-          item.lots = lots.filter(lot => !vm.selectedLots.includes(lot.uuid) && lot.lifetime > 0);
+          item.lots = lots.filter(lot => !vm.selectedLots.includes(lot.uuid) && !isExpired(lot));
         }
       })
       .catch(Notify.handleError);

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -812,6 +812,7 @@ function processMultipleLots(inventories) {
         if (!lot.tracking_expiration) {
           lot.expiration_date = '';
         }
+
         if (lot.tracking_consumption) {
           // apply the same CMM to all lots and update monthly consumption
           lot.avg_consumption = cmm;


### PR DESCRIPTION
Lifetime is calculated in months, not days.  This made products that appear in less than a month break since lifetime is 0.  We've worked around it by changing to a calculation based on days.

Here is how to test this:
  1. Add a lot via integration that expires in a week.
  2. Try to find it in the drop down.

_It will not appear on master_ but will appear in this PR.