### PR TITLE
Fix issue with stock import depot label

### DIFF
--- a/client/src/modules/stock/import/stockImport.js
+++ b/client/src/modules/stock/import/stockImport.js
@@ -63,7 +63,7 @@ function StockImportController(
     function handleSuccess() {
       Notify.success('STOCK.IMPORT.UPLOAD_SUCCESS');
 
-      filters.push({ key : 'depot_uuid', value : vm.depot.uuid });
+      filters.push({ key : 'depot_uuid', value : vm.depot.uuid, displayValue : vm.depot.text });
       $state.go('stockLots', { filters });
     }
 


### PR DESCRIPTION
This fixes a cosmetic problem with Stock Import: Once a successful stock import is performed, the result is shown in Stock Lots.  But the Depot filter was shown as the UUID. This PR fixes that issue.   

Note that this is a fix for the refactor-stock-management branch (but could be applied to 'master' after merging.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5426

TESTING

- Use any DB
- Perform a stock import (example file attached, rename to .csv).
- Notice that the depot label is now correct.  See the screenshot below:

![image](https://user-images.githubusercontent.com/62145/109200572-a3dc9580-7755-11eb-80cb-db3b07f98f54.png)


[test.csv,txt](https://github.com/IMA-WorldHealth/bhima/files/6045090/test.csv.txt)
