### PR TITLE
Add stock entry typeahead support for selecting existing lots

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -437,13 +437,12 @@ li.selected {
 
 /**
  * Temporary header breadcrumb bootstrap fork
- * @todo implement this in less using the boostrap element
+ * @todo implement this in less using the bootstrap element
  */
 .headercrumb {
   padding: 8px 0px;
   list-style: none;
   border-radius: 2px;
-
 }
 ol.headercrumb {
   margin-bottom : 0px !important;

--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -176,7 +176,7 @@
     "VIEW_ACCOUNT_STATEMENT": "View in Account Statement",
     "VIEW_CREDIT_NOTE": "View Credit Note",
     "VIEW_INVOICE": "View Invoices",
-    "VIEW_ARTICLE_IN_STOCK": "View article in stock",
+    "VIEW_ARTICLE_IN_STOCK": "View Article in Stock",
     "VIEW_PATIENT": "View Patient",
     "VIEW_PAYMENTS": "View Cash Payments",
     "VIEW_RECEIPT": "View Receipt",

--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -267,6 +267,7 @@
     "ASSIGNMENT_HISTORIC":"Assignment History",
     "ASSIGNMENT_CURRENT":"Current",
     "NO_ASSIGNMENT":"No Assignment",
+    "LOT_LABEL_EXPIRES": "{{label}} (expires: {{expdate}})",
     "INCLUDE_EXHAUSTED_LOTS":"Include exhausted lots",
     "INCLUDE_ONLY_EXHAUSTED_LOTS": "Include only exhausted lots",
     "CLICK_TO_SEE":"Click here to see lots",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -267,6 +267,7 @@
     "ASSIGNMENT_HISTORIC":"Historique d'assignation",
     "ASSIGNMENT_CURRENT":"En cours",
     "NO_ASSIGNMENT":"Aucune assignation",
+    "LOT_LABEL_EXPIRES": "{{label}} (expirira le {{expdate}})",
     "INCLUDE_EXHAUSTED_LOTS":"Inclure les lots de stocks épuisés",
     "INCLUDE_ONLY_EXHAUSTED_LOTS": "Inclure uniquement les lots de stocks épuisé",
     "CLICK_TO_SEE":"Cliquez ici pour voir les lots",

--- a/client/src/js/services/LotService.js
+++ b/client/src/js/services/LotService.js
@@ -15,7 +15,7 @@ function LotService(Api, $http, util) {
   };
 
   lots.candidates = (params) => {
-    return $http.get(`/lots_candidates/${params.inventory_uuid}`)
+    return $http.get(`/inventory/${params.inventory_uuid}/lot_candidates`)
       .then((res) => {
         res.data.forEach((lot) => {
           lot.expiration_date = new Date(lot.expiration_date);

--- a/client/src/js/services/LotService.js
+++ b/client/src/js/services/LotService.js
@@ -8,18 +8,29 @@ function LotService(Api, $http, util) {
 
   lots.read = (uuid) => {
     return Api.read.call(lots, uuid)
-      .then(res => {
+      .then((res) => {
         res.expiration_date = new Date(res.expiration_date);
         return res;
       });
   };
 
+  lots.candidates = (params) => {
+    return $http.get(`/lots_candidates/${params.inventory_uuid}`)
+      .then((res) => {
+        res.data.forEach((lot) => {
+          lot.expiration_date = new Date(lot.expiration_date);
+        });
+        return res;
+      })
+      .then(util.unwrapHttpResponse);
+  };
+
   lots.dupes = (params) => {
-    return $http.get('/lot/dupes', { params })
-      .then(res => {
-        res.data.forEach((row) => {
-          row.entry_date = new Date(row.entry_date);
-          row.expiration_date = new Date(row.expiration_date);
+    return $http.get('/lots_dupes', { params })
+      .then((res) => {
+        res.data.forEach((lot) => {
+          lot.entry_date = new Date(lot.entry_date);
+          lot.expiration_date = new Date(lot.expiration_date);
         });
         return res;
       })

--- a/client/src/js/services/StockService.js
+++ b/client/src/js/services/StockService.js
@@ -154,8 +154,8 @@ function StockService(Api, StockFilterer, HttpCache, util, Periods) {
    * @function processLotsFromStore
    *
    * @description
-   * This function loops through the store's contents mapping them into a flat array
-   * of lots.
+   * This function loops through the store's contents mapping them into a flat
+   * array of lots.
    *
    * @returns {Array} - lots in an array.
  */

--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -4,9 +4,9 @@ angular.module('bhima.controllers')
 // dependencies injections
 StockEntryController.$inject = [
   'InventoryService', 'NotifyService', 'SessionService', 'util',
-  'bhConstants', 'ReceiptModal', 'PurchaseOrderService', 'StockFormService',
-  'StockService', 'StockModalService', 'uiGridConstants', 'Store',
-  'uuid', '$translate',
+  'bhConstants', 'ReceiptModal', 'PurchaseOrderService',
+  'StockFormService', 'StockService', 'StockModalService', 'LotService',
+  'uiGridConstants', 'Store', 'uuid', '$translate',
 ];
 
 /**
@@ -17,7 +17,7 @@ StockEntryController.$inject = [
  */
 function StockEntryController(
   Inventory, Notify, Session, util, bhConstants, ReceiptModal, Purchase,
-  StockForm, Stock, StockModal, uiGridConstants, Store, Uuid, $translate,
+  StockForm, Stock, StockModal, Lots, uiGridConstants, Store, Uuid, $translate,
 ) {
   // variables
   let inventoryStore;
@@ -43,6 +43,7 @@ function StockEntryController(
   vm.submit = submit;
   vm.reset = reset;
   vm.onDateChange = onDateChange;
+
   vm.gridOptions = {
     appScopeProvider : vm,
     enableSorting : false,
@@ -423,7 +424,7 @@ function StockEntryController(
    * @description [grid] pop up a modal for defining lots for each row in the grid
    */
   function setLots(stockLine) {
-    // Additionnal information for an inventory Group
+    // Additional information for an inventory Group
     const inventory = inventoryStore.get(stockLine.inventory_uuid);
     stockLine.tracking_expiration = inventory.tracking_expiration;
     stockLine.unique_item = inventory.unique_item;
@@ -436,7 +437,7 @@ function StockEntryController(
         if (!res) { return; }
         stockLine.lots = res.lots;
         stockLine.quantity = res.quantity;
-        stockLine.unit_cost = res.unit_cost; // integration and donation price is defined in the lot modal
+        stockLine.unit_cost = res.unit_cost; // integration and donation price are defined in the lot modal
         vm.hasValidInput = hasValidInput();
       })
       .catch(Notify.handleError);
@@ -504,7 +505,6 @@ function StockEntryController(
       })
       .catch(Notify.handleError);
   }
-
 
   /**
    * @method submitIntegration
@@ -605,6 +605,12 @@ function StockEntryController(
     line.unit = inventory.unit;
     line.tracking_expiration = inventory.tracking_expiration;
     setInitialized(line);
+
+    // Store the candidate lots for this inventory code
+    Lots.candidates({ inventory_uuid : line.inventory_uuid })
+      .then((lots) => {
+        line.candidateLots = lots;
+      });
   }
 
   startup();

--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -380,6 +380,12 @@ function StockEntryController(
       item.expiration_date = new Date();
       item.unit = inventory.unit;
 
+      // Store the candidate lots for this inventory code
+      Lots.candidates({ inventory_uuid : item.inventory_uuid })
+        .then((lots) => {
+          item.candidateLots = lots;
+        });
+
       if (vm.movement.entity.type === 'transfer_reception') {
         item.lots.push({
           isValid : true,

--- a/client/src/modules/stock/entry/modals/lots.modal.js
+++ b/client/src/modules/stock/entry/modals/lots.modal.js
@@ -213,6 +213,15 @@ function StockDefineLotsModalController(
       return;
     }
 
+    // Handle differences in selecting vs creating lots
+    vm.form.rows.forEach((row) => {
+      if (typeof row.lot !== 'string') {
+        const { label, uuid } = row.lot;
+        row.lot = label;
+        row.uuid = uuid;
+      }
+    });
+
     if (vm.errors.length === 0) {
       saveSetting();
       Instance.close({

--- a/client/src/modules/stock/entry/modals/templates/lot.expiration.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/lot.expiration.tmpl.html
@@ -2,6 +2,7 @@
   <bh-date-picker
     date="row.entity.expiration_date"
     on-change="grid.appScope.onDateChange(date, row.entity)"
+    ng-disabled="row.entity._initialized"
     required="true">
   </bh-date-picker>
 </div>

--- a/client/src/modules/stock/entry/modals/templates/lot.input.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/lot.input.tmpl.html
@@ -10,7 +10,13 @@
     class="form-control"
     ng-model="row.entity.lot"
     ng-model-options="{ 'debounce' : 0 }"
-    ng-change="grid.appScope.onChanges()"
-    bh-blur="grid.appScope.onLotBlur(row.entity.lot)"
+    typeahead-editable="true"
+    typeahead-append-to-body="true"
+    uib-typeahead="lot as lot.label for lot in grid.appScope.stockLine.candidateLots | filter:$viewValue | limitTo:8"
+    typeahead-template-url="/modules/stock/entry/modals/templates/selectLot.tmpl.html"
+    typeahead-select-on-blur="false"
+    typeahead-select-on-exact="true"
+    typeahead-on-select="grid.appScope.onSelectLot(row.entity, $item)"
+    ng-blur="grid.appScope.onLotBlur(row.entity.lot)"
     required>
 </div>

--- a/client/src/modules/stock/entry/modals/templates/selectLot.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/selectLot.tmpl.html
@@ -1,0 +1,7 @@
+<a id="lot-uuid-{{ match.model.uuid }}" href>
+  <span ng-bind-html="match.model.label | uibTypeaheadHighlight:query"></span>
+  <span style="margin-left: 1em">[</span>
+  <span translate>INVENTORY.EXPIRES</span><span> </span>
+  <span ng-bind-html="match.model.expiration_date | date"></span>
+  <span>]</span>
+</a>

--- a/client/src/modules/stock/lots-duplicates/lots-duplicates.js
+++ b/client/src/modules/stock/lots-duplicates/lots-duplicates.js
@@ -20,17 +20,21 @@ function DuplicateLotsController(
 
   const columns = [
     {
-      field : 'label',
-      displayName : 'TABLE.COLUMNS.LABEL',
-      headerTooltip : 'TABLE.COLUMNS.LABEL',
+      field : 'inventory_code',
+      displayName : 'TABLE.COLUMNS.CODE',
+      headerTooltip : 'TABLE.COLUMNS.CODE',
       headerCellFilter : 'translate',
-
     }, {
       field : 'inventory_text',
       displayName : 'TABLE.COLUMNS.INVENTORY',
       headerTooltip : 'TABLE.COLUMNS.INVENTORY',
       headerCellFilter : 'translate',
       width : '20%',
+    }, {
+      field : 'label',
+      displayName : 'TABLE.COLUMNS.LOT',
+      headerTooltip : 'TABLE.COLUMNS.LOT',
+      headerCellFilter : 'translate',
     }, {
       field : 'quantity',
       displayName : 'TABLE.COLUMNS.QUANTITY',

--- a/client/src/modules/stock/lots/modals/duplicates.modal.html
+++ b/client/src/modules/stock/lots/modals/duplicates.modal.html
@@ -12,6 +12,9 @@
   </div>
 
   <div class="modal-body">
+    <div style="margin-bottom: 0.5em">
+      <span class="text-bold">{{$ctrl.selectedLot.inventory_code}} - {{$ctrl.selectedLot.inventory_text}}</span>
+    </div>
     <div ng-if="$ctrl.lots.length === 1">
       <span translate>LOTS.NO_LOTS_FOUND</span>
     </div>

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -951,7 +951,8 @@ exports.configure = function configure(app) {
   app.put('/lots/:uuid', lots.update);
   app.get('/lots/:uuid/assignments/:depot_uuid', lots.assignments);
   app.post('/lots/:uuid/merge', lots.merge);
-  app.get('/lot/dupes/:label?/:entry_date?/:expiration_date?/:initial_quantity?/:inventory_uuid?', lots.getDupes);
+  app.get('/lots_candidates/:inventory_uuid', lots.getCandidates);
+  app.get('/lots_dupes/:label?/:entry_date?/:expiration_date?/:initial_quantity?/:inventory_uuid?', lots.getDupes);
 
   // API for Account Reference Type routes crud
   app.get('/account_reference_type', accountReferenceType.list);

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -951,7 +951,7 @@ exports.configure = function configure(app) {
   app.put('/lots/:uuid', lots.update);
   app.get('/lots/:uuid/assignments/:depot_uuid', lots.assignments);
   app.post('/lots/:uuid/merge', lots.merge);
-  app.get('/lots_candidates/:inventory_uuid', lots.getCandidates);
+  app.get('/inventory/:uuid/lot_candidates', lots.getCandidates);
   app.get('/lots_dupes/:label?/:entry_date?/:expiration_date?/:initial_quantity?/:inventory_uuid?', lots.getDupes);
 
   // API for Account Reference Type routes crud

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -80,26 +80,36 @@ async function createStock(req, res, next) {
     const createMovementQuery = 'INSERT INTO stock_movement SET ?';
 
     params.lots.forEach(lot => {
-      // parse the expiration date
-      const date = new Date(lot.expiration_date);
 
-      // the lot object to insert
-      const createLotObject = {
-        uuid : db.bid(uuid()),
-        label : lot.label,
-        initial_quantity : lot.quantity,
-        quantity : lot.quantity,
-        unit_cost : lot.unit_cost,
-        expiration_date : date,
-        inventory_uuid : db.bid(lot.inventory_uuid),
-        origin_uuid : db.bid(lot.origin_uuid),
-        delay : 0,
-      };
+      let lotUuid = lot.uuid;
+
+      if (lotUuid === null) {
+        // Create new lot (if one it does not already exist)
+
+        // parse the expiration date
+        const date = new Date(lot.expiration_date);
+
+        // the lot object to insert
+        const createLotObject = {
+          uuid : db.bid(uuid()),
+          label : lot.label,
+          initial_quantity : lot.quantity,
+          quantity : lot.quantity,
+          unit_cost : lot.unit_cost,
+          expiration_date : date,
+          inventory_uuid : db.bid(lot.inventory_uuid),
+          origin_uuid : db.bid(lot.origin_uuid),
+          delay : 0,
+        };
+
+        // adding a lot insertion query into the transaction
+        transaction.addQuery(createLotQuery, [createLotObject]);
+      }
 
       // the movement object to insert
       const createMovementObject = {
         uuid : db.bid(uuid()),
-        lot_uuid : createLotObject.uuid,
+        lot_uuid : db.bid(lotUuid),
         depot_uuid : db.bid(document.depot_uuid),
         document_uuid : db.bid(documentUuid),
         flux_id : params.flux_id,
@@ -115,9 +125,6 @@ async function createStock(req, res, next) {
       if (params.entity_uuid) {
         createMovementObject.entity_uuid = db.bid(params.entity_uuid);
       }
-
-      // adding a lot insertion query into the transaction
-      transaction.addQuery(createLotQuery, [createLotObject]);
 
       // adding a movement insertion query into the transaction
       transaction.addQuery(createMovementQuery, [createMovementObject]);
@@ -199,20 +206,24 @@ async function insertNewStock(session, params, originTable = 'integration') {
   transaction.addQuery(sql, [integration]);
 
   params.lots.forEach((lot) => {
-    const lotUuid = uuid();
+    let lotUuid = lot.uuid;
 
-    // adding a lot insertion query into the transaction
-    transaction.addQuery(`INSERT INTO lot SET ?`, {
-      uuid : db.bid(lotUuid),
-      label : lot.label,
-      initial_quantity : lot.quantity,
-      quantity : lot.quantity,
-      unit_cost : lot.unit_cost,
-      expiration_date : new Date(lot.expiration_date),
-      inventory_uuid : db.bid(lot.inventory_uuid),
-      origin_uuid : db.bid(identifier),
-      delay : 0,
-    });
+    if (lotUuid === null) {
+      // adding a lot insertion query into the transaction
+      // (this is necessary only if we are creating a new lot)
+      lotUuid = uuid();
+      transaction.addQuery(`INSERT INTO lot SET ?`, {
+        uuid : db.bid(lotUuid),
+        label : lot.label,
+        initial_quantity : lot.quantity,
+        quantity : lot.quantity,
+        unit_cost : lot.unit_cost,
+        expiration_date : new Date(lot.expiration_date),
+        inventory_uuid : db.bid(lot.inventory_uuid),
+        origin_uuid : db.bid(identifier),
+        delay : 0,
+      });
+    }
 
     // adding a movement insertion query into the transaction
     transaction.addQuery(`INSERT INTO stock_movement SET ?`, {

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -85,13 +85,14 @@ async function createStock(req, res, next) {
 
       if (lotUuid === null) {
         // Create new lot (if one it does not already exist)
+        lotUuid = uuid();
 
         // parse the expiration date
         const date = new Date(lot.expiration_date);
 
         // the lot object to insert
         const createLotObject = {
-          uuid : db.bid(uuid()),
+          uuid : db.bid(lotUuid),
           label : lot.label,
           initial_quantity : lot.quantity,
           quantity : lot.quantity,

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -83,7 +83,7 @@ async function createStock(req, res, next) {
 
       let lotUuid = lot.uuid;
 
-      if (lotUuid === null) {
+      if (lotUuid === null || typeof lotUuid === 'undefined') {
         // Create new lot (if one it does not already exist)
         lotUuid = uuid();
 

--- a/server/controllers/stock/lots.js
+++ b/server/controllers/stock/lots.js
@@ -97,13 +97,13 @@ async function update(req, res, next) {
 }
 
 /**
- * GET /lots_candidates/:inventory_uuid
+ * GET /inventory/:uuid/lot_candidates
  *
  * @description
- * Returns all lots with the that inventory_uuid
+ * Returns all lots with the that inventory uuid
  */
 function getCandidates(req, res, next) {
-  const inventoryUuid = db.bid(req.params.inventory_uuid);
+  const inventoryUuid = db.bid(req.params.uuid);
 
   const query = `
     SELECT BUID(l.uuid) AS uuid, l.label, l.description, l.expiration_date

--- a/test/integration/mergeLots.js
+++ b/test/integration/mergeLots.js
@@ -139,7 +139,7 @@ describe('Test merging lots', () => {
   // ===========================================================================
   // Verify we have created the lots, tags, etc
   it('Verify we created lot1 and its dupes (lot3, lot4, lot5)', () => {
-    return agent.get('/lot/dupes')
+    return agent.get('/lots_dupes')
       .query({ label : lot1Label, inventory_uuid : vitamineUuid })
       .then((res) => {
         helpers.api.listed(res, 4); // 4 = the lot itself and 3 dupes
@@ -147,7 +147,7 @@ describe('Test merging lots', () => {
       .catch(helpers.handler);
   });
   it('Verify we created lot2', () => {
-    return agent.get('/lot/dupes')
+    return agent.get('/lots_dupes')
       .query({ label : lot2Label, inventory_uuid : vitamineUuid })
       .then((res) => {
         helpers.api.listed(res, 1);
@@ -177,7 +177,7 @@ describe('Test merging lots', () => {
   });
 
   it(`Verify the 'find duplicate lots' query works`, () => {
-    return agent.get('/lot/dupes')
+    return agent.get('/lots_dupes')
       .query({ find_dupes : 1 })
       .then((res) => {
         helpers.api.listed(res, 1); // all dupes can be merged into one

--- a/test/integration/stock/lots.js
+++ b/test/integration/stock/lots.js
@@ -10,8 +10,9 @@ describe('(/lots/) The lots HTTP API', () => {
       .then((res) => {
         expect(res).to.have.status(200);
         const expectedKeys = [
-          'uuid', 'label', 'quantity', 'initial_quantity', 'unit_cost', 'description',
-          'entry_date', 'expiration_date', 'inventory_uuid', 'text', 'tags',
+          'uuid', 'label', 'quantity', 'initial_quantity', 'unit_cost',
+          'description', 'entry_date', 'expiration_date', 'inventory_uuid',
+          'inventory_code', 'inventory_text', 'tags',
         ];
         expect(res.body).to.have.all.keys(expectedKeys);
       })


### PR DESCRIPTION
Support entering lots in Stock Entry using typeahead to select among existing lots. 
     - If an existing lot is selected, its expiration date is inserted to the lot selection form line.
     - If the user types the label of an existing lot, it is selected immediately.  This should prevent users from using duplicate lot names.
     - If a lot label that is typed in is not one of the possible candidate lots for that inventory item, the code assumes that it is a new lot.  The user will then have to correct the expiration date.

### NOTES

- I did not add code to see if the typed-in lot label (not selected) lot exists.  Hopefully the features above make that unnecessary.   
- I was able to verify that this works for integration and donations.  It does not seem relevant to Transfer since those already have lot labels.  
- I fixed the code for Purchases/Transfers so that it knows about the candidate lots for each inventory item.
- This PR does not disable the expiration date field when set for the selected candidate stock.   This will require an update to the bhDatePicker component and should be done in a separate PR.
- **WARNING**: However the current code for candidate lots (for the typeahead) does not check on whether the lots are expired or empty.  I suggest fixing that in another PR.
- BTW, I noticed an unrelated error/problem in Transfers:  When you select a transfer, it lists the lots in the transfer, but they are all flagged as being okay.  But if you click on the lot(s) link, some of the lot items may be invalid (bad expiration date, etc).

### TESTING

- Use one of the production databases for testing so there are multiple lots available for inventory items.
- Try typing a new label and verify that it works like it used to.
- When adding new lots, try the typeahed.  Once you enter a full Lot label, it should automatically select it.
- When testing, please try all 4 means of entry
- For Integration and Dontations, lots can either be created or reused.  Creating new lots (type until no existing lots are shown by the typeahead drop-down for a new Lot) and Using existing lots (selecting an existing lot using the typeahead).   In either case, note the lot labels for new and existing lots.
   - After the integration/donation tests, be sure to try "Find Duplicate Lots" and verify that no duplicate lots were created (check the lot labels in the previous step).  Note that his can also be down via the Stock Lots registry action menu.


