### PR TITLE
Allow multi depot stock sheet report

### DIFF
--- a/client/src/modules/reports/generate/stock_sheet/stock_sheet.config.js
+++ b/client/src/modules/reports/generate/stock_sheet/stock_sheet.config.js
@@ -22,7 +22,7 @@ function StockSheetConfigController($sce, Notify, SavedReports, AppCache, report
   // check cached configuration
   checkCachedConfiguration();
 
-  vm.changeHavingDateInterval = value => {
+  vm.changeHavingDateInterval = (value) => {
     vm.hasDateInterval = value;
     vm.reportDetails.dateFrom = value ? new Date() : undefined;
     vm.reportDetails.dateTo = new Date();
@@ -68,7 +68,6 @@ function StockSheetConfigController($sce, Notify, SavedReports, AppCache, report
     // format date for the server
     options.dateTo = moment(options.dateTo).format('YYYY-MM-DD');
     options.lang = Languages.key;
-
     return SavedReports.requestPreview(reportUrl, reportData.id, options)
       .then((result) => {
         vm.previewGenerated = true;
@@ -94,6 +93,13 @@ function StockSheetConfigController($sce, Notify, SavedReports, AppCache, report
   function checkCachedConfiguration() {
     if (cache.reportDetails) {
       vm.reportDetails = angular.copy(cache.reportDetails);
+      // Make sure dates are Date objects, not strings (as they are when cached)
+      if (typeof vm.reportDetails.dateTo === 'string') {
+        vm.reportDetails.dateTo = new Date(vm.reportDetails.dateTo);
+      }
+      if (vm.reportDetails.dateFrom && typeof vm.reportDetails.dateFrom === 'string') {
+        vm.reportDetails.dateFrom = new Date(vm.reportDetails.dateFrom);
+      }
     }
   }
 }

--- a/client/src/modules/reports/generate/stock_sheet/stock_sheet.html
+++ b/client/src/modules/reports/generate/stock_sheet/stock_sheet.html
@@ -28,7 +28,7 @@
           <bh-depot-select
             depot-uuid="ReportConfigCtrl.reportDetails.depot_uuid"
             on-select-callback="ReportConfigCtrl.onSelectDepot(depot)"
-            required="true">
+            required="false">
             <bh-clear on-clear="ReportConfigCtrl.clear('depot_uuid')"></bh-clear>
           </bh-depot-select>
 
@@ -52,7 +52,7 @@
 
           <bh-date-interval
             ng-if="ReportConfigCtrl.hasDateInterval"
-            date-from="ReportConfigCtrl.reportDetails.dateFrom" 
+            date-from="ReportConfigCtrl.reportDetails.dateFrom"
             date-to="ReportConfigCtrl.reportDetails.dateTo">
           </bh-date-interval>
 

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -788,6 +788,7 @@ function getInventoryMovements(params) {
         const movement = {
           reference : line.documentReference,
           date : line.date,
+          depot_text : line.depot_text,
           label : line.label,
           flux : line.flux,
           entry : { quantity : 0, unit_cost : 0, value : 0 },

--- a/server/controllers/stock/reports/stock/stock_sheet.js
+++ b/server/controllers/stock/reports/stock/stock_sheet.js
@@ -26,7 +26,9 @@ async function stockSheetReport(req, res, next) {
 
     const [inventory, depot, rows] = await Promise.all([
       await db.one('SELECT code, text FROM inventory WHERE uuid = ?;', [db.bid(options.inventory_uuid)]),
-      await db.one('SELECT text FROM depot WHERE uuid = ?;', [db.bid(options.depot_uuid)]),
+      options.depot_uuid
+        ? await db.one('SELECT text FROM depot WHERE uuid = ?;', [db.bid(options.depot_uuid)])
+        : null,
       await Stock.getInventoryMovements(options),
     ]);
 

--- a/server/controllers/stock/reports/stock_sheet.report.handlebars
+++ b/server/controllers/stock/reports/stock_sheet.report.handlebars
@@ -14,7 +14,7 @@
       </h2>
 
       <h3 class="text-center">
-        {{#if depot.text}}{{depot.text}}{{/if}}<br>
+        {{#if depot.text}}{{depot.text}}<br>{{/if}}
         {{#if inventory.code}}<strong>{{inventory.code}} - {{inventory.text}}</strong>{{/if}}
       </h3>
 
@@ -29,7 +29,7 @@
       <table class="table table-condensed table-report">
         <thead>
           <tr style="background-color:#ddd;">
-            <th colspan=4></th>
+            <th colspan={{#if depot.text}}"4"{{else}}"5"{{/if}}></th>
             <th class="text-center" colspan="3">{{translate 'REPORT.STOCK.ENTRIES'}}</th>
             <th class="text-center" colspan="3">{{translate 'REPORT.STOCK.EXITS'}}</th>
             <th class="text-center" colspan="3">{{translate 'REPORT.STOCK.STOCKS'}}</th>
@@ -37,6 +37,9 @@
           <tr style="background-color:#ddd;">
             <th class="text-center" style="border-right: 1px solid #000;">{{translate 'TABLE.COLUMNS.REFERENCE'}}</th>
             <th class="text-center" style="border-right: 1px solid #000;">{{translate 'TABLE.COLUMNS.DATE'}}</th>
+            {{#unless depot.text}}
+            <th class="text-center" style="border-right: 1px solid #000;">{{translate 'STOCK.DEPOT'}}</th>
+            {{/unless}}
             <th class="text-center" style="border-right: 1px solid #000;">{{translate 'STOCK.FLUX'}}</th>
             <th class="text-center" style="border-right: 1px solid #000;">{{translate 'STOCK.LOT'}}</th>
 
@@ -58,6 +61,9 @@
             <tr>
               <td style="border-left: 1px solid #000;">{{reference}}</td>
               <td style="border-right: 1px solid #000;">{{timestamp date}}</td>
+              {{#unless ../depot.text}}
+              <td style="border-right: 1px solid #000;">{{depot_text}}</td>
+              {{/unless}}
               <td style="border-left: 1px solid #000;">{{translate flux}}</td>
               <td style="border-left: 1px solid #000;">{{label}}</td>
 
@@ -79,7 +85,7 @@
         </tbody>
         <tfoot style="border-top: 1px solid #000;">
           <tr class="text-right" style="font-weight: bold; background-color: #efefef;">
-            <th colspan="4"></th>
+            <th colspan={{#if depot.text}}"4"{{else}}"5"{{/if}}></th>
             <th class="text-right">{{totals.entry}}</th> <th></th>
             <th class="text-right">{{currency totals.entryValue metadata.enterprise.currency_id}}</th>
             <th class="text-right">{{totals.exit}}</th> <th></th>


### PR DESCRIPTION
Make the Depot optional for Stock Sheet (Fiche) reports.

Note that this PR also fixes a bug in the stock sheet dialog that was preventing the dateTo from being cached properly.

**Suggestions for Testing**

- Use one of the production sites
- yarn dev
- Use the Stock > Items in stock to identify an inventory item that is in stock and note the depot
- Stock > Report > Stock Sheet (Stock Fiche)
  - Select Depot and inventory item and preview the report
  - Cancel
  - Clear the Depot and try the preview again.
     - Note that there is a new column for the Depot that should show the depot for each stock item.  This column is not present when one Depot is selected.

**After an initial review and dealing with bugs and suggestions, I'll rebase before releasing.**