### PR TITLE
Fix patient merge2

### DIFF
--- a/server/controllers/medical/patients/merge.js
+++ b/server/controllers/medical/patients/merge.js
@@ -89,9 +89,6 @@ router.post('/', async (req, res, next) => {
   const replaceDebtorInStockAssign = `
     UPDATE stock_assign SET entity_uuid = ? WHERE entity_uuid IN (?);
   `;
-  const replaceDebtorInEntityGroupEntity = `
-    UPDATE entity_group_entity SET entity_uuid = ? WHERE entity_uuid IN (?);
-  `;
   const replaceDebtorInVoucherItem = `
     UPDATE voucher_item SET entity_uuid = ? WHERE entity_uuid IN (?);
   `;
@@ -148,7 +145,6 @@ router.post('/', async (req, res, next) => {
     const transaction = db.transaction()
       .addQuery(replaceDebtorInCash, [debtorUuid, [otherDebtorUuids]])
       .addQuery(replaceDebtorInDebtorGroupHistory, [debtorUuid, [otherDebtorUuids]])
-      .addQuery(replaceDebtorInEntityGroupEntity, [debtorUuid, [otherDebtorUuids]])
       .addQuery(replaceDebtorInInvoice, [debtorUuid, [otherDebtorUuids]])
       .addQuery(replaceDebtorInPostingJournal, [debtorUuid, [otherDebtorUuids]])
       .addQuery(replaceDebtorInGeneralLedger, [debtorUuid, [otherDebtorUuids]])

--- a/server/controllers/medical/patients/merge.js
+++ b/server/controllers/medical/patients/merge.js
@@ -127,9 +127,6 @@ router.post('/', async (req, res, next) => {
   const removeOtherPatients = `
     DELETE FROM patient WHERE uuid IN (?);
   `;
-  const removeOtherEntities = `
-    DELETE FROM entity WHERE uuid IN (?);
-  `;
   const removeOtherEntityMap = `
     DELETE FROM entity_map WHERE uuid IN (?);
   `;
@@ -168,7 +165,6 @@ router.post('/', async (req, res, next) => {
       .addQuery(replacePatientInStockMovement, [debtorUuid, [otherDebtorUuids]])
 
       .addQuery(removeOtherDebtors, [otherDebtorUuids])
-      .addQuery(removeOtherEntities, [otherDebtorUuids])
       .addQuery(removeOtherEntityMap, [otherDebtorUuids])
       .addQuery(removeOtherPatients, [otherPatientUuids]);
 


### PR DESCRIPTION
Remove incorrect deletion of record in entity and entity_group_entity tables.  Per @jniles in PR https://github.com/IMA-WorldHealth/bhima/pull/5223, these are not needed:

> Despite the identical name, I don't think this entity table or the
> entity_group_entity table has anything to do with the patient/entity_map/debtor
> tables. I believe it is only concerned with emails.
