### PR TITLE
feat(stock): add minimum delay to stock settings

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -257,7 +257,9 @@
     "ORDER_BY_CREATED_AT" : "Sort lots movements by their true creation date",
     "ORDER_BY_CREATED_AT_HELP_TEXT" : "This option allows you to sort lot movements by their true creation date in the system",
     "ENABLE_STRICT_DEPOT_DISTRIBUTION" : "Activate the restriction of distribution depots",
-    "ENABLE_STRICT_DEPOT_DISTRIBUTION_HELP_TEXT" : "Limits the depots a user can interact with to the depots that the user has access to. Thus, if a user cannot distribute stock from a depot, they also cannot transfer stock to that depot."
+    "ENABLE_STRICT_DEPOT_DISTRIBUTION_HELP_TEXT" : "Limits the depots a user can interact with to the depots that the user has access to. Thus, if a user cannot distribute stock from a depot, they also cannot transfer stock to that depot.",
+    "MIN_PURCHASE_DELAY": "Minimum Purchase Delay",
+    "MIN_PURCHASE_DELAY_HELP_TEXT": "Set the minumum amount of expected delay in months for a supplier to deliver medicines after the purchase order is finalised."
   },
   "STOCK_FLUX" : {
     "ALL_DESTINATION"  : "All Destinations",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -11,7 +11,7 @@
       "END_OF_CONSUMPTION": "Fin de la consommation",
       "START_OF_CONSUMPTION": "Début de la consommation",
       "TITLE": "Consommation de stock agrégée"
-    },    
+    },
     "AMOUNT"          : "Montant",
     "APPROVISIONING"  : "Quantité à commander",
     "AT_LEAST_ONE_CHECKED" : "Au moins une option doit être coché",
@@ -258,7 +258,9 @@
     "ORDER_BY_CREATED_AT" : "Ordonner les mouvements de lots par leurs dates de création",
     "ORDER_BY_CREATED_AT_HELP_TEXT" : "Cette option permet d'ordonner les movements de lots par leurs dates réelles de création dans le système",
     "ENABLE_STRICT_DEPOT_DISTRIBUTION" : "Activer la restriction des depots de distribution",
-    "ENABLE_STRICT_DEPOT_DISTRIBUTION_HELP_TEXT" : "Limite les dépôts qui peuvent recevoir du stock à partir d'un dépôt donné; lors de la sortie de stock vers un dépôt, seul les dépôts autorisés peuvent s'afficher pour le dépôt donné afin de recevoir du stock"
+    "ENABLE_STRICT_DEPOT_DISTRIBUTION_HELP_TEXT" : "Limite les dépôts qui peuvent recevoir du stock à partir d'un dépôt donné; lors de la sortie de stock vers un dépôt, seul les dépôts autorisés peuvent s'afficher pour le dépôt donné afin de recevoir du stock",
+    "MIN_PURCHASE_DELAY": "Délai d'achat minimum",
+    "MIN_PURCHASE_DELAY_HELP_TEXT": "Définit le délai minimum en mois prévu pour un fournisseur pour livrer des médicaments après la finalisation de la commande d'achat. "
   },
   "STOCK_FLUX" : {
     "ALL_DESTINATION"  : "Toutes les destinations",

--- a/client/src/modules/stock/settings/stock-settings.html
+++ b/client/src/modules/stock/settings/stock-settings.html
@@ -52,6 +52,25 @@
             </div>
           </div>
 
+          <div class="form-group"
+            ng-class="{ 'has-error' : StockSettingsForm.$submitted && StockSettingsForm.min_delay.$invalid }">
+            <label class="control-label" translate>
+              SETTINGS.MIN_PURCHASE_DELAY
+            </label>
+            <input type="number" class="form-control" autocomplete="off"
+              name="min_delay"
+              ng-model="StockSettingsCtrl.settings.min_delay"
+              ng-change="StockSettingsCtrl.setMinDelay(value)" min="0"
+              placeholder="0.00">
+            <span class="help-block" translate>
+              SETTINGS.MIN_PURCHASE_DELAY_HELP_TEXT
+            </span>
+            <div class="help-block" ng-messages="StockSettingsForm.min_delay.$error"
+              ng-show="StockSettingsForm.$submitted">
+              <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
+            </div>
+          </div>
+
           <bh-yes-no-radios label="SETTINGS.ENABLE_AUTO_PURCHASE_ORDER_CONFIRMATION_LABEL"
             value="StockSettingsCtrl.settings.enable_auto_purchase_order_confirmation"
             name="enable_auto_purchase_order_confirmation"
@@ -96,7 +115,7 @@
           <div id="average_consumption_algo" class="form-group"
             ng-class="{'has-error' : StockSettingsForm.$submitted && StockSettingsForm.average_consumption_algo.$invalid }">
             <label class="control-label" translate>FORM.LABELS.ALGO_MONTHLY_CONSUMPTION</label>
-            <div ng-repeat="algo in StockSettingsCtrl.algorithmes" class="form-indent">
+            <div ng-repeat="algo in StockSettingsCtrl.algorithms" class="form-indent">
               <label class="radio-inline">
                 <input type="radio" name="average_consumption_algo" id="{{algo.name}}" ng-value="algo.name" ng-model="StockSettingsCtrl.settings.average_consumption_algo" required>
                 <span class="text-bold" translate>{{ algo.label }}</span>

--- a/client/src/modules/stock/settings/stock-settings.js
+++ b/client/src/modules/stock/settings/stock-settings.js
@@ -34,18 +34,17 @@ function StockSettingsController(
 
         // Now look up the stock settings
         // (assume they have already been created )
-        StockSettings.read(null, params)
-          .then(settings => {
-            if (settings.length > 0) {
-              [vm.settings] = settings;
-            }
-          })
-          .catch(Notify.handleError);
+        return StockSettings.read(null, params);
+      })
+      .then(settings => {
+        if (settings.length > 0) {
+          [vm.settings] = settings;
+        }
       })
       .catch(Notify.handleError);
 
-    // load algorithmes for Average Consumption
-    vm.algorithmes = bhConstants.average_consumption_algo;
+    // load algorithms for Average Consumption
+    vm.algorithms = bhConstants.average_consumption_algo;
   }
 
   // form submission
@@ -62,9 +61,11 @@ function StockSettingsController(
     }
 
     const changes = util.filterFormElements(form, true);
+
     Object.keys(vm.settings).forEach(key => {
       delete changes[key];
     });
+
     changes.settings = angular.copy(vm.settings);
 
     const promise = StockSettings.update(vm.enterprise.id, changes);
@@ -101,6 +102,8 @@ function StockSettingsController(
   vm.setDefaultMinMonthsSecurityStock = function setDefaultMinMonthsSecurityStock() {
     $touched = true;
   };
+
+  vm.setMinDelay = () => { $touched = true; };
 
   startup();
 }

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -591,7 +591,7 @@ function listMovements(req, res, next) {
  */
 function dashboard(req, res, next) {
   // eslint-disable-next-line
-  const { month_average_consumption, average_consumption_algo } = req.session.stock_settings;
+  const { month_average_consumption, average_consumption_algo, min_delay } = req.session.stock_settings;
 
   const dbPromises = [];
   let depotsByUser = [];
@@ -642,6 +642,7 @@ function dashboard(req, res, next) {
             is_expiry_risk : '1',
             month_average_consumption,
             average_consumption_algo,
+            min_delay,
           };
 
           dbPromises.push(core.getLotsDepot(
@@ -755,6 +756,7 @@ async function listLotsDepot(req, res, next) {
 
   params.month_average_consumption = req.session.stock_settings.month_average_consumption;
   params.average_consumption_algo = req.session.stock_settings.average_consumption_algo;
+  params.min_delay = req.session.stock_settings.min_delay;
 
   if (req.session.stock_settings.enable_strict_depot_permission) {
     params.check_user_id = req.session.user.id;
@@ -810,6 +812,7 @@ async function listInventoryDepot(req, res, next) {
 
   params.month_average_consumption = req.session.stock_settings.month_average_consumption;
   params.average_consumption_algo = req.session.stock_settings.average_consumption_algo;
+  params.min_delay = req.session.stock_settings.min_delay;
 
   try {
     // FIXME(@jniles) - these two call essentially the same route.  Do we need both?

--- a/server/controllers/stock/reports/stock/expiration_report.js
+++ b/server/controllers/stock/reports/stock/expiration_report.js
@@ -40,7 +40,7 @@ async function stockExpirationReport(req, res, next) {
 
     // define month average and the algo to use
     // eslint-disable-next-line
-    const { month_average_consumption, average_consumption_algo } = req.session.stock_settings;
+    const { month_average_consumption, average_consumption_algo, min_delay } = req.session.stock_settings;
     _.extend(options, { month_average_consumption, average_consumption_algo });
 
     // get the lots for this depot

--- a/server/controllers/stock/setting/index.js
+++ b/server/controllers/stock/setting/index.js
@@ -23,7 +23,8 @@ exports.list = function list(req, res, next) {
     SELECT month_average_consumption, default_min_months_security_stock,
       enable_auto_purchase_order_confirmation, enable_auto_stock_accounting,
       enable_strict_depot_permission, enable_supplier_credit,
-      enable_strict_depot_distribution, average_consumption_algo
+      enable_strict_depot_distribution, average_consumption_algo,
+      min_delay
     FROM stock_setting
     WHERE enterprise_id = ? LIMIT 1;
     `;

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -179,3 +179,11 @@ INSERT INTO `flux` VALUES
 ALTER TABLE `inventory_unit`
 	CHANGE COLUMN `abbr` `abbr` VARCHAR(50),
 	CHANGE COLUMN `text` `text` VARCHAR(50);
+
+
+/*
+ * @author: jniles
+ * @date: 2021-03-05
+ * @description: add minimum delay column to stock settings
+*/
+ALTER TABLE stock_setting ADD COLUMN `min_delay` DECIMAL(19,4) NOT NULL DEFAULT 0;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1871,6 +1871,7 @@ CREATE TABLE `stock_setting` (
   `enable_supplier_credit` TINYINT(1) NOT NULL DEFAULT 0,
   `enable_strict_depot_distribution` TINYINT(1) NOT NULL DEFAULT 0,
   `average_consumption_algo` VARCHAR(100) NOT NULL DEFAULT 'algo_msh', -- Algo MSH
+  `min_delay` DECIMAL(19,4) NOT NULL DEFAULT 0, -- minimum number of months for inventory delay
   CONSTRAINT `stock_setting__enterprise` FOREIGN KEY (`enterprise_id`) REFERENCES `enterprise` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 

--- a/test/integration/stock/stockSettings.js
+++ b/test/integration/stock/stockSettings.js
@@ -21,7 +21,7 @@ describe('(/stock/setting) Stock Settings API', () => {
     'month_average_consumption', 'default_min_months_security_stock',
     'enable_auto_purchase_order_confirmation', 'enable_auto_stock_accounting',
     'enable_strict_depot_permission', 'enable_supplier_credit', 'enable_strict_depot_distribution',
-    'average_consumption_algo',
+    'average_consumption_algo', 'min_delay',
   ];
 
   it('GET /stock/setting/:id returns the stock settings for the default Enterprise and checks a value', () => {


### PR DESCRIPTION
Adds a "minimum delay" setting to stock management to ensure that we are able to detect stock outs on time, even if the purchase data is messy. Previously, we relied on purchasing data solely for the delay, and users who put in a purchase order, then immediately delivered it, shoved the delay closer to 0.  This caused us to not warn users in time of stock outs.  The user can now configure the minimum number of months in decimal form on the stock settings page.

Closes #5407.

Here is what it looks like in action:

![Bq45NpG2Zz](https://user-images.githubusercontent.com/896472/110122693-3b7a5d80-7dc0-11eb-8049-16e638ba4486.gif)

----


How to test:
  1. Load a production database.  Remember to have run the migration file and built the stock movement status tables.
  2. Go to the articles in stock registry.  You'll likely have a mix of states of stock.
  3. Go to the stock settings page.  Notice that the setting for minimum delay is empty. Set it to 500 months.
  4. Go back to the articles in stock registry.  All the stock with CMM should show a critical stock state.
  5. Return and set to something more reasonable such as 1.  You will likely have another mix of stock states.
  


