### PR TITLE
Extend date picker to support disabling

### DIFF
--- a/client/src/js/components/bhDatePicker.js
+++ b/client/src/js/components/bhDatePicker.js
@@ -7,6 +7,7 @@ angular.module('bhima.components')
       onChange : '&', // use a callback to notify for changes
       format   : '<?',
       mode     : '@?', // will this ever change?  If so, we can use '<'
+      disabled : '<?', // Optional flag to disable this field
       required : '<?',
     },
   });
@@ -43,6 +44,10 @@ function DatePickerController(Modal, bhConstants) {
   }
 
   function open() {
+    if (vm.disabled) {
+      // Do not open the date picker popup if the field is disabled
+      return;
+    }
     openDatePicker({ mode : vm.mode })
       .then(date => {
         // notify the parent controller of a date change via a callback

--- a/client/src/modules/stock/entry/modals/lots.modal.js
+++ b/client/src/modules/stock/entry/modals/lots.modal.js
@@ -196,6 +196,7 @@ function StockDefineLotsModalController(
   function onSelectLot(entity, item) {
     const lot = vm.stockLine.candidateLots.find(l => l.uuid === item.uuid);
     entity.expiration_date = new Date(lot.expiration_date);
+    entity.disabled = true;
     onChanges();
   }
 

--- a/client/src/modules/stock/entry/modals/templates/lot.expiration.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/lot.expiration.tmpl.html
@@ -2,7 +2,7 @@
   <bh-date-picker
     date="row.entity.expiration_date"
     on-change="grid.appScope.onDateChange(date, row.entity)"
-    ng-disabled="row.entity._initialized"
+    disabled="row.entity.disabled"
     required="true">
   </bh-date-picker>
 </div>

--- a/client/src/modules/templates/bhDatePickerAction.tmpl.html
+++ b/client/src/modules/templates/bhDatePickerAction.tmpl.html
@@ -1,10 +1,11 @@
 <span class="text-action" ng-dblclick="$ctrl.open()">
-  <input 
+  <input
     uib-datepicker-popup="{{ $ctrl.dateFormat }}"
-    class="form-control text-right" 
-    type="text" 
+    class="form-control text-right"
+    type="text"
     ng-change="$ctrl.notifyDateChange()"
     ng-model="$ctrl.date"
     ng-model-options="{ 'debounce' : { 'default' : 150, 'blur' : 0 }}"
+    ng-disabled="$ctrl.disabled"
     ng-required="$ctrl.required">
 </span>


### PR DESCRIPTION
This PR extends the bhDatePicker component to support disabling the field.   

Closes #5388 

To use this feature: when setting up the bh-date-picker component, add this parameter:

    disabled="obj.disabled"

Where "obj" is the input field for the date picker and 'disabled' is a variable in the object that evaluates to **true** when the field should be disabled.  This should be backwards compatible.

This is currently implemented for the Stock entry page (when selecting/creating lots).  You can see examples of its use in
- client/src/modules/stock/entry/modals/lots.modal.js (search for 'disabled')
- client/src/modules/stock/entry/modals/templates/lot.expiration.tmpl.html

**TESTING**
- Use any database (eg, bhima_test)
- Use Stock > Lots to find an inventory item that has lots that are not expired  (for bhima_test, try inventory Item: Vitamines B1+B6+B12
- Go to Stock > Entry
   - Use integration
   - Do "Add" and select the inventory item from the previous step
   - Click on the "Lots" field to get the lot selection/creation modal
   - On the first row, notice that the expiration date can be changed.
   - Select one of the existing lots using the lot selection typeahead
   - Notice that the expiration date has been overwriten and cannot be modified.



