### PR TITLE
Updated migration script to support site-specific migration files

### DIFF
--- a/sh/setup-migration-script.sh
+++ b/sh/setup-migration-script.sh
@@ -64,9 +64,16 @@ cat $BHIMA_PATH/server/models/functions.sql \
 echo "" >> $MIGRATION_FILE
 
 echo "[migrate] Finished creating script skeleton"
-echo "[migrate] Adding manual migrations from next.sql"
+echo "[migrate] Adding manual migrations from next/migrate.sql"
 
-cat $BHIMA_PATH/server/models/migrations/next/*.sql >> $MIGRATION_FILE
+cat $BHIMA_PATH/server/models/migrations/next/migrate.sql >> $MIGRATION_FILE
+
+# Add migration files specific to this production server
+for sitefile in `ls $BHIMA_PATH/server/models/migrations/next/*$DATABASE*.sql`;
+do
+    echo "[migrate] Adding site-specific migration file \"$sitefile\""
+    cat $sitefile >> $MIGRATION_FILE
+done
 
 echo "[migrate] Finished constructing migration script."
 echo "[migrate] Execute \"mysql $DATABASE < $MIGRATION_FILE\" with appropriate permissions to migrate"


### PR DESCRIPTION
This changes the script that creates migration scripts to support site-specific files:

- It changes the default behavior to include only server/models/migration/next/migrate.sql into the migration SQL script.  In the past, this included ALL *.sql files in that directory.
- If the migration script sees files in the next/ directory that have the name of the current database (eg, 'imck') as part of the file name, it will include those files into the migration SQL script. Note that ONLY files that have the database defined in .env will be included.  

This will allow us to add site-specific files, for instance for IMCK.