### PR TITLE
fix(employees): restore locked employee filter

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -1044,3 +1044,19 @@ a[disabled] {
 .lot-width {
   width: 30%;
 }
+
+/* lock certain items of the checkbox tree when disabled */
+[data-bh-checkbox-tree] input[type="checkbox"][disabled],
+[data-bh-checkbox-tree] input[type="checkbox"][disabled] + span {
+  cursor: not-allowed;
+  font-style: italic;
+}
+
+[data-bh-checkbox-tree] input[type="checkbox"][disabled] + span:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  content : "\f023";
+  padding-right: 5px;
+  text-rendering: auto;
+}

--- a/client/src/js/components/bhCheckboxTree/bhCheckboxTree.html
+++ b/client/src/js/components/bhCheckboxTree/bhCheckboxTree.html
@@ -9,7 +9,7 @@
   <div ng-repeat="node in $ctrl.root.children track by $ctrl.tree.id(node)">
     <div class="checkbox">
       <label data-label="{{node._label}}">
-        <input type="checkbox" ng-model="node._checked" ng-change="$ctrl.setNodeValue(node, node._checked)" />
+        <input type="checkbox" ng-model="node._checked" ng-change="$ctrl.setNodeValue(node, node._checked)" ng-disabled="node._disabled" />
         <span ng-class="{ 'text-bold' : node.children.length }" translate>{{node._label}}</span>
       </label>
     </div>
@@ -18,7 +18,7 @@
       <li ng-repeat="child in node.children track by $ctrl.tree.id(child)">
         <div class="checkbox">
           <label data-label="{{child._label}}">
-            <input type="checkbox" ng-model="child._checked" ng-change="$ctrl.setNodeValue(child, child._checked)" />
+            <input type="checkbox" ng-model="child._checked" ng-change="$ctrl.setNodeValue(child, child._checked)" ng-disabled="child._disabled" />
             <span translate>{{child._label}}</span>
           </label>
         </div>
@@ -27,7 +27,7 @@
           <li ng-repeat="grandchild in child.children track by $ctrl.tree.id(grandchild)">
             <div class="checkbox">
               <label data-label="{{grandchild._label}}">
-                <input type="checkbox" ng-model="grandchild._checked" ng-change="$ctrl.setNodeValue(grandchild, grandchild._checked)" />
+                <input type="checkbox" ng-model="grandchild._checked" ng-change="$ctrl.setNodeValue(grandchild, grandchild._checked)" ng-disabled="grandchild._disabled"  />
                 <span translate>{{grandchild._label}}</span>
               </label>
             </div>

--- a/client/src/modules/payroll/employee_configuration/modals/config.modal.html
+++ b/client/src/modules/payroll/employee_configuration/modals/config.modal.html
@@ -17,6 +17,7 @@
       is-flat-tree="true"
       data="EmployeeConfigModalCtrl.employees"
       checked-ids="EmployeeConfigModalCtrl.checkedUuids"
+      disabled-ids="EmployeeConfigModalCtrl.disabledUuids"
       id-key="uuid"
       label-key="display_name"
       on-change="EmployeeConfigModalCtrl.onChangeRoleSelection(data)">

--- a/client/src/modules/payroll/employee_configuration/modals/config.modal.js
+++ b/client/src/modules/payroll/employee_configuration/modals/config.modal.js
@@ -12,12 +12,10 @@ function EmployeeConfigModalController($state, Config, Notify, AppCache, bhConst
   const cache = AppCache('EmployeeModal');
 
   if (params.isCreateState || params.id) {
-    vm.stateParams = params;
     cache.stateParams = params;
-  } else {
-    vm.stateParams = cache.stateParams;
   }
 
+  vm.stateParams = cache.stateParams;
   vm.isCreateState = vm.stateParams.isCreateState;
 
   vm.onChangeRoleSelection = onChangeRoleSelection;
@@ -44,7 +42,12 @@ function EmployeeConfigModalController($state, Config, Notify, AppCache, bhConst
       return Config.getEmployeeConfiguration(vm.stateParams.id);
     })
     .then((employeeConfig) => {
+
       vm.checkedUuids = employeeConfig.map(row => row.employee_uuid);
+
+      vm.disabledUuids = vm.employees
+        .filter(row => row.locked)
+        .map(row => row.uuid);
 
       // clone the original values as the new values.
       vm.checked = [...vm.checkedUuids];


### PR DESCRIPTION
This commit fixes the "locked" employee feature on the employee
configuration page for payroll which was lost during the migration to
bh-checkbox-tree.  To do this, I added a new feature to bh-checkbox-tree
to allow disabling nodes based on their id, similar to how the
checked-ids functionality works.

In this case, disabled ids will retain the state they came in with,
being ignore in the "setNodeValue()"  function.  Therefore, whatever the
node came in with, it will leave with.  Additionally, the icon disables
the checkbox, makes the font italics, and puts a little lock icon in
front of the text value.

Thanks to @lomamech for pointing this out.