### PR TITLE
Fix lot movement ordering in the stock sheet report

### DIFF
--- a/server/controllers/stock/reports/stock/stock_sheet.js
+++ b/server/controllers/stock/reports/stock/stock_sheet.js
@@ -32,7 +32,13 @@ async function stockSheetReport(req, res, next) {
 
     const data = { inventory, depot };
 
-    data.rows = rows.movements.sort((x, y) => x.date - y.date);
+    if (!parseInt(options.orderByCreatedAt, 10)) {
+      data.rows = rows.movements.sort((x, y) => x.date - y.date);
+    } else {
+      // already sorted by created_at by mysql
+      data.rows = rows.movements;
+    }
+
     data.totals = rows.totals;
     data.result = rows.result;
     data.dateFrom = options.dateFrom;


### PR DESCRIPTION
This PR fixes the use of created_at in the ordering of stock movement in the stock sheet report

![image](https://user-images.githubusercontent.com/5445251/101181214-e86ffd80-364c-11eb-81e9-705e9bdc45d6.png)

Now we can force to see the real order of movements

Close #5149 