### PR TITLE
chore(roles): use bhCheckboxTree for actions

### DIFF
--- a/client/src/js/components/bhCheckboxTree/bhCheckboxTree.js
+++ b/client/src/js/components/bhCheckboxTree/bhCheckboxTree.js
@@ -46,8 +46,10 @@ function bhCheckboxTreeController(Tree) {
     }
 
     if (changes.checkedIds && changes.checkedIds.currentValue) {
-      processCheckedIds();
-      getCheckedNodes();
+      if (!angular.equals(changes.checkedIds.currentValue, changes.checkedIds.previousValue)) {
+        processCheckedIds();
+        getCheckedNodes();
+      }
     }
   };
 
@@ -101,7 +103,7 @@ function bhCheckboxTreeController(Tree) {
       node._disabled = false;
 
       // work on flat arrays by faking a tree
-      if ($ctrl.isFlatTree) { node[$ctrl.parentKey] = 0; }
+      if (angular.isDefined($ctrl.isFlatTree)) { node[$ctrl.parentKey] = 0; }
     });
 
     // create the tree
@@ -127,9 +129,11 @@ function bhCheckboxTreeController(Tree) {
 
     $ctrl.tree.walk(node => { if (node._checked) { checked.push($ctrl.tree.id(node)); } });
 
+    const offset = $ctrl.disabledIds ? $ctrl.disabledIds.length : 0;
+
     // since disabled nodes cannot be checked, remove them from the count
     // this allows the toggle on the root node to function correctly.
-    const numCheckableNodes = ($ctrl.data.length - $ctrl.disabledIds.length);
+    const numCheckableNodes = ($ctrl.data.length - offset);
 
     // toggle the root node if all child nodes are checked
     $ctrl.root._checked = checked.length === numCheckableNodes;

--- a/client/src/modules/roles/modal/roleActions.html
+++ b/client/src/modules/roles/modal/roleActions.html
@@ -1,38 +1,32 @@
-<form name="RoleActionForm" bh-submit="RoleActionsCtrl.assignActionToRole()">
+<form name="RoleActionForm" bh-submit="RoleActionsCtrl.assignActionToRole(RoleActionForm)">
   <div class="modal-header">
     <ol class="headercrumb">
+      <li class="static" translate>TREE.ROLE_MANAGEMENT</li>
+      <li class="title">{{RoleActionsCtrl.role.label}}</li>
       <li class="static" translate>FORM.BUTTONS.ACTIONS</li>
-      <li class="title">
-        <span translate>{{RoleActionsCtrl.role.label}}</span>
-      </li>
     </ol>
-</div>
-
-<div class="modal-body">
-
-  <div class="row">
-    <div class="col-lg-12">
-      <ul class="list-group">
-        <li  class="list-group-item" ng-repeat="action in RoleActionsCtrl.actions track by action.id">
-          <label class="radio-inline">
-            <input type="checkbox" ng-model="action.affected" ng-true-value="1" ng-false-value="0" />
-            <span id="RoleActionForm_{{::action.description}}" translate>{{::action.description}}</span>
-          </label>
-        </li>
-      </ul>
-    </div>
   </div>
-</div>
 
-<div class="modal-footer text-right">
-  <button
-    type="button"
-    class="btn btn-default"
-    ng-click="RoleActionsCtrl.close()"
-    translate>
-    FORM.BUTTONS.CLOSE
-  </button>
-  <bh-loading-button loading-state="RoleActionForm.$loading">
-  </bh-loading-button>
-</div>
+  <div class="modal-body" style="max-height: 75vh; overflow:auto;">
+    <bh-checkbox-tree
+      data="RoleActionsCtrl.actions"
+      checked-ids="RoleActionsCtrl.checkedIds"
+      label-key="description"
+      on-change="RoleActionsCtrl.onChangeSelection(data)"
+      is-flat-tree>
+    </bh-checkbox-tree>
+  </div>
+
+  <div class="modal-footer text-right">
+    <button
+      type="button"
+      class="btn btn-default"
+      ng-click="RoleActionsCtrl.close()"
+      translate>
+      FORM.BUTTONS.CLOSE
+    </button>
+
+    <bh-loading-button loading-state="RoleActionForm.$loading">
+    </bh-loading-button>
+  </div>
 </form>

--- a/client/src/modules/roles/roles.service.js
+++ b/client/src/modules/roles/roles.service.js
@@ -33,7 +33,8 @@ function RolesService(Api) {
 
   service.actions = function actions(roleUuid) {
     const url = `/roles/actions/${roleUuid}`;
-    return service.$http.get(url);
+    return service.$http.get(url)
+      .then(service.util.unwrapHttpResponse);
   };
 
   service.assignActions = function actions(data) {


### PR DESCRIPTION
Transitions the role actions module to using bhCheckboxTree instead of
rolling its own list structure.

I've also changed the behavior of bhCheckboxTree slightly to make it
more user friendly - onChange() now checks if the previous value is
equal to the current value to avoid excessive calls.

Additionally isFlatTree is now a boolean value.

Closes #5378.