### PR TITLE
fix(cash): correctly calculate opening balance

### DIFF
--- a/server/controllers/finance/accounts/extra.js
+++ b/server/controllers/finance/accounts/extra.js
@@ -27,7 +27,6 @@ function getFiscalYearForDate(date) {
     .then(data => data.id);
 }
 
-
 /**
  * @function getPeriodForDate
  * @private
@@ -109,7 +108,6 @@ function getComputedAccountBalanceUntilDate(accountId, date, periodId, includeMa
   return db.one(sql, [accountId, date, periodId]);
 }
 
-
 /**
  * @method getOpeningBalanceForDate
  * @public
@@ -134,6 +132,7 @@ function getOpeningBalanceForDate(accountId, date, includeMaxDate = true) {
 
     // 2. Fetch the current dates period
     .then((previousPeriodClosing) => {
+
       balance += previousPeriodClosing.balance;
       credit += previousPeriodClosing.credit;
       debit += previousPeriodClosing.debit;

--- a/server/controllers/finance/reports/cashReport/index.js
+++ b/server/controllers/finance/reports/cashReport/index.js
@@ -106,7 +106,7 @@ async function document(req, res, next) {
     params.isEnterpriseCurrency = true;
 
     // get the opening balance for the acount
-    const header = await AccountExtras.getOpeningBalanceForDate(cashbox.account_id, params.dateFrom);
+    const header = await AccountExtras.getOpeningBalanceForDate(cashbox.account_id, new Date(params.dateFrom), false);
     _.merge(context, { header });
 
     // get the account's transactions


### PR DESCRIPTION
This commit corrects a bug in the opening balance calculation of the cash report.  The opening balance also included current day, leading to some very hard to detect bugs.  This commit simply removes the `maxDate` option from this report.