### PR TITLE
fix(stock): rewrite monthly consumption report

### DIFF
--- a/server/controllers/stock/reports/monthly_consumption.report.handlebars
+++ b/server/controllers/stock/reports/monthly_consumption.report.handlebars
@@ -18,32 +18,34 @@
       <table class="table table-striped table-condensed table-report table-bordered">
         <thead>
           <tr style="background-color:#ddd;">
-            <th class="text-center" style="width: 3%;"> {{translate 'FORM.LABELS.NR'}}</th>
-            <th class="text-center">{{translate 'FORM.LABELS.INVENTORY'}} </th>
-            {{#each periods}}
-              <th class="text-center" style="width: 7.5%;">{{translate translate_key}}</th>
+            <th class="text-center" style="max-width: 3%;"> {{translate 'FORM.LABELS.NR'}}</th>
+            <th style="min-width:100px;">{{translate 'FORM.LABELS.INVENTORY'}}</th>
+            {{#each header as | key |}}
+              <th class="text-center" style="width: calc(75% / {{../size}});">{{translate key}}</th>
             {{/each}}
             <th style="width: 7.5%;" class="text-center">{{translate 'FORM.LABELS.TOTAL'}} </th>
           </tr>
         </thead>
 
         <tbody>
-        {{#each inventories}}
-          <tr>
-            <td class="text-center">{{ add @index 1}}</td>
-            <td>{{ inventory_text }}</td>
-            {{#each monthlyConsumption}}
-              <td class="text-right">
-                {{#if quantity}}{{ quantity }}{{/if}}
-              </td>
-            {{/each}}
-            <td class="text-right"> <strong> {{ total }} </strong> </td>
-          </tr>
-        {{else}}
-          <tr>
-            <th class="text-center" colspan="{{ spanColumn }}"> {{translate 'STOCK.NO_DATA'}} </th>
-          </tr>
-        {{/each}}
+          {{#each matrix as | row |}}
+            <tr>
+              {{#each row as | column | }}
+                {{#unless @last}}
+                  <td {{#gt @index 2}}class="text-right"{{/gt}}>
+                    {{column}}
+                  </td>
+                {{else}}
+                  <th class="text-right">{{column}}</th>
+                {{/unless}}
+
+              {{/each}}
+            </tr>
+          {{else}}
+            <tr>
+              <th class="text-center" colspan="{{size}}"> {{translate 'STOCK.NO_DATA'}} </th>
+            </tr>
+          {{/each}}
         </tbody>
       </table>
     </div>

--- a/server/controllers/stock/reports/stock_changes.js
+++ b/server/controllers/stock/reports/stock_changes.js
@@ -39,6 +39,7 @@ async function generate(req, res, next) {
       month_average_consumption : req.session.stock_settings.month_average_consumption,
       average_consumption_algo : req.session.stock_settings.average_consumption_algo,
     });
+
     const data = _.groupBy(lots, 'text');
 
     const totals = { lots : lots.length, items : Object.keys(data).length };
@@ -46,6 +47,7 @@ async function generate(req, res, next) {
     const result = await report.render({
       data, depot, period, totals,
     });
+
     res.set(result.headers).send(result.report);
   } catch (e) {
     next(e);

--- a/server/models/procedures/stock.sql
+++ b/server/models/procedures/stock.sql
@@ -326,6 +326,7 @@ CREATE PROCEDURE ComputeStockStatusForStagedInventory(
   DECLARE TO_DEPOT INTEGER DEFAULT 8;
   DECLARE TO_PATIENT INTEGER DEFAULT 9;
   DECLARE TO_SERVICE INTEGER DEFAULT 10;
+  DECLARE TO_AGGREGATE_CONSUMPTION INTEGER DEFAULT 16;
 
   /*
     Creates a temporary table of stock movements for the depot, inventory items, and time frame under consideration.
@@ -342,8 +343,8 @@ CREATE PROCEDURE ComputeStockStatusForStagedInventory(
   CREATE TEMPORARY TABLE stock_movement_grp AS
     SELECT DATE(sm.date) as date, l.inventory_uuid, sm.depot_uuid, sm.quantity, is_exit, flux_id,
       CASE
-        WHEN d.is_warehouse AND flux_id IN (TO_DEPOT, TO_PATIENT, TO_SERVICE) THEN TRUE
-        WHEN flux_id IN (TO_PATIENT, TO_SERVICE) THEN TRUE
+        WHEN d.is_warehouse AND flux_id IN (TO_DEPOT, TO_PATIENT, TO_SERVICE, TO_AGGREGATE_CONSUMPTION) THEN TRUE
+        WHEN flux_id IN (TO_PATIENT, TO_SERVICE, TO_AGGREGATE_CONSUMPTION) THEN TRUE
         ELSE FALSE
       END AS is_consumption
     FROM stage_inventory_for_amc AS tmp


### PR DESCRIPTION
Restored from https://github.com/IMA-WorldHealth/bhima/pull/5436

This commit rewrites the monthly consumption report to use the new version of `stock_movement_status`.

Here is what it looks like:
![image](https://user-images.githubusercontent.com/896472/109285450-63e2e480-7821-11eb-90c1-0517784cb4a3.png)

I've also attempted to improve the layout somewhat so we don't have as much wrapping of text on large screens.

---

How to test:
  1. Load any database.  In this case, load the test one.  Observe that you will find stock movements for February 2021 in Depot Principal.
  2. Go to the stock exit and choose the Depot Principal as your depot
  3. Set the date to January 15 2021.
  4. Make a distribution of Quinine to the server Test Service.
  5. Return to the report.
  6. Observe that this movement now shows up in January.