### PR TITLE
Fixed expired stock report in refactor-stock-management branch

### DIFF
--- a/server/controllers/stock/reports/stock/expiration_report.js
+++ b/server/controllers/stock/reports/stock/expiration_report.js
@@ -46,11 +46,11 @@ async function stockExpirationReport(req, res, next) {
     // get the lots for this depot
     const lots = await stockCore.getLotsDepot(options.depot_uuid, options);
 
-    // get the lots that are "at risk"
-    const risky = lots.filter(lot => (lot.S_RISK < 0 && lot.lifetime > 0));
+    // get the lots that are "at risk" of expiring
+    const risky = lots.filter(lot => (lot.near_expiration && lot.lifetime > 0));
 
     // get expired lots
-    const expired = lots.filter(lot => (lot.S_RISK <= 0 && lot.expiration_date <= today));
+    const expired = lots.filter(lot => lot.flags.expired);
 
     // merge risky and expired
     const riskyAndExpiredLots = risky.concat(expired);
@@ -76,12 +76,12 @@ async function stockExpirationReport(req, res, next) {
           totals.expired.quantity += lot.mvt_quantity;
           total += lot.value;
         } else {
-          lot.quantity_at_risk = (lot.S_RISK_QUANTITY * -1);
+          lot.quantity_at_risk = lot.S_RISK_QUANTITY;
           lot.value = (lot.quantity_at_risk * lot.unit_cost);
           lot.statusKey = 'STOCK.STATUS.IS_IN_RISK_OF_EXPIRATION';
           lot.classKey = 'bg-warning text-warning';
           totals.at_risk.value += lot.value;
-          totals.at_risk.quantity += (lot.S_RISK_QUANTITY * -1);
+          totals.at_risk.quantity += lot.quantity_at_risk;
           total += lot.value;
         }
       });

--- a/server/controllers/stock/reports/stock_expiration_report.handlebars
+++ b/server/controllers/stock/reports/stock_expiration_report.handlebars
@@ -59,32 +59,32 @@
     <table class="table table-condensed table-bordered table-report">
       <thead>
         <tr>
-          <th>{{translate 'STOCK.INVENTORY'}}</th>
-          <th>{{translate 'STOCK.LOT'}}</th>
-          <th>{{translate 'STOCK.EXPIRATION'}}</th>
-          <th>{{translate 'STOCK.CMM'}}</th>
-          <th>{{translate 'STOCK.CURRENT_QUANTITY'}}</th>
-          <th>{{translate 'STOCK.RISK_QUANTITY'}}</th>
-          <th>{{translate 'TABLE.COLUMNS.UNIT'}}</th>
-          <th>{{translate 'REPORT.STOCK.UNIT_COST'}}</th>
-          <th>{{translate 'STOCK.RISK_VALUE'}}</th>
-          <th>{{translate 'STOCK.STATUS.LABEL'}}</th>
+          <th width="34%">{{translate 'STOCK.INVENTORY'}}</th>
+          <th width="12%">{{translate 'STOCK.LOT'}}</th>
+          <th width="8%">{{translate 'STOCK.EXPIRATION'}}</th>
+          <th width="6%">{{translate 'STOCK.CMM'}}</th>
+          <th width="6%">{{translate 'STOCK.CURRENT_QUANTITY'}}</th>
+          <th width="6%">{{translate 'STOCK.RISK_QUANTITY'}}</th>
+          <th width="6%">{{translate 'TABLE.COLUMNS.UNIT'}}</th>
+          <th width="5%">{{translate 'REPORT.STOCK.UNIT_COST'}}</th>
+          <th width="5%">{{translate 'STOCK.RISK_VALUE'}}</th>
+          <th width="12%">{{translate 'STOCK.STATUS.LABEL'}}</th>
         </tr>
       </thead>
 
       <tbody>
         {{#each depot.rows as |lot| }}
           <tr>
-            <td>{{lot.text}}</td>
-            <td>{{lot.label}}</td>
-            <td>{{date lot.expiration_date}}</td>
-            <td class="text-right">{{lot.avg_consumption}}</td>
-            <td class="text-right">{{lot.quantity}}</td>
-            <td class="text-right">{{lot.quantity_at_risk}}</td>
-            <td>{{lot.unit_type}}</td>
-            <td>{{currency lot.unit_cost ../../metadata.enterprise.currency_id}}</td>
-            <td class="text-right">{{currency lot.value ../../metadata.enterprise.currency_id}}</td>
-            <td class="{{lot.classKey}}">{{translate lot.statusKey}}</td>
+            <td width="34%">{{lot.text}}</td>
+            <td width="12%">{{lot.label}}</td>
+            <td width="8%">{{date lot.expiration_date}}</td>
+            <td width="6%" class="text-right">{{lot.avg_consumption}}</td>
+            <td width="6%" class="text-right">{{lot.quantity}}</td>
+            <td width="6%" class="text-right">{{lot.quantity_at_risk}}</td>
+            <td width="6%">{{lot.unit_type}}</td>
+            <td width="5%" class="text-right">{{currency lot.unit_cost ../../metadata.enterprise.currency_id}}</td>
+            <td width="5%" class="text-right">{{currency lot.value ../../metadata.enterprise.currency_id}}</td>
+            <td width="12%" class="{{lot.classKey}}">{{translate lot.statusKey}}</td>
           </tr>
         {{/each}}
       </tbody>


### PR DESCRIPTION
This PR fixes the Expired Stock Report.

The fix was to convert uses of lot.S_RISK (numerical flag) to lot.at_risk (boolean flag).   It seems to work with bhima_test, but I have not tested it with a production database.

Note the comment below for some questions about these variables (https://github.com/IMA-WorldHealth/bhima/pull/5438#issuecomment-786770857).

This PR was updated to address aligning columns between tables for each depot (see Issue https://github.com/IMA-WorldHealth/bhima/issues/5349)
Closes #5349

WARNING: This PR does not fix the totals for the stock at risk!  I'll add a note below about that (https://github.com/IMA-WorldHealth/bhima/pull/5438#issuecomment-786854885)