### PR TITLE
Prevent expired lots from being selected in stock entry

### DIFF
--- a/client/src/i18n/en/errors.json
+++ b/client/src/i18n/en/errors.json
@@ -21,6 +21,7 @@
     "ER_DUP_KEY" : "A key collided in a unique database field.  Please retry your action.  If the problem persists, contact the developers.",
     "ER_DUP_ENTRY" : "You have duplicated a value in a unique field!  Please make sure that the necessary values are unique.",
     "ER_EXPIRED_STOCK_LOTS" : "Some stock lots are expired",
+    "ER_STOCK_LOT_IS_EXPIRED" : "Stock lot '{{label}}' cannot be selected because it is expired",
     "ER_BAD_FIELD_ERROR" : "Column does not exist in database.",
     "ER_ROW_IS_REFERENCED" : "Cannot delete entity because entity is used in another table.",
     "ER_ROW_IS_REFERENCED_2" : "Cannot delete entity because entity is used in another table.",

--- a/client/src/i18n/fr/errors.json
+++ b/client/src/i18n/fr/errors.json
@@ -21,6 +21,7 @@
     "ER_DUP_KEY" : "Il ya déjà un enregistrement avec cette clé. Veuillez réessayer votre action. Si le problème persiste, contactez les développeurs.",
     "ER_DUP_ENTRY" : "Vous avez dupliqué une valeur dans un champ unique! Assurez-vous que les valeurs nécessaires sont uniques.",
     "ER_EXPIRED_STOCK_LOTS" : "Certains lots de stock sont expirés",
+    "ER_STOCK_LOT_IS_EXPIRED" : "Le lot de stock '{{label}}' ne peut être sélectionné car il est expiré",
     "ER_BAD_FIELD_ERROR" : "Vous avez entré un champ qui ne peut pas être stocké dans la base de données.",
     "ER_ROW_IS_REFERENCED" : "Vous ne pouvez pas supprimer cet enregistrement, car il est référencé par un autre enregistrement dans la base de données.",
     "ER_ROW_IS_REFERENCED_2" : "Vous ne pouvez pas supprimer cet enregistrement, car il est référencé par un autre enregistrement dans la base de données.",
@@ -54,6 +55,6 @@
     "ER_DUP_UNIQUE" : "Une clé unique a été dupliquée",
     "ER_ACCESS_DENIED_ERROR" : "Accès interdit pour ce utilisateur",
     "ER_NO_DB_ERROR" : "Aucune base de donnée selectionée"
-    
+
   }
 }

--- a/client/src/js/services/LotService.js
+++ b/client/src/js/services/LotService.js
@@ -14,11 +14,24 @@ function LotService(Api, $http, util) {
       });
   };
 
+  /**
+  * @function candidates()
+  *
+  * @description returns a list of candidate lots for a specific inventory_uuid
+  *
+  * @param {object} params
+  * @param {string} params.inventory_uuid - get all lots for this inventory UUID
+  * @param {string} params.date [now] - Optional date: lots after this date will be marked expired
+  *                             If params.date is not given, it will default to the current time/date
+  * @return {list}
+  */
   lots.candidates = (params) => {
     return $http.get(`/inventory/${params.inventory_uuid}/lot_candidates`)
       .then((res) => {
+        const now = params.date ? new Date(params.date) : new Date();
         res.data.forEach((lot) => {
           lot.expiration_date = new Date(lot.expiration_date);
+          lot.expired = lot.expiration_date < now;
         });
         return res;
       })

--- a/client/src/modules/stock/entry/modals/StockEntryModalForm.service.js
+++ b/client/src/modules/stock/entry/modals/StockEntryModalForm.service.js
@@ -40,7 +40,7 @@ function StockEntryModalForm(uuid) {
 
     if (opts.rows) {
       this.rows = opts.rows.map(row => new Lot(row));
-      this.validate();
+      this.validate(opts.entry_date || new Date());
     }
   }
 
@@ -77,15 +77,18 @@ function StockEntryModalForm(uuid) {
    *
    * @description
    * This function takes in a single row and runs validation against it.
+   * @param row - row of lot info
+   * @param [date] {object} - Entry date for expiration check (not always 'now')
    */
-  function validateSingleRow(row) {
-    let hasFutureExpirationDate = new Date(row.expiration_date) >= new Date();
+  function validateSingleRow(row, date) {
+    const entryDate = date || new Date();
+    let hasFutureExpirationDate = new Date(row.expiration_date) >= entryDate;
     row._error = null;
 
     // if the stock does not expire/have an expiration date, generate a fake one
     if (!this.opts.tracking_expiration) {
       hasFutureExpirationDate = true;
-      row.expiration_date = new Date((new Date().getFullYear() + 1000), new Date().getMonth());
+      row.expiration_date = new Date((entryDate.getFullYear() + 1000), entryDate.getMonth());
     }
     // check invalid lot expiration date
     const hasInvalidExpiration = (!row.expiration_date || !hasFutureExpirationDate);
@@ -107,10 +110,10 @@ function StockEntryModalForm(uuid) {
     row.isValid = !row.isInvalid;
   }
 
-  function validateAllRows() {
+  function validateAllRows(date) {
     const errors = [];
 
-    if (this.rows.length === 0) {
+    if (!this.rows || this.rows.length === 0) {
       errors.push(ERR_NO_ROWS);
     }
 
@@ -131,7 +134,7 @@ function StockEntryModalForm(uuid) {
     }
 
     this.rows.forEach(lot => {
-      validateSingleRow.call(this, lot);
+      validateSingleRow.call(this, lot, date);
 
       if (lot.isInvalid) {
         errors.push(lot._error);
@@ -143,9 +146,8 @@ function StockEntryModalForm(uuid) {
       .filter((err, idx, arr) => arr.indexOf(err) === idx);
   }
 
-  StockForm.prototype.validate = function validate(row) {
-    const validationFn = angular.isDefined(row) ? validateSingleRow : validateAllRows;
-    return validationFn.call(this, row);
+  StockForm.prototype.validate = function validate(date) {
+    return validateAllRows.call(this, date);
   };
 
   return StockForm;

--- a/client/src/modules/stock/entry/modals/lots.modal.html
+++ b/client/src/modules/stock/entry/modals/lots.modal.html
@@ -12,6 +12,16 @@
   </div>
 
   <div class="modal-body">
+
+    <div class="row" style="margin-top: 0.5em; margin-bottom: 0.5em">
+      <div class="col-xs-12">
+        <div>
+          <span class="text-bold" translate>STOCK.ENTRY_DATE</span> :
+          {{ $ctrl.entryDate | date:$ctrl.Constants.dates.format }}
+        </div>
+      </div>
+    </div>
+
     <div class="form-group">
       <label class="control-label" translate>FORM.LABELS.GLOBAL_QUANTITY</label>
 
@@ -52,12 +62,12 @@
     <div style="margin-bottom: 5px;">
       <div class="checkbox">
         <label>
-          <input 
-            id="enableFastInsert" 
-            ng-model="$ctrl.enableFastInsert" 
+          <input
+            id="enableFastInsert"
+            ng-model="$ctrl.enableFastInsert"
             type="checkbox"
             ng-true-value="1"
-            ng-false-value="0"> 
+            ng-false-value="0">
           <span translate>LOTS.ENABLE_FAST_INSERT</span>
         </label>
         <p class="help-block" translate>LOTS.ENABLE_FAST_INSERT_DESCRIPTION</p>

--- a/client/src/modules/stock/entry/modals/lots.modal.js
+++ b/client/src/modules/stock/entry/modals/lots.modal.js
@@ -2,14 +2,13 @@ angular.module('bhima.controllers')
   .controller('StockDefineLotsModalController', StockDefineLotsModalController);
 
 StockDefineLotsModalController.$inject = [
-  'appcache', '$uibModalInstance', 'uiGridConstants', 'data',
-  'SessionService', 'bhConstants', 'StockEntryModalForm',
-  '$translate', 'focus',
+  'appcache', '$uibModalInstance', 'uiGridConstants', 'data', 'SessionService',
+  'bhConstants', 'StockEntryModalForm', '$translate', 'focus',
 ];
 
 function StockDefineLotsModalController(
-  AppCache, Instance, uiGridConstants, Data, Session, bhConstants, EntryForm,
-  $translate, Focus,
+  AppCache, Instance, uiGridConstants, Data, Session,
+  bhConstants, EntryForm, $translate, Focus,
 ) {
   const vm = this;
 
@@ -22,9 +21,11 @@ function StockDefineLotsModalController(
     max_quantity : Data.stockLine.quantity,
     unit_cost : Data.stockLine.unit_cost,
     tracking_expiration : tracking,
+    entry_date : Data.entry_date,
     rows : Data.stockLine.lots,
   });
 
+  vm.Constants = bhConstants;
   vm.hasMissingLotIdentifier = false;
   vm.hasInvalidLotExpiration = false;
   vm.hasInvalidLotQuantity = false;
@@ -32,6 +33,7 @@ function StockDefineLotsModalController(
   vm.enterprise = Session.enterprise;
   vm.stockLine = angular.copy(Data.stockLine);
   vm.entryType = Data.entry_type;
+  vm.entryDate = Data.entry_date;
   vm.isTransfer = (vm.entryType === 'transfer_reception');
 
   // exposing method to the view
@@ -104,13 +106,47 @@ function StockDefineLotsModalController(
       vm.enableFastInsert = cache.enableFastInsert;
     }
 
-    if (vm.form.rows.length) { return; }
+    if (vm.form.rows.length) {
+      // If we are visiting the form again, re-validate it
+      validateForm();
+      return;
+    }
 
     vm.form.addItem();
   }
 
   function onRegisterApi(api) {
     vm.gridApi = api;
+  }
+
+  // Handle the extra validation for expired lot labels
+  function validateForm() {
+    vm.errors = vm.form.validate(vm.entryDate);
+    vm.form.rows.forEach((row) => {
+      if (!row.lot) {
+        // Ignore corner case where the user clicks elsewhere
+        // BEFORE typing in a lot name
+        return;
+      }
+
+      // Note that the type of row.lot will differ depending on whether
+      // we are selecting an existing lot or creating a new one.
+      const lotLabel = typeof row.lot === 'string' ? row.lot : row.lot.label;
+      const existingLot = vm.stockLine.availableLots
+        .find(l => l.label.toUpperCase() === lotLabel.toUpperCase());
+      if (existingLot) {
+        // Disable changing the date for rows with lots already defined.
+        // (This does not prevent changing the quantity.)
+        row.disabled = true;
+      }
+
+      // Check to make sure the lot has not expired
+      if (existingLot && existingLot.expired) {
+        vm.errors.push($translate.instant('ERRORS.ER_STOCK_LOT_IS_EXPIRED',
+          { label : existingLot.label }));
+        vm.form.$invalid = true;
+      }
+    });
   }
 
   /**
@@ -124,8 +160,29 @@ function StockDefineLotsModalController(
    */
   function onLotBlur(rowLot) {
     // NOTE: rowLot will be an object if an existed lot was
-    //       selected from the typeahead.  Otherwise it will
-    //       be the lot name string that was typed in.
+    //       selected from the typeahead. Otherwise
+    //       it will be the lot name string that was typed in.
+    //       Complain if the lot exists and is expired.
+
+    if (!rowLot) {
+      // Handle corner case
+      return;
+    }
+
+    // First make sure that if the entered lot label exists
+    // that it is not expired
+
+    const rowLotLabel = typeof rowLot === 'string' ? rowLot : rowLot.label;
+    const existingLot = vm.stockLine.availableLots
+      .find(l => l.label.toUpperCase() === rowLotLabel.toUpperCase());
+    if (rowLot && existingLot && existingLot.expired) {
+      vm.errors = vm.form.validate(vm.entryDate);
+      vm.errors.push($translate.instant('ERRORS.ER_STOCK_LOT_IS_EXPIRED',
+        { label : existingLot.label }));
+      vm.form.$invalid = true;
+      return;
+    }
+
     if (vm.enableFastInsert && rowLot) {
 
       const emptyLotRow = getFirstEmptyLot();
@@ -155,7 +212,7 @@ function StockDefineLotsModalController(
   }
 
   function onChanges() {
-    vm.errors = vm.form.validate();
+    validateForm();
     vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.EDIT);
   }
 
@@ -206,7 +263,8 @@ function StockDefineLotsModalController(
   }
 
   function submit(form) {
-    vm.errors = vm.form.validate();
+    validateForm();
+
     // unfortunately, a negative number will not trigger the onChange() function
     // on the quantity, since the "min" property is set on the input.  So, we
     // need to through a generic error here.

--- a/test/client-unit/components/bhCheckboxTree/bhCheckboxTree.spec.js
+++ b/test/client-unit/components/bhCheckboxTree/bhCheckboxTree.spec.js
@@ -91,7 +91,6 @@ function bhCheckboxTree() {
     // simulate a click on one of the checkboxes
     const node = find(element, '[data-label="Amy"] input');
 
-    // console.log('node:', node);
     angular.element(node).triggerHandler('click');
     $scope.$digest();
 


### PR DESCRIPTION
When selecting lots via the typeahead entry field for  Stock Entry, prevent expired lots from being selected.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5500

**Testing**
- Use bhima_test
- Using master, go to Stock Entry (integration)
    - Chose the Depot Principal
    - Use stock code QUIN1 (should give only one choice, select it)
    - Click on the "Lots" field on that row to get the lot selection modal
    - Type 'q' into the "Lot" field.  Observe that it shows 'QUININE-A' and that it is expired
- Switch to this PR
    - Repeat the process above but note that 'QUININE-A' is no longer available
    - Try typing in QUININE-A and hitting return or changing to another field.  Notice that the form will not allow it to be used.
- Close the lot selection modal and go back to Stock Entry page
    - Change the entry date to something in 2017 (or earlier)
    - Go back to the lots selection page (Click "Lots" link)
    - Notice that the entry date at the top of the page is the new date
    - Now you should be able to select QUININE-A and everything should work
- Close the lot selection modal and change the entry date back to today
    - Go back to the lots selection page (Click "Lots" link)
    - Notice that the QUININE-A lot is now expired and the form will complain about it



