### PR TITLE
Fixed issue with upload directories

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,7 +37,7 @@ blocks:
         - name: SESS_SECRET
           value: 1a3184a126e42fa0d9466cf14841f8a218cd92e961f5677b30
         - name: DEBUG
-          value: 'app,errors'
+          value: 'app,errors,app:uploader'
         - name: UPLOAD_DIR
           value: client/upload
         - name: MAILGUN_API_KEY

--- a/server/lib/uploader.js
+++ b/server/lib/uploader.js
@@ -41,7 +41,7 @@ const dir = process.env.UPLOAD_DIR || defaultDir;
 if (path.isAbsolute(dir) || dir.startsWith('..')) {
   throw new Error(`UPLOAD_DIR (${dir}) must be a relative path within the BHIMA software installation!`);
 }
-const rootDir = path.resolve(`__dirname/../..`);
+const rootDir = path.resolve(`${__dirname}/../..`);
 const fsdir = path.join(rootDir, dir); // global path
 debug('UPLOAD_DIR: ', dir);
 debug('UPLOAD_DIR Abs dir: ', fsdir);
@@ -79,14 +79,13 @@ function Uploader(prefix, fields) {
   // configure the storage space using multer's diskStorage.  This will allow
   const storage = multer.diskStorage({
     destination : async (req, file, cb) => {
-      const folder = path.join(dir, directory);
-      debug(`creating upload directory ${folder}.`);
 
       try {
         // NOTE: need absolute path here for mkdirp
-        const fullFolderPath = path.join(rootDir, directory);
+        const fullFolderPath = path.join(fsdir, directory);
+        debug(`creating upload directory ${fullFolderPath}.`);
         await mkdirp(fullFolderPath);
-        cb(null, directory);
+        cb(null, fullFolderPath);
       } catch (err) {
         cb(err);
       }

--- a/server/lib/uploader.js
+++ b/server/lib/uploader.js
@@ -41,7 +41,7 @@ const dir = process.env.UPLOAD_DIR || defaultDir;
 if (path.isAbsolute(dir) || dir.startsWith('..')) {
   throw new Error(`UPLOAD_DIR (${dir}) must be a relative path within the BHIMA software installation!`);
 }
-const rootDir = path.normalize(`${process.cwd()}/..`);
+const rootDir = path.resolve(`__dirname/../..`);
 const fsdir = path.join(rootDir, dir); // global path
 debug('UPLOAD_DIR: ', dir);
 debug('UPLOAD_DIR Abs dir: ', fsdir);

--- a/server/lib/uploader.js
+++ b/server/lib/uploader.js
@@ -35,17 +35,24 @@ const { uuid } = require('./util');
 const BadRequest = require('./errors/BadRequest');
 
 // configure the uploads directory based on global process variables
-const defaultDir = 'uploads'; // NOTE: this must be a relative path
-const dir = process.env.UPLOAD_DIR || defaultDir; // relative path
-const fsdir = path.join(process.cwd(), dir); // global path
+const defaultDir = 'uploads';
+const dir = process.env.UPLOAD_DIR || defaultDir;
+// NOTE: 'dir' must be a relative path (for http requests to work)
+if (path.isAbsolute(dir) || dir.startsWith('..')) {
+  throw new Error(`UPLOAD_DIR (${dir}) must be a relative path within the BHIMA software installation!`);
+}
+const rootDir = path.normalize(`${process.cwd()}/..`);
+const fsdir = path.join(rootDir, dir); // global path
+debug('UPLOAD_DIR: ', dir);
+debug('UPLOAD_DIR Abs dir: ', fsdir);
 
 if (!process.env.UPLOAD_DIR) {
   debug(
-    `The environmental variable $UPLOAD_DIR is undefined.  The application will use ${fsdir} as the upload directory.`,
+    `The environmental variable $UPLOAD_DIR is undefined.  The application will use ${dir} as the upload directory.`,
   );
 }
 
-// attach the upload directory path for outside consumption
+// attach the relative upload directory path for outside consumption
 exports.directory = dir;
 
 // export the uploader
@@ -72,14 +79,14 @@ function Uploader(prefix, fields) {
   // configure the storage space using multer's diskStorage.  This will allow
   const storage = multer.diskStorage({
     destination : async (req, file, cb) => {
-      // note: need absolute path here for mkdirp
-      const folder = path.join(process.cwd(), directory);
-      debug(`upload dirctory ${folder} does not exist.`);
+      const folder = path.join(dir, directory);
       debug(`creating upload directory ${folder}.`);
 
       try {
-        await mkdirp(folder);
-        cb(null, folder);
+        // NOTE: need absolute path here for mkdirp
+        const fullFolderPath = path.join(rootDir, directory);
+        await mkdirp(fullFolderPath);
+        cb(null, directory);
       } catch (err) {
         cb(err);
       }


### PR DESCRIPTION
Fix issue with upload directory always being under the bin directory.  Now it obeys the .env setting for UPLOAD_DIR.

**NOTES!**
- Only relative paths within the Bhima installation directory may be used
- Currently it will reject any absolute paths or paths that start with '..' for UPLOAD_DIR.
- Although it is probably possible to support absolute paths outside the Bhima installation, it will require updates to the app's 'app.use' function calls.  Without those changes, paths outside of the Bhima directory cannot be accessed via HTTPS calls without ENOENT errors.
- There are at least 3 ways to avoid conflicts with installation updates:
   - Create a new 'data' (or similar) directory inside the Bhima installation folder and add it to the .gitignore file.
   - Create a directory elsewhere and set up a symbolic/hard link to it within the Bhima directory
   - Revisit this issue and refactor to allow absolute paths.

**TESTING:**
- In your .env file, try changing UPLOAD_DIR to an absolute path and then a path beginning with '..'.  These should both fail.
   - NOTE that these failures are not handled very gracefully because this is an error that should be handled by the installer, not an end-user.
- Test the current default for the upload directory (eg, 'client/uploads'
   - Try uploading a file (eg in the Patient Registry, chose a patient and upload a document)
   - Verify the upload worked and the file is downloadable.  Do not delete it.
- Test in a new directory:
   - Use 'bhima_test' 
   - Create a folder within the Bhima installation directory (eg, 'data')
   - Change UPLOAD_DIR to the relative path for the new subdirectory the Bhima installation directory (eg, 'data').  
   - Enable the debugging option in .env:   DEBUG=app,errors,app:uploader
   - Monitor the client console for errors
   - Run 'yarn dev', notice in the server console the paths match what was given.  Also notice that it is NOT in the bin directory!
   - Try uploading a file (eg in the Patient Registry, chose a patient and upload a document)
   - Verify the upload worked and the file is downloadable
   - Delete the new file
   - Exit 'yarn dev' and delete the temporary upload folder
- Revert to the default UPLOAD directory (eg, 'client/uploads') and verify it still works and that the file uploaded earlier is still accessible.  Delete the file, if desired.
- Undo the debug settings in .env
