### PR TITLE
Fix: end to end test bugs

### DIFF
--- a/docs/en/for-developers/installing-bhima.md
+++ b/docs/en/for-developers/installing-bhima.md
@@ -63,7 +63,7 @@ sudo apt-get install ca-certificates fonts-liberation gconf-service \
   libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 \
   libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
   libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 \
-  libxss1 libxtst6 lsb-release wget -y
+  libxss1 libxtst6 lsb-release libxshmfence1 wget -y
 ```
 
 For more information on other operating systems, [see the puppeteer troubleshooting documentation](https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix).

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@ima-worldhealth/coral": "^2.5.1",
     "@ima-worldhealth/tree": "^2.3.0",
-    "@types/angular": "^1.8.0",
+    "@types/angular": "^1.8.1",
     "@uirouter/angularjs": "^1.0.29",
     "accounting-js": "^1.1.1",
     "angular": "^1.8.2",

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -80,7 +80,10 @@ if (process.env.CI) {
 
 // Add custom Chrome options for local environments
 if (!process.env.CI && process.env.CHROME_OPTIONS) {
-  config.capabilities.chromeOptions.args.push(process.env.CHROME_OPTIONS);
+
+  // normalize options so that multiple options can be used.
+  const opts = process.env.CHROME_OPTIONS.split(' ');
+  config.capabilities.chromeOptions.args.push(...opts);
 }
 
 // expose to the outside world

--- a/server/controllers/medical/reports/patient.fiche.handlebars
+++ b/server/controllers/medical/reports/patient.fiche.handlebars
@@ -24,6 +24,11 @@
           <dt>{{translate "FORM.LABELS.GENDER"}}</dt>
           <dd>{{translate patient.sexFormatted}} ({{ patient.sex }})</dd>
 
+          {{#if patient.mother_name}}
+            <dt>{{translate "FORM.LABELS.MOTHER_NAME"}}</dt>
+            <dd>{{ patient.mother_name }}</dd>
+          {{/if}}
+
           <dt>{{translate "FORM.LABELS.DEBTOR_GROUP"}}<dt>
           <dd>{{patient.debtor_group_name }}</dd>
 

--- a/server/controllers/medical/reports/patient.pos.handlebars
+++ b/server/controllers/medical/reports/patient.pos.handlebars
@@ -24,6 +24,9 @@
 <p><u>{{translate "FORM.LABELS.DOB"}}</u>: {{date patient.dob }}</p>
 <p><u>{{translate "FORM.LABELS.HOSPITAL_FILE_NR"}}</u>: {{ patient.hospital_no }}</p>
 <p><u>{{translate "FORM.LABELS.GENDER"}}</u>: {{ patient.sex }}</p>
+{{#if patient.mother_name}}
+  <p><u>{{translate "FORM.LABELS.MOTHER_NAME"}}</u> {{patient.mother_name}}</p>
+{{/if}}
 <p><u>{{translate "TABLE.COLUMNS.REGISTERED_ON"}}</u>: {{date patient.registration_date }}</p>
 <p><u>{{translate "FORM.LABELS.DEBTOR_GROUP"}}</u>: {{ patient.debtor_group_name }}</p>
 {{#if patient.health_zone}}

--- a/server/controllers/medical/reports/patient.receipt.handlebars
+++ b/server/controllers/medical/reports/patient.receipt.handlebars
@@ -23,6 +23,11 @@
 
       <span><u>{{translate "FORM.LABELS.DOB"}}</u> {{date patient.dob }}</span> <br />
       <span><u>{{translate "FORM.LABELS.SEX"}}</u> {{translate patient.sexFormatted }}</span> <br />
+
+      {{#if patient.mother_name}}
+        <span><u>{{translate "FORM.LABELS.MOTHER_NAME"}}</u> {{patient.mother_name}}</span><br />
+      {{/if}}
+
       {{#if patient.email}}
         <span><u>{{translate "FORM.LABELS.EMAIL"}}</u> {{patient.email}}</span><br />
       {{/if}}

--- a/test/end-to-end/f_employees_config/employees_config.page.js
+++ b/test/end-to-end/f_employees_config/employees_config.page.js
@@ -57,8 +57,12 @@ class EmployeeConfigPage {
     await row.dropdown().click();
     await row.method('config').click();
 
-    // First click for select all
-    await components.bhCheckboxTree.toggleAllCheckboxes();
+    const isAllChecked = await components.bhCheckboxTree.isChecked();
+
+    if (!isAllChecked) {
+      // First click for select all
+      await components.bhCheckboxTree.toggleAllCheckboxes();
+    }
 
     // Second click for unselect all
     await components.bhCheckboxTree.toggleAllCheckboxes();

--- a/test/end-to-end/fiscalYears/fiscalYears.spec.js
+++ b/test/end-to-end/fiscalYears/fiscalYears.spec.js
@@ -13,7 +13,7 @@ describe('Fiscal Year', () => {
   const fiscalYear = {
     label    : 'A Special Fiscal Year',
     note     : 'Note for the new fiscal Year',
-    previous : '2019',
+    previous : '2020',
   };
 
   it('blocks invalid form submission with relevant error classes', async () => {
@@ -39,7 +39,7 @@ describe('Fiscal Year', () => {
     await FU.input('FiscalManageCtrl.fiscal.label', fiscalYear.label);
 
     // select the proper date
-    await components.dateInterval.range('01/01/2021', '31/12/2021');
+    await components.dateInterval.range('01/01/2022', '31/12/2022');
     await FU.select('FiscalManageCtrl.fiscal.previous_fiscal_year_id', fiscalYear.previous);
     await FU.input('FiscalManageCtrl.fiscal.note', fiscalYear.note);
     await FU.buttons.submit();

--- a/test/end-to-end/rubricsConfig/rubrics_config.spec.js
+++ b/test/end-to-end/rubricsConfig/rubrics_config.spec.js
@@ -39,7 +39,7 @@ describe('Rubrics Configuration Management', () => {
     await page.remove(updateRubricConfig.label);
   });
 
-  it('should have 1 rubric to end with', async () => {
+  it('should have 2 rubrics to end with', async () => {
     expect(await page.count()).to.equal(2);
   });
 });

--- a/test/end-to-end/shared/components/bhCheckboxTree.js
+++ b/test/end-to-end/shared/components/bhCheckboxTree.js
@@ -15,4 +15,11 @@ module.exports = {
     const tree = element(locator);
     return tree.$('[data-root-node]').click();
   },
+
+  isChecked(id) {
+    const locator = (id) ? by.id(id) : by.css(this.selector);
+    const tree = element(locator);
+    return tree.$('[data-root-node] input').isSelected();
+  },
+
 };

--- a/test/end-to-end/stock/stock.inventories.js
+++ b/test/end-to-end/stock/stock.inventories.js
@@ -28,10 +28,10 @@ function StockInventoriesRegistryTests() {
     await GU.expectRowCount(gridId, 2 + depotGroupingRow);
   });
 
-  it('find 3 inventory in Depot Principal plus one line for the Grouping', async () => {
+  it('find 5 inventory in Depot Principal plus one line for the Grouping', async () => {
     await modal.setDepot('Depot Principal');
     await modal.submit();
-    await GU.expectRowCount(gridId, 3 + depotGroupingRow);
+    await GU.expectRowCount(gridId, 5 + depotGroupingRow);
     await filters.resetFilters();
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,10 +266,10 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@types/angular@^1.6.25", "@types/angular@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@types/angular/-/angular-1.8.0.tgz#6bce6f21d69f9dfa45e3e3dd76f723496b12c32c"
-  integrity sha512-tF4Ulq9GC54wKboxfvt91tkfJNGcFWEfkuptX5HCNVt4emwJQqWloCpUzepyKLjpKSIEOZaxupb/GX2ESwz3wQ==
+"@types/angular@^1.6.25", "@types/angular@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@types/angular/-/angular-1.8.1.tgz#940b16476adff7b66608aae778e5e9f1c57ab847"
+  integrity sha512-8zEjTC3gpkva6/dbUkiSxIUGUxYm9HD/pJJ0lbqfEM2TWqi/3vs4VtgoFxVXt5bmuJ+6G2caO2HaMD+NzB1VwA==
 
 "@types/cacheable-request@^6.0.1":
   version "6.0.1"


### PR DESCRIPTION
This PR fixes two end to end test bugs:

 1. The end to end tests have been updated for 2021.
 2. The employee config test correctly checks if the `bhCheckboxTree` component is active before blindly clicking on it.

It also includes one cosmetic change to `CHROME_OPTIONS` allowing devs to pass in multiple options by separating them with spaces as so:
```sh
CHROME_OPTIONS="--headless --disable-extensions"
```

Previous PR #5344 