### PR TITLE
Fix: critical stock bugs

### DIFF
--- a/client/src/modules/stock/movements/modals/search.modal.js
+++ b/client/src/modules/stock/movements/modals/search.modal.js
@@ -37,7 +37,7 @@ function SearchMovementsModalController(data, Instance, Periods, Store, util, St
   };
 
   // map key to last display value for lookup in loggedChange
-  const lastDisplayValues = Stock.filter.inlineMovement.getDisplayValueMap();
+  const lastDisplayValues = Stock.filter.movements.getDisplayValueMap();
 
   // custom filter depot_uuid - assign the value to the params object
   vm.onSelectDepot = function onSelectDepot(depot) {

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -397,6 +397,7 @@ async function createMovement(req, res, next) {
   const metadata = {
     project : req.session.project,
     enterprise : req.session.enterprise,
+    stock_settings : req.session.stock_settings,
   };
 
   try {
@@ -469,7 +470,7 @@ async function normalMovement(document, params, metadata) {
   const currencyId = metadata.enterprise.currency_id;
   const postStockParameters = [db.bid(document.uuid), parameters.is_exit, projectId, currencyId];
 
-  if (metadata.enterprise.settings.enable_auto_stock_accounting) {
+  if (metadata.stock_settings.enable_auto_stock_accounting) {
     transaction.addQuery('CALL PostStockMovement(?, ?, ?, ?);', postStockParameters);
   }
 


### PR DESCRIPTION
Fixes two critical bugs related to stock movements.  Both are due to variable changes that were not properly made.

1. The stock movement registry search modal would not open due to a broken reference to `Stock.filter.inlineMovement` which should be `Stock.filter.movements`.
2. The second is that no automatic stock accounting was taking place (!) due to an old `req.session.enterprise.auto_stock_accounting` reference that needed to point to the newer `stock_settings`.


To test these:
   1. Try to search for a stock movement in the registry.  The search button is inoperable.
   2. Make a stock movement (exit to service, for example).  Observe that there is no corresponding exists written to the database in the voucher registry.  On this branch, there will be.

