### PR TITLE
Print out separators between each sub-test

### DIFF
--- a/sh/test.sh
+++ b/sh/test.sh
@@ -9,8 +9,11 @@ source .env || { echo '[test.sh] did not load .env, using variables from environ
 set +a
 
 function startfold {
+  echo
+  echo "----------------------------------------------------------------------"
+  echo $1
+  echo
   if [ -n "$TRAVIS_BUILD_NUMBER" ]; then
-    echo $1
     echo -en "travis_fold:start:$2\r"
   fi
 }


### PR DESCRIPTION
This PR adds an easy-to see separator between each subtest of 'yarn test'.

When I run tests on my PC, and I want to scroll back up to see which subtests may have failed, it was hard to see the break between each subtest.  This PR improves the visibility of each subtest.

To to test it, try running 'yarn test' and observe the new separators.
