### PR TITLE
feat: add ignore reversed record to vouchers

### DIFF
--- a/client/src/i18n/en/vouchers.json
+++ b/client/src/i18n/en/vouchers.json
@@ -46,6 +46,9 @@
       "CASH_TRANSFER":"Cash Transfer",
       "REPORT":"Voucher Registry",
       "TITLE":"Voucher",
+      "INCLUDE_ONLY_REVERSED_RECORDS" : "Include only reversed vouchers",
+      "EXCLUDE_REVERSED_RECORDS" : "Exclude all reversed vouchers",
+      "REVERSED_RECORDS" : "Reversed Records",
       "TRANSACTION_TYPE_INFO": "Transaction type, depending on whether you have an income or an expense",
       "USE_FINANCIAL_ACCOUNT": "This transaction uses a cash or bank account.  Be sure to set a transaction type.",
       "RECEIPT":{

--- a/client/src/i18n/en/vouchers.json
+++ b/client/src/i18n/en/vouchers.json
@@ -48,6 +48,7 @@
       "TITLE":"Voucher",
       "INCLUDE_ONLY_REVERSED_RECORDS" : "Include only reversed vouchers",
       "EXCLUDE_REVERSED_RECORDS" : "Exclude all reversed vouchers",
+      "EXCLUDE_REVERSED_AND_REVERSAL_RECORDS" : "Exclude reversed and reversal vouchers",
       "REVERSED_RECORDS" : "Reversed Records",
       "TRANSACTION_TYPE_INFO": "Transaction type, depending on whether you have an income or an expense",
       "USE_FINANCIAL_ACCOUNT": "This transaction uses a cash or bank account.  Be sure to set a transaction type.",

--- a/client/src/i18n/fr/vouchers.json
+++ b/client/src/i18n/fr/vouchers.json
@@ -53,6 +53,7 @@
       "TITLE": "Quittance",
       "INCLUDE_ONLY_REVERSED_RECORDS":"Inclure uniquement les bordereaux inversés",
       "EXCLUDE_REVERSED_RECORDS":"Exclure tous les bordereaux inversés",
+      "EXCLUDE_REVERSED_AND_REVERSAL_RECORDS" : "Exclure tous les bordereaux inversés et les bordereaux qui fait l'inversion",
       "REVERSED_RECORDS":"Bordereaux Inversés",
       "TRANSACTION_TYPE_INFO": "Le type de transaction dépend du revenu ou bien d'une dépense",
       "USE_FINANCIAL_ACCOUNT": "Utilisation de compte de caisses ou banques dans cette transaction"

--- a/client/src/i18n/fr/vouchers.json
+++ b/client/src/i18n/fr/vouchers.json
@@ -51,6 +51,9 @@
       "REPORT": "Rapport des Quittances",
       "SUPPORT_PAYMENT_DESCRIPTION":"Prise en charge de {{patientName}} ({{patientReference}}) pour {{numInvoices}} facture(s) {{invoiceReferences}}.",
       "TITLE": "Quittance",
+      "INCLUDE_ONLY_REVERSED_RECORDS":"Inclure uniquement les bordereaux inversés",
+      "EXCLUDE_REVERSED_RECORDS":"Exclure tous les bordereaux inversés",
+      "REVERSED_RECORDS":"Bordereaux Inversés",
       "TRANSACTION_TYPE_INFO": "Le type de transaction dépend du revenu ou bien d'une dépense",
       "USE_FINANCIAL_ACCOUNT": "Utilisation de compte de caisses ou banques dans cette transaction"
     },

--- a/client/src/js/services/SearchModal.js
+++ b/client/src/js/services/SearchModal.js
@@ -11,8 +11,17 @@ function SearchModalUtilService() {
     // push all searchQuery values into the changes array to be applied
     angular.forEach(searchQueries, (value, key) => {
       if (angular.isDefined(value)) {
-        // default to the original value if no display value is defined
-        const displayValue = displayValues[key] || lastDisplayValues[key] || value;
+
+        const hasDisplayValue = angular.isDefined(displayValues[key]);
+        const hasLastDisplayValue = angular.isDefined(lastDisplayValues[key]);
+
+        let displayValue = value;
+        if (hasDisplayValue) {
+          displayValue = displayValues[key];
+        } else if (hasLastDisplayValue) {
+          displayValue = lastDisplayValues[key];
+        }
+
         changes.post({ key, value, displayValue });
       }
     });

--- a/client/src/modules/vouchers/modals/search.modal.html
+++ b/client/src/modules/vouchers/modals/search.modal.html
@@ -64,6 +64,26 @@
             on-change="$ctrl.onTransactionTypesChange(transactionTypes)"
             transaction-type-ids="$ctrl.searchQueries.type_ids">
           </bh-transaction-type-select>
+
+          <div class="form-group">
+            <div class="radio">
+              <bh-clear on-clear="$ctrl.clear('reversed')"></bh-clear>
+              <p class="control-label" style="margin-bottom:5px;">
+                <strong translate>VOUCHERS.GLOBAL.REVERSED_RECORDS</strong>
+              </p>
+              <label>
+                <input type="radio" name="reversed" ng-value="1" ng-model="$ctrl.searchQueries.reversed">
+                <span translate>VOUCHERS.GLOBAL.INCLUDE_ONLY_REVERSED_RECORDS</span>
+              </label>
+            </div>
+
+            <div class="radio">
+              <label>
+                <input type="radio" name="reversed" ng-value="0" ng-model="$ctrl.searchQueries.reversed">
+                <span translate>VOUCHERS.GLOBAL.EXCLUDE_REVERSED_RECORDS</span>
+              </label>
+            </div>
+          </div>
         </div>
       </uib-tab>
       <uib-tab index="1" heading="{{ 'FORM.LABELS.DEFAULTS' | translate }}" data-default-filter-tab>

--- a/client/src/modules/vouchers/modals/search.modal.html
+++ b/client/src/modules/vouchers/modals/search.modal.html
@@ -83,6 +83,13 @@
                 <span translate>VOUCHERS.GLOBAL.EXCLUDE_REVERSED_RECORDS</span>
               </label>
             </div>
+
+            <div class="radio">
+              <label>
+                <input type="radio" name="reversed" ng-value="2" ng-model="$ctrl.searchQueries.reversed">
+                <span translate>VOUCHERS.GLOBAL.EXCLUDE_REVERSED_AND_REVERSAL_RECORDS</span>
+              </label>
+            </div>
           </div>
         </div>
       </uib-tab>

--- a/client/src/modules/vouchers/modals/search.modal.js
+++ b/client/src/modules/vouchers/modals/search.modal.js
@@ -20,6 +20,7 @@ function VoucherRegistrySearchModalController(
 ) {
   const vm = this;
   const changes = new Store({ identifier : 'key' });
+
   const searchQueryOptions = [
     'reference', 'description', 'user_id', 'type_ids', 'account_id', 'project_id', 'currency_id', 'reversed',
   ];
@@ -106,7 +107,7 @@ function VoucherRegistrySearchModalController(
     delete vm.searchQueries[key];
   };
 
-  vm.cancel = function cancel() { ModalInstance.close(); };
+  vm.cancel = function cancel() { ModalInstance.dismiss(); };
 
   // submit the filter object to the parent controller.
   vm.submit = function submit() {
@@ -115,7 +116,13 @@ function VoucherRegistrySearchModalController(
       vm.clear('type_ids');
     }
 
+    // update the 'reversed' flag to update the view value correctly
+    if (angular.isDefined(vm.searchQueries.reversed)) {
+      displayValues.reversed = vm.searchQueries.reversed;
+    }
+
     const loggedChanges = SearchModal.getChanges(vm.searchQueries, changes, displayValues, lastDisplayValues);
+
     return ModalInstance.close(loggedChanges);
   };
 

--- a/client/src/modules/vouchers/modals/search.modal.js
+++ b/client/src/modules/vouchers/modals/search.modal.js
@@ -21,7 +21,7 @@ function VoucherRegistrySearchModalController(
   const vm = this;
   const changes = new Store({ identifier : 'key' });
   const searchQueryOptions = [
-    'reference', 'description', 'user_id', 'type_ids', 'account_id', 'project_id', 'currency_id',
+    'reference', 'description', 'user_id', 'type_ids', 'account_id', 'project_id', 'currency_id', 'reversed',
   ];
 
   // displayValues will be an id:displayValue pair

--- a/client/src/modules/vouchers/voucher-registry.ctrl.js
+++ b/client/src/modules/vouchers/voucher-registry.ctrl.js
@@ -135,7 +135,8 @@ function VoucherController(
         vm.latestViewFilters = Vouchers.filters.formatView();
 
         return load(Vouchers.filters.formatHTTP(true));
-      });
+      })
+      .catch(angular.noop);
   }
 
   function load(filters) {
@@ -237,7 +238,6 @@ function VoucherController(
     // state of the columns - this will be saved if the user saves the grid configuration
     gridColumns.openConfigurationModal();
   }
-
 
   vm.saveGridState = state.saveGridState;
   // saves the grid's current configuration

--- a/client/src/modules/vouchers/vouchers.service.js
+++ b/client/src/modules/vouchers/vouchers.service.js
@@ -47,7 +47,7 @@ function VoucherService(
     { key : 'uuid', label : 'FORM.LABELS.REFERENCE' },
     { key : 'user_id', label : 'FORM.LABELS.USER' },
     { key : 'reference', label : 'FORM.LABELS.REFERENCE' },
-    { key : 'reversed', label : 'FORM.INFO.ANNULLED' },
+    { key : 'reversed', label : 'VOUCHERS.GLOBAL.REVERSED_RECORDS' },
     { key : 'description', label : 'FORM.LABELS.DESCRIPTION' },
     { key : 'entity_uuid', label : 'FORM.LABELS.ENTITY' },
     { key : 'account_id', label : 'FORM.LABELS.ACCOUNT' },

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -33,8 +33,8 @@ _.forEach(identifiers, v => {
 });
 
 // services
-const FiscalService = require('../../finance/fiscal');
-const VoucherService = require('../../finance/vouchers');
+const FiscalService = require('../fiscal');
+const VoucherService = require('../vouchers');
 
 // expose to the api
 exports.list = list;
@@ -578,7 +578,6 @@ function transformColumns(rows, newRecord, transactionToEdit, setFiscalData) {
   return q.all(promises)
     .then(() => rows);
 }
-
 
 /**
  * @method reverse

--- a/server/controllers/finance/transactions.js
+++ b/server/controllers/finance/transactions.js
@@ -79,7 +79,6 @@ function deleteTransaction(uuid) {
     });
 }
 
-
 /**
  * PUT /transactions/comments
  *

--- a/server/controllers/finance/vouchers.js
+++ b/server/controllers/finance/vouchers.js
@@ -147,6 +147,7 @@ function find(options) {
   filters.equals('user_id');
   filters.equals('project_id');
   filters.equals('edited');
+  filters.equals('reversed');
   filters.equals('currency_id');
 
   filters.equals('reference', 'text', 'dm');
@@ -267,7 +268,6 @@ function createVoucher(voucherDetails, userId, projectId) {
   voucherDetails.uuid = db.bid(vuid);
 
   const SALARY_PAYMENT_VOUCHER_TYPE_ID = 7;
-
 
   // preprocess the items so they have uuids as required
   items.forEach(value => {

--- a/server/controllers/finance/vouchers.js
+++ b/server/controllers/finance/vouchers.js
@@ -38,6 +38,7 @@ exports.find = find;
 exports.lookupVoucher = lookupVoucher;
 exports.safelyDeleteVoucher = safelyDeleteVoucher;
 exports.totalAmountByCurrency = totalAmountByCurrency;
+
 /**
  * GET /vouchers
  *
@@ -65,13 +66,16 @@ function list(req, res, next) {
 function detail(req, res, next) {
   lookupVoucher(req.params.uuid)
     .then(voucher => res.status(200).json(voucher))
-    .catch(next)
-    .done();
+    .catch(next);
 }
 
-function lookupVoucher(vUuid) {
-  let voucher;
-
+/**
+ * @function lookupVoucher
+ *
+ * @description
+ * Gets a single voucher (and associated details) by its uuid.
+ */
+async function lookupVoucher(vUuid) {
   const sql = `
     SELECT BUID(v.uuid) as uuid, v.date, v.created_at, v.project_id, v.currency_id, v.amount,
       v.description, v.user_id, v.type_id,  u.display_name, transaction_type.text,
@@ -96,15 +100,14 @@ function lookupVoucher(vUuid) {
     ORDER BY vi.account_id DESC, vi.debit DESC, vi.credit ASC, entity_reference;
   `;
 
-  return db.one(sql, [db.bid(vUuid)])
-    .then((record) => {
-      voucher = record;
-      return db.exec(itemSql, [db.bid(vUuid)]);
-    })
-    .then((items) => {
-      voucher.items = items;
-      return voucher;
-    });
+  const [voucher, items] = await Promise.all([
+    db.one(sql, [db.bid(vUuid)]),
+    db.exec(itemSql, [db.bid(vUuid)]),
+  ]);
+
+  voucher.items = items;
+
+  return voucher;
 }
 
 // NOTE(@jniles) - this is used to find references for both vouchers and credit notes.
@@ -147,7 +150,6 @@ function find(options) {
   filters.equals('user_id');
   filters.equals('project_id');
   filters.equals('edited');
-  filters.equals('reversed');
   filters.equals('currency_id');
 
   filters.equals('reference', 'text', 'dm');
@@ -164,6 +166,28 @@ function find(options) {
 
   filters.custom('invoice_uuid', REFERENCE_SQL, [options.invoice_uuid, options.invoice_uuid]);
   filters.custom('cash_uuid', REFERENCE_SQL, [options.cash_uuid, options.cash_uuid]);
+
+  // reversed = 2 implies that we want to filter out both the inversed record and the inverted
+  // record.
+  if (options.reversed === '2') {
+    // get all the uuids of all records matching the current search criteria
+    const innerSQL = `
+      SELECT v.uuid, v.reference_uuid, v.type_id, v.reversed FROM voucher v JOIN document_map dm ON v.uuid = dm.uuid
+    `;
+
+    // apply the query to the innerQuery, ignoring the LIMIT statement
+    const innerQuery = filters.applyQuery(innerSQL, true);
+    const innerParams = filters.parameters();
+    const subquery = db.format(innerQuery, innerParams);
+
+    // for some reason, NOT IN excludes NULL values.  Thata is why this query is so complicated.
+    filters.custom('reversed', `v.reversed = 0 AND (
+      v.reference_uuid IS NULL OR
+      v.reference_uuid NOT IN (SELECT x.uuid FROM (${subquery}) AS x WHERE x.reversed = 1)
+    )`.trim());
+  } else {
+    filters.equals('reversed');
+  }
 
   // @TODO Support ordering query (reference support for limit)?
   filters.setOrder('ORDER BY v.date DESC, dm.text DESC');
@@ -215,7 +239,6 @@ function totalAmountByCurrency(options) {
   filters.custom('invoice_uuid', REFERENCE_SQL, [options.invoice_uuid, options.invoice_uuid]);
   filters.custom('cash_uuid', REFERENCE_SQL, [options.cash_uuid, options.cash_uuid]);
 
-  // @TODO Support ordering query (reference support for limit)?
   filters.setOrder('ORDER BY v.date DESC');
   filters.setGroup('GROUP BY c.id');
 

--- a/server/lib/db/index.js
+++ b/server/lib/db/index.js
@@ -237,6 +237,16 @@ class DatabaseConnector {
     return mysql.escape(key);
   }
 
+  /**
+   * @method format
+   *
+   * @description
+   * This is just an alias for mysql.format()
+   */
+  format(sql, params) {
+    return mysql.format(sql.trim(), params);
+  }
+
   delete(table, idKey, idValue, res, next, notFoundErrorMessage) {
     const sql = `DELETE FROM ${table} WHERE ${idKey} = ?;`;
     return this.exec(sql, [idValue])

--- a/server/lib/filter.js
+++ b/server/lib/filter.js
@@ -95,7 +95,6 @@ class FilterParser {
     }
   }
 
-
   /**
    * @method dateFrom
    *
@@ -204,10 +203,10 @@ class FilterParser {
     this._group = groupString;
   }
 
-  applyQuery(sql) {
+  applyQuery(sql, ignoreLimit = false) {
     // optionally call utility method to parse all remaining options as simple
     // equality filters into `_statements`
-    const limitCondition = this._parseLimit();
+    const limitCondition = ignoreLimit ? '' : this._parseLimit();
 
     if (this._autoParseStatements) {
       this._parseDefaultFilters();

--- a/test/integration/journal.js
+++ b/test/integration/journal.js
@@ -157,7 +157,7 @@ function CorrectionTests() {
     trans_id : 'TPA8',
     transaction_type_id : 5,
     description : 'Transaction reversed using Administrative Voucher Tools TPA8',
-    correctionDescription : 'VOUCHERS.TOOLS.CORRECT.DESCRIPTION',
+    correctionDescription : '(CORRECTION) Transaction reversed using Administrative Voucher Tools TPA8',
   };
 
   const correction = [{

--- a/test/integration/vouchers.js
+++ b/test/integration/vouchers.js
@@ -273,6 +273,10 @@ describe('(/vouchers) The vouchers HTTP endpoint', () => {
       })
       .then((res) => {
         helpers.api.listed(res, 11);
+        return agent.get('/vouchers').query({ reversed : '2' });
+      })
+      .then(res => {
+        helpers.api.listed(res, 9);
       })
       .catch(helpers.handler);
   });

--- a/test/integration/vouchers.js
+++ b/test/integration/vouchers.js
@@ -264,6 +264,18 @@ describe('(/vouchers) The vouchers HTTP endpoint', () => {
       .catch(helpers.handler);
   });
 
+  it('GET /vouchers filters on reversed vouchers', () => {
+    return agent.get('/vouchers')
+      .query({ reversed : 1 })
+      .then((res) => {
+        helpers.api.listed(res, 2);
+        return agent.get('/vouchers').query({ reversed : 0 });
+      })
+      .then((res) => {
+        helpers.api.listed(res, 11);
+      })
+      .catch(helpers.handler);
+  });
 
   it('DELETE /transactions/:uuid deletes a voucher', () => {
     return agent.delete(`/transactions/${TO_DELETE_UUID}`)


### PR DESCRIPTION
Implements #5278.

In this case, we provide three options as suggested by @mbayopanda.

1. Exclude all reversed records
2. Include only reversed records
3. Exclude all reversed records _and_ reversal records

This allows users to filter out both the records that are reversed on the credit/debit notes that are made against those records.

Closes #5278.

![image](https://user-images.githubusercontent.com/896472/105463091-d810f200-5c8f-11eb-9a7f-4174e6dcea0b.png)

