### PR TITLE
Fix: articles in stock excel export options

### DIFF
--- a/client/src/i18n/en/inventory.json
+++ b/client/src/i18n/en/inventory.json
@@ -22,7 +22,7 @@
         "LIST_UNIT": "Inventory Unit form",
         "DEFAULT_QUANTITY_DEFINITION": "The default quantity allows you to customize the default quantity invoiced.  The invoicing module can change this quantity at invoice time.",
         "NO_INVENTORY_FOUND": "No inventory found",
-		"NO_INVENTORY_REGISTERED": "There is no inventory registered yet",
+        "NO_INVENTORY_REGISTERED": "There is no inventory registered yet",
         "REGISTRY": "Inventories Registry",
         "EXPIRES" : "Expires",
         "UNIQUE_ITEM" : "Unique item",

--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -122,9 +122,10 @@
       "ALGO_4"          : "Algorithm 4 (MSH)",
       "ALGO_4_COMMENT"  : "The average consumption is obtained by dividing the quantity consumed during the period by the difference of the number of months in the period minus the total number of days of stock out in the period. The MSH algorithm is recommended by the Management Sciences for Health organization (https://www.msh.org)."
     },
-    "MOTIF"           : "Motif",
+    "MOTIF"           : "Motive",
     "MOVEMENT"        : "Movement",
     "MOVEMENTS"       : "Movements",
+    "MIN_MONTHS_SECURITY_STOCK" : "Min Months Security Stock",
     "NO_ORDER"        : "No Orders",
     "NO_DATA"         : "No Data",
     "NO_ENTRY_TYPES"  : "There are no entry types defined for {{text}}.  Add at least one entry type in the Depot Management module.",
@@ -149,6 +150,7 @@
     "QUANTITY_CONSUMED" : "Quantity Consumed",
     "QUANTITY_LOST" : "Quantity Lost",
     "QUANTITY_REMAINING" : "Quantity Remaining",
+    "INTIAL_QUANTITY" : "Initial Quantity",
     "TRANSFER_RECEIVED" : "Received",
     "TRANSFER_AVAILABLE" : "Available",
     "RECEIPT"         : {

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -19,7 +19,7 @@
       "OVER_MAX"      : "Stock Max Depassé",
       "PRODUCTS_AT_RISK_OUT_STOCK" : "Produits à risque de rupture de stock",
       "PRODUCTS_IN_OVERSTOCK" : "Produits en surstock"
-    },    
+    },
     "DECREASE"        : "Diminution",
     "DECREASE_HELP"   : "Ajustement de stock en reduisant la quantité des lots des produits en stock",
     "DAYS_OF_STOCK_OUT" : "N. jours de rupture de stock",

--- a/client/src/modules/stock/StockFilterer.service.js
+++ b/client/src/modules/stock/StockFilterer.service.js
@@ -34,7 +34,7 @@ function StockFiltererService(Filters, AppCache, Periods, $httpParamSerializer, 
     { key : 'is_expiry_risk', label : 'STOCK.STATUS.IS_IN_RISK_OF_EXPIRATION' },
     { key : 'tag_uuid', label : 'TAG.LABEL' },
     { key : 'tags', label : 'TAG.LABEL' },
-    { key : 'show_only_risky', label : 'LOTS.SHOW_ONLY_RISKY' },
+    { key : 'show_only_risky', label : 'STOCK.LOTS.SHOW_ONLY_RISKY' },
     { key : 'stock_requisition_uuid', label : 'FORM.LABELS.REQUISITION_REFERENCE' },
     {
       key : 'dateFrom', label : 'FORM.LABELS.DATE', comparitor : '>', valueFilter : 'date',

--- a/server/controllers/finance/reports/shared.js
+++ b/server/controllers/finance/reports/shared.js
@@ -21,6 +21,15 @@ const filters = [{
   field : 'cash_uuid',
   displayName : 'FORM.INFO.PAYMENT',
 }, {
+  field : 'min_months_security_stock',
+  displayName : 'STOCK.MIN_MONTHS_SECURITY_STOCK',
+}, {
+  field : 'inital_quantity',
+  displayName : 'STOCK.INITIAL_QUANTITY',
+}, {
+  field : 'unit_cost',
+  displayName : 'FORM.LABELS.COST',
+}, {
   field : 'currency_id',
   displayName : 'FORM.LABELS.CURRENCY',
 }, {
@@ -79,6 +88,11 @@ const filters = [{
   field : 'patient_group_uuid',
   displayName : 'PATIENT_GROUP.PATIENT_GROUP',
 }, {
+  field : 'entry_date',
+  displayName : 'STOCK.ENTRY_DATE',
+  comparitor : '>',
+  isDate : true,
+}, {
   field : 'entry_date_from',
   displayName : 'STOCK.ENTRY_DATE',
   comparitor : '>',
@@ -90,6 +104,11 @@ const filters = [{
   isDate : true,
 }, {
   field : 'expiration_date_from',
+  displayName : 'STOCK.EXPIRATION_DATE',
+  comparitor : '>',
+  isDate : true,
+}, {
+  field : 'expiration_date',
   displayName : 'STOCK.EXPIRATION_DATE',
   comparitor : '>',
   isDate : true,

--- a/server/controllers/stock/reports/stock/inventories_report.js
+++ b/server/controllers/stock/reports/stock/inventories_report.js
@@ -1,5 +1,5 @@
 const {
-  _, ReportManager, Stock, STOCK_INVENTORIES_REPORT_TEMPLATE,
+  _, ReportManager, formatFilters, Stock, STOCK_INVENTORIES_REPORT_TEMPLATE,
 } = require('../common');
 
 /**
@@ -12,9 +12,6 @@ const {
  * GET /reports/stock/inventories
  */
 async function stockInventoriesReport(req, res, next) {
-  const display = {};
-  let filters;
-
   const monthAverageConsumption = req.session.stock_settings.month_average_consumption;
   const averageConsumptionAlgo = req.session.stock_settings.average_consumption_algo;
 
@@ -29,6 +26,8 @@ async function stockInventoriesReport(req, res, next) {
     const options = req.query;
     delete options.label;
 
+    const filters = formatFilters(options);
+
     if (req.session.stock_settings.enable_strict_depot_permission) {
       options.check_user_id = req.session.user.id;
     }
@@ -40,12 +39,12 @@ async function stockInventoriesReport(req, res, next) {
     rows.forEach(row => {
       // remove the CMM object to prevent MS Excel from complaining
       delete row.cmms;
+      delete row.NO_CONSUMPTION;
     });
 
     data.rows = rows;
     data.filters = filters;
     data.csv = rows;
-    data.display = display;
 
     data.dateTo = options.dateTo;
 

--- a/server/lib/renderers/xlsx.js
+++ b/server/lib/renderers/xlsx.js
@@ -28,7 +28,6 @@ exports.render = render;
 exports.find = find;
 exports.extension = '.xlsx';
 exports.headers = headers;
-exports.find = find;
 exports.setValue = setValue;
 exports.IGNORED_COLUMNS = IGNORED_COLUMNS;
 
@@ -116,7 +115,6 @@ function render(data, template, options) {
   return wb.writeToBuffer();
 }
 
-
 /**
  * @function find
  * @description
@@ -133,7 +131,6 @@ function find(data, options = {}) {
   // mask the dataset using lodash and return it
   return dataset.map(row => _.omit(row, mask));
 }
-
 
 // set value to a paticular cell
 function setValue(ws, x, y, value) {


### PR DESCRIPTION
This PR fixes two issues:

 1. It provides the correct i18n key for "SHOW_RISKY_LOTS"
 2. It cleans up the articles in stock filter logic (it was unused) and eliminates the MS Excel export warning about the CMM object in the excel export.

