### PR TITLE
fix(stock): order stock sheet properly

### DIFF
--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -762,13 +762,14 @@ function getInventoryMovements(params) {
       BUID(l.inventory_uuid) AS inventory_uuid, BUID(l.origin_uuid) AS origin_uuid,
       l.entry_date, i.code, i.text, BUID(m.depot_uuid) AS depot_uuid,
       i.avg_consumption, i.purchase_interval, i.delay, iu.text AS unit_type,
-      dm.text AS documentReference
+      dm.text AS documentReference, flux.label as flux
     FROM stock_movement m
-    JOIN lot l ON l.uuid = m.lot_uuid
-    JOIN inventory i ON i.uuid = l.inventory_uuid
-    JOIN inventory_unit iu ON iu.id = i.unit_id
-    JOIN depot d ON d.uuid = m.depot_uuid
-    LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+      JOIN lot l ON l.uuid = m.lot_uuid
+      JOIN inventory i ON i.uuid = l.inventory_uuid
+      JOIN inventory_unit iu ON iu.id = i.unit_id
+      JOIN depot d ON d.uuid = m.depot_uuid
+      JOIN flux ON m.flux_id = flux.id
+      JOIN document_map dm ON dm.uuid = m.document_uuid
   `;
 
   const orderBy = params.orderByCreatedAt ? 'm.created_at' : 'm.date';
@@ -787,6 +788,8 @@ function getInventoryMovements(params) {
         const movement = {
           reference : line.documentReference,
           date : line.date,
+          label : line.label,
+          flux : line.flux,
           entry : { quantity : 0, unit_cost : 0, value : 0 },
           exit : { quantity : 0, unit_cost : 0, value : 0 },
           stock : { quantity : 0, unit_cost : 0, value : 0 },

--- a/server/controllers/stock/reports/stock_sheet.report.handlebars
+++ b/server/controllers/stock/reports/stock_sheet.report.handlebars
@@ -29,8 +29,7 @@
       <table class="table table-condensed table-report">
         <thead>
           <tr style="background-color:#ddd;">
-            <th></th>
-            <th></th>
+            <th colspan=4></th>
             <th class="text-center" colspan="3">{{translate 'REPORT.STOCK.ENTRIES'}}</th>
             <th class="text-center" colspan="3">{{translate 'REPORT.STOCK.EXITS'}}</th>
             <th class="text-center" colspan="3">{{translate 'REPORT.STOCK.STOCKS'}}</th>
@@ -38,6 +37,8 @@
           <tr style="background-color:#ddd;">
             <th class="text-center" style="border-right: 1px solid #000;">{{translate 'TABLE.COLUMNS.REFERENCE'}}</th>
             <th class="text-center" style="border-right: 1px solid #000;">{{translate 'TABLE.COLUMNS.DATE'}}</th>
+            <th class="text-center" style="border-right: 1px solid #000;">{{translate 'STOCK.FLUX'}}</th>
+            <th class="text-center" style="border-right: 1px solid #000;">{{translate 'STOCK.LOT'}}</th>
 
             <th class="text-center">{{translate 'STOCK.QUANTITY'}}</th>
             <th class="text-center">{{translate 'STOCK.UNIT_COST'}}</th>
@@ -57,6 +58,9 @@
             <tr>
               <td style="border-left: 1px solid #000;">{{reference}}</td>
               <td style="border-right: 1px solid #000;">{{timestamp date}}</td>
+              <td style="border-left: 1px solid #000;">{{translate flux}}</td>
+              <td style="border-left: 1px solid #000;">{{label}}</td>
+
               {{!-- entry --}}
               <td class="text-right">{{#if entry.quantity}}{{entry.quantity}}{{/if}}</td> <td class="text-right">{{#if entry.unit_cost}}{{precision entry.unit_cost 4}}{{/if}}</td>
               <td class="text-right" style="border-right: 1px solid #000;">{{#if entry.value}}{{currency entry.value ../metadata.enterprise.currency_id}}{{/if}}</td>
@@ -75,7 +79,7 @@
         </tbody>
         <tfoot style="border-top: 1px solid #000;">
           <tr class="text-right" style="font-weight: bold; background-color: #efefef;">
-            <th colspan="2"></th>
+            <th colspan="4"></th>
             <th class="text-right">{{totals.entry}}</th> <th></th>
             <th class="text-right">{{currency totals.entryValue metadata.enterprise.currency_id}}</th>
             <th class="text-right">{{totals.exit}}</th> <th></th>


### PR DESCRIPTION
Restores the ability for the user to order the stock sheet according to
the creation date. It also adds a couple of columns to the sheet: flux
and lot to provide even better detailed resolution to the query.

Closes #5149.

Here is what it looks like in practice:
![image](https://user-images.githubusercontent.com/896472/100786118-f6860a00-3411-11eb-86ce-f67bb8903c95.png)
