### PR TITLE
fix: typo in old migration script

### DIFF
--- a/server/models/migrations/v1.17.0-v1.17.1/migrate.sql
+++ b/server/models/migrations/v1.17.0-v1.17.1/migrate.sql
@@ -13,7 +13,7 @@ UPDATE `unit` SET `path` = '/reports/patient_standing' WHERE id = 202;
 UPDATE `unit` SET `path` = '/reports/unpaid_invoice_payments' WHERE id = 210;
 UPDATE `unit` SET `path` = '/reports/fee_center' WHERE id = 222;
 UPDATE `unit` SET `path` = '/reports/break_even' WHERE id = 231;
-UPDATE `unit` SET `path` = '/reports/break_even_fee_center' WHERE id = 232
+UPDATE `unit` SET `path` = '/reports/break_even_fee_center' WHERE id = 232;
 UPDATE `unit` SET `path` = '/reports/indicators_report' WHERE id = 238;
 UPDATE `unit` SET `path` = '/reports/monthly_balance' WHERE id = 244;
 UPDATE `unit` SET `path` = '/reports/debtor_summary' WHERE id = 245;


### PR DESCRIPTION
This commit fixes a typo in an old migration script.  If we ever need to upgrade an old database, we'll be bit by this.