### PR TITLE
fix(stock): fix currencies in invoice comp report

### DIFF
--- a/server/controllers/finance/reports/invoiced_received_stock/report.handlebars
+++ b/server/controllers/finance/reports/invoiced_received_stock/report.handlebars
@@ -2,163 +2,162 @@
 <html>
   {{> head title="REPORT.COMPARE_INVOICED_RECEIVED.TITLE"}}
   <body>
-  <div class="container-fluid">
-    {{> header}}
+    <div class="container-fluid">
+      {{> header}}
 
-    <!-- body -->
-    <div class="row">
-      <div class="col-xs-12">
-        <!-- page title  -->
-        <h3 class="text-center text-uppercase">
-          <strong>{{translate 'REPORT.COMPARE_INVOICED_RECEIVED.TITLE'}}</strong>
-        </h3>
+      <!-- body -->
+      <div class="row">
+        <div class="col-xs-12">
+          <!-- page title  -->
+          <h3 class="text-center text-uppercase">
+            <strong>{{translate 'REPORT.COMPARE_INVOICED_RECEIVED.TITLE'}}</strong>
+          </h3>
 
-        <h4 class="text-center"><strong>{{ patient.reference }} | {{ patient.display_name }}</strong></h4>
-        <h4 class="text-center"><strong>{{ patient.debtor_group_name }} ({{ patient.number }})</strong></h4>
+          <h4 class="text-center"><strong>{{ patient.reference }} | {{ patient.display_name }}</strong></h4>
+          <h4 class="text-center"><strong>{{ patient.debtor_group_name }} ({{ patient.number }})</strong></h4>
 
-        <h4 class="text-center">
-          <strong class="text-capitalize">{{date period.dateFrom }}</strong>
-           -
-          <strong class="text-capitalize">{{date period.dateTo }}</strong>
-        </h4>
+          <h4 class="text-center">
+            <strong class="text-capitalize">{{date period.dateFrom }}</strong>
+             -
+            <strong class="text-capitalize">{{date period.dateTo }}</strong>
+          </h4>
+        </div>
+
+        <table style="page-break-after: always; width: 100%; margin-right: auto; margin-left: auto; font-size:80%;" class="table table-striped table-condensed table-report table-bordered">
+          <thead>
+            <tr style="background-color:#efefef;">
+              <th style="width: 28%;" class="text-uppercase text-center text-bold">
+                {{translate 'TABLE.COLUMNS.ITEM'}}
+              </th>
+              <th style="width: 12%;" class="text-uppercase text-center">
+                {{translate 'TABLE.COLUMNS.QUANTITY_INVOICED'}}
+              </th>
+              <th style="width: 12%;" class="text-uppercase text-center">
+                {{translate 'TABLE.COLUMNS.PRICE_INVOICED'}}
+              </th>
+              <th style="width: 8%;" class="text-uppercase text-center">
+                {{translate 'TABLE.COLUMNS.TOTAL'}}
+              </th>
+              <th style="width: 12%;" class="text-uppercase text-center">
+                {{translate 'TABLE.COLUMNS.QUANTITY_DISTRIBUTED'}}
+              </th>
+              <th style="width: 12%;" class="text-uppercase text-center">
+                {{translate 'TABLE.COLUMNS.COST_DISTRIBUTED'}}
+              </th>
+              <th style="width: 8%;" class="text-uppercase text-center">
+                {{translate 'TABLE.COLUMNS.TOTAL'}}
+              </th>
+              <th style="width: 12%;" class="text-uppercase text-center">
+                {{translate 'TABLE.COLUMNS.QUANTITY_DIFFERENCE'}}
+              </th>
+              <th style="width: 12%;" class="text-uppercase text-center">
+                {{translate 'TABLE.COLUMNS.COST_DIFFERENCE'}}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each invoices}}
+            <tr>
+              <td class="text-uppercase text-bold" style="background-color:#cfcfcf;"  colspan="9">
+                {{ text }} | {{ timestamp date }}
+              </td>
+            </tr>
+
+            {{#each inventories}}
+              <tr>
+                <td> {{ inventory_text }} </td>
+                <td class="text-right"> {{ quantity_invoiced }} </td>
+                <td class="text-right">
+                  {{#if price_invoiced }}
+                    {{ debcred price_invoiced ../../metadata.enterprise.currency_id }}
+                  {{/if}}
+                </td>
+                <td class="text-right">
+                  {{#if total_item_invoiced }}
+                    <strong>{{ debcred total_item_invoiced ../../metadata.enterprise.currency_id }}</strong>
+                  {{/if}}
+                </td>
+                <td class="text-right"> {{ quantity_distributed }} </td>
+                <td class="text-right">
+                  {{#if cost_distributed }}
+                    {{ debcred cost_distributed ../../metadata.enterprise.currency_id }}
+                  {{/if}}
+                </td>
+                <td class="text-right">
+                  {{#if total_item_distributed }}
+                    <strong>{{ debcred total_item_distributed ../../metadata.enterprise.currency_id }}</strong>
+                  {{/if}}
+                </td>
+                <td class="text-right"> <strong> {{ lessZero quantity_difference }} </strong></td>
+                <td class="text-right"> <strong> {{ debcred cost_difference ../../metadata.enterprise.currency_id }} </strong></td>
+              </tr>
+            {{/each}}
+            <tr>
+              <td></td>
+              <td class="text-right text-uppercase" colspan="2"><strong> {{translate 'TABLE.COLUMNS.TOTAL_INVOICE'}} </strong></td>
+              <td class="text-right text-uppercase"> <strong>{{ debcred total_invoice ../metadata.enterprise.currency_id }}</strong> </td>
+              <td class="text-right text-uppercase" colspan="2"><strong> {{translate 'TABLE.COLUMNS.TOTAL_DISTRIBUTION_COST'}} </strong></td>
+              <td class="text-right text-uppercase"> <strong>{{ debcred total_distribution ../metadata.enterprise.currency_id }}</strong> </td>
+              <td class="text-right text-uppercase"><strong> {{translate 'TABLE.COLUMNS.DIFFERENCE'}} </strong></td>
+              <td class="text-right text-uppercase"> <strong>{{ debcred difference ../metadata.enterprise.currency_id }}</strong> </td>
+            </tr>
+            {{else}}
+              {{>emptyTable columns=9}}
+            {{/each}}
+          </tbody>
+        </table>
+        <br>
+        <br>
+        <br>
+        {{#if checkNoInvoiceAttribution }}
+        <table style="page-break-after: always; width: 100%; margin-right: auto; margin-left: auto; font-size:80%;" class="table table-striped table-condensed table-report table-bordered">
+          <thead>
+            <tr style="background-color:#cfcfcf;">
+              <th class="text-uppercase text-bold" colspan="5"> {{translate 'REPORT.COMPARE_INVOICED_RECEIVED.NO_INVOICE_ATTRIBUTION'}}</th>
+            </tr>
+            <tr style="background-color:#efefef; font-size:84%;">
+              <th style="width: 28%;" class="text-uppercase text-center text-bold">
+                {{translate 'TABLE.COLUMNS.ITEM'}}
+              </th>
+              <th style="width: 18%;" class="text-uppercase text-center">
+                {{translate 'TABLE.COLUMNS.DATE'}}
+              </th>
+              <th style="width: 18%;" class="text-uppercase text-center">
+                {{translate 'TABLE.COLUMNS.QUANTITY'}}
+              </th>
+              <th style="width: 18%;" class="text-uppercase text-center">
+                {{translate 'TABLE.COLUMNS.VALUE'}}
+              </th>
+              <th style="width: 18%;" class="text-uppercase text-center">
+                {{translate 'TABLE.COLUMNS.TOTAL'}}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each noInvoiceAttributionAggregat}}
+            <tr>
+              <td class="text-uppercase text-bold" style="background-color:#cfcfcf;"  colspan="5">
+                {{ document }}
+              </td>
+            </tr>
+            {{#each inventories}}
+              <tr>
+                <td> {{ inventory_text }} </td>
+                <td> {{ timestamp date }} </td>
+                <td class="text-right"> {{ quantity }} </td>
+                <td class="text-right"> {{ debcred unit_cost ../../metadata.enterprise.currency_id }} </td>
+                <td class="text-right"> <strong>{{ debcred total_cost ../../metadata.enterprise.currency_id }}</strong> </td>
+              </tr>
+            {{/each}}
+            <tr style="background-color:#efefef;">
+              <td colspan="4" class="text-right"><strong>{{translate 'TABLE.COLUMNS.TOTAL'}}</strong></td>
+              <td class="text-right"><strong> {{ debcred total_movement ../metadata.enterprise.currency_id }}  </strong></td>
+            </tr>
+          </tbody>
+          {{/each}}
+        </table>
+        {{/if}}
       </div>
-
-      <table style="page-break-after: always; width: 100%; margin-right: auto; margin-left: auto; font-size:80%;" class="table table-striped table-condensed table-report table-bordered">
-        <thead>
-          <tr style="background-color:#efefef;">
-            <th style="width: 28%;" class="text-uppercase text-center text-bold">
-              {{translate 'TABLE.COLUMNS.ITEM'}}
-            </th>
-            <th style="width: 12%;" class="text-uppercase text-center">
-              {{translate 'TABLE.COLUMNS.QUANTITY_INVOICED'}}
-            </th>
-            <th style="width: 12%;" class="text-uppercase text-center">
-              {{translate 'TABLE.COLUMNS.PRICE_INVOICED'}}
-            </th>
-            <th style="width: 8%;" class="text-uppercase text-center">
-              {{translate 'TABLE.COLUMNS.TOTAL'}}
-            </th>
-            <th style="width: 12%;" class="text-uppercase text-center">
-              {{translate 'TABLE.COLUMNS.QUANTITY_DISTRIBUTED'}}
-            </th>
-            <th style="width: 12%;" class="text-uppercase text-center">
-              {{translate 'TABLE.COLUMNS.COST_DISTRIBUTED'}}
-            </th>
-            <th style="width: 8%;" class="text-uppercase text-center">
-              {{translate 'TABLE.COLUMNS.TOTAL'}}
-            </th>
-            <th style="width: 12%;" class="text-uppercase text-center">
-              {{translate 'TABLE.COLUMNS.QUANTITY_DIFFERENCE'}}
-            </th>
-            <th style="width: 12%;" class="text-uppercase text-center">
-              {{translate 'TABLE.COLUMNS.COST_DIFFERENCE'}}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each invoices}}
-          <tr>
-            <td class="text-uppercase text-bold" style="background-color:#cfcfcf;"  colspan="9">
-              {{ text }} | {{ timestamp date }}
-            </td>
-          </tr>
-
-          {{#each inventories}}
-            <tr>
-              <td> {{ inventory_text }} </td>
-              <td class="text-right"> {{ quantity_invoiced }} </td>
-              <td class="text-right">
-                {{#if price_invoiced }}
-                  {{ debcred price_invoiced ../../metadata.enterprise.currency_id }}
-                {{/if}}
-              </td>
-              <td class="text-right">
-                {{#if total_item_invoiced }}
-                  <strong>{{ debcred total_item_invoiced ../../metadata.enterprise.currency_id }}</strong>
-                {{/if}}
-              </td>
-              <td class="text-right"> {{ quantity_distributed }} </td>
-              <td class="text-right">
-                {{#if cost_distributed }}
-                  {{ debcred cost_distributed ../../metadata.enterprise.currency_id }}
-                {{/if}}
-              </td>
-              <td class="text-right">
-                {{#if total_item_distributed }}
-                  <strong>{{ debcred total_item_distributed ../../metadata.enterprise.currency_id }}</strong>
-                {{/if}}
-              </td>
-              <td class="text-right"> <strong> {{ lessZero quantity_difference }} </strong></td>
-              <td class="text-right"> <strong> {{ debcred cost_difference ../../metadata.enterprise.currency_id }} </strong></td>
-            </tr>
-          {{/each}}
-          <tr>
-            <td></td>
-            <td class="text-right text-uppercase" colspan="2"><strong> {{translate 'TABLE.COLUMNS.TOTAL_INVOICE'}} </strong></td>
-            <td class="text-right text-uppercase"> <strong>{{ debcred total_invoice ../metadata.enterprise.currency_id }}</strong> </td>
-            <td class="text-right text-uppercase" colspan="2"><strong> {{translate 'TABLE.COLUMNS.TOTAL_DISTRIBUTION_COST'}} </strong></td>
-            <td class="text-right text-uppercase"> <strong>{{ debcred total_distribution ../metadata.enterprise.currency_id }}</strong> </td>
-            <td class="text-right text-uppercase"><strong> {{translate 'TABLE.COLUMNS.DIFFERENCE'}} </strong></td>
-            <td class="text-right text-uppercase"> <strong>{{ debcred difference ../metadata.enterprise.currency_id }}</strong> </td>
-          </tr>
-          {{else}}
-            {{>emptyTable columns=9}}
-          {{/each}}
-        </tbody>
-      </table>
-      <br>
-      <br>
-      <br>
-      {{#if checkNoInvoiceAttribution }}
-      <table style="page-break-after: always; width: 100%; margin-right: auto; margin-left: auto; font-size:80%;" class="table table-striped table-condensed table-report table-bordered">
-        <thead>
-          <tr style="background-color:#cfcfcf;">
-            <th class="text-uppercase text-bold" colspan="5"> {{translate 'REPORT.COMPARE_INVOICED_RECEIVED.NO_INVOICE_ATTRIBUTION'}}</th>
-          </tr>
-          <tr style="background-color:#efefef; font-size:84%;">
-            <th style="width: 28%;" class="text-uppercase text-center text-bold">
-              {{translate 'TABLE.COLUMNS.ITEM'}}
-            </th>
-            <th style="width: 18%;" class="text-uppercase text-center">
-              {{translate 'TABLE.COLUMNS.DATE'}}
-            </th>
-            <th style="width: 18%;" class="text-uppercase text-center">
-              {{translate 'TABLE.COLUMNS.QUANTITY'}}
-            </th>
-            <th style="width: 18%;" class="text-uppercase text-center">
-              {{translate 'TABLE.COLUMNS.VALUE'}}
-            </th>
-            <th style="width: 18%;" class="text-uppercase text-center">
-              {{translate 'TABLE.COLUMNS.TOTAL'}}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each noInvoiceAttributionAggregat}}
-          <tr>
-            <td class="text-uppercase text-bold" style="background-color:#cfcfcf;"  colspan="5">
-              {{ document }}
-            </td>
-          </tr>
-          {{#each inventories}}
-            <tr>
-              <td> {{ inventory_text }} </td>
-              <td> {{ timestamp date }} </td>
-              <td class="text-right"> {{ quantity }} </td>
-              <td class="text-right"> {{ debcred unit_cost ../../metadata.enterprise.currency_id }} </td>
-              <td class="text-right"> <strong>{{ debcred total_cost ../../metadata.enterprise.currency_id }}</strong> </td>
-            </tr>
-          {{/each}}
-          <tr style="background-color:#efefef;">
-            <td colspan="4" class="text-right"><strong>{{translate 'TABLE.COLUMNS.TOTAL'}}</strong></td>
-            <td class="text-right"><strong> {{ debcred total_movement ../../metadata.enterprise.currency_id }}  </strong></td>
-          </tr>
-        </tbody>
-        {{/each}}
-      </table>
-      {{/if}}
     </div>
-  </div>
-
-</body>
+  </body>
 </html>


### PR DESCRIPTION
Restored from https://github.com/IMA-WorldHealth/bhima/pull/5456

Renders currencies correctly on the report comparing invoiced stock and received stock.  The report now uses the enterprise currency for comparison.

Closes #5351.

![image](https://user-images.githubusercontent.com/896472/109804784-efde7d00-7c22-11eb-826b-ba0e7f5c3813.png)
