### PR TITLE
Feat: add multiple account report link to account references

### DIFF
--- a/client/src/i18n/en/section_bilan.json
+++ b/client/src/i18n/en/section_bilan.json
@@ -1,7 +1,0 @@
-{"SECTION_BILAN":{"ADD_SECTION_BILAN":"Add a bilan Section",
-"ALERT":"Bilan section management",
-"ALL":"All Bilan Sections",
-"EDIT":"Bilan section editing",
-"NEW":"New bilan section",
-"NO_SECTION_BILAN":"No bilan section found",
-"TITLE":"Bilan section Management"}}

--- a/client/src/i18n/en/section_resultat.json
+++ b/client/src/i18n/en/section_resultat.json
@@ -1,7 +1,0 @@
-{"SECTION_RESULTAT":{"ADD_SECTION_RESULTAT":"Add a result Section",
-"ALERT":"Result Section Management",
-"ALL":"All Result Sections",
-"EDIT":"Edit Result Section",
-"NEW":"New Result Section",
-"NO_SECTION_RESULTAT":"No Result Sections",
-"TITLE":"Result Section Management"}}

--- a/client/src/i18n/en/tree.json
+++ b/client/src/i18n/en/tree.json
@@ -137,8 +137,6 @@
     "ROLE_MANAGEMENT" : "Role Management",
     "ROOT" : "Root",
     "RUBRIC_MANAGEMENT" : "Rubrics Management",
-    "SECTION_BILAN" : "Bilan section",
-    "SECTION_RESULTAT" : "Result Section",
     "SERVICE" : "Services",
     "SIMPLE_VOUCHER" : "Simple Voucher",
     "STAFFING_INDICES_MANAGEMENT" : "Staffing indices management",

--- a/client/src/i18n/fr/section_bilan.json
+++ b/client/src/i18n/fr/section_bilan.json
@@ -1,7 +1,0 @@
-{"SECTION_BILAN":{"ADD_SECTION_BILAN":"Ajouter une section du Bilan",
-"ALERT":"Gestion des sections du Bilan",
-"ALL":"Tous les sections du bilan",
-"EDIT":"Éditer une section du bilan",
-"NEW":"Nouvelle section du bilan",
-"NO_SECTION_BILAN":"Pas de section du bilan",
-"TITLE":"Section du bilan"}}

--- a/client/src/i18n/fr/section_resultat.json
+++ b/client/src/i18n/fr/section_resultat.json
@@ -1,7 +1,0 @@
-{"SECTION_RESULTAT":{"ADD_SECTION_RESULTAT":"Ajouter une section de résultats",
-"ALERT":"Gestion des sections de résultats",
-"ALL":"Tous les sections de résultats",
-"EDIT":"Éditer une séction de résultats",
-"NEW":"Nouvelle section de résultats",
-"NO_SECTION_RESULTAT":"Pas de section de résultats",
-"TITLE":"Section de résultats"}}

--- a/client/src/i18n/fr/tree.json
+++ b/client/src/i18n/fr/tree.json
@@ -122,8 +122,6 @@
     "ROOT":"Racine",
     "RUBRIC_MANAGEMENT":"Gestion Rubriques",
     "INVOICES":"Facturation",
-    "SECTION_BILAN":"Section du bilan",
-    "SECTION_RESULTAT":"Section des Résultats",
     "SERVICE":"Services",
     "SIMPLE_VOUCHER":"Bordereau de transfert",
     "STOCK":"Stock",

--- a/client/src/modules/account_reference/account_reference.ctrl.js
+++ b/client/src/modules/account_reference/account_reference.ctrl.js
@@ -2,20 +2,21 @@ angular.module('bhima.controllers')
   .controller('AccountReferenceController', AccountReferenceController);
 
 AccountReferenceController.$inject = [
-  '$state', 'AccountReferenceService', 'NotifyService', 'uiGridConstants', '$translate',
+  '$state', 'AccountReferenceService', 'NotifyService', 'uiGridConstants', '$translate', 'bhConstants',
 ];
 
 /**
  * AccountReference Controller
  * This module is responsible for handling the CRUD operation on the account references
  */
-function AccountReferenceController($state, AccountReferences, Notify, uiGridConstants, $translate) {
+function AccountReferenceController($state, AccountReferences, Notify, uiGridConstants, $translate, bhConstants) {
   const vm = this;
   vm.gridApi = {};
   vm.filterEnabled = false;
   vm.toggleFilter = toggleFilter;
   vm.search = search;
   vm.onRemoveFilter = onRemoveFilter;
+  vm.viewInAccountStatement = viewInAccountStatement;
 
   // options for the UI grid
   vm.gridOptions = {
@@ -91,7 +92,6 @@ function AccountReferenceController($state, AccountReferences, Notify, uiGridCon
     return loadGrid(AccountReferences.filters.formatHTTP(true));
   }
 
-
   // bind methods
   vm.edit = edit;
   vm.remove = remove;
@@ -155,6 +155,20 @@ function AccountReferenceController($state, AccountReferences, Notify, uiGridCon
 
   function toggleLoadingIndicator() {
     vm.loading = !vm.loading;
+  }
+
+  const isNotTitleAccount = account => account.account_type_id !== bhConstants.accounts.TITLE;
+
+  function viewInAccountStatement(abbr) {
+    return AccountReferences.getAccountsForReference(abbr)
+      .then(list => {
+        const accountIds = list
+          .filter(account => (isNotTitleAccount(account) && !account.hidden))
+          .map(account => account.account_id);
+
+        return $state.go('reportsBase.account_report_multiple', { data : { accountIds } });
+      })
+      .catch(Notify.handleError);
   }
 
   loadGrid();

--- a/client/src/modules/account_reference/account_reference.service.js
+++ b/client/src/modules/account_reference/account_reference.service.js
@@ -17,6 +17,17 @@ function AccountReferenceService(Api, Filters, $uibModal, AppCache) {
   service.filters = referencesFilters;
   service.openSearchModal = openSearchModal;
 
+  /**
+   * @method getAccountsForReference
+   *
+   * @description
+   * Returns the list of accounts associated with a reference.
+   */
+  service.getAccountsForReference = function getAccountsForReference(abbr) {
+    return service.$http.get(`/accounts/references/${abbr}/accounts`)
+      .then(service.util.unwrapHttpResponse);
+  };
+
   referencesFilters.registerCustomFilters([
     { key : 'abbr', label : 'ACCOUNT.REFERENCE.REFERENCE' },
     { key : 'number', label : 'FORM.LABELS.ACCOUNT' },

--- a/client/src/modules/account_reference/templates/action.cell.html
+++ b/client/src/modules/account_reference/templates/action.cell.html
@@ -12,6 +12,13 @@
         <i class="fa fa-edit"></i> <span translate>FORM.BUTTONS.EDIT</span>
       </a>
     </li>
+    <li class="divider"></li>
+
+    <li>
+      <a data-method="view-account-statement" ng-click="grid.appScope.viewInAccountStatement(row.entity.abbr)" href>
+        <i class="fa fa-list"></i> <span translate>REPORT.VIEW_ACCOUNT_STATEMENT</span>
+      </a>
+    </li>
 
     <li class="divider"></li>
 

--- a/client/src/modules/reports/generate/account_report_multiple/account_report_multiple.config.js
+++ b/client/src/modules/reports/generate/account_report_multiple/account_report_multiple.config.js
@@ -20,6 +20,14 @@ function AccountReportMultipleConfigController(
     accountIds : [],
   };
 
+  function handleStateParameters() {
+    const { data } = reportData.params;
+
+    if (data && data.accountIds) {
+      vm.reportDetails.accountIds = data.accountIds;
+    }
+  }
+
   vm.dateInterval = 1;
 
   checkCachedConfiguration();
@@ -102,4 +110,6 @@ function AccountReportMultipleConfigController(
       vm.reportDetails = angular.copy(cache.reportDetails);
     }
   }
+
+  handleStateParameters();
 }

--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -5,6 +5,12 @@ BalanceReportConfigController.$inject = [
   '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
 ];
 
+/**
+ * @function BalanceReportConfigController
+ *
+ * @description
+ * This function renders the balance report.
+ */
 function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('BalanceReport');
@@ -25,6 +31,7 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
     vm.previewGenerated = false;
     vm.previewResult = null;
   };
+
   vm.onChangeLayout = (bool) => {
     vm.reportDetails.useSeparateDebitsAndCredits = bool;
   };

--- a/client/src/modules/reports/reports.routes.js
+++ b/client/src/modules/reports/reports.routes.js
@@ -57,9 +57,10 @@ angular.module('bhima.routes')
       const reportKey = $stateParams.key;
       return SavedReports.requestKey(reportKey)
         .then((results) => {
-          return results[0];
+          const data = results[0];
+          data.params = { ...$stateParams };
+          return data;
         });
-
     }
 
     // make sure that the state's transitions refresh the abstract state
@@ -95,8 +96,8 @@ angular.module('bhima.routes')
       $stateProvider.state('reportsBase.'.concat(key), {
         url : '/'.concat(key),
         controller : key.concat('Controller as ReportConfigCtrl'),
-        templateUrl : '/modules/reports/generate/'.concat(key, '/', key, '.html'),
-        params : { key },
+        templateUrl : `/modules/reports/generate/${key}/${key}.html`,
+        params : { key, data : { value : null } },
         resolve : {
           reportData : ['$stateParams', 'BaseReportService', resolveReportData],
         },

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -229,6 +229,7 @@ exports.configure = function configure(app) {
   app.post('/accounts/references', accounts.references.create);
   app.put('/accounts/references/:id', accounts.references.update);
   app.delete('/accounts/references/:id', accounts.references.remove);
+  app.get('/accounts/references/:id/accounts', accounts.references.getAccountsForReferenceHTTP);
 
   // API for account importation
   app.get('/accounts/template', accounts.importing.downloadTemplate);

--- a/server/controllers/finance/accounts/references.compute.js
+++ b/server/controllers/finance/accounts/references.compute.js
@@ -156,9 +156,11 @@ function getAccountsForReference(abbr, isAmoDep = 0) {
    * @link http://www.mysqltutorial.org/mysql-minus/
    */
   const queryAccounts = `
-    SELECT includeTable.account_id, includeTable.account_number FROM (
+    SELECT includeTable.account_id, includeTable.account_number, includeTable.account_type_id,
+    includeTable.hidden, includeTable.locked FROM (
       SELECT DISTINCT
-        account.id AS account_id, account.number AS account_number FROM account
+        account.id AS account_id, account.number AS account_number, account.type_id AS account_type_id,
+          hidden, locked FROM account
         JOIN (
           SELECT a.id, a.number FROM account a
           JOIN account_reference_item ari ON ari.account_id = a.id
@@ -168,7 +170,8 @@ function getAccountsForReference(abbr, isAmoDep = 0) {
     ) AS includeTable
     LEFT JOIN (
       SELECT DISTINCT
-        account.id AS account_id, account.number AS account_number FROM account
+        account.id AS account_id, account.number AS account_number, account.type_id as account_type_id,
+          hidden, locked FROM account
         JOIN (
           SELECT a.id, a.number FROM account a
           JOIN account_reference_item ari ON ari.account_id = a.id

--- a/server/controllers/finance/accounts/references.js
+++ b/server/controllers/finance/accounts/references.js
@@ -287,6 +287,22 @@ async function lookupAccountReference(id) {
   return reference;
 }
 
+/**
+ * @function getAccountsForReferenceHTTP
+ *
+ * @description
+ * HTTP interface to compute the accounts associated with a particular reference.
+ */
+async function getAccountsForReferenceHTTP(req, res, next) {
+  const { id } = req.params;
+  try {
+    const accounts = await compute.getAccountsForReference(id);
+    res.status(200).json(accounts);
+  } catch (err) {
+    next(err);
+  }
+}
+
 exports.list = list;
 exports.create = create;
 exports.update = update;
@@ -294,6 +310,7 @@ exports.remove = remove;
 exports.detail = detail;
 exports.getAllValues = getAllValues;
 exports.getValue = getValue;
+exports.getAccountsForReferenceHTTP = getAccountsForReferenceHTTP;
 
 // expose computations for values
 exports.getAccountsForReference = compute.getAccountsForReference;

--- a/server/controllers/finance/accounts/references.js
+++ b/server/controllers/finance/accounts/references.js
@@ -60,10 +60,10 @@ async function list(req, res, next) {
       GROUP_CONCAT(IF(ari.is_exception = 0, a.number, CONCAT('(sauf ', a.number, ')')) SEPARATOR ', ') AS accounts,
       ar.reference_type_id, art.label as account_reference_type_label
     FROM account_reference ar
-    LEFT JOIN account_reference arp ON arp.id = ar.parent
-    LEFT JOIN account_reference_item ari ON ari.account_reference_id = ar.id
-    LEFT JOIN account a ON a.id = ari.account_id
-    LEFT JOIN account_reference_type art ON art.id = ar.reference_type_id
+      LEFT JOIN account_reference arp ON arp.id = ar.parent
+      LEFT JOIN account_reference_item ari ON ari.account_reference_id = ar.id
+      LEFT JOIN account a ON a.id = ari.account_id
+      LEFT JOIN account_reference_type art ON art.id = ar.reference_type_id
   `;
 
     filters.fullText('description');
@@ -84,7 +84,6 @@ async function list(req, res, next) {
     next(err);
   }
 }
-
 
 /**
  * @method create

--- a/server/controllers/finance/reports/account_reference/report.handlebars
+++ b/server/controllers/finance/reports/account_reference/report.handlebars
@@ -43,7 +43,7 @@
           {{#each data as |reference|}}
             <tr>
               <td>
-                {{ reference.abbr }} 
+                {{ reference.abbr }}
                 {{#if reference.is_amo_dep}} <i><small>({{translate 'ACCOUNT.REFERENCE.AMO_DEP'}})</small></i> {{/if}}
               </td>
               <td>{{ reference.description }}</td>

--- a/server/controllers/finance/reports/ohada_balance_sheet/index.js
+++ b/server/controllers/finance/reports/ohada_balance_sheet/index.js
@@ -198,7 +198,6 @@ function reporting(options, session) {
           _.extend(item, aggregateReferences(list, currentReferences, previousReferences));
         }
 
-
         if (item.ref === 'CP') {
           list = ['CA', 'CB', 'CD', 'CE', 'CF', 'CH', 'CI', 'CK', 'CG', 'CL', 'CM'];
           _.extend(item, aggregateReferences(list, currentReferences, previousReferences));


### PR DESCRIPTION
This PR implements a link from "account references" to the multiple account statement, auto-populating the data in the multiple account select input.  We can use this mechanism to auto-populate other reports as well (such as stock).  Here is what it looks like in action:

![rQM9i2kLQM](https://user-images.githubusercontent.com/896472/98641537-38002980-232c-11eb-8d6d-a3a1e6046922.gif)


We also need something like this to filter our balance sheet, though that is probably best left for a totally different report (https://github.com/IMA-WorldHealth/bhima/issues/5094).