### PR TITLE
feat(stock): implement stock changes report

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -479,6 +479,10 @@
       "PAYMENTS" : "Payments",
       "AVERAGE_COST" : "Average Cost",
       "RECOVERY_CAPACITY" : "Recovery Capacity"
+    },
+    "STOCK_CHANGES" : {
+      "TITLE" : "Stock Changes Report",
+      "DESCRIPTION" : "This report allows you to record changes to the stock of a depot by comparing the amount in the system to the amount found on the shelves."
     }
   }
 }

--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -15,6 +15,7 @@
     "DECREASE_HELP"   : "Adjust stock by decreasing the quantity of lots of products in stock",
     "DEPOT"           : "Depot",
     "DEPOT_RESPONSIBLE" : "Depot Manager",
+    "DAYS_OF_STOCK_OUT" : "# Days of Stock Out",
     "DESTINATION"     : "Destination",
     "DETAILS"         : "Details",
     "DOCUMENT"        : "Document",
@@ -136,6 +137,9 @@
     "QUANTITY_SENT"       : "Sent Quantity",
     "QUANTITY_RECEIVED"   : "Received Quantity",
     "QUANTITY_DIFFERENCE" : "Difference",
+    "QUANTITY_CONSUMED" : "Quantity Consumed",
+    "QUANTITY_LOST" : "Quantity Lost",
+    "QUANTITY_REMAINING" : "Quantity Remaining",
     "TRANSFER_RECEIVED" : "Received",
     "TRANSFER_AVAILABLE" : "Available",
     "RECEIPT"         : {

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -481,6 +481,10 @@
       "PAYMENTS" : "Paiements",
       "AVERAGE_COST" : "Coût moyen",
       "RECOVERY_CAPACITY" : "Capacite de recouvrement"
+    },
+    "STOCK_CHANGES" : {
+      "TITLE" : "Rapport sur les variations de stock",
+      "DESCRIPTION": "Ce rapport vous permet d'enregistrer les modifications du stock d'un dépôt en comparant la quantité dans le système à la quantité trouvée sur les étagères."
     }
   }
 }

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -14,6 +14,7 @@
     "COST"            : "Coût",
     "DECREASE"        : "Diminution",
     "DECREASE_HELP"   : "Ajustement de stock en reduisant la quantité des lots des produits en stock",
+    "DAYS_OF_STOCK_OUT" : "N. jours de rupture de stock",
     "DEPOT"           : "Dépôt",
     "DEPOT_RESPONSIBLE" : "Gestionnaire du dépôt",
     "DETAILS"         : "Details",
@@ -139,6 +140,9 @@
     "QUANTITY_SENT"       : "Quantité envoyée",
     "QUANTITY_RECEIVED"   : "Quantité reçue",
     "QUANTITY_DIFFERENCE" : "Ecart",
+    "QUANTITY_CONSUMED" : "Quantité consommée",
+    "QUANTITY_LOST" : "Quantité perdue",
+    "QUANTITY_REMAINING" : "Quantité restante",
     "TRANSFER_RECEIVED" : "Reçu",
     "TRANSFER_AVAILABLE" : "Disponible",
     "RECEIPT"         : {

--- a/client/src/modules/reports/generate/stock_changes/stock_changes.config.js
+++ b/client/src/modules/reports/generate/stock_changes/stock_changes.config.js
@@ -1,0 +1,73 @@
+angular.module('bhima.controllers')
+  .controller('stock_changesController', StockChangesReportConfigCtrl);
+
+StockChangesReportConfigCtrl.$inject = [
+  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+  'LanguageService',
+];
+
+function StockChangesReportConfigCtrl($sce, Notify, SavedReports, AppCache, reportData, $state, Languages) {
+  const vm = this;
+
+  const cache = new AppCache('stock_changes');
+  const reportUrl = 'reports/stock/changes';
+
+  // default values
+  vm.reportDetails = {};
+  vm.previewGenerated = false;
+
+  // check cached configuration
+  checkCachedConfiguration();
+
+  vm.onSelectFiscalYear = year => {
+    vm.reportDetails.fiscal_id = year.id;
+  };
+
+  vm.onSelectPeriod = period => {
+    vm.reportDetails.period_id = period.id;
+  };
+
+  vm.onSelectDepot = depot => {
+    vm.reportDetails.depot_uuid = depot.uuid;
+  };
+
+  vm.clearPreview = () => {
+    vm.previewGenerated = false;
+    vm.previewResult = null;
+  };
+
+  vm.preview = form => {
+    if (form.$invalid) {
+      return 0;
+    }
+
+    // update cached configuration
+    cache.reportDetails = angular.copy(vm.reportDetails);
+    angular.extend(vm.reportDetails, { lang : Languages.key });
+
+    return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
+      .then((result) => {
+        vm.previewGenerated = true;
+        vm.previewResult = $sce.trustAsHtml(result);
+      })
+      .catch(Notify.handleError);
+  };
+
+  vm.requestSaveAs = function requestSaveAs() {
+    const options = {
+      url : reportUrl,
+      report : reportData,
+      reportOptions : angular.copy(vm.reportDetails),
+    };
+
+    return SavedReports.saveAsModal(options)
+      .then(() => {
+        $state.go('reportsBase.reportsArchive', { key : options.report.report_key });
+      })
+      .catch(Notify.handleError);
+  };
+
+  function checkCachedConfiguration() {
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
+  }
+}

--- a/client/src/modules/reports/generate/stock_changes/stock_changes.html
+++ b/client/src/modules/reports/generate/stock_changes/stock_changes.html
@@ -1,0 +1,55 @@
+<bh-report-preview
+  ng-if="ReportConfigCtrl.previewGenerated"
+  source-document="ReportConfigCtrl.previewResult"
+  on-clear-callback="ReportConfigCtrl.clearPreview()"
+  on-save-callback="ReportConfigCtrl.requestSaveAs()">
+</bh-report-preview>
+
+<div ng-show="!ReportConfigCtrl.previewGenerated">
+  <div class="row">
+    <div class="col-md-12">
+      <h3 translate>REPORT.STOCK_CHANGES.TITLE</h3>
+      <p class="text-info" translate>REPORT.STOCK_CHANGES.DESCRIPTION</p>
+    </div>
+  </div>
+
+  <div class="row" style="margin-top : 10px">
+    <div class="col-md-6">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <span translate>REPORT.UTIL.OPTIONS</span>
+        </div>
+
+        <div class="panel-body">
+
+          <form name="ConfigForm" bh-submit="ReportConfigCtrl.preview(ConfigForm)" novalidate>
+
+            <bh-fiscal-year-select
+              fiscal-id="ReportConfigCtrl.reportDetails.fiscal_id"
+              on-select-fiscal-callback="ReportConfigCtrl.onSelectFiscalYear(fiscalYear)">
+            </bh-fiscal-year-select>
+
+            <bh-period-selection
+              fiscal-year-id="ReportConfigCtrl.reportDetails.fiscal_id"
+              period-id="ReportConfigCtrl.reportDetails.period_id"
+              disable="!ReportConfigCtrl.reportDetails.fiscal_id"
+              on-select-callback="ReportConfigCtrl.onSelectPeriod(period)">
+            </bh-period-selection>
+
+            <!-- select depot -->
+            <bh-depot-select
+              depot-uuid="ReportConfigCtrl.reportDetails.depot_uuid"
+              on-select-callback="ReportConfigCtrl.onSelectDepot(depot)">
+              <bh-clear on-clear="ReportConfigCtrl.clear('depot_uuid')"></bh-clear>
+            </bh-depot-select>
+
+            <!-- preview -->
+            <bh-loading-button loading-state="ConfigForm.$loading">
+              <span translate>REPORT.UTIL.PREVIEW</span>
+            </bh-loading-button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/client/src/modules/reports/reports.routes.js
+++ b/client/src/modules/reports/reports.routes.js
@@ -51,10 +51,12 @@ angular.module('bhima.routes')
       'recoveryCapacity',
       'stock_movement_report',
       'stock_expiration_report',
+      'stock_changes',
     ];
 
     function resolveReportData($stateParams, SavedReports) {
       const reportKey = $stateParams.key;
+
       return SavedReports.requestKey(reportKey)
         .then((results) => {
           const data = results[0];

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -831,6 +831,7 @@ exports.configure = function configure(app) {
   app.get('/reports/stock/consumption_graph', stockReports.consumptionGraph);
   app.get('/reports/stock/movement_report', stockReports.movementReport);
   app.get('/reports/stock/expiration_report', stockReports.expirationReport);
+  app.get('/reports/stock/changes', stockReports.stockChangesReport);
 
   app.get('/reports/stock/lots', stockReports.stockLotsReport);
   app.get('/reports/stock/movements', stockReports.stockMovementsReport);

--- a/server/controllers/finance/period.js
+++ b/server/controllers/finance/period.js
@@ -4,6 +4,7 @@ const FilterParser = require('../../lib/filter');
 
 exports.list = list;
 exports.details = details;
+exports.lookupPeriodById = lookupPeriodById;
 
 function list(req, res, next) {
   const params = req.query;
@@ -31,14 +32,18 @@ function list(req, res, next) {
     .catch(next);
 }
 
-function details(req, res, next) {
-  const { id } = req.params;
+function lookupPeriodById(id) {
   const query = `
     SELECT p.id, p.fiscal_year_id, p.number, p.start_date, p.end_date, p.locked
     FROM period p WHERE id = ?;
   `;
 
-  db.one(query, [id])
+  return db.one(query, [id]);
+}
+
+function details(req, res, next) {
+  const { id } = req.params;
+  lookupPeriodById(id)
     .then(period => {
       res.status(200).json(period);
     })

--- a/server/controllers/stock/reports/index.js
+++ b/server/controllers/stock/reports/index.js
@@ -34,6 +34,7 @@ const stockAdjustmentReceipt = require('./stock/adjustment_receipt');
 const stockValue = require('./stock/value');
 const stockAssignReceipt = require('./stock/assign_receipt');
 const stockRequisitionReceipt = require('../requisition/requisition.receipt');
+const stockChangesReport = require('./stock_changes');
 
 /**
  * @function determineReceiptType
@@ -144,5 +145,6 @@ exports.stockAssignReceipt = stockAssignReceipt;
 exports.stockRequisitionReceipt = stockRequisitionReceipt;
 exports.purchaseOrderAnalysis = require('./purchaseOrderAnalysis');
 
+exports.stockChangesReport = stockChangesReport;
 exports.stockAdjustmentReceipt = stockAdjustmentReceipt;
 exports.monthlyConsumption = require('./stock/monthly_consumption');

--- a/server/controllers/stock/reports/stock_changes.handlebars
+++ b/server/controllers/stock/reports/stock_changes.handlebars
@@ -1,0 +1,59 @@
+{{> head title="REPORT.STOCK_CHANGES.TITLE" }}
+
+<body class="container">
+  {{> header}}
+  <!-- body  -->
+  <div class="row">
+    <div class="col-xs-12">
+
+      <h2 class="text-center">
+        {{translate 'REPORT.STOCK_CHANGES.TITLE'}}
+      </h2>
+
+      <h3 class="text-center">{{depot.text}}</h3>
+
+      <p class="text-center">{{date period.start_date}} - {{date period.end_date}}</p>
+
+      <table class="table table-condensed table-report">
+        <thead>
+          <tr>
+            <th>{{translate "STOCK.LOT"}}</th>
+            <th>{{translate "STOCK.EXPIRATION_DATE"}}</th>
+            <th>{{translate "STOCK.QUANTITY"}}</th>
+            <th>{{translate "STOCK.QUANTITY_CONSUMED"}}</th>
+            <th>{{translate "STOCK.QUANTITY_LOST"}}</th>
+            <th>{{translate "STOCK.QUANTITY_REMAINING"}}</th>
+          </tr>
+        </thead>
+
+        {{#each data}}
+          <tbody>
+          {{#with @key as |inventory|}}
+            <tr class="title-row">
+              <th colspan="4">{{inventory}}</th>
+              <th colspan="2"><u>{{translate "STOCK.DAYS_OF_STOCK_OUT"}}: <span style="min-width:300px;">&nbsp;</span></u></th>
+            </tr>
+          {{/with}}
+            {{#each this as |lot|}}
+              <tr>
+                <td>{{lot.label}}</td>
+                <td class="text-right">{{date lot.expiration_date}}</td>
+                <td class="text-right">{{lot.quantity}}</td>
+                <td class="text-right"></td>
+                <td class="text-right"></td>
+                <td class="text-right"></td>
+              </tr>
+            {{/each}}
+          </tbody>
+        {{/each}}
+
+        <tfoot>
+          <tr>
+            <th colspan="4">{{translate "STOCK.ITEMS"}} : <u>{{ totals.items}}</u></th>
+            <th colspan="2">{{translate "STOCK.LOTS"}} : <u>{{ totals.lots }}</u></th>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </div>
+</body>

--- a/server/controllers/stock/reports/stock_changes.js
+++ b/server/controllers/stock/reports/stock_changes.js
@@ -1,0 +1,50 @@
+const {
+  _, ReportManager, Stock, db,
+} = require('./common');
+
+const Periods = require('../../finance/period');
+
+const DEFAULT_PARAMS = {
+  csvKey : 'rows',
+  filename : 'REPORTS.STOCK_CHANGES.TITLE',
+  orientation : 'landscape',
+};
+
+const STOCK_CHANGES_REPORT_TEMPLATE = './server/controllers/stock/reports/stock_changes.handlebars';
+
+/**
+ * @function generate
+ *
+ * @description
+ * Generates the stock changes report.
+ *
+ */
+async function generate(req, res, next) {
+
+  try {
+    const options = _.extend(req.query, DEFAULT_PARAMS);
+
+    const report = new ReportManager(STOCK_CHANGES_REPORT_TEMPLATE, req.session, options);
+
+    // get query the period dates and the depot for the name
+    const [period, depot] = await Promise.all([
+      Periods.lookupPeriodById(options.period_id),
+      db.one('SELECT * FROM depot WHERE uuid = ?', db.bid(options.depot_uuid)),
+    ]);
+
+    // get the stock in the depot as of the end of the period
+    const lots = await Stock.getLotsDepot(depot.uuid, { dateTo : period.end_date, includeEmptyLot : 0 });
+    const data = _.groupBy(lots, 'text');
+
+    const totals = { lots : lots.length, items : Object.keys(data).length };
+
+    const result = await report.render({
+      data, depot, period, totals,
+    });
+    res.set(result.headers).send(result.report);
+  } catch (e) {
+    next(e);
+  }
+}
+
+module.exports = generate;

--- a/server/models/bhima.sql
+++ b/server/models/bhima.sql
@@ -163,7 +163,8 @@ INSERT INTO unit VALUES
   (287,'Inventory Reports','TREE.REPORTS','reports for the inventory modules', 138,'/inventory/reports'),
   (288, '[Stock] Movement Report','TREE.STOCK_MOVEMENT_REPORT','Stock Movement Report', 282,'/reports/stock_movement_report'),
   (289, '[Stock] Expiration report','TREE.STOCK_EXPIRATION_REPORT','Stock expiration report', 282,'/reports/stock_expiration_report'),
-  (290, '[SETTINGS] Settings', 'TREE.STOCK_SETTINGS', 'Stock Settings', 160, '/stock/setting');
+  (290, '[SETTINGS] Settings', 'TREE.STOCK_SETTINGS', 'Stock Settings', 160, '/stock/setting'),
+  (292, '[Stock] Changes Report', 'REPORT.STOCK_CHANGES.TITLE', 'Stock Changes Report', 282, '/reports/stock_changes');
 
 -- Reserved system account type
 INSERT INTO `account_category` VALUES
@@ -232,7 +233,8 @@ INSERT INTO `report` (`report_key`, `title_key`) VALUES
   ('invoicedReceivedStock', 'REPORT.COMPARE_INVOICED_RECEIVED.TITLE'),
   ('invoiceRegistryReport', 'Invoice Registry as report'),
   ('stock_movement_report', 'Stock Movement Report'),
-  ('stock_expiration_report', 'REPORT.STOCK_EXPIRATION_REPORT.TITLE');
+  ('stock_expiration_report', 'REPORT.STOCK_EXPIRATION_REPORT.TITLE'),
+  ('stock_changes', 'REPORT.STOCK_CHANGES.TITLE');
 
 -- Supported Languages
 INSERT INTO `language` VALUES

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -1,5 +1,5 @@
 /**
- * Migration from version 1.16.0
+ * Migration from the version 1.16.1
  */
 
 
@@ -10,3 +10,9 @@
  * @description: Fix typo in menu report name "System Usage Statistics"
  */
 UPDATE `unit` SET name='System Usage Statistics', description='System Usage Statistics' WHERE id=250;
+
+INSERT INTO unit VALUES
+  (292, '[Stock] Changes Report', 'REPORT.STOCK_CHANGES.TITLE', 'Stock Changes Report', 282, '/reports/stock_changes');
+
+INSERT INTO `report` (`report_key`, `title_key`) VALUES
+  ('stock_changes', 'REPORT.STOCK_CHANGES.TITLE');


### PR DESCRIPTION
Implements the "stock changes" report to allow users to download the
current inventory in a depot as of the end of a period.  This should
allow them to fill out the details and quickly compute the quantities in
stock to then make stock adjustments.

Closes #5108.

![image](https://user-images.githubusercontent.com/896472/98985985-97c12500-2524-11eb-8b6b-af92bdd35970.png)
