### PR TITLE
Add description and dhis2_uid to depot table

### DIFF
--- a/client/src/i18n/en/depot.json
+++ b/client/src/i18n/en/depot.json
@@ -27,6 +27,7 @@
     "WAREHOUSE" : "Warehouse",
     "WAREHOUSE_INFO" : "This depot can distribute to other depots",
     "ALLOWED_DESTINATION_DEPOTS":"Allowed destination depots",
+    "DHIS2_UID": "DHIS2 UID",
     "MODAL" : {
       "SELECTION" : "Depot Selection",
       "TYPE_DEPOT_NAME" : "Type the depot's name",

--- a/client/src/i18n/fr/depot.json
+++ b/client/src/i18n/fr/depot.json
@@ -28,6 +28,7 @@
     "WAREHOUSE" : "Entrepôts",
     "WAREHOUSE_INFO" : "Ce dépôt est en mesure d'approvisionner d'autres dépôts",
     "ALLOWED_DESTINATION_DEPOTS":"Les dépôts de destination autorisés",
+    "DHIS2_UID": "DHIS2 UID",
     "MODAL" : {
       "SELECTION" : "Sélection du dépôt",
       "TYPE_DEPOT_NAME" : "Saisir le nom du depot",

--- a/client/src/modules/depots/modals/depot.modal.html
+++ b/client/src/modules/depots/modals/depot.modal.html
@@ -1,16 +1,16 @@
 <form name="DepotForm" bh-submit="DepotModalCtrl.submit(DepotForm)" novalidate>
   <div class="modal-header">
-  <ol class="headercrumb">
-    <li ng-if="DepotModalCtrl.isCreateState" class="title">
-      <span translate>DEPOT.ADD_DEPOT</span>
-      <label class="badge badge-warning" translate>FORM.LABELS.CREATE</label>
-    </li>
-    <li ng-if="!DepotModalCtrl.isCreateState" class="title">
-      <span translate>DEPOT.EDIT_DEPOT</span>
-      <label class="badge badge-warning" translate>FORM.LABELS.UPDATE</label>
-    </li>
-  </ol>
-</div>
+    <ol class="headercrumb">
+      <li ng-if="DepotModalCtrl.isCreateState" class="title">
+        <span translate>DEPOT.ADD_DEPOT</span>
+        <label class="badge badge-warning" translate>FORM.LABELS.CREATE</label>
+      </li>
+      <li ng-if="!DepotModalCtrl.isCreateState" class="title">
+        <span translate>DEPOT.EDIT_DEPOT</span>
+        <label class="badge badge-warning" translate>FORM.LABELS.UPDATE</label>
+      </li>
+    </ol>
+  </div>
 
   <div class="modal-body">
 
@@ -28,25 +28,29 @@
         <label translate>STOCK.ENTRY</label>
         <div class="checkbox">
           <label>
-            <input type="checkbox" name="allow_entry_purchase" ng-true-value="1" ng-false-value="0" ng-model="DepotModalCtrl.depot.allow_entry_purchase">
+            <input type="checkbox" name="allow_entry_purchase" ng-true-value="1" ng-false-value="0"
+              ng-model="DepotModalCtrl.depot.allow_entry_purchase">
             <span translate>STOCK.ENTRY_PURCHASE</span>
           </label>
         </div>
         <div class="checkbox">
           <label>
-            <input type="checkbox" name="allow_entry_donation" ng-true-value="1" ng-false-value="0" ng-model="DepotModalCtrl.depot.allow_entry_donation">
+            <input type="checkbox" name="allow_entry_donation" ng-true-value="1" ng-false-value="0"
+              ng-model="DepotModalCtrl.depot.allow_entry_donation">
             <span translate>STOCK.ENTRY_DONATION</span>
           </label>
         </div>
         <div class="checkbox">
           <label>
-            <input type="checkbox" name="allow_entry_integration" ng-true-value="1" ng-false-value="0" ng-model="DepotModalCtrl.depot.allow_entry_integration">
+            <input type="checkbox" name="allow_entry_integration" ng-true-value="1" ng-false-value="0"
+              ng-model="DepotModalCtrl.depot.allow_entry_integration">
             <span translate>STOCK.ENTRY_INTEGRATION</span>
           </label>
         </div>
         <div class="checkbox">
           <label>
-            <input type="checkbox" name="allow_entry_transfer" ng-true-value="1" ng-false-value="0" ng-model="DepotModalCtrl.depot.allow_entry_transfer">
+            <input type="checkbox" name="allow_entry_transfer" ng-true-value="1" ng-false-value="0"
+              ng-model="DepotModalCtrl.depot.allow_entry_transfer">
             <span translate>STOCK.ENTRY_TRANSFER</span>
           </label>
         </div>
@@ -57,25 +61,29 @@
         <label translate>STOCK.EXIT</label>
         <div class="checkbox">
           <label>
-            <input type="checkbox" name="allow_exit_debtor" ng-true-value="1" ng-false-value="0" ng-model="DepotModalCtrl.depot.allow_exit_debtor">
+            <input type="checkbox" name="allow_exit_debtor" ng-true-value="1" ng-false-value="0"
+              ng-model="DepotModalCtrl.depot.allow_exit_debtor">
             <span translate>STOCK.EXIT_INDIVIDUAL</span>
           </label>
         </div>
         <div class="checkbox">
           <label>
-            <input type="checkbox" name="allow_exit_service" ng-true-value="1" ng-false-value="0" ng-model="DepotModalCtrl.depot.allow_exit_service">
+            <input type="checkbox" name="allow_exit_service" ng-true-value="1" ng-false-value="0"
+              ng-model="DepotModalCtrl.depot.allow_exit_service">
             <span translate>STOCK.EXIT_SERVICE</span>
           </label>
         </div>
         <div class="checkbox">
           <label>
-            <input type="checkbox" name="allow_exit_transfer" ng-true-value="1" ng-false-value="0" ng-model="DepotModalCtrl.depot.allow_exit_transfer">
+            <input type="checkbox" name="allow_exit_transfer" ng-true-value="1" ng-false-value="0"
+              ng-model="DepotModalCtrl.depot.allow_exit_transfer">
             <span translate>STOCK.EXIT_DEPOT</span>
           </label>
         </div>
         <div class="checkbox">
           <label>
-            <input type="checkbox" name="allow_exit_loss" ng-true-value="1" ng-false-value="0" ng-model="DepotModalCtrl.depot.allow_exit_loss">
+            <input type="checkbox" name="allow_exit_loss" ng-true-value="1" ng-false-value="0"
+              ng-model="DepotModalCtrl.depot.allow_exit_loss">
             <span translate>STOCK.EXIT_LOSS</span>
           </label>
         </div>
@@ -88,11 +96,7 @@
       <label translate>DEPOT.WAREHOUSE_INFO</label>
       <div class="checkbox">
         <label>
-          <input
-            type="checkbox"
-            name="is_warehouse"
-            ng-true-value="1"
-            ng-false-value="0"
+          <input type="checkbox" name="is_warehouse" ng-true-value="1" ng-false-value="0"
             ng-model="DepotModalCtrl.depot.is_warehouse">
           <span translate>DEPOT.WAREHOUSE</span>
         </label>
@@ -102,39 +106,32 @@
     <div class="form-group">
       <div class="checkbox">
         <label>
-          <input
-            type="checkbox"
-            name="has_location"
-            ng-true-value="1"
-            ng-false-value="0"
+          <input type="checkbox" name="has_location" ng-true-value="1" ng-false-value="0"
             ng-model="DepotModalCtrl.hasLocation">
           <span translate>DEPOT.JOIN_LOCATION</span>
         </label>
       </div>
 
       <div ng-if="DepotModalCtrl.hasLocation">
-        <bh-location-select
-          location-uuid="DepotModalCtrl.depot.location_uuid">
+        <bh-location-select location-uuid="DepotModalCtrl.depot.location_uuid">
         </bh-location-select>
       </div>
     </div>
 
-    <bh-depot-select
-      label="DEPOT.PARENT_DEPOT"
-      depot-uuid="DepotModalCtrl.depot.parent_uuid"
-      on-select-callback="DepotModalCtrl.onSelectDepot(depot)"
-      exception="DepotModalCtrl.depot.uuid">
+    <bh-depot-select label="DEPOT.PARENT_DEPOT" depot-uuid="DepotModalCtrl.depot.parent_uuid"
+      on-select-callback="DepotModalCtrl.onSelectDepot(depot)" exception="DepotModalCtrl.depot.uuid">
       <bh-clear on-clear="DepotModalCtrl.clear('parent_uuid')"></bh-clear>
     </bh-depot-select>
 
-    <div class="form-group" ng-class="{ 'has-error' : DepotForm.$submitted && DepotForm.min_months_security_stock.$invalid }">
+    <div class="form-group"
+      ng-class="{ 'has-error' : DepotForm.$submitted && DepotForm.min_months_security_stock.$invalid }">
       <label class="control-label" translate>
         FORM.LABELS.MIN_MONTHS_SECURITY_STOCK
       </label>
-      <input name="min_months_security_stock" class="form-control" ng-model="DepotModalCtrl.depot.min_months_security_stock"
-        type="number" min="1" autocomplete="off" required bh-integer>
-      <div class="help-block" ng-show="DepotForm.$submitted"
-           ng-messages="DepotForm.min_months_security_stock.$error">
+      <input name="min_months_security_stock" class="form-control"
+        ng-model="DepotModalCtrl.depot.min_months_security_stock" type="number" min="1" autocomplete="off" required
+        bh-integer>
+      <div class="help-block" ng-show="DepotForm.$submitted" ng-messages="DepotForm.min_months_security_stock.$error">
         <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
       </div>
     </div>
@@ -142,14 +139,30 @@
     <div ng-if="DepotModalCtrl.enable_strict_depot_distribution">
       <label class="control-label" translate>DEPOT.ALLOWED_DESTINATION_DEPOTS</label>
       <p ng-if="!DepotModalCtrl.depot.allowed_distribution_depots.length"><i translate>DEPOT.NO_DEPOT</i></p>
-      <bh-depot-search-select
-        label="STOCK.DEPOT"
-        id="distribution_depots"
-        depots-uuids = "DepotModalCtrl.depot.allowed_distribution_depots"
-        on-change="DepotModalCtrl.onDistributionDepotChange(depots)"
-        form-name="DepotForm">
+      <bh-depot-search-select label="STOCK.DEPOT" id="distribution_depots"
+        depots-uuids="DepotModalCtrl.depot.allowed_distribution_depots"
+        on-change="DepotModalCtrl.onDistributionDepotChange(depots)" form-name="DepotForm">
       </bh-depot-search-select>
     </div>
+
+    <div class="form-group" ng-class="{'has-error' : DepotForm.description.$invalid && DepotForm.$submitted}">
+      <label class="control-label" translate>FORM.LABELS.DESCRIPTION</label>
+      <textarea
+        class="form-control"
+        name="description"
+        ng-model="DepotModalCtrl.depot.description"
+        rows="4">
+      </textarea>
+      <div class="help-block" ng-messages="DepotForm.description.$error" ng-show="DepotForm.$submitted">
+        <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+      </div>
+    </div>
+
+    <bh-input-text
+      label="DEPOT.DHIS2_UID"
+      key="dhis2_uid"
+      text-value="DepotModalCtrl.depot.dhis2_uid">
+    </bh-input-text>
 
   </div>
 

--- a/server/controllers/inventory/depots/index.js
+++ b/server/controllers/inventory/depots/index.js
@@ -168,10 +168,11 @@ async function update(req, res, next) {
     await tx.execute();
 
     const sql = `
-      SELECT BUID(uuid) as uuid, text, enterprise_id, is_warehouse,
+      SELECT BUID(uuid) as uuid, text, description, enterprise_id, is_warehouse,
         allow_entry_purchase, allow_entry_donation, allow_entry_integration, allow_entry_transfer,
         allow_exit_debtor, allow_exit_service, allow_exit_transfer, allow_exit_loss,
-        min_months_security_stock, IF(parent_uuid IS NULL, 0, BUID(parent_uuid)) as parent_uuid
+        min_months_security_stock, IF(parent_uuid IS NULL, 0, BUID(parent_uuid)) as parent_uuid,
+        dhis2_uid
       FROM depot WHERE uuid = ?`;
     const rows = await db.exec(sql, [uid]);
 
@@ -211,12 +212,12 @@ function list(req, res, next) {
 
   const sql = `
     SELECT
-      BUID(d.uuid) as uuid, d.text, d.is_warehouse,
+      BUID(d.uuid) as uuid, d.text, d.description, d.is_warehouse,
       GROUP_CONCAT(DISTINCT u.display_name ORDER BY u.display_name DESC SEPARATOR ', ') AS users,
       d.allow_entry_purchase, d.allow_entry_donation, d.allow_entry_integration,
       d.allow_entry_transfer, d.allow_exit_debtor, d.allow_exit_service,
       d.allow_exit_transfer, d.allow_exit_loss, BUID(d.location_uuid) AS location_uuid,
-      d.min_months_security_stock, IFNULL(BUID(d.parent_uuid), 0) as parent_uuid,
+      d.min_months_security_stock, IFNULL(BUID(d.parent_uuid), 0) as parent_uuid, d.dhis2_uid,
       v.name as village_name, s.name as sector_name, p.name as province_name, c.name as country_name
     FROM depot d
       LEFT JOIN village v ON v.uuid = d.location_uuid
@@ -290,11 +291,11 @@ function searchByName(req, res, next) {
 
   const sql = `
     SELECT
-      BUID(d.uuid) as uuid, d.text, d.is_warehouse,
+      BUID(d.uuid) as uuid, d.text, d.description, d.is_warehouse,
       d.allow_entry_purchase, d.allow_entry_donation, d.allow_entry_integration,
       d.allow_entry_transfer, d.allow_exit_debtor, d.allow_exit_service,
       d.allow_exit_transfer, d.allow_exit_loss, BUID(d.location_uuid) AS location_uuid,
-      IF(parent_uuid, BUID(parent_uuid), 0) as parent_uuid,
+      IF(parent_uuid, BUID(parent_uuid), 0) as parent_uuid, d.dhis2_uid,
       v.name as village_name, s.name as sector_name, p.name as province_name, c.name as country_name
     FROM depot d
       LEFT JOIN village v ON v.uuid = d.location_uuid
@@ -336,10 +337,10 @@ async function detail(req, res, next) {
 
   const sql = `
     SELECT
-      BUID(d.uuid) as uuid, d.text, d.is_warehouse,
+      BUID(d.uuid) as uuid, d.text, d.description, d.is_warehouse,
       allow_entry_purchase, allow_entry_donation, allow_entry_integration, allow_entry_transfer,
       allow_exit_debtor, allow_exit_service, allow_exit_transfer, allow_exit_loss,
-      BUID(parent_uuid) parent_uuid,
+      BUID(parent_uuid) parent_uuid, dhis2_uid,
       min_months_security_stock
     FROM depot AS d
     WHERE d.enterprise_id = ? AND d.uuid = ? `;

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -1,9 +1,10 @@
 
 -- 2021-01-04
--- author: @jniles
+-- author: @jniles  (updated by jmcameron 2021-01-12)
 ALTER TABLE `user` MODIFY COLUMN `last_login` TIMESTAMP NULL;
-ALTER TABLE `user` ADD COLUMN `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
-ALTER TABLE `user` ADD COLUMN `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CALL add_column_if_missing('user', 'created_at', ' TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `last_login`');
+CALL add_column_if_missing('user', 'updated_at', ' TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `created_at`');
 
 -- reset all last_login information
 UPDATE `user` SET `last_login` = NULL;
@@ -69,3 +70,11 @@ BEGIN
 
   -- NOTE: this does not handle any rounding - it simply converts the currency as needed.
 END $$
+
+/*
+ * @author: jmcameron
+ * @date: 2021-01-12
+ * @subject : Add description and dhis2_uid fields to the depot table
+ */
+CALL add_column_if_missing('depot', 'description', 'TEXT DEFAULT NULL AFTER `text`');
+CALL add_column_if_missing('depot', 'dhis2_uid', 'VARCHAR(150) DEFAULT NULL AFTER `parent_uuid`');

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -449,6 +449,7 @@ DROP TABLE IF EXISTS `depot`;
 CREATE TABLE `depot` (
   `uuid` BINARY(16) NOT NULL,
   `text` VARCHAR(191) NOT NULL,
+  `description` TEXT DEFAULT NULL,
   `enterprise_id` SMALLINT(5) UNSIGNED NOT NULL,
   `is_warehouse` SMALLINT(5) UNSIGNED NOT NULL DEFAULT 0,
   `allow_entry_purchase` TINYINT(1) UNSIGNED NOT NULL DEFAULT 0,
@@ -462,6 +463,7 @@ CREATE TABLE `depot` (
   `location_uuid` BINARY(16) NULL,
   `min_months_security_stock` SMALLINT(5) NOT NULL DEFAULT 2,
   `parent_uuid` BINARY(16) NULL,
+  `dhis2_uid` VARCHAR(150) DEFAULT NULL,
   PRIMARY KEY (`uuid`),
   UNIQUE KEY `depot_1` (`text`),
   INDEX `parent_uuid` (`parent_uuid`)

--- a/test/data.sql
+++ b/test/data.sql
@@ -2978,9 +2978,9 @@ SET @second_depot_uuid = HUID('d4bb1452-e4fa-4742-a281-814140246877');
 SET @third_deposit_uuid = HUID('bd4b1452-4742-e4fa-a128-246814140877');
 
 INSERT INTO `depot` VALUES
-  (@depot_uuid, 'Depot Principal', 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 2, NULL),
-  (@second_depot_uuid, 'Depot Secondaire', 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3, NULL),
-  (@third_deposit_uuid, 'Depot Tertiaire', 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3, NULL);
+  (@depot_uuid, 'Depot Principal', NULL, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 2, NULL, NULL),
+  (@second_depot_uuid, 'Depot Secondaire', NULL, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3, NULL, NULL),
+  (@third_deposit_uuid, 'Depot Tertiaire', NULL, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3, NULL, NULL);
 
 
 -- Set Depot Management By User

--- a/test/data/service-stock.sql
+++ b/test/data/service-stock.sql
@@ -25,9 +25,9 @@ SET @third_depot_uuid = HUID('bd4b1452-4742-e4fa-a128-246814140877');
 --
 
 INSERT INTO `depot` VALUES
-  (@depot_uuid, 'Depot Principal', 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 2, NULL),
-  (@second_depot_uuid, 'Depot Secondaire', 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3, NULL),
-  (@third_depot_uuid, 'Depot Tertiaire', 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3, NULL);
+  (@depot_uuid, 'Depot Principal', NULL, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 2, NULL, NULL),
+  (@second_depot_uuid, 'Depot Secondaire', NULL, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3, NULL, NULL),
+  (@third_depot_uuid, 'Depot Tertiaire', NULL, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3, NULL, NULL);
 
 --
 -- Set Depot Management By User

--- a/test/data/stock.sql
+++ b/test/data/stock.sql
@@ -24,9 +24,9 @@ SET @third_deposit_uuid = HUID('bd4b1452-4742-e4fa-a128-246814140877');
 --
 
 INSERT INTO `depot` VALUES
-  (@depot_uuid, 'Depot Principal', 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 2, NULL),
-  (@second_depot_uuid, 'Depot Secondaire', 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3, NULL),
-  (@third_deposit_uuid, 'Depot Tertiaire', 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3, NULL);
+  (@depot_uuid, 'Depot Principal', NULL, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 2, NULL, NULL),
+  (@second_depot_uuid, 'Depot Secondaire', NULL, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3, NULL, NULL),
+  (@third_deposit_uuid, 'Depot Tertiaire', NULL, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, NULL, 3, NULL, NULL);
 
 --
 -- Set Depot Management By User


### PR DESCRIPTION
Add support for `description` and `dhis2_uid` fields to the `depot` table and adds the ability to add/modify those fields when creating or editing depots.  Also update the migration file to add these new fields to production servers.

NOTE:   While editing the next/migration.sql file, I updated a previous entry to use the add_column_if_missing() function so that the migration file can be applied multiple times.

Testing:  Try adding/editing the Description and DHIS2 UID fields when creating or editing Depots.