### PR TITLE
fix(stock): stock movement status on delete

### DIFF
--- a/test/integration/stock/stock.js
+++ b/test/integration/stock/stock.js
@@ -252,9 +252,14 @@ describe('(/stock/) The Stock HTTP API', () => {
   it(`DELETE /stock/movements/ delete the stock movement of ${quantityForEntry} Quinines`, async () => {
     const res = await agent.delete(`/stock/movements/${movementUuid}`);
     helpers.api.deleted(res);
+
     const res2 = await agent.get(`/stock/inventories/depots`).query(inventoryQuantityQuery);
     const currentQuantityAfterDeletion = res2.body[0].quantity;
+
     expect(currentQuantityAfterDeletion).to.be.equal(quantityBeforeEntry);
+
+    expect(currentQuantityAfterDeletion, 'quantity in stock is not equal to quantity')
+      .to.equal(res2.body[0].cmms.quantity_in_stock);
   });
 
   // create Aggregate consumption


### PR DESCRIPTION
Corrects the computation of stock_movement_status on deletion of a stock movement.  The previous version had too many calls to string -> binary conversion that caused matching issues.  Additionally, the date wasn't set correctly.