### PR TITLE
Enable filtering on status in Articles in Stock

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -900,7 +900,7 @@ a[disabled] {
 }
 
 .icon-at-risk-of-stock-out {
-  color: #FFFFA9 !important;
+  color: #FFFF00 !important;
 }
 
 .at-risk-of-expiring {
@@ -909,6 +909,21 @@ a[disabled] {
 
 .icon-at-risk-of-expiring {
   color: #FFB766 !important;
+}
+
+.out-of-stock-status {
+  color: black !important;
+  background-color: red !important;
+}
+
+.critical-stock-status {
+  color: black !important;;
+  background-color: #FFB766 !important;
+}
+
+.low-stock-status {
+  color: black !important;;
+  background-color: #FFFF00 !important;
 }
 
 .out-of-stock {

--- a/client/src/js/services/StockService.js
+++ b/client/src/js/services/StockService.js
@@ -77,7 +77,7 @@ function StockService(Api, StockFilterer, HttpCache, util, Periods) {
 
   // stock status label keys
   const stockStatusLabelKeys = {
-    stock_out          : 'STOCK.STATUS.STOCK_OUT',
+    stock_out         : 'STOCK.STATUS.STOCK_OUT',
     in_stock          : 'STOCK.STATUS.IN_STOCK',
     security_reached  : 'STOCK.STATUS.SECURITY',
     minimum_reached   : 'STOCK.STATUS.MINIMUM',

--- a/client/src/modules/stock/inventories/registry.js
+++ b/client/src/modules/stock/inventories/registry.js
@@ -6,6 +6,7 @@ StockInventoriesController.$inject = [
   'uiGridConstants', 'StockModalService', 'LanguageService', 'SessionService',
   'GridGroupingService', 'bhConstants', 'GridStateService',
   '$state', 'GridColumnService', '$httpParamSerializer', 'BarcodeService',
+  '$translate',
 ];
 
 /**
@@ -15,7 +16,7 @@ StockInventoriesController.$inject = [
 function StockInventoriesController(
   Stock, Notify, uiGridConstants, Modal, Languages,
   Session, Grouping, bhConstants, GridState, $state, Columns,
-  $httpParamSerializer, Barcode,
+  $httpParamSerializer, Barcode, $translate,
 ) {
   const vm = this;
   const cacheKey = 'stock-inventory-grid';
@@ -59,12 +60,11 @@ function StockInventoriesController(
     displayName      : '',
     cellTemplate     : 'modules/stock/inventories/templates/warning.cell.html',
     width            : 50,
+    enableFiltering  : false,
   }, {
-    field            : 'status',
+    field            : 'status_translated',
     displayName      : 'STOCK.STATUS.LABEL',
     headerCellFilter : 'translate',
-    enableFiltering  : false,
-    enableSorting    : false,
     cellTemplate     : 'modules/stock/inventories/templates/status.cell.html',
   }, {
     field           : 'avg_consumption',
@@ -233,7 +233,10 @@ function StockInventoriesController(
         rows.sort(orderByDepot);
 
         // set status flags
-        rows.forEach(setStatusFlag);
+        rows.forEach(row => {
+          setStatusFlag(row);
+          row.status_translated = $translate.instant(Stock.statusLabelMap(row.status));
+        });
 
         vm.gridOptions.data = rows;
 

--- a/client/src/modules/stock/inventories/templates/status.cell.html
+++ b/client/src/modules/stock/inventories/templates/status.cell.html
@@ -1,18 +1,18 @@
-<div class="ui-grid-cell-contents" translate>
-    <div ng-if="row.entity.hasStockOut" class="label label-danger" translate>
+<div class="ui-grid-cell-contents">
+    <div ng-if="row.entity.hasStockOut" class="label out-of-stock-status" translate>
       STOCK.STATUS.STOCK_OUT
+    </div>
+
+    <div ng-if="row.entity.hasSecurityWarning" class="label critical-stock-status" translate>
+      STOCK.STATUS.SECURITY
+    </div>
+
+    <div ng-if="row.entity.hasMinimumWarning" class="label low-stock-status" translate>
+      STOCK.STATUS.MINIMUM
     </div>
 
     <div ng-if="row.entity.isInStock" class="label label-success" translate>
       STOCK.STATUS.IN_STOCK
-    </div>
-
-    <div ng-if="row.entity.hasSecurityWarning" class="label label-warning" translate>
-      STOCK.STATUS.SECURITY
-    </div>
-
-    <div ng-if="row.entity.hasMinimumWarning" class="label label-info" translate>
-      STOCK.STATUS.MINIMUM
     </div>
 
     <div ng-if="row.entity.hasOverageWarning" class="label label-primary" translate>

--- a/test/integration/mergeLots.js
+++ b/test/integration/mergeLots.js
@@ -99,7 +99,6 @@ function addStockMovementSQL(params) {
     + `  '${createdAt}', ${isExit}, ${userId}, 9, '${createdAt}', '${periodId}');`;
 }
 
-
 describe('Test merging lots', () => {
 
   before('Note original counts of lots, tags, etc', () => {
@@ -188,70 +187,43 @@ describe('Test merging lots', () => {
   // ===========================================================================
   // NOW do the merge tests
 
-  it('Merge lot 3 with lot 1 (single lot)', () => {
-    return agent.post(`/lots/${lot1Uuid}/merge`)
-      .send({ lotsToMerge : [lot3Uuid] })
-      .then(res => {
-        // Verify the operation was successful
-        expect(res).to.have.status(200);
-      })
-      .then(() => {
-        db.exec(`SELECT uuid from lot WHERE uuid = 0x${lot3Uuid}`)
-          .then((res) => {
-            expect(res.length).to.equal(0,
-              'Verify lot3 no longer exists');
-          });
-      })
-      .then(() => {
-        db.exec(`SELECT HEX(lot_uuid) as lot_uuid from lot_tag WHERE tag_uuid = 0x${tag3Uuid}`)
-          .then((res) => {
-            expect(res.length).to.equal(1);
-            expect(res[0].lot_uuid).to.equal(lot1Uuid,
-              'Verify that tag3 now refers to lot1');
-          });
-      })
-      .then(() => {
-        db.exec(`SELECT HEX(lot_uuid) as lot_uuid from stock_movement WHERE uuid = 0x${stockMovement1Uuid}`)
-          .then((res) => {
-            expect(res.length).to.equal(1);
-            expect(res[0].lot_uuid).to.equal(lot1Uuid,
-              'Verify that the stock movement now refers to lot1');
-          });
-      });
+  it('Merge lot 3 with lot 1 (single lot)', async () => {
+    let res = await agent.post(`/lots/${lot1Uuid}/merge`)
+      .send({ lotsToMerge : [lot3Uuid] });
+    expect(res).to.have.status(200);
+
+    res = await db.exec(`SELECT uuid from lot WHERE uuid = 0x${lot3Uuid}`);
+    expect(res.length).to.equal(0,
+      'Verify lot3 no longer exists');
+
+    res = await db.exec(`SELECT HEX(lot_uuid) as lot_uuid from lot_tag WHERE tag_uuid = 0x${tag3Uuid}`);
+    expect(res.length).to.equal(1);
+    expect(res[0].lot_uuid).to.equal(lot1Uuid,
+      'Verify that tag3 now refers to lot1');
+
+    res = await db.exec(`SELECT HEX(lot_uuid) as lot_uuid from stock_movement WHERE uuid = 0x${stockMovement1Uuid}`);
+    expect(res.length).to.equal(1);
+    expect(res[0].lot_uuid).to.equal(lot1Uuid,
+      'Verify that the stock movement now refers to lot1');
   });
 
   // ---------------------------------------------------------------------------
 
-  it('Merge lots 4 and 5 with lot 1 (multiple lots)', () => {
-    return agent.post(`/lots/${lot1Uuid}/merge`)
-      .send({ lotsToMerge : [lot4Uuid, lot5Uuid] })
-      .then(res => {
-        // Verify the operation was successful
-        expect(res).to.have.status(200);
-      })
-      .then(() => {
-        db.exec(`SELECT * from lot WHERE uuid IN (0x${lot4Uuid}, 0x${lot5Uuid})`)
-          .then((res) => {
-            expect(res.length).to.equal(0,
-              'Verify lots 4 and 5 no longer exist');
-          });
-      })
-      .then(() => {
-        db.exec(`SELECT HEX(lot_uuid) as lot_uuid from lot_tag WHERE tag_uuid = 0x${tag4Uuid}`)
-          .then((res) => {
-            expect(res.length).to.equal(1);
-            expect(res[0].lot_uuid).to.equal(lot1Uuid,
-              'Verify that tag4 now points to lot1');
-          });
-      })
-      .then(() => {
-        db.exec(`SELECT HEX(lot_uuid) as lot_uuid from lot_tag WHERE tag_uuid = 0x${tag5Uuid}`)
-          .then((res) => {
-            expect(res.length).to.equal(1);
-            expect(res[0].lot_uuid).to.equal(lot1Uuid,
-              'Verify that tag5 now points to lot1');
-          });
-      });
+  it('Merge lots 4 and 5 with lot 1 (multiple lots)', async () => {
+    let res = await agent.post(`/lots/${lot1Uuid}/merge`)
+      .send({ lotsToMerge : [lot4Uuid, lot5Uuid] });
+    expect(res).to.have.status(200);
+
+    res = await db.exec(`SELECT * from lot WHERE uuid IN (0x${lot4Uuid}, 0x${lot5Uuid})`);
+    expect(res.length).to.equal(0, 'Verify lots 4 and 5 no longer exist');
+
+    res = await db.exec(`SELECT HEX(lot_uuid) as lot_uuid from lot_tag WHERE tag_uuid = 0x${tag4Uuid}`);
+    expect(res.length).to.equal(1);
+    expect(res[0].lot_uuid).to.equal(lot1Uuid, 'Verify that tag4 now points to lot1');
+
+    res = await db.exec(`SELECT HEX(lot_uuid) as lot_uuid from lot_tag WHERE tag_uuid = 0x${tag5Uuid}`);
+    expect(res.length).to.equal(1);
+    expect(res[0].lot_uuid).to.equal(lot1Uuid, 'Verify that tag5 now points to lot1');
   });
 
   // ===========================================================================


### PR DESCRIPTION
This PR also updates the stock status label coloring per https://github.com/IMA-WorldHealth/bhima/issues/5478#issuecomment-796820000.   This aligns most of the coloring between the Articles in Stock page and the Lots registry page (except that red is used for stock-out in the Articles in Stock.  But in the Lots registry, red is used for expired stock and purple is used for stock-out.  That still needs to be aligned, but was not covered in this PR.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5478

**Testing**
- You may want to use a production database to see all of the possible values.
- Update default filters to allow showing exhausted lots
- In the Articles in Stock page, enable filtering and enter a value in the "Status" filter to observe that it does filter correctly.
- Try all options:  Stock Out (red), Critical Stock (orange), Low Stock (yellow),  Over Maximum (blue), In Stock (green)
- Try these in English as French (use the French status names)