### PR TITLE
Fix: two MySQL & Test bugs

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -70,6 +70,7 @@ blocks:
             - env_var: MYSQL_VERSION
               values:
                 - '5.7'
+                - '8'
             - env_var: NODEJS_VERSION
               values:
                 - '12'

--- a/server/models/procedures/trial_balance.sql
+++ b/server/models/procedures/trial_balance.sql
@@ -319,22 +319,23 @@ BEGIN
   DELETE FROM posting_journal WHERE record_uuid IN (SELECT record_uuid FROM stage_trial_balance_transaction);
 
   -- Let specify that this invoice or the cash payment is posted
-  SELECT COUNT(uuid) INTO isInvoice  FROM invoice  WHERE invoice.uuid IN (SELECT record_uuid FROM stage_trial_balance_transaction);
-  SELECT COUNT(uuid) INTO isCash  FROM cash  WHERE cash.uuid IN (SELECT record_uuid FROM stage_trial_balance_transaction);
-  SELECT COUNT(uuid) INTO isVoucher  FROM voucher  WHERE voucher.uuid IN (SELECT record_uuid FROM stage_trial_balance_transaction);
+  SELECT COUNT(uuid) INTO isInvoice FROM invoice WHERE invoice.uuid IN (SELECT record_uuid FROM stage_trial_balance_transaction);
+  SELECT COUNT(uuid) INTO isCash FROM cash WHERE cash.uuid IN (SELECT record_uuid FROM stage_trial_balance_transaction);
+  SELECT COUNT(uuid) INTO isVoucher FROM voucher WHERE voucher.uuid IN (SELECT record_uuid FROM stage_trial_balance_transaction);
 
   IF isInvoice > 0 THEN
-    UPDATE invoice SET posted = 1 WHERE uuid IN (SELECT record_uuid FROM stage_trial_balance_transaction);
+    UPDATE invoice SET posted = 1 WHERE EXISTS (SELECT 1 FROM stage_trial_balance_transaction t WHERE t.record_uuid = invoice.uuid);
   END IF;
 
   IF isCash > 0 THEN
-    UPDATE cash SET posted = 1 WHERE uuid IN (SELECT record_uuid FROM stage_trial_balance_transaction);
+    UPDATE cash SET posted = 1 WHERE EXISTS (SELECT 1 FROM stage_trial_balance_transaction t WHERE t.record_uuid = cash.uuid);
   END IF;
 
   IF isVoucher > 0 THEN
-    UPDATE voucher SET posted = 1 WHERE uuid IN (SELECT record_uuid FROM stage_trial_balance_transaction);
+    UPDATE voucher SET posted = 1 WHERE EXISTS (SELECT 1 FROM stage_trial_balance_transaction t WHERE t.record_uuid = voucher.uuid);
   END IF;
 
+  /* DROP TEMPORARY TABLE stage_trial_balance_transaction; */
 END $$
 
 DELIMITER ;

--- a/test/end-to-end/f_employees_config/employees_config.page.js
+++ b/test/end-to-end/f_employees_config/employees_config.page.js
@@ -57,8 +57,12 @@ class EmployeeConfigPage {
     await row.dropdown().click();
     await row.method('config').click();
 
-    // First click for select all
-    await components.bhCheckboxTree.toggleAllCheckboxes();
+    const isAllChecked = await components.bhCheckboxTree.isChecked();
+
+    if (!isAllChecked) {
+      // First click for select all
+      await components.bhCheckboxTree.toggleAllCheckboxes();
+    }
 
     // Second click for unselect all
     await components.bhCheckboxTree.toggleAllCheckboxes();

--- a/test/end-to-end/fiscalYears/fiscalYears.spec.js
+++ b/test/end-to-end/fiscalYears/fiscalYears.spec.js
@@ -13,7 +13,7 @@ describe('Fiscal Year', () => {
   const fiscalYear = {
     label    : 'A Special Fiscal Year',
     note     : 'Note for the new fiscal Year',
-    previous : '2019',
+    previous : '2020',
   };
 
   it('blocks invalid form submission with relevant error classes', async () => {
@@ -39,7 +39,7 @@ describe('Fiscal Year', () => {
     await FU.input('FiscalManageCtrl.fiscal.label', fiscalYear.label);
 
     // select the proper date
-    await components.dateInterval.range('01/01/2021', '31/12/2021');
+    await components.dateInterval.range('01/01/2022', '31/12/2022');
     await FU.select('FiscalManageCtrl.fiscal.previous_fiscal_year_id', fiscalYear.previous);
     await FU.input('FiscalManageCtrl.fiscal.note', fiscalYear.note);
     await FU.buttons.submit();

--- a/test/end-to-end/shared/components/bhCheckboxTree.js
+++ b/test/end-to-end/shared/components/bhCheckboxTree.js
@@ -15,4 +15,11 @@ module.exports = {
     const tree = element(locator);
     return tree.$('[data-root-node]').click();
   },
+
+  isChecked(id) {
+    const locator = (id) ? by.id(id) : by.css(this.selector);
+    const tree = element(locator);
+    return tree.$('[data-root-node] input').isSelected();
+  },
+
 };


### PR DESCRIPTION
This PR fixes two bugs in our MySQL stored procedures and tests.

First, it fixes an end-to-end test bug in the employee config where the bhCheckboxTree state was not being taken into account in the test.  Now, we check if it is all checked before clicking.

Second, it changes the PostToGeneralLedger() trial balance method to be more mysql-8 compatible.  I'm still not 100% sure that this works _every_ time, but I cannot reproduce the issue with these queries re-written.  I believe that MySQL is being fancy and doing some subquery optimizations, which is why we had flakey tests on MySQL8.

To be sure, I'm turning Semaphore's MySQL 8 test suite back on.