### PR TITLE
feat(stock): link voucher from stock movement

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -665,6 +665,7 @@
             "REFERENCE_GROUP": "Reference Group",
             "REFERENCE_PATIENT": "Patient Reference",
             "REFERENCE": "Reference",
+            "REFERENCE_STOCK_MOVEMENT" : "Stock Movement Reference",
             "REFERENCES": "References",
             "REGISTER_EMPLOYEE_PATIENT": "Save as an employee",
             "REGISTRATION_NUMBER": "Registration number",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -666,6 +666,7 @@
             "REFERENCE_GROUP": "Groupe de référence",
             "REFERENCE_PATIENT": "Référence Patient",
             "REFERENCE": "Référence",
+            "REFERENCE_STOCK_MOVEMENT" : "Référence de mouvement stock",
             "REFERENCES": "Références",
             "REGISTER_EMPLOYEE_PATIENT": "Enregistrer comme un employé",
             "REGISTRATION_NUMBER": "Matricule",

--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -265,6 +265,8 @@ function StockMovementsController(
     vm.latestViewFilters = stockMovementsFilters.formatView();
   }
 
+  vm.hasAutoStockAccounting = Session.stock_settings.enable_auto_stock_accounting;
+
   vm.downloadExcel = () => {
     const filterOpts = stockMovementsFilters.formatHTTP();
     const defaultOpts = {

--- a/client/src/modules/stock/movements/templates/action.cell.html
+++ b/client/src/modules/stock/movements/templates/action.cell.html
@@ -29,5 +29,11 @@
         <span class="fa fa-file-text-o"></span> <span translate>REPORT.VIEW_INVOICE</span>
       </a>
     </li>
+
+    <li ng-if="grid.appScope.hasAutoStockAccounting">
+      <a data-method="view-voucher" href ui-sref="vouchers({ filters : [{ key : 'period', value : 'allTime' }, { key : 'stockReference', value : row.entity.document_uuid, displayValue: row.entity.documentReference, cacheable:false }]})">
+        <span class="fa fa-file-text-o"></span> <span translate>REPORT.VIEW_VOUCHER</span>
+      </a>
+    </li>
   </ul>
 </div>

--- a/client/src/modules/vouchers/vouchers.service.js
+++ b/client/src/modules/vouchers/vouchers.service.js
@@ -56,6 +56,7 @@ function VoucherService(
     { key : 'type_ids', label : 'FORM.LABELS.TRANSACTION_TYPE' },
     { key : 'project_id', label : 'FORM.LABELS.PROJECT' },
     { key : 'currency_id', label : 'FORM.LABELS.CURRENCY' },
+    { key : 'stockReference', label : 'FORM.LABELS.REFERENCE_STOCK_MOVEMENT' },
   ]);
 
   if (filterCache.filters) {

--- a/server/controllers/finance/vouchers.js
+++ b/server/controllers/finance/vouchers.js
@@ -119,7 +119,7 @@ const REFERENCE_SQL = `
   )`;
 
 function find(options) {
-  db.convert(options, ['uuid', 'reference_uuid', 'entity_uuid', 'cash_uuid', 'invoice_uuid']);
+  db.convert(options, ['uuid', 'reference_uuid', 'entity_uuid', 'cash_uuid', 'invoice_uuid', 'stockReference']);
 
   const filters = new FilterParser(options, { tableAlias : 'v' });
   let typeIds = [];
@@ -166,6 +166,11 @@ function find(options) {
 
   filters.custom('invoice_uuid', REFERENCE_SQL, [options.invoice_uuid, options.invoice_uuid]);
   filters.custom('cash_uuid', REFERENCE_SQL, [options.cash_uuid, options.cash_uuid]);
+
+  filters.custom('stockReference',
+    `v.uuid IN (
+      SELECT vi.voucher_uuid FROM voucher_item AS vi WHERE vi.document_uuid = ?
+    )`);
 
   // reversed = 2 implies that we want to filter out both the inversed record and the inverted
   // record.


### PR DESCRIPTION
Links the voucher from the stock movement if the enterprise has "auto_stock_accounting" enabled.  This should make it easier to
compare the movements of stock with the financial movements.

Closes #5505.

Here is what it looks like in action:
![Qg1pwMiF4c](https://user-images.githubusercontent.com/896472/111085080-0b486280-8516-11eb-8b24-dee8300f127d.gif)
