### PR TITLE
fix(stock): update inventory text on lot edit

### DIFF
--- a/client/src/modules/stock/lots/modals/edit.modal.html
+++ b/client/src/modules/stock/lots/modals/edit.modal.html
@@ -2,14 +2,14 @@
     <div class="modal-header">
       <ol class="headercrumb">
         <li class="static" translate>LOTS.DETAILS</li>
-        <li class="title" translate>{{$ctrl.model.text}}</li>
+        <li class="title">{{$ctrl.model.inventory_code}} - {{$ctrl.model.inventory_text}}</li>
       </ol>
     </div>
 
     <div class="modal-body">
       <div class="form-group">
         <label class="control-label" translate>FORM.LABELS.INVENTORY</label>
-        <p>{{$ctrl.model.text}}</p>
+        <p>{{$ctrl.model.inventory_text}}</p>
       </div>
 
       <div class="form-group"

--- a/client/src/modules/stock/lots/modals/edit.modal.js
+++ b/client/src/modules/stock/lots/modals/edit.modal.js
@@ -9,6 +9,7 @@ EditLotModalController.$inject = [
 function EditLotModalController(Data, Session, Lots, Inventory, Notify, Instance) {
   const vm = this;
   vm.model = {};
+
   vm.enterprise = Session.enterprise;
   vm.onDateChange = onDateChange;
   vm.onSelectTags = onSelectTags;
@@ -18,6 +19,7 @@ function EditLotModalController(Data, Session, Lots, Inventory, Notify, Instance
   vm.trackingExpiration = true;
 
   function startup() {
+
     Lots.read(Data.uuid)
       .then(lot => {
         vm.model = lot;


### PR DESCRIPTION
Updates the bindings on the lot edit modal.

Closes #5430.


![image](https://user-images.githubusercontent.com/896472/109654459-8008bd80-7b62-11eb-99ee-ec990619216b.png)
