### PR TITLE
feat(stock): add user to stock movement registry

### DIFF
--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -112,6 +112,10 @@ function StockMovementsController(
       cellFilter : 'date',
       cellClass : 'text-right',
     }, {
+      field : 'userName',
+      displayName : 'FORM.LABELS.USER',
+      headerCellFilter : 'translate',
+    }, {
       field : 'action',
       displayName : '',
       enableFiltering : false,

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -429,12 +429,14 @@ async function getMovements(depotUuid, params) {
     BUID(m.depot_uuid) AS depot_uuid, m.is_exit, m.date, BUID(m.document_uuid) AS document_uuid,
     m.flux_id, BUID(m.entity_uuid) AS entity_uuid, SUM(m.unit_cost * m.quantity) AS cost,
     f.label AS flux_label, BUID(m.invoice_uuid) AS invoice_uuid, dm.text AS documentReference,
-    BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.text AS document_requisition
+    BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.text AS document_requisition,
+    u.display_name AS userName
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
     JOIN depot d ON d.uuid = m.depot_uuid
     JOIN flux f ON f.id = m.flux_id
+    JOIN user u ON u.id = m.user_id
     LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
     LEFT JOIN service AS serv ON serv.uuid = m.entity_uuid
     LEFT JOIN document_map sr_m ON sr_m.uuid = m.stock_requisition_uuid

--- a/server/controllers/stock/reports/stock_inline_movements.report.handlebars
+++ b/server/controllers/stock/reports/stock_inline_movements.report.handlebars
@@ -25,10 +25,10 @@
         <thead>
           <tr>
             <th>{{translate 'TABLE.COLUMNS.REFERENCE'}}</th>
-            <th>{{translate 'STOCK.IO'}}</th>
-            <th>{{translate 'STOCK.COST'}}</th>
             <th>{{translate 'FORM.LABELS.DATE'}}</th>
-            <th>{{translate 'STOCK.FLUX'}}</th>
+            <th>{{translate 'STOCK.IO'}}</th>
+            <th>{{translate 'FORM.LABELS.USER'}}</th>
+            <th>{{translate 'STOCK.COST'}}</th>
           </tr>
         </thead>
         <tbody>
@@ -37,10 +37,10 @@
 
             <!-- this is the depot group header -->
             <tr style="border:none">
-              <th style="border:none; border-bottom: solid black 2px;" class="text-uppercase">
+              <th colspan="3" style="border:none; border-bottom: solid black 1px;" class="text-uppercase">
                 {{ name }}
               </th>
-              <th colspan="4" style="border:none; border-bottom: solid black 2px;" class="text-right">
+              <th colspan="2" style="border:none; border-bottom: solid black 1px;" class="text-right">
                 ({{ items.length }} {{ translate "TABLE.AGGREGATES.RECORDS" }})
               </th>
             </tr>
@@ -49,16 +49,16 @@
             {{#each items}}
               <tr {{#if is_exit}}class="text-danger"{{/if}}>
                 <td>{{documentReference}}</td>
+                <td>{{date date}}</td>
                 <td>
                   {{#if is_exit}}
-                    {{translate 'STOCK.OUTPUT'}}
+                    {{translate 'STOCK.OUTPUT'}} - {{translate flux_label}}
                   {{else}}
-                    {{translate 'STOCK.INPUT'}}
+                    {{translate 'STOCK.INPUT'}} - {{translate flux_label}}
                   {{/if}}
                 </td>
+                <td>{{ userName }}</td>
                 <td class="text-right">{{currency cost ../../metadata.enterprise.currency_id}}</td>
-                <td>{{date date}}</td>
-                <td>{{translate flux_label}}</td>
               </tr>
             {{/each}}
 


### PR DESCRIPTION
Adds the user to the stock movement registry so that we are better able to track which user performed which movements.

Closes #5502.

Here is what it looks like:
![image](https://user-images.githubusercontent.com/896472/111081404-7ccae580-8503-11eb-944f-1707d2af05c6.png)
