### PR TITLE
Fix stockImport procedure

### DIFF
--- a/client/src/i18n/en/errors.json
+++ b/client/src/i18n/en/errors.json
@@ -10,6 +10,7 @@
     "NO_EXCHANGE_RATE" : "No Exchange rate defined",
     "NO_FISCAL_YEAR" : "You are missing a fiscal year for that date!",
     "NOT_ALLOWED" : "You are not allowed to perform this action",
+    "NOT_A_NUMBER" : "You did not provide a number to a field intended for a number",
     "NOT_FOUND" : "This record could not be found",
     "NO_PERMISSIONS" : "The login succeeded, but you have no permissions. Please see a system administrator.",
     "NO_PROJECT" : "No permissions for that project.  Please see a system administrator",

--- a/client/src/i18n/en/errors.json
+++ b/client/src/i18n/en/errors.json
@@ -11,6 +11,7 @@
     "NO_FISCAL_YEAR" : "You are missing a fiscal year for that date!",
     "NOT_ALLOWED" : "You are not allowed to perform this action",
     "NOT_A_NUMBER" : "You did not provide a number to a field intended for a number",
+    "NOT_A_TEXT" : "You did not provide valid text in a text field",
     "NOT_FOUND" : "This record could not be found",
     "NO_PERMISSIONS" : "The login succeeded, but you have no permissions. Please see a system administrator.",
     "NO_PROJECT" : "No permissions for that project.  Please see a system administrator",

--- a/client/src/i18n/fr/errors.json
+++ b/client/src/i18n/fr/errors.json
@@ -10,6 +10,7 @@
     "NO_EXCHANGE_RATE" : "Aucun taux de change defini pour aujourd'hui!",
     "NOT_ALLOWED" : "Vous n'etes pas authorisé à faire cette action",
     "NOT_FOUND" : "Cet enregistrement n'a pas pu être trouvé",
+    "NOT_A_NUMBER" : "Vous n'avez pas fourni un nombre à un champs destiné à un nombre",
     "NO_PERMISSIONS" : "La connexion a réussi, mais vous n'avez aucune autorisation. Veuillez contacter un administrateur système.",
     "NO_PROJECT" : "Aucune autorisation pour ce projet, Veuillez contacter un administrateur système",
     "NO_FISCAL_YEAR" : "Aucune année fiscale pour cette date!",

--- a/client/src/i18n/fr/errors.json
+++ b/client/src/i18n/fr/errors.json
@@ -11,6 +11,7 @@
     "NOT_ALLOWED" : "Vous n'etes pas authorisé à faire cette action",
     "NOT_FOUND" : "Cet enregistrement n'a pas pu être trouvé",
     "NOT_A_NUMBER" : "Vous n'avez pas fourni un nombre à un champs destiné à un nombre",
+    "NOT_A_TEXT" : "Vous n'avez pas fourni un texte valide dans un champs destiné à un texte",
     "NO_PERMISSIONS" : "La connexion a réussi, mais vous n'avez aucune autorisation. Veuillez contacter un administrateur système.",
     "NO_PROJECT" : "Aucune autorisation pour ce projet, Veuillez contacter un administrateur système",
     "NO_FISCAL_YEAR" : "Aucune année fiscale pour cette date!",

--- a/client/src/modules/stock/import/stockImport.js
+++ b/client/src/modules/stock/import/stockImport.js
@@ -13,7 +13,7 @@ StockImportController.$inject = [
  * This module helps to import stock from a file
  */
 function StockImportController(
-  Notify, Stock, Upload, $state
+  Notify, Stock, Upload, $state,
 ) {
   const vm = this;
 

--- a/server/controllers/stock/import.js
+++ b/server/controllers/stock/import.js
@@ -103,29 +103,83 @@ async function importStock(req, res, next) {
 function checkDataFormat(data = []) {
   for (let i = 0; i < data.length; i++) {
     const item = data[i];
-    const isUnitPriceDefined = typeof (item.inventory_unit_price) !== 'undefined';
+    const isInventoryGroupDefined = typeof (item.inventory_group_name) === 'string'
+      && item.inventory_group_name.length > 0;
+    const isInventoryTextDefined = typeof (item.inventory_text) === 'string' && item.inventory_text.length > 0;
+    const isInventoryTypeDefined = typeof (item.inventory_type) === 'string' && item.inventory_type.length > 0;
+    const isInventoryUnitDefined = typeof (item.inventory_unit) === 'string' && item.inventory_unit.length > 0;
+    const isStockLotLabelDefined = typeof (item.stock_lot_label) === 'string' && item.stock_lot_label.length > 0;
+    const isExpirationDefined = typeof (item.stock_lot_expiration) === 'string' && item.stock_lot_expiration.length > 0;
+
     const isUnitPriceNumber = !Number.isNaN(Number(item.inventory_unit_price));
     const isLotQuantityNumber = !Number.isNaN(Number(item.stock_lot_quantity));
-    const validity = item.inventory_group_name
-      && item.inventory_text && item.inventory_type && item.inventory_unit
-      && isUnitPriceDefined && item.stock_lot_label
-      && item.stock_lot_quantity && item.stock_lot_expiration
-      && isUnitPriceNumber && isLotQuantityNumber;
+
+    /**
+     * The key parameter of BadRequest must be properly translated for the user
+     */
+
+    if (!isInventoryGroupDefined) {
+      throw new BadRequest(
+        `[line : ${i + 2}] The inventory group ${item.inventory_group_name} must be a valid text`,
+        `[line : ${i + 2}] The inventory group ${item.inventory_group_name} must be a valid text`,
+        // 'ERRORS.NOT_A_TEXT',
+      );
+    }
+
+    if (!isInventoryTextDefined) {
+      throw new BadRequest(
+        `[line : ${i + 2}] The inventory text ${item.inventory_text} must be a valid text`,
+        `[line : ${i + 2}] The inventory text ${item.inventory_text} must be a valid text`,
+        // 'ERRORS.NOT_A_TEXT',
+      );
+    }
+
+    if (!isInventoryTypeDefined) {
+      throw new BadRequest(
+        `[line : ${i + 2}] The inventory type ${item.inventory_type} must be a valid text`,
+        `[line : ${i + 2}] The inventory type ${item.inventory_type} must be a valid text`,
+        // 'ERRORS.NOT_A_TEXT',
+      );
+    }
+
+    if (!isInventoryUnitDefined) {
+      throw new BadRequest(
+        `[line : ${i + 2}] The inventory unit ${item.inventory_unit} must be a valid text`,
+        `[line : ${i + 2}] The inventory unit ${item.inventory_unit} must be a valid text`,
+        // 'ERRORS.NOT_A_TEXT',
+      );
+    }
+
+    if (!isStockLotLabelDefined) {
+      throw new BadRequest(
+        `[line : ${i + 2}] The stock lot ${item.stock_lot_label} must be a valid text`,
+        `[line : ${i + 2}] The stock lot ${item.stock_lot_label} must be a valid text`,
+        // 'ERRORS.NOT_A_TEXT',
+      );
+    }
+
+    if (!isExpirationDefined) {
+      throw new BadRequest(
+        `[line : ${i + 2}] The stock lot ${item.stock_lot_expiration} must be in this format "YYYY-MM-DD"`,
+        `[line : ${i + 2}] The stock lot ${item.stock_lot_expiration} must be in this format "YYYY-MM-DD"`,
+        // 'ERRORS.NOT_A_TEXT',
+      );
+    }
 
     if (!isUnitPriceNumber) {
       throw new BadRequest(
-        `[line : ${i + 2}] The value ${item.inventory_unit_price} is not a valid number`, 'ERRORS.NOT_A_NUMBER',
+        `[line : ${i + 2}] The unit price value ${item.inventory_unit_price} is not a valid number`,
+        `[line : ${i + 2}] The unit price value ${item.inventory_unit_price} is not a valid number`,
+        // 'ERRORS.NOT_A_NUMBER',
       );
     }
 
     if (!isLotQuantityNumber) {
       throw new BadRequest(
-        `[line : ${i + 2}] The value ${item.stock_lot_quantity} is not a valid number`, 'ERRORS.NOT_A_NUMBER',
+        `[line : ${i + 2}] The lot quantity value ${item.stock_lot_quantity} is not a valid number`,
+        `[line : ${i + 2}] The lot quantity value ${item.stock_lot_quantity} is not a valid number`,
+        // 'ERRORS.NOT_A_NUMBER',
       );
-    }
-
-    if (!validity) {
-      throw new BadRequest('The given file has a bad data format for stock', 'ERRORS.BAD_DATA_FORMAT');
     }
   }
 }

--- a/server/controllers/stock/import.js
+++ b/server/controllers/stock/import.js
@@ -70,10 +70,10 @@ function importStock(req, res, next) {
           item.inventory_text,
           item.inventory_type,
           item.inventory_unit,
-          item.inventory_unit_price,
-          item.inventory_cmm || 0,
+          formatDecimal(item.inventory_unit_price),
+          formatDecimal(item.inventory_cmm),
           item.stock_lot_label,
-          item.stock_lot_quantity,
+          formatInt(item.stock_lot_quantity),
           moment(item.stock_lot_expiration).format('YYYY-MM-DD'),
           periodId,
         ];
@@ -92,6 +92,28 @@ function importStock(req, res, next) {
     .then(() => res.sendStatus(201))
     .catch(next)
     .done();
+}
+
+/**
+ * @function formatInt
+ * @param {string} quantity
+ * @description
+ * remove number formatting commas and convert into integer
+ * the decimal separator accepted is . not ,
+ */
+function formatInt(quantity) {
+  return typeof (quantity) === 'string' ? parseInt(quantity.replace(/,/g, ''), 10) : quantity;
+}
+
+/**
+ * @function formatDecimal
+ * @param {string} quantity
+ * @description
+ * remove number formatting commas and convert into a decimal (float)
+ * the decimal separator accepted is . not ,
+ */
+function formatDecimal(quantity) {
+  return typeof (quantity) === 'string' ? parseFloat(quantity.replace(/,/g, '')) : quantity;
 }
 
 /**


### PR DESCRIPTION
This PR is about : 

- Update the `ImportStock` procedure to fix : 
  - MySQL data too long error when the `stockLotQuantity` and `inventoryUnitCost` are not in the good format
  - Error related to `inventory_uuid` is null during the importation
  - Error related to `inventory_unit` with its `abbr` column which must be unique during the importation

- Add inventories to `inventory_group` defined by its code instead of the inventory group name in the template file

NOTE:
- The CMM is not changed by the import since we are using the `stock_movement_status` table, the CMM defined in the template file is successfully saved in the `avg_consumption` column of the inventory.
