### PR TITLE
fix(lots): edit modal min size

### DIFF
--- a/client/src/modules/stock/lots/modals/edit.modal.html
+++ b/client/src/modules/stock/lots/modals/edit.modal.html
@@ -35,6 +35,7 @@
       <bh-currency-input
         label="STOCK.UNIT_COST"
         data-lot-currency-input
+        min="0.00009"
         currency-id="$ctrl.enterprise.currency_id"
         model="$ctrl.model.unit_cost">
       </bh-currency-input>


### PR DESCRIPTION
This commit changes the minimum price allowed on the lot edit modal to be the minimum allowed in the database.

Closes #5189