### PR TITLE
fix(stock): refresh inventory adjustment on submit

### DIFF
--- a/client/src/modules/stock/inventory-adjustment/inventory-adjustment.js
+++ b/client/src/modules/stock/inventory-adjustment/inventory-adjustment.js
@@ -129,8 +129,9 @@ function StockInventoryAdjustmentController(
   function startup() {
     vm.movement = {
       date : new Date(),
-      entity : {},
     };
+
+    setupStock();
   }
 
   // ============================ Inventories ==========================
@@ -217,7 +218,7 @@ function StockInventoryAdjustmentController(
         ReceiptModal.stockAdjustmentReport(movement.depot_uuid, movement.date, INVENTORY_ADJUSTMENT);
 
         startup();
-        setupStock();
+        return loadInventories(vm.depot);
       })
       .catch(Notify.handleError);
   }


### PR DESCRIPTION
Refreshes the inventory adjustments page on submit so that users don't have to click the refresh button again to get current values in stock.

Closes #5255.