### PR TITLE
Refactor stock sheet report to use the current period filter for its date range

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -233,6 +233,7 @@
       "ALL_INVENTORIES": "All Inventories",
       "ONE_INVENTORY": "One Specific Inventory",
       "INVENTORY_REPORT": "Stock Sheet",
+      "INVENTORY_REPORT_TOOLTIP": "The Stock Sheet Report will be generated for the period currently selected in the search filter",
       "INVENTORY_REPORT_DESCRIPTION": "This report shows all movements of a product and its stock status and value.",
       "QUANTITY": "Quantity",
       "UNIT_COST": "Unit Cost",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -235,6 +235,7 @@
       "ALL_INVENTORIES" : "Tous les articles",
       "ONE_INVENTORY" : "Un article en particulier",
       "INVENTORY_REPORT" : "Fiche de stock",
+      "INVENTORY_REPORT_TOOLTIP": "Le fiche de stock sera généré pour la période actuellement sélectionnée dans le filtre de recherche.",
       "INVENTORY_REPORT_DESCRIPTION" : "Ce rapport affiche montre les mouvements d'un article ainsi que son état et sa valeur dans le stock",
       "QUANTITY" : "Quantité",
       "UNIT_COST" : "Coût Unitaire",

--- a/client/src/js/services/util.js
+++ b/client/src/js/services/util.js
@@ -39,7 +39,6 @@ function UtilService(moment) {
     hiddenElement.click();
   };
 
-
   /** @todo comments showing usage */
   service.filterFormElements = function filterFormElements(formDefinition, requireDirty) {
     const response = {};
@@ -129,7 +128,6 @@ function UtilService(moment) {
     };
   };
 
-
   /**
    * @function before
    *
@@ -209,7 +207,6 @@ function UtilService(moment) {
   service.isEmptyObject = function isEmptyObject(object) {
     return Object.keys(object).length === 0;
   };
-
 
   /**
    * @function xor

--- a/client/src/modules/stock/inventories/registry.js
+++ b/client/src/modules/stock/inventories/registry.js
@@ -328,15 +328,17 @@ function StockInventoriesController(
   }
 
   function openStockSheetReport(row) {
-    const [dateTo] = new Date().toISOString().split('T');
-
+    const filters = stockInventoryFilters.formatHTTP();
     const options = {
       renderer : 'pdf',
       lang : Languages.key,
       inventory_uuid : row.inventory_uuid,
       depot_uuid : row.depot_uuid,
       report_id : 14,
-      dateTo,
+      period : filters.period || 'year',
+      custom_period_end : filters.custom_period_end,
+      custom_period_start : filters.custom_period_start,
+      orientation : 'landscape',
     };
 
     // return  serialized options

--- a/client/src/modules/stock/inventories/templates/inventory.action.html
+++ b/client/src/modules/stock/inventories/templates/inventory.action.html
@@ -42,13 +42,17 @@
     <li class="divider"></li>
 
     <li>
-      <a data-method="view-amc-calculations" href ng-click="grid.appScope.viewAMCCalculations(row.entity)">
+      <a data-method="view-amc-calculations" href
+        ng-click="grid.appScope.viewAMCCalculations(row.entity)">
         <i class="fa fa-newspaper-o"></i> <span translate>INVENTORY.OPEN_AMC_CALCULATION</span>
       </a>
     </li>
 
     <li>
-      <a ng-href="/reports/stock/sheet?{{ grid.appScope.openStockSheetReport(row.entity) }}" target="_blank">
+      <a uib-tooltip="{{ 'REPORT.STOCK.INVENTORY_REPORT_TOOLTIP' | translate }}"
+        tooltip-placement="left"
+        ng-href="/reports/stock/sheet?{{ grid.appScope.openStockSheetReport(row.entity) }}"
+        target="_blank">
         <span class="fa fa-file-pdf-o"></span> <span translate>REPORT.STOCK.INVENTORY_REPORT</span>
       </a>
     </li>

--- a/client/src/modules/stock/lots-duplicates/lots-duplicates.html
+++ b/client/src/modules/stock/lots-duplicates/lots-duplicates.html
@@ -37,6 +37,7 @@
             <li role="menuitem">
               <a href data-method="auto-merge"
                 uib-tooltip="{{ 'FORM.BUTTONS.AUTO_MERGE_LOTS_TOOLTIP' | translate }}"
+                tooltip-placement="left"
                 ng-click="DupeLotsCtrl.autoMergeLots()">
                 <i class="fa"></i> <span translate>FORM.BUTTONS.AUTO_MERGE_LOTS</span>
               </a>

--- a/server/controllers/stock/reports/stock_sheet.report.handlebars
+++ b/server/controllers/stock/reports/stock_sheet.report.handlebars
@@ -20,7 +20,7 @@
 
       <h4 class="text-center">
         {{#if dateFrom}}{{date dateFrom}} - {{/if}}
-        {{date dateTo}}
+        {{#if dateTo}}{{date dateTo}}{{/if}}
       </h4>
 
       <br>

--- a/server/lib/period.js
+++ b/server/lib/period.js
@@ -67,10 +67,10 @@ class PeriodService {
       const currentPeriod = Moment().get(periodKey);
 
       return {
-        start : () =>
-          (new Moment(self.timestamp)).set(periodKey, currentPeriod + dateModifier).startOf(periodKey).toDate(),
-        end : () =>
-          (new Moment(self.timestamp)).set(periodKey, currentPeriod + dateModifier).endOf(periodKey).toDate(),
+        start : () => (new Moment(self.timestamp))
+          .set(periodKey, currentPeriod + dateModifier).startOf(periodKey).toDate(),
+        end : () => (new Moment(self.timestamp))
+          .set(periodKey, currentPeriod + dateModifier).endOf(periodKey).toDate(),
       };
     }
   }


### PR DESCRIPTION
Refactor stock sheet report (fiche de stock) to use the current period filter for the date range of the report.

This PR absorbs PR https://github.com/IMA-WorldHealth/bhima/pull/5488 as suggested by @jniles in https://github.com/IMA-WorldHealth/bhima/pull/5488#issuecomment-794954182.

This update passes the value of the period filter (from the default filters) to specify the date range for the report.
This done as a separate PR so that it could be tested without modifying the previous PR.

**Notes**
- if the 'allTime' option is used, no start  or end dates are printed on the report.  This could be improved by including a message such as "All stock data until the present" or "All stock data until <todays-date>"  Open to suggestions on this.
- Since there may be some confusion, I added a tooltip for the Articles In Stock action menus for the "Stock Sheet" command.

**Testing**
- Please try all the options for the period (in the [Search] -> DefaultFilters tab) and verify that they all produce report dates and contents that make sense.