### PR TITLE
chore(reports): clean up wkhtmltopdf references

### DIFF
--- a/server/controllers/admin/metadataReport/index.js
+++ b/server/controllers/admin/metadataReport/index.js
@@ -12,10 +12,8 @@ const templateReport = './server/controllers/admin/metadataReport/metadataReport
 
 const DEFAULT_OPTS = {
   orientation     : 'landscape',
-  footerRight     : '[page] / [toPage]',
   filename        : 'TREE.DISPLAY_METADATA',
   csvKey          : 'metadata',
-  footerFontSize  : '7',
 };
 
 function metadataCard(req, res, next) {
@@ -51,7 +49,7 @@ function metadataCard(req, res, next) {
   `;
 
   const sqlData = `
-    SELECT BUID(sd.uuid) AS uuid, sd.date AS dateSurvey, sd.data_collector_management_id, sd.user_id, 
+    SELECT BUID(sd.uuid) AS uuid, sd.date AS dateSurvey, sd.data_collector_management_id, sd.user_id,
     BUID(sdi.uuid) AS survey_data_item_uuid, sdi.value,
     GROUP_CONCAT(IF (clm.label IS NULL, sdi.value, clm.label) SEPARATOR ', ') AS datavalue,
     sf.id AS survey_form_id, sf.name AS columnName, sf.label AS columnLabel, ms.patient_uuid
@@ -177,7 +175,6 @@ function reportMetadata(req, res, next) {
 
   const options = {
     orientation   : 'landscape',
-    footerRight   : '[page] / [toPage]',
     lang          : req.query.lang,
     renderer      : req.query.renderer,
     filename      : 'TREE.DATA_KIT_REPORT',

--- a/server/controllers/finance/indicator/dashboard/report.js
+++ b/server/controllers/finance/indicator/dashboard/report.js
@@ -35,8 +35,6 @@ function report(req, res, next) {
   _.extend(query, {
     filename : 'INVOICE_REGISTRY.TITLE',
     csvKey : 'rows',
-    footerRight : '[page] / [toPage]',
-    footerFontSize : '8',
   });
 
   const indicatorTypes = ['finances', 'hospitalization', 'staff'];

--- a/server/controllers/finance/reports/accounts/index.js
+++ b/server/controllers/finance/reports/accounts/index.js
@@ -25,7 +25,6 @@ function chart(req, res, next) {
     csvKey : 'accounts',
     filename : 'REPORT.CHART_OF_ACCOUNTS',
     orientation : 'landscape',
-    footerRight : '[page] / [toPage]',
   });
 
   try {

--- a/server/controllers/finance/reports/break_even_fee_center/index.js
+++ b/server/controllers/finance/reports/break_even_fee_center/index.js
@@ -16,7 +16,6 @@ const DEFAULT_PARAMS = {
   csvKey : 'brea_report',
   filename : 'TREE.BREAK_EVEN_REPORT',
   orientation : 'portrait',
-  footerRight : '[page] / [toPage]',
 };
 
 /**
@@ -62,7 +61,7 @@ function report(req, res, next) {
   `;
 
   const getFeeCenterReference = `
-    SELECT fc.label, fc.id, fc.is_principal, rf.fee_center_id, rf.account_reference_id, 
+    SELECT fc.label, fc.id, fc.is_principal, rf.fee_center_id, rf.account_reference_id,
     rf.is_cost, rf.is_variable, rf.is_turnover, ar.abbr
     FROM fee_center AS fc
     JOIN reference_fee_center AS rf ON rf.fee_center_id = fc.id
@@ -72,7 +71,7 @@ function report(req, res, next) {
 
   const getFeeCenterDistribution = `
     SELECT fcd.principal_fee_center_id, fcd.auxiliary_fee_center_id, fcd.is_cost,
-    fcd.is_variable, fcd.is_turnover, BUID(fcd.row_uuid) AS row_uuid,    
+    fcd.is_variable, fcd.is_turnover, BUID(fcd.row_uuid) AS row_uuid,
     fca.label AS auxiliary, fcp.label AS principal, SUM(fcd.debit_equiv) AS debit,
     SUM(fcd.credit_equiv) AS credit, gl.trans_date
     FROM fee_center_distribution AS fcd

--- a/server/controllers/finance/reports/cashflow/index.js
+++ b/server/controllers/finance/reports/cashflow/index.js
@@ -48,8 +48,6 @@ async function reportByService(req, res, next) {
     filename : 'TREE.CASHFLOW_BY_SERVICE',
     csvKey : 'matrix',
     orientation : 'landscape',
-    footerRight : '[page] / [toPage]',
-    footerFontSize : '7',
   });
 
   try {

--- a/server/controllers/finance/reports/configurable_analysis_report/index.js
+++ b/server/controllers/finance/reports/configurable_analysis_report/index.js
@@ -5,7 +5,7 @@ const ReportManager = require('../../../../lib/ReportManager');
 const NotFound = require('../../../../lib/errors/NotFound');
 
 const TEMPLATE = './server/controllers/finance/reports/configurable_analysis_report/report.handlebars';
-const cashboxes = require('../../../finance/cashboxes');
+const cashboxes = require('../../cashboxes');
 const AccountExtras = require('../../accounts/extra');
 
 // expose to the API
@@ -15,8 +15,6 @@ exports.report = report;
 const DEFAULT_PARAMS = {
   csvKey : 'configurable_analysis_report',
   filename : 'TREE.BREAK_EVEN_REPORT',
-  orientation : 'landscape',
-  footerRight : '[page] / [toPage]',
 };
 
 /**
@@ -229,7 +227,6 @@ function report(req, res, next) {
         GROUP BY gl.account_id
         ORDER BY a.number ASC, a.label
       `;
-
 
       const sqlCombinedLedger = `
         SELECT a.number, a.label, cl.account_id, SUM(cl.debit) AS debit, SUM(cl.credit) AS credit,

--- a/server/controllers/finance/reports/creditors/index.js
+++ b/server/controllers/finance/reports/creditors/index.js
@@ -8,7 +8,6 @@
  * days.
  */
 
-
 const _ = require('lodash');
 const moment = require('moment');
 const ReportManager = require('../../../../lib/ReportManager');
@@ -17,12 +16,9 @@ const db = require('../../../../lib/db');
 // path to the template to render
 const TEMPLATE = './server/controllers/finance/reports/creditors/aged.handlebars';
 
-
 const DEFAULT_OPTIONS = {
   csvKey : 'creditors',
   orientation : 'landscape',
-  footerRight : '[page] / [toPage]',
-  footerFontSize : '7',
 };
 
 /**

--- a/server/controllers/finance/reports/debtors/index.js
+++ b/server/controllers/finance/reports/debtors/index.js
@@ -26,8 +26,6 @@ const TEMPLATE = './server/controllers/finance/reports/debtors/aged.handlebars';
 const DEFAULT_OPTIONS = {
   csvKey : 'debtors',
   orientation : 'landscape',
-  footerRight : '[page] / [toPage]',
-  footerFontSize : '7',
 };
 
 /**
@@ -68,7 +66,6 @@ function agedDebtorReport(req, res, next) {
     .catch(next)
     .done();
 }
-
 
 /**
  * @method queryContext
@@ -150,7 +147,6 @@ async function queryContext(params = {}) {
       AND gl.fiscal_year_id = ?
     ${includeZeroes ? '' : havingNonZeroValues}
   `;
-
 
   const debtors = await db.exec(debtorSql, [...dates, params.fiscal_id]);
 

--- a/server/controllers/finance/reports/debtors/openDebtors.js
+++ b/server/controllers/finance/reports/debtors/openDebtors.js
@@ -53,8 +53,6 @@ function convertToBoolean(numberString) {
 function build(req, res, next) {
   const qs = _.extend(req.query, {
     csvKey : 'debtors',
-    footerRight : '[page] / [toPage]',
-    footerFontSize : '7',
   });
 
   const metadata = _.clone(req.session);

--- a/server/controllers/finance/reports/debtors/summaryReport.js
+++ b/server/controllers/finance/reports/debtors/summaryReport.js
@@ -16,8 +16,6 @@ const TEMPLATE = './server/controllers/finance/reports/debtors/summaryReport.han
 const DEFAULT_OPTIONS = {
   csvKey : 'debtors',
   orientation : 'landscape',
-  footerRight : '[page] / [toPage]',
-  footerFontSize : '7',
 };
 
 /**

--- a/server/controllers/finance/reports/income_expense/index.js
+++ b/server/controllers/finance/reports/income_expense/index.js
@@ -13,7 +13,6 @@
  * @requires constrollers/fiscal
  */
 
-
 const _ = require('lodash');
 const Tree = require('@ima-worldhealth/tree');
 
@@ -31,8 +30,6 @@ const TITLE_ID = 6;
 const DEFAULT_PARAMS = {
   csvKey : 'rows',
   filename : 'TREE.INCOME_EXPENSE',
-  orientation : 'landscape',
-  footerRight : '[page] / [toPage]',
 };
 
 // expose to the API
@@ -81,7 +78,7 @@ function document(req, res, next) {
       if (!Array.isArray(root.children) || root.children.length < 2) {
         throw new BadRequest(
           'Could not find both income and expense accounts for the time period',
-          'ERRORS.NO_DATA_FOUND'
+          'ERRORS.NO_DATA_FOUND',
         );
       }
 
@@ -222,7 +219,6 @@ function combineIntoSingleDataset(currentBalances, previousBalances) {
     return record;
   });
 }
-
 
 /**
  * @function constructAndPruneTree

--- a/server/controllers/finance/reports/income_expense_by_month/index.js
+++ b/server/controllers/finance/reports/income_expense_by_month/index.js
@@ -12,7 +12,6 @@
  * @requires controllers/fiscal
  */
 
-
 const _ = require('lodash');
 const Tree = require('@ima-worldhealth/tree');
 
@@ -33,7 +32,6 @@ const DEFAULT_PARAMS = {
   csvKey : 'rows',
   filename : 'TREE.INCOME_EXPENSE_BY_MONTH',
   orientation : 'landscape',
-  footerRight : '[page] / [toPage]',
 };
 
 // expose to the API
@@ -56,7 +54,6 @@ function document(req, res, next) {
   const { periodId, periodNumber, fiscalYearId } = options;
   const data = {};
 
-
   const periodNum = parseInt(periodNumber, 10);
   const isOutOfRange = (periodNum - 2 <= 0);
 
@@ -66,7 +63,7 @@ function document(req, res, next) {
   if (isOutOfRange) {
     next(new BadRequest(
       'Period selection is out of range.  Choose a period at least two months past the start of the fiscal year.',
-      'ERRORS.BAD_DATE_INTERVAL'
+      'ERRORS.BAD_DATE_INTERVAL',
     ));
     return;
   }
@@ -85,7 +82,6 @@ function document(req, res, next) {
       _.extend(data, {
         firstPeriod, secondPeriod, thirdPeriod, fiscalYear,
       });
-
 
       return Promise.all([
         getAccountBalances(fiscalYear.id, firstPeriod.id),

--- a/server/controllers/finance/reports/income_expense_by_year/index.js
+++ b/server/controllers/finance/reports/income_expense_by_year/index.js
@@ -12,7 +12,6 @@
  * @requires controllers/fiscal
  */
 
-
 const _ = require('lodash');
 const Tree = require('@ima-worldhealth/tree');
 
@@ -31,8 +30,6 @@ const TITLE_ID = 6;
 const DEFAULT_PARAMS = {
   csvKey : 'rows',
   filename : 'TREE.INCOME_EXPENSE_BY_MONTH',
-  orientation : 'landscape',
-  footerRight : '[page] / [toPage]',
 };
 
 // expose to the API
@@ -59,7 +56,6 @@ async function document(req, res, next) {
   const secondYear = await Fiscal.lookupFiscalYear(thirdYear.previous_fiscal_year_id);
   const firstYear = await Fiscal.lookupFiscalYear(secondYear.previous_fiscal_year_id);
 
-
   if (!firstYear || !secondYear || !thirdYear) {
     res.status(500).json({ msg : `bad fiscal year's range` });
     return;
@@ -69,7 +65,6 @@ async function document(req, res, next) {
     secondYear,
     thirdYear,
   });
-
 
   const [firstBalances, secondBalances, thirdBalances] = await Promise.all([
     getAccountBalances(firstYear.id),

--- a/server/controllers/finance/reports/ohada_profit_loss/index.js
+++ b/server/controllers/finance/reports/ohada_profit_loss/index.js
@@ -30,7 +30,6 @@ const DEFAULT_PARAMS = {
   csvKey : 'accounts',
   filename : 'TREE.BALANCE',
   orientation : 'landscape',
-  footerRight : '[page] / [toPage]',
 };
 
 // RB, RD, RF
@@ -178,15 +177,10 @@ profitLossTable.forEach(item => {
 function reporting(options, session) {
   const params = options;
   const context = {};
-  let report;
 
   _.defaults(params, DEFAULT_PARAMS);
 
-  try {
-    report = new ReportManager(TEMPLATE, session, params);
-  } catch (e) {
-    throw e;
-  }
+  const report = new ReportManager(TEMPLATE, session, params);
 
   return getFiscalYearDetails(params.fiscal_id)
     .then(fiscalYear => {
@@ -316,7 +310,6 @@ function document(req, res, next) {
     .catch(next);
 }
 
-
 function setSign(item) {
   if (item.sign === '+') {
     item.currentNet = (item.currentNet || 0) * -1;
@@ -375,7 +368,6 @@ function getFiscalYearDetails(fiscalYearId) {
       return bundle;
     });
 }
-
 
 function aggregateReferences(references, currentDb, previousDb, mapRef) {
   const item = {

--- a/server/controllers/finance/reports/ohada_profit_loss/report.handlebars
+++ b/server/controllers/finance/reports/ohada_profit_loss/report.handlebars
@@ -15,7 +15,7 @@
       </h2>
 
       <h5 class="text-center text-uppercase">{{ ./fiscalYear.current.label }}</h5>
-      
+
 
       {{!-- assets --}}
       <table class="table table-condensed table-report" style="margin-bottom: 15px;">
@@ -39,7 +39,7 @@
             {{/if}}
           </tr>
         </thead>
-        
+
         <tbody>
           {{#each assetTable as | poste |}}
             <tr {{#if poste.is_title}} class="text-uppercase" style="background-color:#efefef; font-weight: bold;"{{/if}}>
@@ -55,17 +55,9 @@
             </tr>
           {{/each}}
 
-          <!--
-          <tr>
-            <td colspan="4" class="text-right"><b>{{ translate 'FORM.LABELS.TOTAL'}}</b></td>
-            <td  class="text-right">{{ debcred totals.currentNet metadata.enterprise.currency_id }}</td>
-            <td  class="text-right">{{ debcred totals.previousNet metadata.enterprise.currency_id }}</td>
-          </tr>
-          -->
         </tbody>
       </table>
     </div>
   </div>
-
 </div>
 </body>

--- a/server/controllers/finance/reports/priceList/index.js
+++ b/server/controllers/finance/reports/priceList/index.js
@@ -103,7 +103,6 @@ function lookupPriceList(uuid) {
   ]);
 }
 
-
 exports.downloadRegistry = (req, res, next) => {
 
   const REPORT_TEMPLATE = './server/controllers/finance/reports/priceList/registry.handlebars';
@@ -114,10 +113,7 @@ exports.downloadRegistry = (req, res, next) => {
     csvKey                   : 'rows',
     suppressDefaultFiltering : true,
     suppressDefaultFormatting : false,
-    footerRight : '[page] / [toPage]',
-    footerFontSize : '7',
   });
-
 
   let report;
 

--- a/server/controllers/payroll/multiplePayrollIndice/report.js
+++ b/server/controllers/payroll/multiplePayrollIndice/report.js
@@ -1,4 +1,3 @@
-
 /**
  * @overview
  * Journal Reports
@@ -28,8 +27,6 @@ function multipayIndiceExport(req, res, next) {
     csvKey                   : 'rows',
     suppressDefaultFiltering : true,
     suppressDefaultFormating : false,
-    footerRight : '[page] / [toPage]',
-    footerFontSize : '7',
   });
 
   let report;

--- a/server/controllers/payroll/reports/payslipGenerator.js
+++ b/server/controllers/payroll/reports/payslipGenerator.js
@@ -21,10 +21,8 @@ const configurationData = require('../multiplePayroll/find');
 
 const DEFAULT_OPTS = {
   orientation     : 'landscape',
-  footerRight     : '[page] / [toPage]',
   filename        : 'FORM.LABELS.PAYSLIP',
   csvKey          : 'payslipGenerator',
-  footerFontSize  : '7',
 };
 
 function build(req, res, next) {
@@ -52,7 +50,6 @@ function build(req, res, next) {
     options.filename = 'FORM.LABELS.REPORT';
   } else {
     template = templatePayslip;
-    delete options.footerRight;
   }
 
   const data = {};

--- a/server/controllers/payroll/reports/registrations.js
+++ b/server/controllers/payroll/reports/registrations.js
@@ -1,4 +1,3 @@
-
 /**
  * @overview reports/registrations
  *
@@ -40,8 +39,6 @@ function build(req, res, next) {
     filename : 'EMPLOYEE.TITLE',
     csvKey : 'employees',
     orientation : 'landscape',
-    footerRight : '[page] / [toPage]',
-    footerFontSize : '7',
   });
 
   let report;

--- a/server/controllers/payroll/staffingIndices/report.js
+++ b/server/controllers/payroll/staffingIndices/report.js
@@ -1,4 +1,3 @@
-
 /**
  * @overview
  * Journal Reports
@@ -9,7 +8,7 @@
 
 const _ = require('lodash');
 const staffing = require('./index');
-const shared = require('../../../controllers/finance/reports/shared.js');
+const shared = require('../../finance/reports/shared.js');
 const ReportManager = require('../../../lib/ReportManager');
 
 const REPORT_TEMPLATE = './server/controllers/payroll/staffingIndices/report.handlebars';
@@ -21,7 +20,7 @@ exports.document = staffingIndicesExport;
  *
  * @method postingJournalExport
  */
-function staffingIndicesExport(req, res, next) {
+async function staffingIndicesExport(req, res, next) {
 
   const options = _.extend(req.query, {
     filename                 : 'TREE.STAFFING_INDICES_MANAGEMENT',
@@ -29,24 +28,17 @@ function staffingIndicesExport(req, res, next) {
     csvKey                   : 'rows',
     suppressDefaultFiltering : true,
     suppressDefaultFormating : false,
-    footerRight : '[page] / [toPage]',
-    footerFontSize : '7',
   });
 
-  let report;
-
   try {
-    report = new ReportManager(REPORT_TEMPLATE, req.session, options);
-  } catch (e) {
-    return next(e);
-  }
-  const filters = shared.formatFilters(options);
+    const report = new ReportManager(REPORT_TEMPLATE, req.session, options);
+    const filters = shared.formatFilters(options);
 
-  return staffing.lookUp(options).then(indices => {
-    return report.render({ filters, indices });
-  })
-    .then((result) => {
-      res.set(result.headers).send(result.report);
-    })
-    .catch(next);
+    const indices = await staffing.lookUp(options);
+
+    const result = await report.render({ filters, indices });
+    res.set(result.headers).send(result.report);
+  } catch (e) {
+    next(e);
+  }
 }


### PR DESCRIPTION
This commit cleans up some wkhtmltopdf options that are no longer relevant since we are using coral.  Basically, I removed `footerRight` and `footerFontSize` wherever I found it.  I also ran ESLint on a lot of these files.