### PR TITLE
Reload after changing the date

### DIFF
--- a/client/src/modules/stock/inventory-adjustment/inventory-adjustment.js
+++ b/client/src/modules/stock/inventory-adjustment/inventory-adjustment.js
@@ -28,6 +28,7 @@ function StockInventoryAdjustmentController(
 
   vm.onDateChange = date => {
     vm.movement.date = date;
+    loadInventories(vm.depot);
   };
 
   vm.onChangeDepot = depot => {


### PR DESCRIPTION
In Issue https://github.com/IMA-WorldHealth/bhima/issues/4981, @jniles indicated the steps to be taken in the callback. However, it seems to me that all you need to do is change the date and reload the inventory items (I think the loadInventories() function does all that is needed).  I believe the grid will not get control back until the reload is complete.

I was not sure how to test this, since I'm a bit confused about what adjusting the inventory at some past date really means and how to test it.

-Jonathan