### PR TITLE
fix(stock): show empty lots filter on stock lots

### DIFF
--- a/client/src/js/services/StockService.js
+++ b/client/src/js/services/StockService.js
@@ -79,6 +79,18 @@ function StockService(Api, StockFilterer) {
     requisition : StockRequisitionFilters,
   };
 
+  function assignNoEmptyLotsDefaultFilter(service) {
+    // add in the default key for the stock lots filter
+    const assignedKeys = Object.keys(service._filters.formatHTTP());
+    // assign default includeEmptyLot filter
+    if (assignedKeys.indexOf('includeEmptyLot') === -1) {
+      service._filters.assignFilter('includeEmptyLot', 0);
+    }
+  }
+
+  // assign non empty lots filter to the stockLots Filterer
+  assignNoEmptyLotsDefaultFilter(stockFilter.lot);
+
   // uniformSelectedEntity function implementation
   // change name, text and display_nam into displayName
   function uniformSelectedEntity(entity) {

--- a/client/src/modules/stock/StockFilterer.service.js
+++ b/client/src/modules/stock/StockFilterer.service.js
@@ -145,12 +145,6 @@ function StockFiltererService(Filters, AppCache, Periods, $httpParamSerializer, 
       if (assignedKeys.indexOf('limit') === -1) {
         this._filters.assignFilter('limit', 100);
       }
-
-      // assign default includeEmptyLot filter
-      if (assignedKeys.indexOf('includeEmptyLot') === -1) {
-        this._filters.assignFilter('includeEmptyLot', 0);
-      }
-
     }
 
     assignFilter(key, value) {


### PR DESCRIPTION
This commit ensures that the empty lots filter is only shown on stock lots.

Closes #4954.