### PR TITLE
fix: remove old bin before archive upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "hooks": {
       "before:init": "node utilities/translation/tfcomp.js client/src/i18n/en client/src/i18n/fr",
       "after:bump": [
+        "rm bin",
         "cross-env NODE_ENV=production yarn build",
         "rm bin/.env",
         "GZIP=-9 tar -czvf ${version}.tar.gz bin/"


### PR DESCRIPTION
If your bin isn't clean, you upload old artifacts.  This cleans bin before running yarn build in production mode while releasing.