### PR TITLE
fix(cash): filter correctly on patient debtor_uuid

### DIFF
--- a/client/src/i18n/en/transactions.json
+++ b/client/src/i18n/en/transactions.json
@@ -1,7 +1,7 @@
 {
   "TRANSACTIONS":{
     "VERIFIED_TRANSACTIONS": "Verified Transactions",
-    "VIEW_TRANSACTIONS" : "View transactions",
+    "VIEW_TRANSACTIONS" : "View Transactions",
     "INCLUDE_POSTED_TRANSACTIONS_DETAIL": "Include posted transactions in search",
     "INCLUDE_POSTED_TRANSACTIONS_SHORT": "Posted Transactions",
     "SINGLE_ACCOUNT_TRANSACTION":"This transaction only concerns a single account.  Please select multiple accounts to complete the transaction.",

--- a/client/src/modules/cash/payments/templates/action.cell.html
+++ b/client/src/modules/cash/payments/templates/action.cell.html
@@ -23,7 +23,7 @@
 
     <!-- view linked records -->
     <li>
-      <a data-method="view-patient" href ui-sref="patientRegistry({ filters : [{ key : 'period', value : 'allTime' }, { key : 'display_name', value : row.entity.patientName }]})">
+      <a data-method="view-patient" href ui-sref="patientRegistry({ filters : [{ key : 'period', value : 'allTime' }, { key : 'debtor_uuid', value: row.entity.debtor_uuid, displayValue : row.entity.patientName, cacheable:false }]})">
         <i class="fa fa-user"></i> <span translate>REPORT.VIEW_PATIENT</span>
       </a>
     </li>


### PR DESCRIPTION
This commit fixes the link from the cash payments registry to the patient registry, so that we filter by debtor_uuid instead of patient name.  This is much stricter, and results in finding the exact patient.