### PR TITLE
Improvements to Stock Movement Registry

### DIFF
--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -56,6 +56,11 @@ function StockMovementsController(
       headerCellFilter : 'translate',
       cellTemplate : 'modules/stock/movements/templates/io.cell.html',
     }, {
+      field : 'flux_id',
+      displayName : 'STOCK.FLUX',
+      headerCellFilter : 'translate',
+      cellTemplate : 'modules/stock/movements/templates/flux.cell.html',
+    }, {
       field : 'cost',
       type : 'number',
       displayName : 'STOCK.COST',
@@ -69,11 +74,6 @@ function StockMovementsController(
       headerCellFilter : 'translate',
       cellFilter : 'date',
       cellClass : 'text-right',
-    }, {
-      field : 'flux_id',
-      displayName : 'STOCK.FLUX',
-      headerCellFilter : 'translate',
-      cellTemplate : 'modules/stock/movements/templates/flux.cell.html',
     }, {
       field : 'action',
       displayName : '',

--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -35,6 +35,39 @@ function StockMovementsController(
 
   vm.gridApi = {};
 
+  function aggregateCostColumn(rows) {
+    // base case: no data to aggregate, just return 0.
+    if (rows.length === 0) {
+      return 0;
+    }
+
+    // get the last direction
+    const direction = rows[rows.length - 1].entity.is_exit;
+
+    let value = 0;
+    let i = rows.length;
+    let hasMixedEntryExit = false;
+
+    while (i--) {
+      const row = rows[i].entity;
+
+      // skip group headers
+      if (row.is_exit === undefined) {
+        continue; // eslint-disable-line
+      }
+
+      // do not sum if the direction is not correct
+      if (row.is_exit !== direction) {
+        hasMixedEntryExit = true;
+        break;
+      }
+
+      value += row.cost;
+    }
+
+    return hasMixedEntryExit ? '---' : value;
+  }
+
   // global variables
   vm.enterprise = Session.enterprise;
 
@@ -67,6 +100,10 @@ function StockMovementsController(
       headerCellFilter : 'translate',
       cellFilter : 'currency:grid.appScope.enterprise.currency_id',
       cellClass : 'text-right',
+      footerCellClass : 'text-right',
+      footerCellFilter : 'currency:grid.appScope.enterprise.currency_id',
+      aggregationHideLabel : true,
+      aggregationType : aggregateCostColumn,
     }, {
       field : 'date',
       type : 'date',


### PR DESCRIPTION
This commit moves the flux column over to the I/O column so that a user can more easily determine the reason for the directionality of the flow.

Partially addresses #5424.

This commit adds a dynamic sum to the movements registry to allow us to quickly sum the outgoing medications.  Here is what that looks like:

![UIZvL5Q21G](https://user-images.githubusercontent.com/896472/109820956-c8dd7680-7c35-11eb-98ed-34723dbe9fac.gif)


Closes #4304.

