### PR TITLE
docs(stock): touch up stock docs

### DIFF
--- a/docs/en/stock-management/depot.md
+++ b/docs/en/stock-management/depot.md
@@ -13,13 +13,19 @@
 </div>
 
 
-Depots are used to store products.  We can not talk about stock without talking about depots. The depot forms
-a container for the enterprise's stock, and allows users to enter stock through [Stock Entry](), or dispense
-stock through [Stock Exit]().
+Depots are used to store articles.  We can not talk about stock without talking about depots. The depot forms
+a container for the enterprise's stock, and allows users to enter stock through [Stock Entry](./movement.entry.md), or dispense
+stock through [Stock Exit](./movement.exit.md). 
 
 To create a new depot, click on the **Add Depot** button in the top right corner of the module.  This opens a
 modal window to enter the depot information.
 
+
+## Depot Heirarchies
+BHIMA allows users to structure their depots in a tree hierachary of parents and children, similar to the chart
+of accounts.  This feature exists to allow easier permissions management.  If a user is responsible for many depots
+in a region, it may make sense to group these regionally and assign a user the permissions to all child depots in that
+region.  Functionally, the parent-child relationship has no bearing on which depots can transfer stock between one another.
 
 
 ## Depot Capabilities
@@ -39,3 +45,13 @@ or _services_.  These are considered consumption of the depot and factor into th
 For warehouses, BHIMA considers transfers to other depots as consumption in addition to the exits to patients and services.
 By including transfers, BHIMA can estimate when to refill stock in warehouses when they otherwise would not be considered.
 
+BHIMA offers two choices of algorithm that differ slighty:
+
+  1. **Default Algorithm** - The average monthly consumption is obtained by dividing the quantity consumed during the period by
+  the number of days with stock during the period, and by multiplying the result by 30.5.
+  2. **MSH Algorithm** - The average consumption is obtained by dividing the quantity consumed during the period by number of
+  months of stock (found by subtracting the number of days of stock outs divided by 30.5 from the number of months in the period).
+  The MSH algorithm is recommended by the [Management Sciences for Health](https://www.msh.org) organization.
+
+These algorithms produce identical or similar results.  The main difference is in rounding - the MSH algorithm converts to months
+before the computation while the default algorithm converts to months as a last step.

--- a/docs/en/stock-management/index.md
+++ b/docs/en/stock-management/index.md
@@ -1,8 +1,9 @@
-&raquo; [Home](../index.md) / Inventory Management
+&raquo; [Home](../index.md) / Inventory & Stock Management
 
 # Inventory and Stock Management
 
-Inventory and stock management modules enable you to make stock movements as well as to track all these movements.
+Inventory and stock management modules provide a robust stock management solution for
+hospitals.  Below you'll find an index to particular subsections that may be of interest.
 
 1. [Overview](./overview.md)
 2. [Inventories](./inventory.md)

--- a/docs/en/stock-management/movement.entry.md
+++ b/docs/en/stock-management/movement.entry.md
@@ -1,3 +1,5 @@
-&raquo; [Home](../index.md) / [Inventory Management](./index.md) /  [stocks movements](./movement.md) / Stock Entry
+&raquo; [Home](../index.md) / [Inventory Management](./index.md) / [Stock Movements](./movement.md) / Stock Entry
 
 # Stock Entry
+
+

--- a/docs/en/stock-management/overview.md
+++ b/docs/en/stock-management/overview.md
@@ -27,34 +27,34 @@ The following are properties of **stock**:
 
 <div class="bs-callout bs-callout-primary">
 <h4>A Philosophical Analogy</h4>
-If you are still struggling to understand the relationship between stock and inventory, a useful analogy is that _inventory_ is a platonic form and _stock_ is the physical manifestation of that form.  The institutions sells the inventory item of "Quinine in 500 milligram capsules", but it may not be in stock.  If it is in stock, a particular lot of Quinine might have an expiration date that is different from other Quinines in stock.
+If you are still struggling to understand the relationship between stock and inventory, a useful analogy is that <i>inventory</i> is a platonic form and <i>stock</i> is the physical manifestation of that form.  The institutions sells the inventory item of "Quinine in 500 milligram capsules", but it may not be in stock.  If it is in stock, a particular lot of Quinine might have an expiration date that is different from other Quinines in stock.
 </div>
 
 ## Features of Stock Management
 
-Inventory management in BHIMA allows you to:
+Stock management in BHIMA has some powerful features:
 
-- Have the stock sheet of each item (inventory) in real time
-- Valuate stocks in real time
-- Know the status of stocks in real time
-- Make the entries of stocks:
-    - Entry of stocks from purchases
-    - Entry of stocks from integrations
-    - Entry of stocks from donations
-    - Entry of stocks from another warehouse
-- Make out of stocks:
-    - Outflow of stocks to patients
-    - Outputs from stocks to services
-    - Outflow of stocks to other deposits
-    - Out of stock as inventory loss
-- Make inventory adjustments
-- Make inventory assignments
-- Consult the registers of stocks:
-    - The batch register
-    - The inventory register
-    - Inventory movements register
+- A stock sheet containing the entries, exists, and balance of each article in stock is available in real time
+- Real-time valuation of the hospital's stock assets, including real-time computation of Cost of Goods Sold (COGS)
+- Easy access to stock status reports
+- Entry of stock into depots/pharmacies from:
+    - Purchases
+    - Integrations
+    - Donations
+    - Other depots/pharmacies
+- Exists of stock from depots/pharamcies to:
+    - Patients, optionally linking an invoice
+    - Services
+    - Other depots/pharmacies
+    - Record losses
+- Adjustments to stock levels during routine inventory
+- Assign stock to individuals
+- Consult stock registries:
+    - The stock lots registry
+    - The articles in stock registry
+    - The stock movements registry
 
-### the dependencies of the stock management
+### Stock Management's Dependencies
 
 To manage stock with BHIMA there are some dependencies that must be completed beforehand.
 
@@ -62,8 +62,14 @@ To manage stock with BHIMA there are some dependencies that must be completed be
 
 This management requires certain prerequisites:
 
-- **The presence of depots**: stocks are always in deposits, from which you can not manage stocks without defining deposits.
+- **The presence of depots**: stocks are always in depots, from which you can not manage stocks without defining depots.
 
-- **The presence of inventories**: the inventories in BHIMA are the information on articles or services, but in the context of the stock it is the information on articles that can be stored in repositories
+- **The presence of inventories**: the inventories in BHIMA are the information on articles or services, but in the context of the stock it is the information on articles that can be stored in depots
 
-- **The presence of users with the required permissions on the repositories**: BHIMA has a permission policy on deposits, that is to say that only authorized users can have access to a given repository
+- **The presence of users with the required permissions on the depots**: BHIMA has a permission policy on depots, that is to say that only authorized users can have access to a given repository
+
+### Stock Management & Accounting
+Stock management in BHIMA can be a standalone package or work in concert with the finance modules.  When automatic stock accounting
+is turned on, BHIMA will create writings in the appropriately configured accounts for these items.  If automatic stock accounting
+is turned off, the system will simply move stock around.
+

--- a/docs/en/stock-management/stock.settings.md
+++ b/docs/en/stock-management/stock.settings.md
@@ -29,62 +29,54 @@ order more stock.
 ## Individual Stock Settings
 The Stock Settings page allows access to the following items:
 
-- **Number of months for calculating the average monthly consumption** (integer, default 6 months)  
+- **Number of months for calculating the average monthly consumption** (integer, default 6 months)
   This determines the number of months (**N**) in the past to use to estimate
   the average monthly consumption. The AMC is a "moving" average, since
   it uses a window of only the previous **N** months to determine the
   average. This setting will set the value of **N**.
 
-- **Default minimum number of months of security stock for depots** (integer, default 2 months)  
+- **Default minimum number of months of security stock for depots** (integer, default 2 months)
   The stock supply should provide at least this many months of stock at
   all times for the depot involved.
 
-- **Enable automatic confirmation of purchase orders** (yes/NO)  
+- **Minimum Purchase Delay**
+  Sets the minumum amount of expected delay in months for a supplier to deliver medicines after
+  the purchase order is finalised.
+
+- **Enable automatic confirmation of purchase orders** (yes/NO)
   Enable automatic confirmation of purchase orders when they are created
   without requiring manual confirmation
 
-- **Enable permission to view depots in stock registries** (yes/NO)  
+- **Enable permission to view depots in stock registries** (yes/NO)
   Limit the consultation of stock registries to users according to their
   depots
 
-- **Enable automatic stock accounting** (YES/no)  
+- **Enable automatic stock accounting** (YES/no)
   Enabling this feature will write stock movement transactions into the
   posting journal in automatically, in real time. It requires all inventory
   accounts to be correctly configured.
 
-- **Enable automatic crediting of supplier on stock entry** (yes/NO)  
+- **Enable automatic crediting of supplier on stock entry** (yes/NO)
   Automatically adds the transactions to credit the supplier for the value of
   stock received in a depot when entering stock from a purchase order. This is
   only triggered if the automatic stock accounting is set as well.
 
-- **Activate the restriction of distribution depots** (yes/NO)  
+- **Activate the restriction of distribution depots** (yes/NO)
   Limits the depots a user can interact with to the depots that the user has
   access to. Thus, if a user cannot distribute stock from a depot, they also
   cannot transfer stock to that depot.
 
-- **Algorithm for calculating Average Monthly Consumption (AMC)**.  
+- **Algorithm for calculating Average Monthly Consumption (AMC)**.
   Possible choices:
 
-  - **Algorithm 1**: The average monthly consumption is obtained by
+  - **Default Algorithm**: The average monthly consumption is obtained by
     dividing the quantity consumed during the period by the number of
     days having stock for the period, and by multiplying the result
     by 30.5.
 
     ![Algorithm 1](./images/algorithm1.png)
 
-  - **Algorithm 2**: The average consumption is obtained by dividing the
-    quantity consumed during the period by the number of days of
-    consumption for the period, and by multiplying the result by 30.5.
-
-    ![Algorithm 2](./images/algorithm2.png)
-
-  - **Algorithm 3**: The average consumption is obtained by dividing the
-    quantity consumed during the period by the number of days in the
-    period, and by multiplying the result obtained by 30.5.
-
-    ![Algorithm 3](./images/algorithm3.png)
-
-  - **Algorithm 4 (MSH)** (default): The average consumption is obtained
+  - **MSH Algorithm** (default): The average consumption is obtained
     by dividing the quantity consumed during the period by the
     difference of number of months in the period minus the total number
     of days of stock out in the period.  The MSH algorithm is


### PR DESCRIPTION
This commit touches up the stock management documentation to make things a bit clearer.  It also anticipates #5499 being merged and removes the documentation on the old algorithms.

This is by no means complete - we need to explain the difference between OHADA and Western accounting methods when it comes to stock.  But I find writing large chunks of documenation at once difficult, so this is a nibble at it.

-----
[View rendered docs/en/stock-management/depot.md](https://github.com/jniles/bhima/blob/docs-improve-stock-management-documentation/docs/en/stock-management/depot.md)
[View rendered docs/en/stock-management/index.md](https://github.com/jniles/bhima/blob/docs-improve-stock-management-documentation/docs/en/stock-management/index.md)
[View rendered docs/en/stock-management/movement.entry.md](https://github.com/jniles/bhima/blob/docs-improve-stock-management-documentation/docs/en/stock-management/movement.entry.md)
[View rendered docs/en/stock-management/overview.md](https://github.com/jniles/bhima/blob/docs-improve-stock-management-documentation/docs/en/stock-management/overview.md)
[View rendered docs/en/stock-management/stock.settings.md](https://github.com/jniles/bhima/blob/docs-improve-stock-management-documentation/docs/en/stock-management/stock.settings.md)