### PR TITLE
Change English label to 'Assignment History'

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -227,7 +227,7 @@
     "DETAILS":"Lot Information",
     "LOT_LABEL":"Lot label",
     "SUCCESSFULLY_EDITED":"Lot updated with success",
-    "ASSIGNMENT_HISTORIC":"Assignment Historic",
+    "ASSIGNMENT_HISTORIC":"Assignment History",
     "ASSIGNMENT_CURRENT":"Current",
     "NO_ASSIGNMENT":"No Assignment",
     "INCLUDE_EXHAUSTED_LOTS":"Include exhausted lots",


### PR DESCRIPTION
Simple adjustment to change the "Stock Lots" action menu label "Assignment Historic" to "Assignment History".