### PR TITLE
fix(patients): remove duplicate stock movements in financial standing

### DIFF
--- a/server/controllers/finance/reports/financial.patient.handlebars
+++ b/server/controllers/finance/reports/financial.patient.handlebars
@@ -60,9 +60,9 @@
         </tr>
       </tfoot>
     </table>
+
     {{#if includeStockDistributed }}
-      <br>
-      <br>
+      <br />
       <table class="table table-condensed table-bordered table-report">
         <thead>
           <tr>
@@ -71,61 +71,64 @@
             </th>
           </tr>
         </thead>
-        <tbody>
-          {{#each stockMovement}}
-            <tr>
-              <td class="text-uppercase" style="background-color: #eee;" colspan="8">
+        {{#each stockMovement}}
+          <tbody style="padding-bottom: 2px;">
+            <tr style="background-color: #eee;">
+              <td
+                class="text-uppercase"
+                colspan="{{#if invoiceReference}}6{{else}}8{{/if}}">
                 <strong>
-                  ({{ add @index 1 }}): {{translate "FORM.LABELS.REFERENCE" }} : {{ reference_text }}  | {{timestamp date}}
+                  ({{ add @index 1 }}): {{ hrReference }}  | {{timestamp date}}
                 </strong>
               </td>
+
+              {{#if invoiceReference}}
+                <th colspan=2 class="text-right">{{invoiceReference}}</th>
+              {{/if}}
             </tr>
             <tr class="text-capitalize text-bold" style="background-color: #efefef;">
-              <td style="width: 2%;"></td>
-              <td style="width: 2%;"> {{translate "FORM.LABELS.NR" }} </td>
-              <td> {{translate "FORM.LABELS.INVENTORY" }} </td>
-              <td> {{translate "FORM.LABELS.UNIT" }} </td>
-              <td> {{translate "FORM.LABELS.LOT" }} </td>
-              <td> {{translate "FORM.LABELS.QUANTITY" }} </td>
-              <td> {{translate "FORM.LABELS.UNIT_PRICE" }} </td>
-              <td> {{translate "FORM.LABELS.TOTAL" }} </td>
+              <td class="text-center" colspan=2 style="width: 4%;">{{translate "FORM.LABELS.NR" }}</td>
+              <td>{{translate "FORM.LABELS.INVENTORY" }} </td>
+              <td>{{translate "FORM.LABELS.UNIT" }} </td>
+              <td>{{translate "FORM.LABELS.LOT" }} </td>
+              <td>{{translate "FORM.LABELS.QUANTITY" }} </td>
+              <td>{{translate "FORM.LABELS.UNIT_PRICE" }} </td>
+              <td>{{translate "FORM.LABELS.TOTAL" }} </td>
             </tr>
               {{#each consumed}}
                 <tr>
-                  <td></td>
-                  <td>{{ add @index 1 }}</td>
-                  <td><strong> {{ inventory_text }} </strong></td>
-                  <td> {{ inventoryUnit }} </td>
-                  <td>
-                    <strong>
-                      {{ lotLabel }}
-                    </strong>
-                  </td>
-                  <td> {{ quantity }} </td>
-                  <td> {{ unit_cost }} </td>
+                  <td colspan=2 class="text-center">{{ add @index 1 }}</td>
+                  <td>{{ inventory_text }}</td>
+                  <td>{{ inventoryUnit }}</td>
+                  <td>{{ lotLabel }}</td>
+                  <td class="text-right"> {{ quantity }} </td>
+                  <td class="text-right"> {{ currency unit_cost ../../metadata.enterprise.currency_id }} </td>
                   <td class="text-right"> {{ debcred  total ../../metadata.enterprise.currency_id }} </td>
                 </tr>
               {{/each}}
               <tr class="text-right text-bold">
-                <td></td>
-                <td  colspan="6"> {{translate "FORM.LABELS.TOTAL" }} </td>
-                <td> {{ debcred  totalMovement ../metadata.enterprise.currency_id }} </td>
+                <td colspan="7"> {{translate "FORM.LABELS.TOTAL" }} </td>
+                <td>{{ debcred value ../metadata.enterprise.currency_id }} </td>
               </tr>
-              <tr>
-                <td colspan="8"></td>
-              <tr>
+
+              <!-- dummy row to make offset padding -->
+              <tr style="border: 0;"><td colspan="8" style="border:0;"></td></tr>
+            </tbody>
           {{else}}
-            {{>emptyTable columns=8}}
+            <tbody>
+              {{>emptyTable columns=8}}
+            </tbody>
           {{/each}}
-          <tr style="background-color: #ddd; font-size: 17" class="text-uppercase text-right">
-            <td  colspan="7"><h5><strong>{{translate "REPORT.PATIENT_STANDING.TOTAL_ALL_STOCK_MOV" }}</strong></h5></td>
-            <td>
-              <h5>
-                <strong>{{ debcred  totalAllMovement metadata.enterprise.currency_id }}</strong>
-              </h5>
-            </td>
-          </tr>
-        </tbody>
+          <tfoot>
+            <tr style="background-color: #ddd;" class="text-uppercase">
+              <th class="text-right" colspan="7">
+                {{translate "REPORT.PATIENT_STANDING.TOTAL_ALL_STOCK_MOV" }}
+              </th>
+              <th class="text-right">
+               {{ debcred totalAllMovement metadata.enterprise.currency_id }}
+              </th>
+            </tr>
+          </tfoot>
       </table>
     {{/if}}
   </section>

--- a/server/controllers/finance/reports/financial.patient.js
+++ b/server/controllers/finance/reports/financial.patient.js
@@ -65,25 +65,17 @@ function build(req, res, next) {
       if (data.includeStockDistributed) {
         data.stockMovement = stockMovement;
         data.stockMovement.forEach(item => {
-          item.consumed = [];
-          item.totalMovement = 0;
-          stockConsumed.forEach(inv => {
-            if (item.reference_text === inv.reference_text) {
-              inv.total = inv.quantity * inv.unit_cost;
-              item.totalMovement += inv.total;
-              item.consumed.push(inv);
-            }
-          });
-
-          data.totalAllMovement += item.totalMovement;
+          item.consumed = stockConsumed
+            .filter(inv => item.hrReference === inv.reference_text);
+          data.totalAllMovement += item.value;
         });
       }
 
       aggregates.balanceText = aggregates.balance >= 0 ? 'FORM.LABELS.DEBIT_BALANCE' : 'FORM.LABELS.CREDIT_BALANCE';
 
       _.extend(data, { transactions, aggregates });
+      return report.render(data);
     })
-    .then(() => report.render(data))
     .then(result => {
       res.set(result.headers).send(result.report);
     })

--- a/test/integration/patients.js
+++ b/test/integration/patients.js
@@ -280,9 +280,12 @@ describe('(/patients) Patients', () => {
   it('GET patients/:uuid/stock/movements Returns the stock movement related to the Patient', () => {
     return agent.get(`/patients/${patientTest2}/stock/movements`)
       .then((res) => {
-        const expectedKeys = ['document_uuid', 'depot_uuid', 'date', 'reference_text'];
+        const expectedKeys = [
+          'document_uuid', 'depot_uuid', 'date', 'invoiceReference',
+          'value', 'depot_name', 'hrReference',
+        ];
         expect(res.body[0]).to.contain.keys(expectedKeys);
-        expect(res.body[0].reference_text).to.equal('SM.9.7');
+        expect(res.body[0].hrReference).to.equal('SM.9.7');
       });
 
   });
@@ -376,7 +379,6 @@ function PatientGroups() {
       .catch(helpers.handler);
   });
 }
-
 
 // Tests for /patients/hospital_number/:id/exists
 function HospitalNumber() {


### PR DESCRIPTION
Removes duplicate stock movements from the patient standing report. Also improves the SQL/JS code by removing extraneous values and grouping where it should be grouped.  Finally, we've added the invoice reference to the stock movement where possible.

Closes #5350.

Here is what it looks like, with the invoice reference highlighted:
![image](https://user-images.githubusercontent.com/896472/110177036-99c92f80-7e04-11eb-8cc4-a9b45441be71.png)
