### PR TITLE
feat(users): add "last_login" functionality

### DIFF
--- a/client/src/i18n/en/users.json
+++ b/client/src/i18n/en/users.json
@@ -16,6 +16,7 @@
     "TITLE" : "Users and Permissions Management",
     "UPDATED" : "Updated",
     "UPDATE" : "Update",
+    "LAST_LOGIN" : "Last Login",
     "UPDATING_USER" : "Edit User",
     "VIEW_USERS" : "View Users"
   }

--- a/client/src/i18n/fr/users.json
+++ b/client/src/i18n/fr/users.json
@@ -16,6 +16,7 @@
     "TITLE" : "Gestion des utilisateurs et des autorisations",
     "UPDATED" : "Modifie avec succes",
     "UPDATE" : "Éditer",
+    "LAST_LOGIN" : "Dernière connexion",
     "UPDATING_USER" : "Mise à jour utilisateur",
     "VIEW_USERS" : "View Users"
   }

--- a/client/src/modules/users/users.js
+++ b/client/src/modules/users/users.js
@@ -65,6 +65,14 @@ function UsersController($state, $uibModal, Users, Notify, Modal, uiGridConstant
         cellClass : muteDisabledCells,
       },
       {
+        field : 'lastLogin',
+        type : 'date',
+        displayName : 'USERS.LAST_LOGIN',
+        cellFilter : 'date:"dd/MM/yyyy HH:mm:ss"',
+        headerCellFilter : 'translate',
+        cellClass : muteDisabledCells,
+      },
+      {
         field : 'action',
         displayName : '',
         cellTemplate : '/modules/users/templates/grid/action.cell.html',

--- a/server/controllers/admin/users/index.js
+++ b/server/controllers/admin/users/index.js
@@ -96,7 +96,7 @@ async function list(req, res, next) {
 
   try {
     const sql = `
-      SELECT user.id, user.display_name, user.username, user.deactivated,
+      SELECT user.id, user.display_name, user.username, user.deactivated, user.last_login as lastLogin,
         GROUP_CONCAT(DISTINCT role.label ORDER BY role.label DESC SEPARATOR ', ') AS roles,
         GROUP_CONCAT(DISTINCT depot.text ORDER BY depot.text DESC SEPARATOR ', ') AS depots,
         GROUP_CONCAT(DISTINCT cb.label ORDER BY cb.label DESC SEPARATOR ', ') AS cashboxes

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -1,0 +1,9 @@
+
+-- 2021-01-04
+-- author: @jniles
+ALTER TABLE `user` MODIFY COLUMN `last_login` TIMESTAMP NULL;
+ALTER TABLE `user` ADD COLUMN `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE `user` ADD COLUMN `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- reset all last_login information
+UPDATE `user` SET `last_login` = NULL;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1735,16 +1735,17 @@ CREATE TABLE `unit` (
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `user`;
-
 CREATE TABLE `user` (
   `id`            SMALLINT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
   `username`      VARCHAR(80) NOT NULL,
   `password`      VARCHAR(100) NOT NULL,
   `display_name`  TEXT NOT NULL,
-  `email`         VARCHAR(100) DEFAULT NULL,
+  `email`         VARCHAR(99) DEFAULT NULL,
   `active`        TINYINT(4) NOT NULL DEFAULT 0,
   `deactivated`   TINYINT(1) NOT NULL DEFAULT 0,
-  `last_login`    TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
+  `last_login`    TIMESTAMP NULL,
+  `created_at`    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `user_1` (`username`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;


### PR DESCRIPTION
This commit adds the functionality to actually display the last login date of the user.  This column had been playing the role of "updated_at" rather than "last_login" since it was only changed automatically when user information had been changed.  Now, the last_login it updated whenever a user logs in.

I've also reset all values of the last_login to NULL in the migration script.

Closes #5216.