### PR TITLE
fix(reports): properly exchange cash report

### DIFF
--- a/server/controllers/finance/accounts/transactions.js
+++ b/server/controllers/finance/accounts/transactions.js
@@ -110,7 +110,6 @@ function getTableSubquery(options, table) {
   return { query, parameters };
 }
 
-
 /**
  * @function getSubquery
  *
@@ -155,7 +154,6 @@ function getTotalsSQL(options) {
 
   return { totalsQuery, totalsParameters };
 }
-
 
 /**
  * @function getAccountTransactions

--- a/server/controllers/finance/reports/cashReport/index.js
+++ b/server/controllers/finance/reports/cashReport/index.js
@@ -53,7 +53,6 @@ const templates = {
   SPLIT : TEMPLATE_SEPARATED,
 };
 
-
 /**
  * @function document
  * @description process and render the cash report document
@@ -96,10 +95,15 @@ async function document(req, res, next) {
     _.merge(context, { cashbox });
 
     // determine the currency rendering
+    params.currency_id = cashbox.currency_id;
+
     // Update By @lomamech
     // As the report of the boxes can only be viewed in the company currency,
     // we set the variable isEnterpriseCurrency to true
-    params.currency_id = cashbox.currency_id;
+    // NOTE(@jniles): @lomamech is right.  'isEnterpriseCurrency' is used to change the target
+    // that this report rendered _to_.  Since we don't have a currency select on the client side
+    // we always are rendering to the enterprise currency.
+    params.isEnterpriseCurrency = true;
 
     // get the opening balance for the acount
     const header = await AccountExtras.getOpeningBalanceForDate(cashbox.account_id, params.dateFrom);

--- a/server/controllers/finance/reports/cashReport/report_separated.handlebars
+++ b/server/controllers/finance/reports/cashReport/report_separated.handlebars
@@ -106,12 +106,12 @@
       {{#if hasBoth}}
         <p class="text-right">
           <strong>{{translate "FORM.LABELS.INCOME"}} - {{translate "FORM.LABELS.EXPENSE"}}:</strong>
-          <span>{{debcred footer.totals.balance txn.currency_id}}</span>
+          <span>{{debcred footer.totals.balance metadata.enterprise.currency_id}}</span>
         </p>
 
         <p class="text-right">
           <strong>{{translate "TABLE.COLUMNS.BALANCE"}}:</strong>
-          <span>{{debcred footer.exchangedCumSum txn.currency_id}}</span>
+          <span>{{debcred footer.exchangedCumSum metadata.enterprise.currency_id}}</span>
         </p>
       {{/if}}
 


### PR DESCRIPTION
Uses the correct currency_id in the report with separated income/expenses.

Closes #5239.

Demonstration:
![MLnm1erhnn](https://user-images.githubusercontent.com/896472/104592683-e0a17100-566e-11eb-928e-a44a9575ed8d.gif)

