### PR TITLE
chore(stock): improve exit report formatting

### DIFF
--- a/server/controllers/stock/reports/stock_exit.report.handlebars
+++ b/server/controllers/stock/reports/stock_exit.report.handlebars
@@ -27,7 +27,7 @@
         <table class="table table-condensed table-report">
           <thead>
             <tr style="background-color: #EFEFEF;">
-              <th colspan="5"><h3 style="margin: 0px;">{{translate 'STOCK.RECEIPT.EXIT_PATIENTS'}}</h3></th>
+              <th colspan="5">{{translate 'STOCK.RECEIPT.EXIT_PATIENTS'}}</th>
               <th colspan="2" class="text-right">{{currency exitToPatient.cost metadata.enterprise.currency_id}}</th>
             </tr>
           </thead>
@@ -35,7 +35,7 @@
             <thead>
               <tr>
                 <th colspan="4">{{ data.inventory_name }}</th>
-                <th class="text-right">{{ data.inventory_stock_exit_quantity }} <i>({{ data.inventory_unit }})</i></th>
+                <th class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
                 <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../metadata.enterprise.currency_id}}</th>
               </tr>
             </thead>
@@ -45,14 +45,14 @@
                 {{#each data.inventory_stock_exit_data as | item |}}
                   <tr>
                     <td style="border:none; width: 20%; padding-left: 30px;"><b>{{ document_reference }}</b></td>
-                    <td class="text-left" style="border:none; width: 40%;">({{ patient_reference }}) {{ patient_display_name }}</td>
+                    <td class="text-left" style="border:none; width: 40%;">{{ patient_reference }} {{ patient_display_name }}</td>
                     <td class="text-left" style="border:none; width: 15%">
                       {{#if invoice_reference}}
                         {{translate 'FORM.LABELS.INVOICE' }}: <b>{{ invoice_reference }}</b>
                       {{/if}}
                     </td>
                     <td style="border:none;">{{date date }}</td>
-                    <td class="text-right" style="border:none;">{{ quantity }} <i>({{ unit_text }})</i></td>
+                    <td class="text-right" style="border:none;">{{ quantity }} {{ unit_text }}</td>
                     <td class="text-right" style="border:none;">{{currency unit_cost ../../metadata.enterprise.currency_id}}</td>
                     <td class="text-right" style="border:none;">{{currency cost ../../metadata.enterprise.currency_id}}</td>
                   </tr>
@@ -76,7 +76,7 @@
         <table class="table table-condensed table-report">
           <thead>
             <tr style="background-color: #EFEFEF;">
-              <th colspan="5"><h3 style="margin: 0px;">{{translate 'STOCK.RECEIPT.EXIT_SERVICES'}} <small>{{translate 'STOCK.BY_INVENTORY'}}</small></h3></th>
+              <th colspan="5">{{translate 'STOCK.RECEIPT.EXIT_SERVICES'}} <small>{{translate 'STOCK.BY_INVENTORY'}}</small></th>
               <th colspan="2" class="text-right">{{currency exitToService.cost metadata.enterprise.currency_id}}</th>
             </tr>
           </thead>
@@ -84,7 +84,7 @@
             <thead>
               <tr>
                 <th colspan="4">{{ data.inventory_name }}</th>
-                <th class="text-right">{{ data.inventory_stock_exit_quantity }} <i>({{ data.inventory_unit }})</i></th>
+                <th class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
                 <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../metadata.enterprise.currency_id}}</th>
               </tr>
             </thead>
@@ -97,7 +97,7 @@
                     <td class="text-left" style="border:none; width: 40%;">{{ service_display_name }}</td>
                     <td class="text-left" style="border:none; width: 15%">&nbsp;</td>
                     <td style="border:none;">{{date date }}</td>
-                    <td class="text-right" style="border:none;">{{ quantity }} <i>({{ unit_text }})</i></td>
+                    <td class="text-right" style="border:none;">{{ quantity }} {{ unit_text }}</td>
                     <td class="text-right" style="border:none;">{{currency unit_cost ../../metadata.enterprise.currency_id}}</td>
                     <td class="text-right" style="border:none;">{{currency cost ../../metadata.enterprise.currency_id}}</td>
                   </tr>
@@ -121,7 +121,7 @@
         <table class="table table-condensed table-report">
           <thead>
             <tr style="background-color: #EFEFEF;">
-              <th colspan="5"><h3 style="margin: 0px;">{{translate 'STOCK.RECEIPT.EXIT_SERVICES'}} <small>{{translate 'STOCK.BY_SERVICE'}}</small></h3></th>
+              <th colspan="5">{{translate 'STOCK.RECEIPT.EXIT_SERVICES'}} <small>{{translate 'STOCK.BY_SERVICE'}}</small></th>
               <th colspan="2" class="text-right">{{currency exitToServiceGrouped.cost metadata.enterprise.currency_id}}</th>
             </tr>
           </thead>
@@ -137,7 +137,7 @@
               <thead>
                 <tr>
                   <th style="padding-left: 30px;" colspan="4">{{ newData.inventory_name }}</th>
-                  <th class="text-right">{{ newData.inventory_stock_exit_quantity }} <i>({{ newData.inventory_unit }})</i></th>
+                  <th class="text-right">{{ newData.inventory_stock_exit_quantity }} {{ newData.inventory_unit }}</th>
                   <th colspan="2" class="text-right">{{currency newData.inventory_stock_exit_cost ../../metadata.enterprise.currency_id}}</th>
                 </tr>
               </thead>
@@ -150,7 +150,7 @@
                       <td class="text-left" style="border:none; width: 40%;">{{ text }}</td>
                       <td class="text-left" style="border:none; width: 15%">&nbsp;</td>
                       <td style="border:none;">{{date date }}</td>
-                      <td class="text-right" style="border:none;">{{ quantity }} <i>({{ unit_text }})</i></td>
+                      <td class="text-right" style="border:none;">{{ quantity }} {{ unit_text }}</td>
                       <td class="text-right" style="border:none;">{{currency unit_cost ../../../metadata.enterprise.currency_id}}</td>
                       <td class="text-right" style="border:none;">{{currency cost ../../../metadata.enterprise.currency_id}}</td>
                     </tr>
@@ -175,7 +175,7 @@
         <table class="table table-condensed table-report">
           <thead>
             <tr style="background-color: #EFEFEF;">
-              <th colspan="5"><h3 style="margin: 0px">{{translate 'STOCK.RECEIPT.EXIT_DEPOT'}}</h3></th>
+              <th colspan="5">{{translate 'STOCK.RECEIPT.EXIT_DEPOT'}}</th>
               <th colspan="2" class="text-right">{{currency exitToDepot.cost metadata.enterprise.currency_id}}</th>
             </tr>
           </thead>
@@ -183,7 +183,7 @@
             <thead>
               <tr>
                 <th colspan="4">{{ data.inventory_name }}</th>
-                <th class="text-right">{{ data.inventory_stock_exit_quantity }} <i>({{ data.inventory_unit }})</i></th>
+                <th class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
                 <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../metadata.enterprise.currency_id}}</th>
               </tr>
             </thead>
@@ -196,7 +196,7 @@
                     <td class="text-left" style="border:none;  width: 40%;">{{ depot_name }}</td>
                     <td class="text-left" style="border:none; width: 15%">&nbsp;</td>
                     <td style="border:none;">{{date date }}</td>
-                    <td class="text-right" style="border:none;">{{ quantity }} <i>({{ unit_text }})</i></td>
+                    <td class="text-right" style="border:none;">{{ quantity }} {{ unit_text }}</td>
                     <td class="text-right" style="border:none;">{{currency unit_cost ../../metadata.enterprise.currency_id}}</td>
                     <td class="text-right" style="border:none;">{{currency cost ../../metadata.enterprise.currency_id}}</td>
                   </tr>
@@ -220,7 +220,7 @@
         <table class="table table-condensed table-report">
           <thead>
             <tr style="background-color: #EFEFEF;">
-              <th colspan="5"><h3 style="margin: 0px;">{{translate 'STOCK.RECEIPT.EXIT_LOSS'}}</h3></th>
+              <th colspan="5">{{translate 'STOCK.RECEIPT.EXIT_LOSS'}}</th>
               <th colspan="2" class="text-right">{{currency exitToLoss.cost metadata.enterprise.currency_id}}</th>
             </tr>
           </thead>
@@ -228,7 +228,7 @@
             <thead>
               <tr>
                 <th colspan="4">{{ data.inventory_name }}</th>
-                <th class="text-right">{{ data.inventory_stock_exit_quantity }} <i>({{ data.inventory_unit }})</i></th>
+                <th class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
                 <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../metadata.enterprise.currency_id}}</th>
               </tr>
             </thead>
@@ -241,7 +241,7 @@
                     <td class="text-left" style="border:none;  width: 40%;">{{ description }}</td>
                     <td class="text-left" style="border:none; width: 15%">&nbsp;</td>
                     <td style="border:none;">{{date date }}</td>
-                    <td class="text-right" style="border:none;">{{ quantity }} <i>({{ unit_text }})</i></td>
+                    <td class="text-right" style="border:none;">{{ quantity }} {{ unit_text }}</td>
                     <td class="text-right" style="border:none;">{{currency unit_cost ../../metadata.enterprise.currency_id}}</td>
                     <td class="text-right" style="border:none;">{{currency cost ../../metadata.enterprise.currency_id}}</td>
                   </tr>


### PR DESCRIPTION
This commit improves the stock exit report by:

 1. making the titles smaller
 2. removing the italics and parens around the units

Closes #5419.

![image](https://user-images.githubusercontent.com/896472/109800622-b6efd980-7c1d-11eb-9455-81f00206c804.png)
