### PR TITLE
Fix typo report name 'System Usage Statistics'

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -99,7 +99,7 @@
       "TITLE": "Monthly Balance"
     },
     "SYSTEM_USAGE_STAT" : {
-      "TITLE" : "Sytem usage statistic",
+      "TITLE" : "System Usage Statistics",
       "DESCRIPTION" : " This report  produce, for a given period, stats of, Total of patients recorded by hour of the day, Total of invoices made by hour of the day and total of cash payments made by hour of the day"
     },
     "OPEN_DEBTORS": {

--- a/server/models/bhima.sql
+++ b/server/models/bhima.sql
@@ -131,7 +131,7 @@ INSERT INTO unit VALUES
   (247,'Client Support Report','TREE.CLIENT_SUPPORT_REPORT','Client support report',281,'/reports/clientSupport'),
   (248,'Analysis of Cashboxes','REPORT.ANALYSIS_AUX_CASHBOXES.TITLE','Analysis of auxiliary cashboxes',281,'/reports/analysisAuxiliaryCash'),
   (249,'Realized Profit Report','TREE.REALIZED_PROFIT_REPORT','Realized profit report',281,'/reports/realizedProfit'),
-  (250,'System Usage Statistic','REPORT.SYSTEM_USAGE_STAT.TITLE','Sytem usage statistic',280,'/reports/systemUsageStat'),
+  (250,'System Usage Statistics','REPORT.SYSTEM_USAGE_STAT.TITLE','System usage statistics',280,'/reports/systemUsageStat'),
   (251,'Indexes','TREE.INDEXES','The payroll index',57,'/PAYROLL_INDEX_FOLDER'),
   (252,'Staffing indexes management','TREE.STAFFING_INDICES_MANAGEMENT','Staffing indices management',251,'/staffing_indices'),
   (253,'Multiple Payroll by Indice','TREE.MULTI_PAYROLL_INDICE','Multiple Payroll (indice)',251,'/multiple_payroll_indice'),

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -6,7 +6,7 @@
 /*
  * @author: jmcameron
  * @date: 2020-11-18
- * @pull-release: TBD
+ * @pull-release: 5129
  * @description: Fix typo in menu report name "System Usage Statistics"
  */
 UPDATE `unit` SET name='System Usage Statistics', description='System Usage Statistics' WHERE id=250;

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -1,3 +1,12 @@
 /**
- * Migration from the version 1.16.0
+ * Migration from version 1.16.0
  */
+
+
+/*
+ * @author: jmcameron
+ * @date: 2020-11-18
+ * @pull-release: TBD
+ * @description: Fix typo in menu report name "System Usage Statistics"
+ */
+UPDATE `unit` SET name='System Usage Statistics', description='System Usage Statistics' WHERE id=250;


### PR DESCRIPTION
This is a report under the **Hospital** menu.

This should also fix this error in the production sites using the migration script.