### PR TITLE
Fixed bhStockFilterExhausted to support help text

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -75,7 +75,6 @@
     "GROUPING"        : "Grouping",
     "JOIN_INVOICE"    : "Join an invoice",
     "INCLUDE_EMPTY_LOTS" : "Include empty lots",
-    "INCLUDE_EMPTY_LOTS_HELP" : "Shows inventory lots with quantity equal to zero",
     "INCLUDE_ARTICLES_NOT_IN_STOCK" : "Include articles not in stock",
     "INCLUDE_ARTICLES_NOT_IN_STOCK_HELP" : "Shows inventory articles not in stock (with quantity equal to zero)",
     "INCLUDE_EMPTY_OR_NEGATIVE_LOTS" : "Include exhausted or negative lots",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -76,7 +76,6 @@
     "GROUPING"        : "Groupage",
     "JOIN_INVOICE"    : "Joindre une facture",
     "INCLUDE_EMPTY_LOTS" : "Inclure les lots épuisés",
-    "INCLUDE_EMPTY_LOTS_HELP" : "Afficher les lots dont la quantité est zero",
     "INCLUDE_ARTICLES_NOT_IN_STOCK" : "Inclure les articles non en stock",
     "INCLUDE_ARTICLES_NOT_IN_STOCK_HELP" : "Afficher les articles non en stock (dont la quantité est zero)",
     "INCLUDE_EMPTY_OR_NEGATIVE_LOTS" : "Inclure les lots épuisés ou négatives",

--- a/client/src/modules/templates/bhStockFilterExhausted.tmpl.html
+++ b/client/src/modules/templates/bhStockFilterExhausted.tmpl.html
@@ -46,7 +46,7 @@
     </div>
 
     <span class="help-block" ng-show="$ctrl.helpText" translate>
-      STOCK.INCLUDE_EMPTY_LOTS_HELP
+      {{$ctrl.helpText}}
     </span>
   </div>
 </div>


### PR DESCRIPTION
Fix bhStockFilterExhausted to enable callers to specify help text to be shown below the stock filter exhausted options.   Note that this was not correctly implemented before (the help text was hardcoded). 

**Testing**
- Run Bhima
- In the Stock Lots page, open the search modal and click on the defaults tab.  There should be no additional text below the 'include exhausted lots' options.
- Edit client/src/modules/stock/lots/modals/search.modal.html
- Search for bh-stock-exhausted (around line 108)
- Add this to the component invocation:   help-text="TEST TEXT"
- Run Bhima
- In the Stock Lots page, open the search modal and click on the defaults tab.  The additional text should appear below the 'include exhausted lots'  options.

It is not clear that this will ever be needed, but since it was there, I though we should fix it so that it will work properly.