### PR TITLE
feat(stock): default filter on depot for movements

### DIFF
--- a/client/src/modules/stock/inventories/templates/inventory.action.html
+++ b/client/src/modules/stock/inventories/templates/inventory.action.html
@@ -10,7 +10,8 @@
       <a data-method="stock-movement" ui-sref="stockMovements({
         filters : [
           { key : 'period', value : 'allTime' },
-          { key : 'inventory_uuid', value : row.entity.inventory_uuid, displayValue : row.entity.text }
+          { key : 'inventory_uuid', value : row.entity.inventory_uuid, displayValue : row.entity.text },
+          { key : 'depot_uuid', value : row.entity.depot_uuid, displayValue : row.entity.depot_text},
         ]})" href>
         <span class="fa fa-file-text-o"></span> <span translate>TREE.STOCK_MOVEMENTS</span>
       </a>


### PR DESCRIPTION
Adds a default filter on the link from the Articles in Stock registry to the stock movements registry to filter by the depot.

Closes #5327.