### PR TITLE
feat(sh): add script to download latest release

### DIFF
--- a/sh/download-latest-release.sh
+++ b/sh/download-latest-release.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# bash script mode
+set -eo pipefail
+
+OWNER="ima-worldhealth"
+REPO="bhima"
+
+echo "looking up latest version of $REPO"
+VERSION=$(curl -s "https://github.com/$OWNER/$REPO/releases/latest/download" 2>&1 | sed "s/^.*download\/\([^\"]*\).*/\1/")
+echo "found $VERSION"
+
+echo "downloading $VERSION from codeload.github.com to /tmp/bhima.tar.gz"
+wget -O /tmp/bhima.tar.gz -q https://codeload.github.com/$OWNER/$REPO/legacy.tar.gz/$VERSION
+echo "done."


### PR DESCRIPTION
Adds a bash script to download the latest BHIMA release. Useful for upgrading applications that do not use git for version control.