### PR TITLE
fix(fee centers): do not show uuids

### DIFF
--- a/client/src/modules/dashboards/indicators_files_registry/modals/finance.modal.html
+++ b/client/src/modules/dashboards/indicators_files_registry/modals/finance.modal.html
@@ -1,7 +1,7 @@
 <form name="FinanceForm" bh-submit="$ctrl.submit(FinanceForm)" novalidate>
   <div class="modal-body">
     <h3 style="padding:0; margin:0; margin-bottom: 20px;">
-      <span translate>DASHBOARD.INDICATORS_FILES.WRITE_FINANCES_INDICATORS</span> 
+      <span translate>DASHBOARD.INDICATORS_FILES.WRITE_FINANCES_INDICATORS</span>
       <small ng-show="$ctrl.selectedPeriod"><strong>{{ $ctrl.selectedPeriod }}</strong></small>
     </h3>
 
@@ -29,7 +29,7 @@
             is-currency="true"
             autocomplete="off">
           </bh-input-text>
-  
+
           <bh-input-text
             key="total_subsidies"
             text-value="$ctrl.indicators.total_subsidies"
@@ -38,7 +38,7 @@
             is-currency="true"
             autocomplete="off">
           </bh-input-text>
-  
+
           <bh-input-text
             key="total_drugs_sale"
             text-value="$ctrl.indicators.total_drugs_sale"
@@ -47,7 +47,7 @@
             is-currency="true"
             autocomplete="off">
           </bh-input-text>
-  
+
           <bh-input-text
             key="total_expenses"
             text-value="$ctrl.indicators.total_expenses"
@@ -56,7 +56,7 @@
             is-currency="true"
             autocomplete="off">
           </bh-input-text>
-  
+
           <bh-input-text
             key="total_other_charge"
             text-value="$ctrl.indicators.total_other_charge"
@@ -65,7 +65,7 @@
             is-currency="true"
             autocomplete="off">
           </bh-input-text>
-  
+
           <bh-input-text
             key="total_drugs_purchased"
             text-value="$ctrl.indicators.total_drugs_purchased"
@@ -74,7 +74,7 @@
             is-currency="true"
             autocomplete="off">
           </bh-input-text>
-  
+
           <bh-input-text
             key="total_staff_charge"
             text-value="$ctrl.indicators.total_staff_charge"
@@ -83,7 +83,7 @@
             is-currency="true"
             autocomplete="off">
           </bh-input-text>
-  
+
           <bh-input-text
             key="total_operating_charge"
             text-value="$ctrl.indicators.total_operating_charge"
@@ -92,7 +92,7 @@
             is-currency="true"
             autocomplete="off">
           </bh-input-text>
-  
+
           <bh-input-text
             key="total_depreciation"
             text-value="$ctrl.indicators.total_depreciation"
@@ -101,7 +101,7 @@
             is-currency="true"
             autocomplete="off">
           </bh-input-text>
-  
+
           <bh-input-text
             key="total_debts"
             text-value="$ctrl.indicators.total_debts"
@@ -110,7 +110,7 @@
             is-currency="true"
             autocomplete="off">
           </bh-input-text>
-  
+
           <bh-input-text
             key="total_cash"
             text-value="$ctrl.indicators.total_cash"
@@ -119,7 +119,7 @@
             is-currency="true"
             autocomplete="off">
           </bh-input-text>
-  
+
           <bh-input-text
             key="total_stock_value"
             text-value="$ctrl.indicators.total_stock_value"
@@ -128,7 +128,7 @@
             is-currency="true"
             autocomplete="off">
           </bh-input-text>
-  
+
           <bh-input-text
             key="total_staff"
             text-value="$ctrl.indicators.total_staff"

--- a/client/src/modules/distribution_center/templates/update.tmpl.html
+++ b/client/src/modules/distribution_center/templates/update.tmpl.html
@@ -1,14 +1,25 @@
-<div class="ui-grid-cell-contents text-right" uib-dropdown dropdown-append-to-body uib-dropdown-toggle ng-if="row.groupHeader">
-  <a href>
-    <span data-method="action" translate>FORM.BUTTONS.ACTIONS</span>
+<div
+  class="ui-grid-cell-contents text-right"
+  uib-dropdown
+  dropdown-append-to-body
+  ng-if="row.groupHeader"
+  ng-init="item = row.treeNode.children[0].row.entity"
+  data-row="{{ row.treeNode.children[0].row.entity.trans_id }}">
+  <a uib-dropdown-toggle href data-action="open-dropdown-menu">
+    <span translate>FORM.BUTTONS.ACTIONS</span>
     <span class="caret"></span>
   </a>
-
-  <ul data-action="{{ rowRenderIndex}}"  class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
-    <li class="bh-dropdown-header">{{row.entity.label}}</li>
+  <ul data-row-menu="{{item.trans_id}}" class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
+    <li class="bh-dropdown-header">{{item.trans_id}}</li>
     <li>
-      <a data-method="edit" ng-click="grid.appScope.updateDistribution(row.treeNode.children)" href>
+      <a data-method="edit-record" ng-click="grid.appScope.updateDistribution(row.treeNode.children)" href>
         <span class="fa fa-edit"></span> <span translate> FORM.LABELS.EDIT </span>
+      </a>
+    </li>
+    <li>
+      <a data-method="view-transaction" href ui-sref="journal({ filters : [{ key: 'record_uuid', value : item.record_uuid, displayValue: item.hrRecord}, { key : 'period', value : 'allTime' }, { key : 'includeNonPosted', value : 1 }]})">
+        <span class="fa fa-file-text-o"></span> <span translate>TRANSACTIONS.VIEW_TRANSACTIONS</span>
+      </a>
       </a>
     </li>
   </ul>

--- a/client/src/modules/distribution_center/update/update_center.html
+++ b/client/src/modules/distribution_center/update/update_center.html
@@ -1,26 +1,26 @@
-<div class="flex-header"> 
-  <div class="bhima-title"> 
-    <ol class="headercrumb"> 
-      <li class="static" translate> TREE.FINANCE </li> 
-      <li class="title" translate> TREE.UPDATE_DISTRIBUTION </li> 
-    </ol> 
-    
-    <div class="toolbar"> 
-      <div class="toolbar-item"> 
+<div class="flex-header">
+  <div class="bhima-title">
+    <ol class="headercrumb">
+      <li class="static" translate> TREE.FINANCE </li>
+      <li class="title" translate> TREE.UPDATE_DISTRIBUTION </li>
+    </ol>
+
+    <div class="toolbar">
+      <div class="toolbar-item">
         <button
           ng-click="UpdateCenterCtrl.setting()"
           data-method="setting"
           class="btn btn-default">
           <span class="fa fa-cogs"></span> <span class="hidden-xs" translate> FORM.BUTTONS.SETTING </span>
         </button>
-      </div> 
-      
-      <div class="toolbar-item"> 
+      </div>
+
+      <div class="toolbar-item">
         <bh-filter-toggle on-toggle="UpdateCenterCtrl.toggleFilter()">
         </bh-filter-toggle>
       </div>
-    </div> 
-  </div> 
+    </div>
+  </div>
 </div>
 
 <div class="flex-util bh-filter-bar">
@@ -30,22 +30,21 @@
   </bh-filters>
 </div>
 
-<!-- main content --> 
-<div class="flex-content"> 
-  <div class="container-fluid"> 
+<!-- main content -->
+<div class="flex-content">
+  <div class="container-fluid">
     <div id="distribution-center-grid"
-      ui-grid="UpdateCenterCtrl.gridOptions" 
+      ui-grid="UpdateCenterCtrl.gridOptions"
       class="grid-full-height-with-filters"
       ui-grid-auto-resize
-      ui-grid-selection
       ui-grid-grouping
-      ui-grid-resize-columns> 
-      
-      <bh-grid-loading-indicator 
-        loading-state="UpdateCenterCtrl.loading" 
-        empty-state="UpdateCenterCtrl.gridOptions.data.length === 0" 
-        error-state="UpdateCenterCtrl.hasError"> 
-      </bh-grid-loading-indicator> 
-    </div> 
-  </div> 
+      ui-grid-resize-columns>
+
+      <bh-grid-loading-indicator
+        loading-state="UpdateCenterCtrl.loading"
+        empty-state="UpdateCenterCtrl.gridOptions.data.length === 0"
+        error-state="UpdateCenterCtrl.hasError">
+      </bh-grid-loading-indicator>
+    </div>
+  </div>
 </div>

--- a/client/src/modules/distribution_center/update/update_center.js
+++ b/client/src/modules/distribution_center/update/update_center.js
@@ -12,8 +12,10 @@ UpdateCenterController.$inject = [
  * This controller is about the updating Distribution Center module in the Finance zone
  * It's responsible for editing and updating a Distribution Center
  */
-function UpdateCenterController(DistributionUpdateCenters, DistributionCenters, ModalService, Notify, uiGridConstants,
-  $state, Grouping, uiGridGroupingConstants, Session) {
+function UpdateCenterController(
+  DistributionUpdateCenters, DistributionCenters, ModalService, Notify, uiGridConstants,
+  $state, Grouping, uiGridGroupingConstants, Session,
+) {
   const vm = this;
 
   // bind methods
@@ -21,11 +23,14 @@ function UpdateCenterController(DistributionUpdateCenters, DistributionCenters, 
 
   // global variables
   vm.gridApi = {};
-  vm.filterEnabled = false;
   vm.setting = setting;
   vm.loading = false;
   vm.updateDistribution = updateDistribution;
   vm.onRemoveFilter = onRemoveFilter;
+
+  const customTreeAggregationFinalizerFn = (aggregation) => {
+    aggregation.rendered = aggregation.value;
+  };
 
   // options for the UI grid
   vm.gridOptions = {
@@ -39,14 +44,17 @@ function UpdateCenterController(DistributionUpdateCenters, DistributionCenters, 
     gridFooterTemplate : 'modules/distribution_center/templates/footer.template.html',
     onRegisterApi     : onRegisterApiFn,
     columnDefs : [{
-      field : 'row_uuid',
-      displayName : 'TABLE.COLUMNS.TRANSACTION',
-      headerCellFilter : 'translate',
-    }, {
       field : 'trans_id',
       displayName : 'TABLE.COLUMNS.TRANSACTION',
       headerCellFilter : 'translate',
       cellTemplate : 'modules/journal/templates/transaction-id.cell.html',
+    }, {
+      field : 'hrRecord',
+      displayName : 'TABLE.COLUMNS.RECORD',
+      headerCellFilter : 'translate',
+      visible : true,
+      cellTemplate : '/modules/journal/templates/record.cell.html',
+      footerCellTemplate : '<i></i>',
     }, {
       field : 'fee_center_label',
       displayName : 'TABLE.COLUMNS.AUXILIARY_CENTER',
@@ -61,13 +69,6 @@ function UpdateCenterController(DistributionUpdateCenters, DistributionCenters, 
       displayName : 'TABLE.COLUMNS.DATE',
       headerCellFilter : 'translate',
       type : 'date',
-      footerCellTemplate : '<i></i>',
-    }, {
-      field : 'hrRecord',
-      displayName : 'TABLE.COLUMNS.RECORD',
-      headerCellFilter : 'translate',
-      visible : true,
-      cellTemplate : '/modules/journal/templates/record.cell.html',
       footerCellTemplate : '<i></i>',
     }, {
       field : 'account_number',
@@ -85,9 +86,7 @@ function UpdateCenterController(DistributionUpdateCenters, DistributionCenters, 
       enableFiltering : true,
       treeAggregationType : uiGridGroupingConstants.aggregation.SUM,
       cellFilter : 'currency:'.concat(Session.enterprise.currency_id),
-      customTreeAggregationFinalizerFn : (aggregation) => {
-        aggregation.rendered = aggregation.value;
-      },
+      customTreeAggregationFinalizerFn,
     }, {
       field : 'credit_equiv',
       type : 'number',
@@ -99,9 +98,7 @@ function UpdateCenterController(DistributionUpdateCenters, DistributionCenters, 
       enableFiltering : true,
       treeAggregationType : uiGridGroupingConstants.aggregation.SUM,
       cellFilter : 'currency:'.concat(Session.enterprise.currency_id),
-      customTreeAggregationFinalizerFn : (aggregation) => {
-        aggregation.rendered = aggregation.value;
-      },
+      customTreeAggregationFinalizerFn,
     }, {
       field : 'user_name',
       displayName : 'TABLE.COLUMNS.RESPONSIBLE',
@@ -116,15 +113,14 @@ function UpdateCenterController(DistributionUpdateCenters, DistributionCenters, 
     }],
   };
 
-  vm.grouping = new Grouping(vm.gridOptions, true, 'row_uuid', vm.grouped, true);
+  vm.grouping = new Grouping(vm.gridOptions, true, 'trans_id');
 
   function onRegisterApiFn(gridApi) {
     vm.gridApi = gridApi;
   }
 
   function toggleFilter() {
-    vm.filterEnabled = !vm.filterEnabled;
-    vm.gridOptions.enableFiltering = vm.filterEnabled;
+    vm.gridOptions.enableFiltering = !vm.gridOptions.enableFiltering;
     vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
   }
 

--- a/test/end-to-end/distributionFeesCenters/distribution_feescenters.page.js
+++ b/test/end-to-end/distributionFeesCenters/distribution_feescenters.page.js
@@ -6,7 +6,6 @@
  * behaviour so it is a Distribution page object
  */
 
-const GA = require('../shared/GridAction');
 const GU = require('../shared/GridUtils');
 const FU = require('../shared/FormUtils');
 const GridRow = require('../shared/GridRow');
@@ -111,8 +110,9 @@ class DistributionPage {
 
     await FU.buttons.submit();
 
-    const { rowIndex } = await GU.getGridIndexesMatchingText(this.gridId, dataset.uuid);
-    await GA.clickOnMethod(rowIndex, this.actionLinkUpdateColumn, 'edit', this.gridId);
+    const row = new GridRow(dataset.trans_id);
+    await row.dropdown().click();
+    await row.edit().click();
 
     await components.currencyInput.set(1000, 'principal_1');
     await components.currencyInput.set(100, 'principal_2');

--- a/test/end-to-end/distributionFeesCenters/distribution_feescenters.spec.js
+++ b/test/end-to-end/distributionFeesCenters/distribution_feescenters.spec.js
@@ -42,11 +42,11 @@ describe('Update Distributed Auxiliary Fee Center', () => {
   const page = new DistributionPage();
 
   const dataset = {
-    uuid : 'E701230AE0DC11E89F4F507B9DD6DEA5 (3)',
     fiscal_id : 4,
     periodFrom_id : 201801,
     periodTo_id : 201812,
     costCenter : 1,
+    trans_id : 'TPA37',
   };
 
   it('Update Distributed Fee Center', async () => {

--- a/test/end-to-end/distributionFeesCenters/distribution_key.page.js
+++ b/test/end-to-end/distributionFeesCenters/distribution_key.page.js
@@ -12,14 +12,14 @@ const components = require('../shared/components');
 class FeeCenterPage {
   constructor() {
     this.gridId = 'distribution-key-center-grid';
-    this.rubricGrid = element(by.id(this.gridId));
+    this.distributionGrid = element(by.id(this.gridId));
   }
 
   /**
    * The numbers of transactions related to auxiliary centers to be returned to the main expense centers
    */
   getDistributionKeyCount() {
-    return this.rubricGrid
+    return this.distributionGrid
       .element(by.css('.ui-grid-render-container-body'))
       .all(by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index'))
       .count();

--- a/test/end-to-end/distributionFeesCenters/distribution_key.spec.js
+++ b/test/end-to-end/distributionFeesCenters/distribution_key.spec.js
@@ -23,10 +23,6 @@ describe('Distribution keys Management', () => {
     expect(await Page.getDistributionKeyCount()).to.equal(distributionKeyElements);
   });
 
-  it('displays all distributions keys loaded from the database', async () => {
-    expect(await Page.getDistributionKeyCount()).to.equal(distributionKeyElements);
-  });
-
   it('reset distributions key for an Auxiliary Fee Center', async () => {
     await Page.resetDistributionKey(resetAuxiliary2);
   });


### PR DESCRIPTION
Fixes the client to group by transaction ID, not UUID.  Also removes the selection from the grid.  Finally, it also adds a "view transactions" feature to allow users to quickly browse the linked transactions in the posting journal.

Closes #4938.