### PR TITLE
fix(stock): give descriptions to adjustments

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -69,6 +69,8 @@
     "EXIT_SERVICE"    : "Distribution to a service",
     "EXIT_SERVICE_ADVANCED" : "Distribution to the service {{service}} from {{depot}}",
     "EXIT_LOSS"       : "Loss",
+    "EXIT_ADJUSTMENT" : "Negative adjustment of {{numArticles}} articles from {{depot}} by {{user}}.",
+    "ENTRY_ADJUSTMENT" : "Positive adjustment of {{numArticles}} articles into {{depot}} by {{user}} .",
     "EXIT_INDIVIDUAL" : "Exit to Individual",
     "FILE"            : "Stock File",
     "FLUX"            : "Reason",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -70,6 +70,8 @@
     "EXIT_SERVICE_ADVANCED" : "Distribution vers le service {{service}} à partir du dépôt {{depot}}",
     "EXIT_LOSS"       : "Perte",
     "EXIT_INDIVIDUAL" : "Distribution aux individus",
+    "EXIT_ADJUSTMENT" : "Ajustement négatif de {{numArticles}} articles de {{depot}} par {{user}}.",
+    "ENTRY_ADJUSTMENT" : "Ajustement positif de {{numArticles}} articles de dans {{depot}} par {{user}}.",
     "FILE"            : "Fiche de stock",
     "FLUX"            : "Raison",
     "FROM"            : "Provenance",

--- a/client/src/modules/stock/adjustment/adjustment.js
+++ b/client/src/modules/stock/adjustment/adjustment.js
@@ -5,7 +5,7 @@ angular.module('bhima.controllers')
 StockAdjustmentController.$inject = [
   'NotifyService', 'SessionService', 'util',
   'bhConstants', 'ReceiptModal', 'StockFormService', 'StockService',
-  'uiGridConstants',
+  'uiGridConstants', '$translate',
 ];
 
 /**
@@ -16,7 +16,7 @@ StockAdjustmentController.$inject = [
  */
 function StockAdjustmentController(
   Notify, Session, util, bhConstants, ReceiptModal, StockForm,
-  Stock, uiGridConstants,
+  Stock, uiGridConstants, $translate,
 ) {
   const vm = this;
 
@@ -207,12 +207,14 @@ function StockAdjustmentController(
   }
 
   // ================================= Submit ================================
-  function submit() {
+  function submit(form) {
     let isExit;
     let fluxId;
 
     // check stock validity
     checkValidity();
+
+    if (form.$invalid) { return 0; }
 
     if (!vm.validForSubmit || !vm.adjustmentOption) { return 0; }
 
@@ -220,19 +222,31 @@ function StockAdjustmentController(
       return Notify.danger('ERRORS.ER_DUPLICATED_LOT', 20000);
     }
 
+    let description;
+
     if (vm.adjustmentOption === 'increase') {
       isExit = 0;
       fluxId = bhConstants.flux.FROM_ADJUSTMENT;
+      description = $translate.instant('STOCK.ENTRY_ADJUSTMENT', {
+        numArticles : vm.Stock.store.data.length,
+        user : Session.user.display_name,
+        depot : vm.depot.text,
+      });
     } else if (vm.adjustmentOption === 'decrease') {
       isExit = 1;
       fluxId = bhConstants.flux.TO_ADJUSTMENT;
+      description = $translate.instant('STOCK.EXIT_ADJUSTMENT', {
+        numArticles : vm.Stock.store.data.length,
+        user : Session.user.display_name,
+        depot : vm.depot.text,
+      });
     }
 
     const movement = {
       depot_uuid : vm.depot.uuid,
       entity_uuid : vm.movement.entity.uuid,
       date : vm.movement.date,
-      description : vm.movement.description,
+      description : description.concat(' -- ', vm.movement.description || ''),
       is_exit : isExit,
       flux_id : fluxId,
       user_id : Session.user.id,

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -438,10 +438,6 @@ async function normalMovement(document, params, metadata) {
   const transaction = db.transaction();
   const parameters = params;
 
-  const isDistributable = !!(
-    (parameters.flux_id === core.flux.TO_PATIENT || parameters.flux_id === core.flux.TO_SERVICE) && parameters.is_exit
-  );
-
   parameters.entity_uuid = parameters.entity_uuid ? db.bid(parameters.entity_uuid) : null;
   parameters.invoice_uuid = parameters.invoice_uuid ? db.bid(parameters.invoice_uuid) : null;
 


### PR DESCRIPTION
This commit creates templated descriptions to adjustments and makes
the description mandatory.

Closes #5444.

Here is what it looks like:
![image](https://user-images.githubusercontent.com/896472/109557011-d41a9000-7ad7-11eb-8220-bd09192c2856.png)

----

How to test:

1. Load any database off master or refactor-stock-management. 
2. Try to do a negative stock adjustment for any product, _without_ putting in a description.
3. Observe the receipt renders and the app accepts the submit, despite showing a red mark on the description box.
3. Notice that the receipt does not print with a "note" field.

Now, load this branch.

You should not be able to make an adjustment without a description.  And when the description renders, it should look something like what the screenshot I posted above.