### PR TITLE
Fix distribution keys folding

### DIFF
--- a/client/src/modules/distribution_center/distribution_key/distribution_key.js
+++ b/client/src/modules/distribution_center/distribution_key/distribution_key.js
@@ -114,6 +114,7 @@ function DistributionKeyController(DistributionCenters, Notify, uiGridConstants,
     DistributionCenters.getDistributionKey()
       .then((data) => {
         vm.gridOptions.data = data;
+        vm.grouping.unfoldAllGroups();
       })
       .catch(errorHandler)
       .finally(toggleLoadingIndicator);


### PR DESCRIPTION
Fix a problem that was preventing the Distribution Keys page from opening up fully expanded by default on Chrome.  This was affecting the End2End tests.  

Debugged with help from @jniles!
