### PR TITLE
Add opening balance to the fiche de stock

### DIFF
--- a/server/controllers/stock/reports/stock/stock_sheet.js
+++ b/server/controllers/stock/reports/stock/stock_sheet.js
@@ -6,10 +6,10 @@ const {
  * @method stockSheetReport
  *
  * @description
- * This method builds the stock inventory report as either a JSON, PDF, or HTML
+ * This method builds the stock sheet report as either a JSON, PDF, or HTML
  * file to be sent to the client.
  *
- * GET /reports/stock/inventory
+ * GET /reports/stock/sheet
  */
 async function stockSheetReport(req, res, next) {
   const optionReport = _.extend(req.query, {
@@ -40,6 +40,11 @@ async function stockSheetReport(req, res, next) {
       // already sorted by created_at by mysql
       data.rows = rows.movements;
     }
+
+    // mark rows if they contain negative balances
+    data.rows.forEach(row => {
+      row.hasNegativeValues = row.stock.quantity < 0;
+    });
 
     data.totals = rows.totals;
     data.result = rows.result;

--- a/server/controllers/stock/reports/stock/stock_sheet.js
+++ b/server/controllers/stock/reports/stock/stock_sheet.js
@@ -46,8 +46,17 @@ async function stockSheetReport(req, res, next) {
       row.hasNegativeValues = row.stock.quantity < 0;
     });
 
+    const header = rows.openingBalance;
+    header.hasNegativeValues = rows.openingBalance && rows.openingBalance.value < 0;
+
+    // if this is negative, show 0 for total value
+    if (header.hasNegativeValues) {
+      header.value = 0;
+    }
+
     data.totals = rows.totals;
     data.result = rows.result;
+    data.header = header;
     data.dateFrom = options.dateFrom;
     data.dateTo = options.dateTo;
 

--- a/server/controllers/stock/reports/stock_sheet.report.handlebars
+++ b/server/controllers/stock/reports/stock_sheet.report.handlebars
@@ -58,7 +58,7 @@
         </thead>
         <tbody>
           {{#each rows}}
-            <tr>
+            <tr {{#if hasNegativeValues}}class="bg-danger text-danger"{{/if}}>
               <td style="border-left: 1px solid #000;">{{reference}}</td>
               <td style="border-right: 1px solid #000;">{{timestamp date}}</td>
               {{#unless ../depot.text}}
@@ -77,9 +77,9 @@
               <td class="text-right" style="border-right: 1px solid #000;">{{#if exit.value}}{{currency exit.value ../metadata.enterprise.currency_id}}{{/if}}</td>
 
               {{!-- stock --}}
-              <td class="text-right" style="background-color:#efefef;">{{stock.quantity}}</td>
-              <td class="text-right" style="background-color:#efefef;">{{precision stock.unit_cost 4}}</td>
-              <td class="text-right" style="background-color:#efefef;border-right: 1px solid #000;">{{currency stock.value ../metadata.enterprise.currency_id}}</td>
+              <td class="text-right" {{#unless hasNegativeValues}}style="background-color:#efefef;"{{/unless}}>{{stock.quantity}}</td>
+              <td class="text-right" {{#unless hasNegativeValues}}style="background-color:#efefef;"{{/unless}}>{{precision stock.unit_cost 4}}</td>
+              <td class="text-right" {{#unless hasNegativeValues}}style="background-color:#efefef;border-right: 1px solid #000;"{{/unless}}>{{currency stock.value ../metadata.enterprise.currency_id}}</td>
             </tr>
           {{/each}}
         </tbody>

--- a/server/controllers/stock/reports/stock_sheet.report.handlebars
+++ b/server/controllers/stock/reports/stock_sheet.report.handlebars
@@ -57,6 +57,15 @@
           </tr>
         </thead>
         <tbody>
+          {{#if header}}
+            <tr {{#if header.hasNegativeValues}}class="bg-danger text-danger"{{/if}}>
+              <td style="border-left: 1px solid #000; border-right:1px solid #000; border-bottom: 1px solid #000;" colspan={{#if depot.text}}"10"{{else}}"11"{{/if}} class="text-center"><b>{{translate 'REPORT.OPENING_BALANCE'}}</b></td>
+              <td style="border-right: 1px solid #000; border-bottom: 1px solid #000;" class="text-right" {{#unless header.hasNegativeValues}}style="background-color:#efefef;"{{/unless}}><b>{{header.quantity}}</b></td>
+              <td style="border-right: 1px solid #000; border-bottom: 1px solid #000;" class="text-right" {{#unless header.hasNegativeValues}}style="background-color:#efefef;"{{/unless}}><b>{{precision header.unit_cost 4}}</b></td>
+              <td style="border-right: 1px solid #000; border-bottom: 1px solid #000;" class="text-right" {{#unless header.hasNegativeValues}}style="background-color:#efefef;border-right: 1px solid #000;"{{/unless}}><b>{{currency header.value metadata.enterprise.currency_id}}</b></td>
+            </tr>
+          {{/if}}
+
           {{#each rows}}
             <tr {{#if hasNegativeValues}}class="bg-danger text-danger"{{/if}}>
               <td style="border-left: 1px solid #000;">{{reference}}</td>
@@ -79,12 +88,12 @@
               {{!-- stock --}}
               <td class="text-right" {{#unless hasNegativeValues}}style="background-color:#efefef;"{{/unless}}>{{stock.quantity}}</td>
               <td class="text-right" {{#unless hasNegativeValues}}style="background-color:#efefef;"{{/unless}}>{{precision stock.unit_cost 4}}</td>
-              <td class="text-right" {{#unless hasNegativeValues}}style="background-color:#efefef;border-right: 1px solid #000;"{{/unless}}>{{currency stock.value ../metadata.enterprise.currency_id}}</td>
+              <td class="text-right" style="{{#unless hasNegativeValues}}background-color:#efefef;{{/unless}} border-right: 1px solid #000;">{{currency stock.value ../metadata.enterprise.currency_id}}</td>
             </tr>
           {{/each}}
         </tbody>
-        <tfoot style="border-top: 1px solid #000;">
-          <tr class="text-right" style="font-weight: bold; background-color: #efefef;">
+        <tfoot>
+          <tr class="text-right" style="font-weight: bold; background-color: #efefef; border-top: 1px solid #000;">
             <th colspan={{#if depot.text}}"4"{{else}}"5"{{/if}}></th>
             <th class="text-right">{{totals.entry}}</th> <th></th>
             <th class="text-right">{{currency totals.entryValue metadata.enterprise.currency_id}}</th>


### PR DESCRIPTION
This PR addresses the blocking part of #5414.  It adds an opening balance calculation to the fiche de stock.  It also colors negative values red so they jump out.

Here is what it looks like:
![image](https://user-images.githubusercontent.com/896472/109707222-320fac00-7b9a-11eb-86ac-d1521d3db4b6.png)


How to test this:

1. Build any production database
2. Ensure you've rebuilt the stock_movement_status tables
3. Load the fiche de stock.
4. Pick a variety of date ranges.  You should see that the opening balance is always the end of the previous date range.

