### PR TITLE
4834 - Fix calculation and status about expired and at risk lots

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -92,6 +92,7 @@
     "CURRENT_QUANTITY" : "Current Quantity",
     "RISK"            : "Risk",
     "RISK_QUANTITY"   : "Risk Quantity",
+    "RISK_VALUE"      : "Risk Value",
     "CMM"             : "CMM",
     "MSD"             : "MSD",
     "LOSS"            : "Stock Loss",

--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -89,6 +89,7 @@
     "LEGEND"          : "Legend",
     "LIFETIME"        : "Lifetime",
     "LOT_LIFETIME"    : "Lifetime By Lot",
+    "CURRENT_QUANTITY" : "Current Quantity",
     "RISK"            : "Risk",
     "RISK_QUANTITY"   : "Risk Quantity",
     "CMM"             : "CMM",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -95,6 +95,7 @@
     "RISK"            : "Risque",
     "CURRENT_QUANTITY" : "Quantité actuelle",
     "RISK_QUANTITY"   : "Quantité à risque",
+    "RISK_VALUE"      : "Valeur à risque",
     "CMM"             : "CMM",
     "MSD"             : "MSD",
     "LOSS"            : "Perte de stock",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -93,6 +93,7 @@
     "LIFETIME"        : "Durée de vie",
     "LOT_LIFETIME"    : "Durée par lot",
     "RISK"            : "Risque",
+    "CURRENT_QUANTITY" : "Quantité actuelle",
     "RISK_QUANTITY"   : "Quantité à risque",
     "CMM"             : "CMM",
     "MSD"             : "MSD",

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -296,21 +296,21 @@ async function getLotsDepot(depotUuid, params, finalClause) {
   }
 
   const inventoriesWithManagementData = await stockManagementProcess(resultFromProcess);
-  const inventoriesWithLotsProcessed = await processMultipleLots(inventoriesWithManagementData);
+  let inventoriesWithLotsProcessed = await processMultipleLots(inventoriesWithManagementData);
 
   if (_status) {
-    return inventoriesWithLotsProcessed.filter(row => row.status === _status);
+    inventoriesWithLotsProcessed = inventoriesWithLotsProcessed.filter(row => row.status === _status);
   }
 
   // Since the status of a product risking expiry is only defined
   // after the comparison with the CMM, reason why the filtering
   // is not carried out with an SQL request
-  if (params.is_expiry_risk === '1') {
-    return inventoriesWithLotsProcessed.filter(item => (item.S_RISK < 0 && item.lifetime > 0));
+  if (parseInt(params.is_expiry_risk, 10) === 1) {
+    inventoriesWithLotsProcessed = inventoriesWithLotsProcessed.filter(item => (item.S_RISK < 0 && item.lifetime > 0));
   }
 
-  if (params.is_expiry_risk === '0') {
-    return inventoriesWithLotsProcessed.filter(item => (item.S_RISK >= 0 && item.lifetime > 0));
+  if (parseInt(params.is_expiry_risk, 10) === 0) {
+    inventoriesWithLotsProcessed = inventoriesWithLotsProcessed.filter(item => (item.S_RISK >= 0 && item.lifetime > 0));
   }
 
   return inventoriesWithLotsProcessed;

--- a/server/controllers/stock/reports/stock/expiration_report.js
+++ b/server/controllers/stock/reports/stock/expiration_report.js
@@ -93,7 +93,7 @@ async function stockExpirationReport(req, res, next) {
     });
 
     const reportResult = await report.render({
-      depot, result : values, totals,
+      depot, result : values, totals, today,
     });
 
     res.set(reportResult.headers).send(reportResult.report);

--- a/server/controllers/stock/reports/stock/expiration_report.js
+++ b/server/controllers/stock/reports/stock/expiration_report.js
@@ -11,6 +11,7 @@ const stockCore = require('../../core');
  *
  */
 async function stockExpirationReport(req, res, next) {
+  const today = new Date();
 
   try {
     const params = { includeEmptyLot : 0, ...req.query };
@@ -21,7 +22,6 @@ async function stockExpirationReport(req, res, next) {
 
     // set up the report with report manager
     const report = new ReportManager(STOCK_EXPIRATION_REPORT_TEMPLATE, req.session, optionReport);
-
     const options = params;
 
     if (req.session.stock_settings.enable_strict_depot_permission) {
@@ -38,14 +38,24 @@ async function stockExpirationReport(req, res, next) {
     // clean off the label if it exists so it doesn't mess up the PDF export
     delete options.label;
 
+    // define month average and the algo to use
+    options.monthAverageConsumption = req.session.stock_settings.month_average_consumption;
+    options.averageConsumptionAlgo = req.session.stock_settings.average_consumption_algo;
+
     // get the lots for this depot
     const lots = await stockCore.getLotsDepot(options.depot_uuid, options);
 
     // get the lots that are "at risk"
-    const risky = lots.filter(lot => lot.IS_IN_RISK_EXPIRATION);
+    const risky = lots.filter(lot => (lot.S_RISK < 0 && lot.lifetime > 0));
+
+    // get expired lots
+    const expired = lots.filter(lot => (lot.S_RISK <= 0 && lot.expiration_date <= today));
+
+    // merge risky and expired
+    const riskyAndExpiredLots = risky.concat(expired);
 
     // make sure lots are grouped by depot.
-    const groupedByDepot = _.groupBy(risky, 'depot_uuid');
+    const groupedByDepot = _.groupBy(riskyAndExpiredLots, 'depot_uuid');
 
     // grand totals
     const totals = {
@@ -53,25 +63,25 @@ async function stockExpirationReport(req, res, next) {
       at_risk : { value : 0, quantity : 0 },
     };
 
-    const today = new Date();
-
     const values = _.map(groupedByDepot, (rows) => {
       let total = 0;
 
       rows.forEach(lot => {
-        lot.value = (lot.mvt_quantity * lot.unit_cost);
-        total += lot.value;
-
         if (lot.expiration_date < today) {
+          lot.value = (lot.mvt_quantity * lot.unit_cost);
           lot.statusKey = 'STOCK.EXPIRED';
           lot.classKey = 'bg-danger text-danger';
           totals.expired.value += lot.value;
           totals.expired.quantity += lot.mvt_quantity;
+          total += lot.value;
         } else {
+          lot.quantity_at_risk = (lot.S_RISK_QUANTITY * -1);
+          lot.value = (lot.quantity_at_risk * lot.unit_cost);
           lot.statusKey = 'STOCK.STATUS.IS_IN_RISK_OF_EXPIRATION';
           lot.classKey = 'bg-warning text-warning';
           totals.at_risk.value += lot.value;
-          totals.at_risk.quantity += lot.mvt_quantity;
+          totals.at_risk.quantity += (lot.S_RISK_QUANTITY * -1);
+          total += lot.value;
         }
       });
 

--- a/server/controllers/stock/reports/stock_expiration_report.handlebars
+++ b/server/controllers/stock/reports/stock_expiration_report.handlebars
@@ -67,7 +67,7 @@
           <th>{{translate 'STOCK.RISK_QUANTITY'}}</th>
           <th>{{translate 'TABLE.COLUMNS.UNIT'}}</th>
           <th>{{translate 'REPORT.STOCK.UNIT_COST'}}</th>
-          <th>{{translate 'FORM.LABELS.VALUE'}}</th>
+          <th>{{translate 'STOCK.RISK_VALUE'}}</th>
           <th>{{translate 'STOCK.STATUS.LABEL'}}</th>
         </tr>
       </thead>
@@ -78,7 +78,7 @@
             <td>{{lot.text}}</td>
             <td>{{lot.label}}</td>
             <td>{{date lot.expiration_date}}</td>
-            <td class="text-right">{{lot.cmms.algo_msh}}</td>
+            <td class="text-right">{{lot.avg_consumption}}</td>
             <td class="text-right">{{lot.quantity}}</td>
             <td class="text-right">{{lot.quantity_at_risk}}</td>
             <td>{{lot.unit_type}}</td>

--- a/server/controllers/stock/reports/stock_expiration_report.handlebars
+++ b/server/controllers/stock/reports/stock_expiration_report.handlebars
@@ -58,7 +58,9 @@
           <th>{{translate 'STOCK.INVENTORY'}}</th>
           <th>{{translate 'STOCK.LOT'}}</th>
           <th>{{translate 'STOCK.EXPIRATION'}}</th>
-          <th>{{translate 'STOCK.QUANTITY'}}</th>
+          <th>{{translate 'STOCK.CMM'}}</th>
+          <th>{{translate 'STOCK.CURRENT_QUANTITY'}}</th>
+          <th>{{translate 'STOCK.RISK_QUANTITY'}}</th>
           <th>{{translate 'TABLE.COLUMNS.UNIT'}}</th>
           <th>{{translate 'REPORT.STOCK.UNIT_COST'}}</th>
           <th>{{translate 'FORM.LABELS.VALUE'}}</th>
@@ -72,7 +74,9 @@
             <td>{{lot.text}}</td>
             <td>{{lot.label}}</td>
             <td>{{date lot.expiration_date}}</td>
+            <td class="text-right">{{lot.cmms.algo_msh}}</td>
             <td class="text-right">{{lot.quantity}}</td>
+            <td class="text-right">{{lot.quantity_at_risk}}</td>
             <td>{{lot.unit_type}}</td>
             <td>{{currency lot.unit_cost ../../metadata.enterprise.currency_id}}</td>
             <td class="text-right">{{currency lot.value ../../metadata.enterprise.currency_id}}</td>
@@ -82,7 +86,7 @@
       </tbody>
       <tfoot>
         <tr>
-          <th colspan="6">{{translate 'TABLE.COLUMNS.TOTAL'}}</th>
+          <th colspan="8">{{translate 'TABLE.COLUMNS.TOTAL'}}</th>
           <th class="text-right">{{currency depot.total ../metadata.enterprise.currency_id}}</th>
           <td></td>
         </tr>
@@ -91,7 +95,7 @@
     <br />
   {{else}}
     <table>
-      <tbody>{{> emptyTable columns=8}}</tbody>
+      <tbody>{{> emptyTable columns=10}}</tbody>
     </table>
   {{/each}}
 </body>

--- a/server/controllers/stock/reports/stock_expiration_report.handlebars
+++ b/server/controllers/stock/reports/stock_expiration_report.handlebars
@@ -29,6 +29,10 @@
     <h4 class="text-center">{{depot.text}}</h4>
   {{/if}}
 
+  <h4 class="text-center">
+    {{date today}}
+  </h4>
+
   <div class="row">
     <div class="col-xs-6">
       <div class="card" >


### PR DESCRIPTION
This PR fixes the report "Stock Expiration Report" by : 

- Adding new columns: CMM and quantity_at_risk
- Fix the way of fetching risky lots
- Fix calculation of the values of lots at risk
- Correctly display expired and risky lots in the table
- Adding the date of the day in the report 

![image](https://user-images.githubusercontent.com/5445251/99654270-5c5db380-2a5a-11eb-89e1-1ae86e8509a6.png)

