### PR TITLE
Fixed bug in server /patient/duplicates database query function

### DIFF
--- a/server/controllers/medical/patients/merge.js
+++ b/server/controllers/medical/patients/merge.js
@@ -34,17 +34,19 @@ router.get('/count_employees', async (req, res, next) => {
 });
 
 router.get('/duplicates', async (req, res, next) => {
-  const sensitivity = req.params.sensitivity || 2;
+  const sensitivity = req.query.sensitivity || 2;
+  const limit = parseInt(req.query.limit, 10) || 25;
   const duplicateSQL = `
-    SELECT COUNT(p.uuid) AS num_patients, p.display_name, GROUP_CONCAT(CONCAT(BUID(p.uuid), ':', em.text)) AS others
+    SELECT COUNT(p.uuid) AS num_patients, p.display_name,
+    GROUP_CONCAT(CONCAT(BUID(p.uuid), ':', em.text)) AS others
     FROM patient p LEFT JOIN entity_map em ON p.uuid = em.uuid
     GROUP BY LOWER(p.display_name) HAVING COUNT(p.uuid) > ?
     ORDER BY COUNT(p.uuid) DESC
-    LIMIT 25;
+    LIMIT ?;
   `;
 
   try {
-    const patients = await db.exec(duplicateSQL, [sensitivity]);
+    const patients = await db.exec(duplicateSQL, [sensitivity, limit]);
     res.status(200).json(patients);
   } catch (e) {
     next(e);

--- a/test/integration/patients.js
+++ b/test/integration/patients.js
@@ -199,7 +199,7 @@ describe('(/patients) Patients', () => {
           .query({ sensitivity : 0 });
       })
       .then((res) => {
-        helpers.api.listed(res, 0);
+        helpers.api.listed(res, 5);
       })
       .catch(helpers.handler);
   });


### PR DESCRIPTION
Fix a bug in the server query function.  The code was trying to get the parameters from req.params, which does not work (with express Router), but req.query does work.    Also update the code so the limit was not hardcoded in the SQL code but came from the client side via the parameters.

Note that this also fixes an integration test that was succeeding incorrectly because the parameters passed into the test calls to this function were being ignored.