### PR TITLE
chore(stock): rm CMM based on days of consumption

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -190,8 +190,6 @@
     "ENABLE_AUTO_PURCHASE_ORDER_CONFIRMATION_HELP_TEXT" : "Enable automatic confirmation of purchase orders when they are created without requiring manual confirmation",
     "ENABLE_AUTO_STOCK_ACCOUNTING_LABEL" : "Enables realtime stock accounting",
     "ENABLE_AUTO_STOCK_ACCOUNTING_HELP_TEXT" : "Enabling this feature will write stock movement transactions into the posting journal in real time. It requires all inventory accounts to be correctly configured.",
-    "ENABLE_DAILY_CONSUMPTION_LABEL" : "Enable CMM calculation based on days of consumption",
-    "ENABLE_DAILY_CONSUMPTION_HELP_TEXT" : "The CMM (Average Monthly Consumption) is calculated taking into account the quantities consumed over the number of days on which there was consumption",
     "ENABLE_STRICT_DEPOT_PERMISSION" : "Enable permission to view depots in stock registries",
     "ENABLE_STRICT_DEPOT_PERMISSION_HELP_TEXT" : "Limit the consultation of stock registries to users according to their depots",
     "ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY" : "Enable Automatic Crediting of Supplier on Stock Entry",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -194,8 +194,6 @@
     "ENABLE_AUTO_PURCHASE_ORDER_CONFIRMATION_HELP_TEXT" : "Activer la confirmation automatique des bons de commande lorsqu'ils sont créés sans nécessiter de confirmation manuelle.",
     "ENABLE_AUTO_STOCK_ACCOUNTING_LABEL" : "Activer la comptabilisation de stock en temps réel",
     "ENABLE_AUTO_STOCK_ACCOUNTING_HELP_TEXT" : "L'activation de cette option va écrire automatiquement et en temps réel dans le journal toutes les transactions liées aux mouvements de stock. Les comptes des inventaires et groupes d'inventaire doivent être bien configurés au préalable",
-    "ENABLE_DAILY_CONSUMPTION_LABEL" : "Activer le calcul du CMM sur base des jours de consommation",
-    "ENABLE_DAILY_CONSUMPTION_HELP_TEXT" : "La Consommation Moyenne Mensuelle (CMM) est calculée en tenant compte des quantités consommées sur le nombre de jours où il y a eu des consommation",
     "ENABLE_STRICT_DEPOT_PERMISSION" : "Activer la permission de voir les depots dans les registres",
     "ENABLE_STRICT_DEPOT_PERMISSION_HELP_TEXT" : "Limiter la consultation des registres de stock aux utilisateurs selon leurs depots",
     "ENABLE_SUPPLIER_CREDIT_ON_STOCK_ENTRY" : "Activer le crédit automatique du fournisseur lors de l'entrée de stock",

--- a/client/src/modules/stock/settings/stock-settings.html
+++ b/client/src/modules/stock/settings/stock-settings.html
@@ -46,14 +46,6 @@
             </div>
           </div>
 
-          <bh-yes-no-radios label="SETTINGS.ENABLE_DAILY_CONSUMPTION_LABEL"
-            value="StockSettingsCtrl.settings.enable_daily_consumption"
-            name="enable_daily_consumption"
-            id="enable_daily_consumption"
-            help-text="SETTINGS.ENABLE_DAILY_CONSUMPTION_HELP_TEXT"
-            on-change-callback="StockSettingsCtrl.enableDailyConsumption(value)">
-          </bh-yes-no-radios>
-
           <bh-yes-no-radios label="SETTINGS.ENABLE_AUTO_PURCHASE_ORDER_CONFIRMATION_LABEL"
             value="StockSettingsCtrl.settings.enable_auto_purchase_order_confirmation"
             name="enable_auto_purchase_order_confirmation"

--- a/client/src/modules/stock/settings/stock-settings.js
+++ b/client/src/modules/stock/settings/stock-settings.js
@@ -92,7 +92,6 @@ function StockSettingsController(
 
   vm.enableAutoStockAccounting = proxy('enable_auto_stock_accounting');
   vm.enableAutoPurchaseOrderConfirmation = proxy('enable_auto_purchase_order_confirmation');
-  vm.enableDailyConsumption = proxy('enable_daily_consumption');
   vm.enableStrictDepotPermission = proxy('enable_strict_depot_permission');
   vm.enableSupplierCredit = proxy('enable_supplier_credit');
   vm.enableStrictDepotDistribution = proxy('enable_strict_depot_distribution');

--- a/server/controllers/inventory/depots/extra.js
+++ b/server/controllers/inventory/depots/extra.js
@@ -32,11 +32,9 @@ router.get('/inventories/:inventoryUuid/lots', getInventoryLots);
 async function getInventory(req, res, next) {
   try {
     const monthAvgConsumption = req.session.stock_settings.month_average_consumption;
-    const enableDailyConsumption = req.session.stock_settings.enable_daily_consumption;
     const inventory = await core.getInventoryQuantityAndConsumption(
       { depot_uuid : req.params.uuid },
       monthAvgConsumption,
-      enableDailyConsumption,
     );
 
     res.status(200).json(inventory);

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -265,7 +265,7 @@ async function getLotsDepot(depotUuid, params, finalClause) {
   const queryParameters = filters.parameters();
 
   const inventories = await db.exec(query, queryParameters);
-  const processParameters = [inventories, params.dateTo, params.monthAverageConsumption, params.enableDailyConsumption];
+  const processParameters = [inventories, params.dateTo, params.monthAverageConsumption];
   const resultFromProcess = await processStockConsumptionAverage(...processParameters);
 
   if (resultFromProcess.length > 0) {
@@ -625,7 +625,7 @@ async function getDailyStockConsumption(params) {
  * @param {Date} periodDate - a date for finding the correspondant period
  * @param {number} monthAverageConsumption - the number of months for calculating the average (optional)
  */
-async function getStockConsumptionAverage(periodId, periodDate, monthAverageConsumption, enableDailyConsumption) {
+async function getStockConsumptionAverage(periodId, periodDate, monthAverageConsumption) {
   const numberOfMonths = monthAverageConsumption - 1;
   let ids = [];
 
@@ -657,63 +657,24 @@ async function getStockConsumptionAverage(periodId, periodDate, monthAverageCons
     GROUP BY i.uuid, d.uuid;
   `;
 
-  // the value ((w.quantity/w.days) * 30.5) is the CMM
-  // is mentionned here as quantity to fit into the expected values
-  // for returned values
-  const queryConsumptionByDays = `
-  SELECT
-    w.consumption AS counted_consumption,
-    w.quantity AS consumed_quantity,
-    ROUND((w.quantity / w.days) * 30.5) AS quantity,
-    w.code, w.text, w.days,
-    BUID(w.depot_uuid) depot_uuid, BUID(w.inventory_uuid) uuid
-  FROM
-  (
-    SELECT
-      z.text, SUM(IF(z.date, 1, 0)) days, SUM(z.consumption) consumption, SUM(z.quantity) quantity,
-      z.depot_uuid, z.inventory_uuid, z.code
-    FROM (
-      SELECT
-        count(*) consumption, SUM(sm.quantity) quantity,  sm.date,
-        i.uuid inventory_uuid, i.text, i.code,
-        sm.depot_uuid
-      FROM stock_movement sm
-      JOIN lot l ON l.uuid = sm.lot_uuid
-      JOIN inventory i ON i.uuid = l.inventory_uuid
-      WHERE
-        (DATE(sm.date) BETWEEN ? AND ?) AND flux_id IN (${flux.TO_PATIENT}, ${flux.TO_SERVICE})
-      GROUP BY sm.depot_uuid, i.uuid, DATE(sm.date)
-      HAVING quantity > 0
-      ORDER BY i.text
-    )z
-    GROUP BY z.depot_uuid, z.inventory_uuid
-  )w WHERE w.days <> 0
-  `;
-
-  const checkPeriod = `
-    SELECT id FROM period;
-  `;
+  const checkPeriod = 'SELECT id FROM period;';
 
   const getBeginningPeriod = `
     SELECT id FROM period WHERE DATE(?) BETWEEN DATE(start_date) AND DATE(end_date) LIMIT 1;
   `;
 
-  let execStockConsumption;
-  if (enableDailyConsumption) {
-    execStockConsumption = db.exec(queryConsumptionByDays, [beginningDate, baseDate]);
+  const periods = await db.exec(checkPeriod);
 
-  } else {
-    const periods = await db.exec(checkPeriod);
-    // Just to avoid that db.one requests can query empty tables, and generate errors
-    if (periods.length) {
-      const period = await db.one(queryPeriodId, [periodId || baseDate]);
-      const beginningPeriod = await db.one(getBeginningPeriod, [beginningDate]);
-      const paramPeriodRange = beginningPeriod.id ? [beginningPeriod.id, period.id] : [1, period.id];
-      const rows = await db.exec(queryPeriodRange, paramPeriodRange);
-      ids = rows.map(row => row.id);
-    }
-    execStockConsumption = periods.length ? db.exec(queryStockConsumption, [ids]) : [];
+  // Just to avoid that db.one requests can query empty tables, and generate errors
+  if (periods.length) {
+    const period = await db.one(queryPeriodId, [periodId || baseDate]);
+    const beginningPeriod = await db.one(getBeginningPeriod, [beginningDate]);
+    const paramPeriodRange = beginningPeriod.id ? [beginningPeriod.id, period.id] : [1, period.id];
+    const rows = await db.exec(queryPeriodRange, paramPeriodRange);
+    ids = rows.map(row => row.id);
   }
+
+  const execStockConsumption = periods.length ? db.exec(queryStockConsumption, [ids]) : [];
 
   return execStockConsumption;
 }
@@ -721,9 +682,7 @@ async function getStockConsumptionAverage(periodId, periodDate, monthAverageCons
 /**
  * Inventory Quantity and Consumptions
  */
-async function getInventoryQuantityAndConsumption(params, monthAverageConsumption,
-  enableDailyConsumption, averageConsumptionAlgo) {
-
+async function getInventoryQuantityAndConsumption(params, monthAverageConsumption, averageConsumptionAlgo) {
   let _status;
   let delay;
   let purchaseInterval;
@@ -782,7 +741,7 @@ async function getInventoryQuantityAndConsumption(params, monthAverageConsumptio
   const clause = ` GROUP BY l.inventory_uuid, m.depot_uuid ${emptyLotToken} ORDER BY ig.name, i.text `;
 
   const inventories = await getLots(sql, params, clause);
-  const processParams = [inventories, params.dateTo, monthAverageConsumption, enableDailyConsumption];
+  const processParams = [inventories, params.dateTo, monthAverageConsumption];
   const inventoriesProcessed = await processStockConsumptionAverage(...processParams);
 
   let filteredRows = inventoriesProcessed;
@@ -900,10 +859,10 @@ function processMultipleLots(inventories) {
  * in a depot.
  */
 async function processStockConsumptionAverage(
-  inventories, dateTo, monthAverageConsumption, enableDailyConsumption,
+  inventories, dateTo, monthAverageConsumption,
 ) {
   const consumptions = await getStockConsumptionAverage(
-    null, dateTo, monthAverageConsumption, enableDailyConsumption,
+    null, dateTo, monthAverageConsumption,
   );
 
   for (let i = 0; i < consumptions.length; i++) {

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -599,7 +599,6 @@ async function listLotsDepot(req, res, next) {
   const params = req.query;
 
   params.monthAverageConsumption = req.session.stock_settings.month_average_consumption;
-  params.enableDailyConsumption = req.session.stock_settings.enable_daily_consumption;
   params.averageConsumptionAlgo = req.session.stock_settings.average_consumption_algo;
 
   if (req.session.stock_settings.enable_strict_depot_permission) {
@@ -649,7 +648,6 @@ async function listLotsDepot(req, res, next) {
 async function listInventoryDepot(req, res, next) {
   const params = req.query;
   const monthAverageConsumption = req.session.stock_settings.month_average_consumption;
-  const enableDailyConsumption = req.session.stock_settings.enable_daily_consumption;
   const averageConsumptionAlgo = req.session.stock_settings.average_consumption_algo;
 
   // expose connected user data
@@ -658,7 +656,7 @@ async function listInventoryDepot(req, res, next) {
   }
 
   try {
-    const inventoriesParameters = [params, monthAverageConsumption, enableDailyConsumption, averageConsumptionAlgo];
+    const inventoriesParameters = [params, monthAverageConsumption, averageConsumptionAlgo];
 
     const [inventories, lots] = await Promise.all([
       core.getInventoryQuantityAndConsumption(...inventoriesParameters),

--- a/server/controllers/stock/reports/stock/inventories_report.js
+++ b/server/controllers/stock/reports/stock/inventories_report.js
@@ -16,7 +16,6 @@ async function stockInventoriesReport(req, res, next) {
   let display = {};
   let filters;
   const monthAverageConsumption = req.session.stock_settings.month_average_consumption;
-  const enableDailyConsumption = req.session.stock_settings.enable_daily_consumption;
   const averageConsumptionAlgo = req.session.stock_settings.average_consumption_algo;
 
   const data = {};
@@ -42,7 +41,7 @@ async function stockInventoriesReport(req, res, next) {
       options.check_user_id = req.session.user.id;
     }
 
-    const inventoriesParameters = [options, monthAverageConsumption, enableDailyConsumption, averageConsumptionAlgo];
+    const inventoriesParameters = [options, monthAverageConsumption, averageConsumptionAlgo];
     const report = new ReportManager(STOCK_INVENTORIES_REPORT_TEMPLATE, req.session, optionReport);
     const rows = await Stock.getInventoryQuantityAndConsumption(...inventoriesParameters);
 

--- a/server/controllers/stock/reports/stock/lots_report.js
+++ b/server/controllers/stock/reports/stock/lots_report.js
@@ -46,7 +46,6 @@ function stockLotsReport(req, res, next) {
   }
 
   options.monthAverageConsumption = req.session.stock_settings.month_average_consumption;
-  options.enableDailyConsumption = req.session.stock_settings.enable_daily_consumption;
 
   if (req.session.stock_settings.enable_strict_depot_permission) {
     options.check_user_id = req.session.user.id;

--- a/server/controllers/stock/setting/index.js
+++ b/server/controllers/stock/setting/index.js
@@ -22,9 +22,8 @@ exports.list = function list(req, res, next) {
   const sql = `
     SELECT month_average_consumption, default_min_months_security_stock,
       enable_auto_purchase_order_confirmation, enable_auto_stock_accounting,
-      enable_daily_consumption, enable_strict_depot_permission,
-      enable_supplier_credit, enable_strict_depot_distribution,
-      average_consumption_algo
+      enable_strict_depot_permission, enable_supplier_credit,
+      enable_strict_depot_distribution, average_consumption_algo
     FROM stock_setting
     WHERE enterprise_id = ? LIMIT 1;
     `;

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -93,19 +93,16 @@ CREATE TABLE `depot_distribution_permission` (
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
 /*
- * @author: lomamech
- * @date: 2020-10-05
- * @desc: Parameter setting of the CMM calculation algorithm to be used #4984
- *
-  ALTER TABLE `stock_setting` ADD COLUMN `average_consumption_algo` VARCHAR(100) NOT NULL DEFAULT 'algo_msh';
-
-  NOTE, JMC 2020-11-05: No longer need to add this separately.  It is folded into the table creation above.
- */
-
-/*
  * @author: jmcameron
  * @date: 2020-10-30
  * @pull-release: 5075
  * @description:  Add data field for helpdesk info
  */
 CALL add_column_if_missing('enterprise', 'helpdesk', 'TEXT DEFAULT NULL AFTER `po_box`');
+
+/*
+ * @author: jniles
+ * @date: 2020-10-20
+ * @desc: remove the "enable_daily_consumption" option as this is taken care of by our algo choice.
+ */
+ALTER TABLE `stock_setting` DROP COLUMN `enable_daily_consumption`;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1865,7 +1865,6 @@ CREATE TABLE `stock_setting` (
   `default_min_months_security_stock` SMALLINT(5) NOT NULL DEFAULT 2,
   `enable_auto_purchase_order_confirmation` TINYINT(1) NOT NULL DEFAULT 0,
   `enable_auto_stock_accounting` TINYINT(1) NOT NULL DEFAULT 1,
-  `enable_daily_consumption` TINYINT(1) NOT NULL DEFAULT 0,
   `enable_strict_depot_permission` TINYINT(1) NOT NULL DEFAULT 0,
   `enable_supplier_credit` TINYINT(1) NOT NULL DEFAULT 0,
   `enable_strict_depot_distribution` TINYINT(1) NOT NULL DEFAULT 0,

--- a/test/end-to-end/stock/stock.setting.js
+++ b/test/end-to-end/stock/stock.setting.js
@@ -17,7 +17,6 @@ function StockSettingTests() {
     await page.defineMonthAverageConsumption(5);
     await page.defaultMinMonthsSecurityStock(4);
 
-    await page.setRadio('yes', 'enable_daily_consumption');
     await page.setRadio('yes', 'enable_auto_purchase_order_confirmation');
     await page.setRadio('yes', 'enable_strict_depot_permission');
     await page.setRadio('yes', 'enable_auto_stock_accounting');
@@ -43,7 +42,6 @@ function StockSettingTests() {
     await page.defineMonthAverageConsumption(10);
     await page.defaultMinMonthsSecurityStock(2);
 
-    await page.setRadio('no', 'enable_daily_consumption');
     await page.setRadio('no', 'enable_auto_purchase_order_confirmation');
     await page.setRadio('no', 'enable_strict_depot_permission');
     await page.setRadio('no', 'enable_auto_stock_accounting');

--- a/test/integration/stock/stockSettings.js
+++ b/test/integration/stock/stockSettings.js
@@ -20,8 +20,7 @@ describe('(/stock/setting) Stock Settings API', () => {
   const responseKeys = [
     'month_average_consumption', 'default_min_months_security_stock',
     'enable_auto_purchase_order_confirmation', 'enable_auto_stock_accounting',
-    'enable_daily_consumption', 'enable_strict_depot_permission',
-    'enable_supplier_credit', 'enable_strict_depot_distribution',
+    'enable_strict_depot_permission', 'enable_supplier_credit', 'enable_strict_depot_distribution',
     'average_consumption_algo',
   ];
 


### PR DESCRIPTION
Removes the option to select the CMM based on days of consumption. This was a stopgap until we got the CMM calculation based on the correct algorithm.  Now we've removed it entirely since we have the option of specifying the correct algorithm in the stock_settings.

Closes #5030