### PR TITLE
test: add missing unit tests for bhSubmit directive

### DIFF
--- a/client/src/js/directives/bhSubmit.js
+++ b/client/src/js/directives/bhSubmit.js
@@ -42,9 +42,9 @@ function bhSubmitDirective() {
         // the response is a promise, toggle the loading state on
         // fulfillment/rejection
         if (isPromise(response)) {
-          response.finally(function () {
-            FormController.$toggleLoading();
-          });
+          response
+            .then(() => FormController.$toggleLoading())
+            .catch(() => FormController.$toggleLoading());
 
         // otherwise, toggle the loading state off right away.
         } else {

--- a/test/client-unit/directives/bhSubmit.spec.js
+++ b/test/client-unit/directives/bhSubmit.spec.js
@@ -1,0 +1,89 @@
+/* global inject, expect, chai */
+describe('(directive) bhSubmit', () => {
+  let $scope;
+  let element;
+  let deferred;
+
+  beforeEach(module('bhima.directives'));
+  beforeEach(inject(($q, $rootScope) => {
+    $scope = $rootScope;
+    deferred = $q.defer();
+
+    $scope.models = {
+      formValue : null,
+      submit : chai.spy(() => deferred.promise),
+    };
+  }));
+
+  describe('when the directive is added to a form', () => {
+    beforeEach(inject(($compile) => {
+      element = angular.element(`
+        <form name="form" bh-submit="models.submit(form)" novalidate>
+          <input ng-model="models.formValue" name="formValue">
+        </form>
+      `);
+
+      $compile(element)($scope);
+      $scope.$digest();
+    }));
+
+    it('sets $loading to false on the FormControl', () => {
+      expect($scope.form.$loading).to.equal(false);
+    });
+
+    describe('when the form is submitted', () => {
+      beforeEach(() => {
+        angular.element(element).trigger('submit');
+      });
+
+      it('sets $loading to true on the FormControl', () => {
+        expect($scope.form.$loading).to.equal(true);
+      });
+
+      it('calls the submit callback function', () => {
+        expect($scope.models.submit).to.have.been.called.with($scope.form);
+      });
+
+      describe('when the submit callback is resolved', () => {
+        beforeEach(() => {
+          deferred.resolve();
+          $scope.$digest();
+        });
+
+        it('sets $loading to false on the FormControl', () => {
+          expect($scope.form.$loading).to.equal(false);
+        });
+      });
+
+      describe('when the submit callback is rejected', () => {
+        beforeEach(() => {
+          deferred.reject(new Error('callback rejected'));
+          $scope.$digest();
+        });
+
+        it('sets $loading to false on the FormControl', () => {
+          expect($scope.form.$loading).to.equal(false);
+        });
+      });
+    });
+  });
+
+  describe('when the directive is not added to a form', () => {
+    it('the compilation fails', inject(($compile) => {
+      element = angular.element(`
+        <form name="form">
+          <div bh-submit="models.submit(form)">
+            <input ng-model="models.formValue" name="formValue">
+          </div>
+        </form>
+      `);
+
+      try {
+        $compile(element)($scope);
+      } catch (error) {
+        expect(error.message).to.have.string('Controller \'form\', '
+            + 'required by directive \'bhSubmit\', can\'t be found');
+      }
+    }));
+  });
+});


### PR DESCRIPTION
Add missing unit tests for bhSubmit directive and changes the bhSubmit directive to better handle when the callback promise has a rejection.