### PR TITLE
fix(feeCenters): fix name collision with report

### DIFF
--- a/client/src/modules/fee_center/fee_center.js
+++ b/client/src/modules/fee_center/fee_center.js
@@ -1,5 +1,5 @@
 angular.module('bhima.controllers')
-  .controller('fee_centerController', feeCenterController);
+  .controller('feeCenterController', feeCenterController);
 
 feeCenterController.$inject = [
   'FeeCenterService', 'ModalService', 'NotifyService', 'uiGridConstants',

--- a/client/src/modules/reports/generate/fee_center/fee_center.config.js
+++ b/client/src/modules/reports/generate/fee_center/fee_center.config.js
@@ -1,11 +1,12 @@
 angular.module('bhima.controllers')
-  .controller('feeCenterController', FeeCenterConfigController);
+  .controller('fee_centerController', FeeCenterConfigController);
 
 FeeCenterConfigController.$inject = [
   '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
 ];
 
-
+// TODO(@jniles) - this name is remarkably close to the fee center controller.  Let's name
+// it something else that is more distant.
 function FeeCenterConfigController($sce, Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('configure_fee_center');


### PR DESCRIPTION
This commit fixes a fee center name collision bug that is breaking the fee center module.

Steps to reproduce:
  -> Click on the fee center module.  Observe everything is broken.

This also prevents the end to end tests from passing locally.