### PR TITLE
fix(depots): store depot uuid in URL

### DIFF
--- a/client/src/modules/depots/depots.routes.js
+++ b/client/src/modules/depots/depots.routes.js
@@ -10,7 +10,7 @@ angular.module('bhima.routes')
       .state('depots.create', {
         url : '/create',
         params : {
-          parentId : { squash : true, value : null },
+          parentUuid : { squash : true, value : null },
           isCreateState : { value : true },
         },
         onEnter : ['$uibModal', '$transition$', depotModal],
@@ -18,9 +18,9 @@ angular.module('bhima.routes')
       })
 
       .state('depots.edit', {
-        url : '/edit',
+        url : '/:uuid/edit',
         params : {
-          uuid : { value : null },
+          uuid : { value : null, squash : true },
           isCreateState : { value : false },
         },
         onEnter : ['$uibModal', '$transition$', depotModal],

--- a/client/src/modules/depots/modals/depot.modal.js
+++ b/client/src/modules/depots/modals/depot.modal.js
@@ -18,8 +18,8 @@ function DepotModalController($state, Depots, Notify, Session, params) {
   vm.clear = clear;
   vm.submit = submit;
 
-  if (params.parentId) {
-    vm.depot.parent_uuid = params.parentId;
+  if (params.parentUuid) {
+    vm.depot.parent_uuid = params.parentUuid;
   }
 
   if (!vm.isCreateState) {


### PR DESCRIPTION
Stores the depot uuid in the URL so that we have a reference to it even if we refresh the page.  Also contains some typo fixes.

Closes #5194