### PR TITLE
Restore default aspect ratio for chartjs in report

### DIFF
--- a/server/controllers/stock/reports/stock/consumption_graph.js
+++ b/server/controllers/stock/reports/stock/consumption_graph.js
@@ -58,6 +58,7 @@ async function stockConsumptionGraphReport(req, res, next) {
       chart_data : data,
       chart_x_axis_label : i18n(options.lang)(`FORM.LABELS.${reportType.toUpperCase()}`),
       chart_type : 'horizontalBar',
+      chart_option : { maintainAspectRatio : false },
     };
 
     const lineHeight = 16; // height of an inventory line

--- a/server/lib/chart.js
+++ b/server/lib/chart.js
@@ -161,7 +161,6 @@ function renderChart(options) {
   const type = options.chart_type || 'bar';
 
   const defaultOption = {
-    maintainAspectRatio : false,
     responsiveAnimationDuration : 0,
     animation : { duration : 0 },
     hover : { animationDuration : 0 },


### PR DESCRIPTION
The current chart aspct ratio break the report : `Rapport graphique des mouvements`

![image](https://user-images.githubusercontent.com/5445251/110384864-831e1500-805e-11eb-8efc-6c07ccf99bd7.png)

