### PR TITLE
fix(stock): make "at risk of expiration" flag work

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -1,4 +1,5 @@
-{ "STOCK" : {
+{
+  "STOCK" : {
     "ALERT" : "Alert",
     "ADJUSTMENT"      : "Adjustment",
     "ADJUSTMENT_TYPE" : "Adjustment Type",

--- a/client/src/modules/stock/StockFilterer.service.js
+++ b/client/src/modules/stock/StockFilterer.service.js
@@ -33,7 +33,7 @@ function StockFiltererService(Filters, AppCache, $httpParamSerializer, Languages
     { key : 'is_expiry_risk', label : 'STOCK.STATUS.IS_IN_RISK_OF_EXPIRATION' },
     { key : 'tag_uuid', label : 'TAG.LABEL' },
     { key : 'tags', label : 'TAG.LABEL' },
-    { key : 'show_only_risky', label : 'STOCK.LOTS.SHOW_ONLY_RISKY' },
+    { key : 'show_only_risky', label : 'LOTS.SHOW_ONLY_RISKY_LOTS' },
     { key : 'stock_requisition_uuid', label : 'FORM.LABELS.REQUISITION_REFERENCE' },
     {
       key : 'dateFrom', label : 'FORM.LABELS.DATE', comparitor : '>', valueFilter : 'date',

--- a/client/src/modules/stock/inventories/registry.js
+++ b/client/src/modules/stock/inventories/registry.js
@@ -196,6 +196,7 @@ function StockInventoriesController(
   }
 
   function setStatusFlag(item) {
+
     item.noAlert = !item.hasRiskyLots && !item.hasNearExpireLots && !item.hasExpiredLots;
     item.alert = item.hasExpiredLots;
     item.warning = !item.hasExpiredLots && (item.hasNearExpireLots || item.hasRiskyLots);

--- a/client/src/modules/stock/inventories/templates/inventory.action.html
+++ b/client/src/modules/stock/inventories/templates/inventory.action.html
@@ -31,6 +31,8 @@
       <a data-method="stock-lots" href
         ui-sref="stockLots({
           filters : [
+            { key : 'period', value : 'allTime', cacheable: false },
+            { key : 'depot_uuid', value : row.entity.depot_uuid, displayValue : row.entity.depot_text, cacheable: false},
             { key : 'inventory_uuid', value : row.entity.inventory_uuid, displayValue: row.entity.text, cacheable: false }
         ]})">
         <i class="fa fa-cubes"></i> <span translate>INVENTORY.VIEW_LOTS_IN_STOCK</span>

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -742,7 +742,7 @@ function computeLotIndicators(inventories) {
           lot.expiration_date = '';
         }
 
-        lot.exhausted = lot.quantity === 0;
+        lot.exhausted = lot.quantity <= 0;
         lot.expired = !lot.exhausted && (lot.expiration_date < today);
 
         // algorithm for tracking the stock consumption by day

--- a/test/integration-stock/depots.js
+++ b/test/integration-stock/depots.js
@@ -60,12 +60,12 @@ describe('(/depots) The depots API ', () => {
       expect(res).to.be.json; // eslint-disable-line
 
       let values = {
-        algo1 : 53.33,
+        algo1 : 53.48,
         algo2 : 2168.89,
-        algo3 : 53.33,
+        algo3 : 53.48,
         algo_msh : 53.33,
-        sum_days : 366,
-        sum_stock_day : 366,
+        sum_days : 365,
+        sum_stock_day : 365,
         sum_consumption_day : 9,
         sum_consumed_quantity : 640,
         number_of_month : 12,
@@ -77,16 +77,17 @@ describe('(/depots) The depots API ', () => {
       expect(res.body.algo2, 'quinine CMM algorithm 2 is not calculated correctly').to.equal(values.algo2);
       expect(res.body.algo3, 'quinine CMM algorithm 3 is not calculated correctly').to.equal(values.algo3);
       expect(res.body.algo_msh, 'quinine CMM algorithm MSH is not calculated correctly').to.equal(values.algo_msh);
+
       expect(res.body, 'quinine CMM not calculated correctly').to.deep.include(values);
 
       res = await agent.get(`/depots/${principal}/inventories/${oxytocine}/cmm`);
       values = {
-        algo1 : 74.17,
+        algo1 : 74.37,
         algo2 : 3393.13,
-        algo3 : 74.17,
+        algo3 : 74.37,
         algo_msh : 74.17,
-        sum_days : 366,
-        sum_stock_day : 366,
+        sum_days : 365,
+        sum_stock_day : 365,
         sum_consumption_day : 8,
         sum_consumed_quantity : 890,
         number_of_month : 12,
@@ -102,16 +103,16 @@ describe('(/depots) The depots API ', () => {
 
       res = await agent.get(`/depots/${principal}/inventories/${ampicilline}/cmm`);
       values = {
-        algo1 : 33.39,
+        algo1 : 33.27,
         algo2 : 1143.75,
-        algo3 : 25,
-        algo_msh : 33.39,
-        sum_days : 366,
-        sum_stock_day : 274,
+        algo3 : 25.07,
+        algo_msh : 33.15,
+        sum_days : 365,
+        sum_stock_day : 275,
         sum_consumption_day : 8,
         sum_consumed_quantity : 300,
         number_of_month : 12,
-        sum_stock_out_days : 92,
+        sum_stock_out_days : 90,
         head_days : 0,
       };
 


### PR DESCRIPTION
This fix restores the functionality of the "at risk of expiration" flag
on the articles in stock registry.  It does not affect the API, just the
internal calculations.

In addition, we also changed the behavior of the articles in stock
action dropdown menu so the link to the stock lots now filters on the
depot and time period in question.

![image](https://user-images.githubusercontent.com/896472/109151831-f7a5a980-776a-11eb-8044-0097b0aacd81.png)


Closes #5422.