### PR TITLE
Updated bhDateInterval to use placeholder labels

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -712,6 +712,7 @@
             "STAFF_COST": "Staff",
             "STAFFING_BASE_INDICES" : "Basic indices for recruitment",
             "START": "Start",
+            "START_DATE": "Start date",
             "STATUS": "Status",
             "STOCK": "Stock",
             "SUBSIDIES": "Subsidies Applied",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -713,6 +713,7 @@
             "STAFF_COST": "les employés",
             "STAFFING_BASE_INDICES" : "Indices de base au recrutement",
             "START": "Début",
+            "START_DATE": "Start date",
             "STATUS": "État",
             "STOCK": "Stock",
             "SUBSIDIES": "Les subventions appliqués",

--- a/client/src/js/components/bhDateInterval.js
+++ b/client/src/js/components/bhDateInterval.js
@@ -28,6 +28,8 @@ angular.module('bhima.components')
       canClear : '<?', // flag for displaying clear button
       label : '@?',
       mode : '@?', // the date mode (day|month|year)
+      startDatePlaceholder : '@?',
+      endDatePlaceholder : '@?',
       limitMinFiscal : '@?', // do not allow the minimum date to be before the first fiscal year
     },
   });
@@ -35,11 +37,11 @@ angular.module('bhima.components')
 // dependencies injection
 bhDateInterval.$inject = [
   'bhConstants', 'FiscalService',
-  'SessionService', 'PeriodService',
+  'SessionService', 'PeriodService', '$translate',
 ];
 
 // controller definition
-function bhDateInterval(bhConstants, Fiscal, Session, PeriodService) {
+function bhDateInterval(bhConstants, Fiscal, Session, PeriodService, $translate) {
   const $ctrl = this;
 
   PeriodService.dateFormat = 'YYYY-MM-DD';
@@ -64,6 +66,8 @@ function bhDateInterval(bhConstants, Fiscal, Session, PeriodService) {
     $ctrl.dateFormat = bhConstants.dayOptions.format;
     $ctrl.pickerFromOptions = { showWeeks : false };
     $ctrl.pickerToOptions = { showWeeks : false, minDate : $ctrl.dateFrom };
+    $ctrl.startDatePlaceholder = $translate.instant($ctrl.startDatePlaceholder || 'FORM.LABELS.START_DATE');
+    $ctrl.endDatePlaceholder = $translate.instant($ctrl.endDatePlaceholder || 'FORM.LABELS.END_DATE');
 
     // if controller has requested limit-min-fiscal, fetch required information
     if (angular.isDefined($ctrl.limitMinFiscal)) {

--- a/client/src/modules/templates/bhDateInterval.tmpl.html
+++ b/client/src/modules/templates/bhDateInterval.tmpl.html
@@ -41,6 +41,7 @@
           show-button-bar="false"
           ng-model="$ctrl.dateFrom"
           ng-change="$ctrl.onChangeDate()"
+          placeholder="{{ $ctrl.startDatePlaceholder }}"
           ng-required="$ctrl.required">
         <span class="input-group-btn">
           <button class="btn btn-default" type="button" ng-click="$ctrl.dateFromIsOpen =! $ctrl.dateFromIsOpen">
@@ -71,6 +72,7 @@
           show-button-bar="false"
           ng-model="$ctrl.dateTo"
           ng-change="$ctrl.onChangeDate()"
+          placeholder="{{ $ctrl.endDatePlaceholder }}"
           ng-required="$ctrl.required">
         <span class="input-group-btn">
           <button class="btn btn-default" type="button" ng-click="$ctrl.dateToIsOpen =! $ctrl.dateToIsOpen">


### PR DESCRIPTION
Add start-date and end-date placeholder labels which default to FORMS.LABELS.START_DATE/END_DATE.  I think this helps make it easier for users to automatically understand what the form is asking for.   Here is what it looks like:
![image](https://user-images.githubusercontent.com/62145/108551516-ebba7300-72a4-11eb-9df5-b8cec7653883.png)

Note the circled placeholders. Once actual dates are selected, they disappear.  But when you clear the field they are restored.

**NOTES**  
  - This applies to all appearances of the bhDateInterval component.
  - Code using the bhDateInterval component can provide the 'startDatePlaceholder' and 'endDataPlaceholder' to override these labels.  These will be  translated so should be language tokens.

**TESTING**

- Use bhima_test or any DB.
- On the Stock > Lots page, bring up the Search dialog and scroll down to see the date interval fields.

