### PR TITLE
feat(purchase): update purchase orders

### DIFF
--- a/client/src/js/components/bhSupplierSelect.js
+++ b/client/src/js/components/bhSupplierSelect.js
@@ -7,7 +7,6 @@ angular.module('bhima.components')
       supplierUuid     : '<',
       onSelectCallback : '&',
       label            : '@?',
-      required         : '<?',
     },
   });
 

--- a/client/src/js/services/Pool.js
+++ b/client/src/js/services/Pool.js
@@ -35,7 +35,6 @@ function PoolService(Store) {
     return item;
   };
 
-
   // return the unavailable item to the pool
   Pool.prototype.release = function release(id) {
     const item = this.unavailable.get(id);
@@ -45,6 +44,11 @@ function PoolService(Store) {
     }
 
     return item;
+  };
+
+  // lists all available data in the Pool
+  Pool.prototype.list = function list() {
+    return this.available.data;
   };
 
   // the total number of items stored in the Pool

--- a/client/src/js/services/Store.js
+++ b/client/src/js/services/Store.js
@@ -11,10 +11,8 @@ angular.module('bhima.services')
 function StoreService() {
 
   /** @constructor */
-  function Store(options) {
-
+  function Store(options = {}) {
     // default to empty options
-    options = options || {};
 
     // default index and data
     this.index = {};
@@ -53,18 +51,18 @@ function StoreService() {
    * matches.  Otherwise, it returns undefined.
    */
   Store.prototype.get = function get(id) {
-    var key = this.index[id];
-    if (angular.isUndefined(key)) { return; }
+    const key = this.index[id];
+    if (angular.isUndefined(key)) { return undefined; }
     return this.data[key];
   };
 
   // return only the latest (indexed) copy of each data element
   Store.prototype.getAll = function getAll() {
-    var keys = Object.keys(this.index);
-    return keys.map(function (key) {
+    const keys = Object.keys(this.index);
+    return keys.map((key) => {
       return this.data[this.index[key]];
-    }.bind(this));
-  }
+    });
+  };
 
   /**
    * @method post
@@ -76,19 +74,17 @@ function StoreService() {
    * @param {Object} object - an object to be inserted into the store.
    */
   Store.prototype.post = function post(object) {
-    var data = this.data;
-    var index = this.index;
-    var identifier = this.identifier;
+    const { data, index, identifier } = this;
 
     // default to an empty array if data not provided
     if (!data) { this.data = []; }
 
-    var id = object[identifier];
+    const id = object[identifier];
 
     if (angular.isUndefined(id)) {
       throw new Error(
-        'Trying to insert an object without the identity property "' + identifier + '".\n' +
-        'Failing object: ' + JSON.stringify(object)
+        `Trying to insert an object without the identity property "${identifier}".\n`
+        + `Failing object: ${JSON.stringify(object)}`,
       );
     }
 
@@ -103,9 +99,8 @@ function StoreService() {
    *
    * @param {Object} object - an object to be inserted into the store
    */
-   Store.prototype.remove = function remove(id) {
-    var data = this.data;
-    var index = this.index;
+  Store.prototype.remove = function remove(id) {
+    const { data, index } = this;
 
     if (id in index) {
       data.splice(index[id], 1);
@@ -146,11 +141,11 @@ function StoreService() {
    * Recalculates the stores index when data is added/removed via other methods.
    */
   Store.prototype.recalculateIndex = function recalculateIndex() {
-    var data = this.data;
-    var index = this.index = {};
-    var identifier = this.identifier;
+    const { data } = this;
+    this.index = {};
+    const { index, identifier } = this;
 
-    for (var i = 0, l = data.length; i < l; i += 1) {
+    for (let i = 0, l = data.length; i < l; i += 1) {
       index[data[i][identifier]] = i;
     }
   };

--- a/client/src/modules/purchases/create/createUpdate.html
+++ b/client/src/modules/purchases/create/createUpdate.html
@@ -25,9 +25,8 @@
                 <div class="col-md-6">
                   <bh-supplier-select
                     supplier-uuid="PurchaseCtrl.order.details.supplier_uuid"
-                    required="true"
-                    on-select-callback="PurchaseCtrl.setSupplier(supplier)">
-                    </bh-supplier-select>
+                    on-select-callback="PurchaseCtrl.order.setSupplier(supplier)">
+                  </bh-supplier-select>
 
                   <div class="form-group">
                     <label class="control-label">
@@ -113,7 +112,7 @@
                 type="button"
                 ng-click="PurchaseCtrl.optimalPurchase()"
                 id="optimal_purchase"
-                ng-disabled="!PurchaseCtrl.supplier || PurchaseCtrl.optimalPurchaseLoading">
+                ng-disabled="!PurchaseCtrl.order.hasSupplier() || PurchaseCtrl.optimalPurchaseLoading">
                 <span ng-hide="PurchaseCtrl.optimalPurchaseLoading">
                   <i class="fa fa-shopping-cart"></i>
                   <span translate>FORM.BUTTONS.OPTIMAL_PURCHASE_ORDER </span>
@@ -126,8 +125,8 @@
 
             <!-- "Add number of grid rows" input-group -->
             <bh-add-item
-              disable="PurchaseCtrl.supplier"
-              callback="PurchaseCtrl.addItems(numItem)">
+              disable="PurchaseCtrl.order.hasSupplier()"
+              callback="PurchaseCtrl.order.addItems(numItem)">
             </bh-add-item>
 
             <!-- @todo - hacky check for inventory to prevent local variables -->
@@ -142,7 +141,7 @@
             <p
               style="padding-top : 10px;"
               class="text-info"
-              ng-show="!PurchaseCtrl.supplier">
+              ng-show="!PurchaseCtrl.order.hasSupplier()">
               <span class="fa fa-info-circle"></span>
               <span translate>FORM.INFO.NO_SUPPLIER</span>
             </p>
@@ -150,34 +149,33 @@
         </div>
 
         <div
-            id="purchase-order-grid"
-            ui-grid="PurchaseCtrl.gridOptions"
-            style="height : {{ ::PurchaseCtrl.bhConstants.GRID_HEIGHT }}px; width : 100%;">
+          id="purchase-order-grid"
+          ui-grid="PurchaseCtrl.gridOptions"
+          style="height : {{ ::PurchaseCtrl.bhConstants.GRID_HEIGHT }}px; width : 100%;">
         </div>
 
-        <div class="row" ng-if="PurchaseCtrl.supplier">
+        <div class="row" ng-if="PurchaseCtrl.order.hasSupplier()">
           <h4 class="text-right" style="margin-right: 25px;">
             <span translate>FORM.LABELS.TOTAL</span>
             {{ PurchaseCtrl.order.totals.rows | currency:PurchaseCtrl.enterprise.currency_id }}
           </h4>
         </div>
 
-        <!-- TODO Temporary styles -->
         <div class="row" style="padding-top : 5px; padding-bottom : 5px;">
           <div class="col-md-12 text-right">
-              <bh-loading-button
-                disabled="!PurchaseCtrl.supplier"
-                loading-state="PurchaseCtrl.loadingState">
-                <span translate>FORM.BUTTONS.SAVE</span>
-              </bh-loading-button>
+            <bh-loading-button
+              disabled="!PurchaseCtrl.order.hasSupplier()"
+              loading-state="PurchaseCtrl.loadingState">
+              <span translate>FORM.BUTTONS.SAVE</span>
+            </bh-loading-button>
 
-              <button
-                type="button"
-                class="btn btn-default"
-                ng-click="PurchaseCtrl.clear(PurchaseOrderForm)"
-                data-method="clear" translate>
-                FORM.BUTTONS.CLEAR
-              </button>
+            <button
+              type="button"
+              class="btn btn-default"
+              ng-click="PurchaseCtrl.clear(PurchaseOrderForm)"
+              data-method="clear" translate>
+              FORM.BUTTONS.CLEAR
+            </button>
             <p
               class="text-danger"
               ng-show="PurchaseCtrl.order._invalid && PurchaseOrderForm.$submitted">

--- a/client/src/modules/purchases/modals/status.js
+++ b/client/src/modules/purchases/modals/status.js
@@ -2,11 +2,17 @@ angular.module('bhima.controllers')
   .controller('PurchaseOrderStatusModalController', PurchaseOrderStatusModalController);
 
 PurchaseOrderStatusModalController.$inject = [
-  '$uibModalInstance', 'NotifyService', 'PurchaseOrderService', 'data',
+  '$uibModalInstance', 'NotifyService', 'PurchaseOrderService', 'data', 'bhConstants',
 ];
 
-function PurchaseOrderStatusModalController(Instance, Notify, PurchaseOrder, Data) {
+function PurchaseOrderStatusModalController(Instance, Notify, PurchaseOrder, Data, Constants) {
   const vm = this;
+
+  const isStoredCheck = [
+    Constants.purchase.RECEIVED,
+    Constants.purchase.PARTIALLY_RECEIVED,
+    Constants.purchase.EXCESSIVE_RECEIVED_QUANTITY,
+  ];
 
   // global variables
   vm.purchase = Data;
@@ -15,13 +21,13 @@ function PurchaseOrderStatusModalController(Instance, Notify, PurchaseOrder, Dat
   vm.close = Instance.close;
   vm.submit = submit;
 
-  vm.isStored = vm.purchase.status_id === 3 || vm.purchase.status_id === 4;
+  vm.isStored = isStoredCheck.includes(vm.purchase.status_id);
 
   // submit the choice
   function submit() {
-    const data = { status_id : vm.status, date : new Date() };
+    const data = { status_id : vm.status };
 
-    PurchaseOrder.update(vm.purchase.uuid, data)
+    return PurchaseOrder.update(vm.purchase.uuid, data)
       .then(() => {
         Instance.close(true);
       })

--- a/client/src/modules/purchases/modals/status.js
+++ b/client/src/modules/purchases/modals/status.js
@@ -23,7 +23,7 @@ function PurchaseOrderStatusModalController(Instance, Notify, PurchaseOrder, Dat
 
     PurchaseOrder.update(vm.purchase.uuid, data)
       .then(() => {
-        Instance.close();
+        Instance.close(true);
       })
       .catch(Notify.handleError);
   }

--- a/client/src/modules/purchases/modals/status.tmpl.html
+++ b/client/src/modules/purchases/modals/status.tmpl.html
@@ -5,16 +5,16 @@
   </ol>
 </div>
 
-<form 
+<form
   name="ModalForm"
-  ng-submit="$ctrl.submit($ctrl.status)"
+  bh-submit="$ctrl.submit($ctrl.status)"
   data-modal="purchase-status"
   novalidate>
 
 <div class="modal-body">
   <div class="form-group" ng-if="$ctrl.purchase.status_id !== 2">
     <label class="text-action">
-      <input type="radio" name="status" ng-model="$ctrl.status" value="2" ng-disabled="$ctrl.isStored"> 
+      <input type="radio" name="status" ng-model="$ctrl.status" value="2" ng-disabled="$ctrl.isStored">
       <span class="label label-primary" translate>PURCHASES.STATUS.CONFIRMED</span>
       <p translate>PURCHASES.STATUS.CONFIRMED_DESC</p>
     </label>
@@ -22,7 +22,7 @@
 
   <div class="form-group" ng-if="$ctrl.purchase.status_id !== 1">
     <label class="text-action">
-      <input type="radio" name="status" ng-model="$ctrl.status" value="1" ng-disabled="$ctrl.isStored"> 
+      <input type="radio" name="status" ng-model="$ctrl.status" value="1" ng-disabled="$ctrl.isStored">
       <span class="label label-default" translate>PURCHASES.STATUS.WAITING_CONFIRMATION</span>
       <p translate>PURCHASES.STATUS.WAITING_CONFIRMATION_DESC</p>
     </label>
@@ -30,7 +30,7 @@
 
   <div class="form-group" ng-if="$ctrl.purchase.status_id !== 5">
     <label class="text-action">
-      <input type="radio" name="status" ng-model="$ctrl.status" value="5"  ng-disabled="$ctrl.isStored"> 
+      <input type="radio" name="status" ng-model="$ctrl.status" value="5"  ng-disabled="$ctrl.isStored">
       <span class="label label-danger" translate>PURCHASES.STATUS.CANCELLED</span>
       <p translate>PURCHASES.STATUS.CANCELLED_DESC</p>
     </label>

--- a/client/src/modules/purchases/purchases.routes.js
+++ b/client/src/modules/purchases/purchases.routes.js
@@ -8,6 +8,14 @@ angular.module('bhima.routes')
         templateUrl : 'modules/purchases/create/createUpdate.html',
       })
 
+    // purchases/:uuid/update
+      .state('purchasesUpdate', {
+        url         : '/purchases/:uuid/update',
+        params  : { uuid : { squash : true, value : null } },
+        controller  : 'PurchaseOrderController as PurchaseCtrl',
+        templateUrl : 'modules/purchases/create/createUpdate.html',
+      })
+
     // purchases/list
       .state('purchasesList', {
         url         : '/purchases',

--- a/client/src/modules/purchases/purchases.service.js
+++ b/client/src/modules/purchases/purchases.service.js
@@ -96,23 +96,26 @@ function PurchaseOrderService(
    * Preprocesses purchase order data for submission to the server
    */
   function create(data) {
+    return Api.create.call(service, data);
+  }
+
+  service.preprocessItemsForSubmission = function preprocessItemsForSubmission(items) {
     // loop through the items ensuring that they are properly formatted for
     // inserting into the database.  We only want to send minimal information
     // to the server.
     // Technically, this filtering is also done on the server, but this reduces
     // bandwidth required for the POST request.
-    data.items = data.items.map((item) => {
-      delete item._initialised;
-      delete item._invalid;
-      delete item._valid;
+    return items.map((item) => {
       delete item.code;
       delete item.description;
       delete item.unit;
+      delete item._hasValidAccounts;
+      delete item._initialised;
+      delete item._invalid;
+      delete item._valid;
       return item;
     });
-
-    return Api.create.call(service, data);
-  }
+  };
 
   function stockStatus(id) {
     const url = ''.concat(id, '/stock_status');

--- a/client/src/modules/purchases/registry/registry.js
+++ b/client/src/modules/purchases/registry/registry.js
@@ -138,8 +138,10 @@ function PurchaseListController(
   // edit status
   function editStatus(purchase) {
     Modal.openPurchaseOrderStatus(purchase)
-      .then(() => {
-        return load(PurchaseOrder.filters.formatHTTP(true));
+      .then((reload) => {
+        if (reload) {
+          load(PurchaseOrder.filters.formatHTTP(true));
+        }
       })
       .catch(handler);
   }

--- a/client/src/modules/purchases/templates/action.cell.html
+++ b/client/src/modules/purchases/templates/action.cell.html
@@ -5,7 +5,13 @@
   </a>
 
   <ul class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
-    <li class="bh-dropdown-header">{{row.entity.reference}}</li>
+    <li class="bh-dropdown-header">
+      {{row.entity.reference}}
+      <span ng-show="row.entity.edited" class="text-primary">
+        <i class="fa fa-pencil"></i>
+        <span translate>FORM.INFO.EDITED</span>
+      </span>
+    </li>
     <li>
       <a
         href
@@ -23,6 +29,12 @@
       </a>
     </li>
 
+    <li ng-if="row.entity.status_id === grid.appScope.status.WAITING_CONFIRMATION">
+      <a href data-method="edit-record" ui-sref="purchasesUpdate({ uuid : row.entity.uuid })" >
+        <i class="fa fa-edit"></i><span translate>FORM.LABELS.EDIT</span>
+      </a>
+    </li>
+
     <li class="divider"></li>
 
     <li ng-if="row.entity.hasStockMovement">
@@ -37,8 +49,6 @@
       </a>
     </li>
 
-
-
     <li ng-if="row.entity.hasStockMovement">
       <a data-method="view-stock-lot" href
         ui-sref="stockInventories({ filters : [
@@ -48,6 +58,7 @@
         <i class="fa fa-cart-plus"></i> <span translate>REPORT.VIEW_ARTICLE_IN_STOCK</span>
       </a>
     </li>
+
 
     <li ng-if="!row.entity.hasStockMovement">
       <a
@@ -59,6 +70,7 @@
         <i class="fa fa-edit"></i><span translate>FORM.LABELS.EDIT_STATUS</span>
       </a>
     </li>
+
 
     <li class="divider" ng-if="grid.appScope.allowsRecordDeletion(row.entity)"></li>
 

--- a/client/src/modules/purchases/templates/action.cell.html
+++ b/client/src/modules/purchases/templates/action.cell.html
@@ -35,7 +35,18 @@
       </a>
     </li>
 
-    <li class="divider"></li>
+    <li ng-if="!row.entity.hasStockMovement && row.entity.status_id !== grid.appScope.status.CANCELLED">
+      <a
+        href
+        class="text-action"
+        ng-click="grid.appScope.editStatus(row.entity)"
+        data-edit-metadata="{{ row.entity.uuid }}"
+        data-method="edit-status">
+        <i class="fa fa-edit"></i><span translate>FORM.LABELS.EDIT_STATUS</span>
+      </a>
+    </li>
+
+    <li class="divider" ng-if="row.entity.hasStockMovement"></li>
 
     <li ng-if="row.entity.hasStockMovement">
       <a href
@@ -56,18 +67,6 @@
           { key : 'includeEmptyLot', value : 1 },
           { key : 'purchase_uuid', value : row.entity.uuid, displayValue: row.entity.reference }]})">
         <i class="fa fa-cart-plus"></i> <span translate>REPORT.VIEW_ARTICLE_IN_STOCK</span>
-      </a>
-    </li>
-
-
-    <li ng-if="!row.entity.hasStockMovement">
-      <a
-        href
-        class="text-action"
-        ng-click="grid.appScope.editStatus(row.entity)"
-        data-edit-metadata="{{ row.entity.uuid }}"
-        data-method="edit">
-        <i class="fa fa-edit"></i><span translate>FORM.LABELS.EDIT_STATUS</span>
       </a>
     </li>
 

--- a/client/src/modules/templates/bhSupplierSelect.tmpl.html
+++ b/client/src/modules/templates/bhSupplierSelect.tmpl.html
@@ -3,19 +3,22 @@
     class="form-group"
     ng-class="{ 'has-error' : SupplierForm.$submitted && SupplierForm.supplier_uuid.$invalid }">
 
-    <label class="control-label" translate>
-      {{$ctrl.label}}
-    </label>
+    <label class="control-label" translate>{{$ctrl.label}}</label>
 
     <ng-transclude></ng-transclude>
+
     <ui-select
-        name="supplier_uuid"
-        ng-model="$ctrl.supplierUuid"
-        on-select="$ctrl.onSelect($item)">
+      name="supplier_uuid"
+      ng-model="$ctrl.supplierUuid"
+      on-select="$ctrl.onSelect($item)">
+
       <ui-select-match placeholder="{{ 'FORM.SELECT.SUPPLIER' | translate }}">
         {{$select.selected.display_name}}
       </ui-select-match>
-      <ui-select-choices ui-select-focus-patch repeat="supplier.uuid as supplier in $ctrl.suppliers | filter: { 'display_name': $select.search }">
+
+      <ui-select-choices
+        ui-select-focus-patch
+        repeat="supplier.uuid as supplier in $ctrl.suppliers | filter: { 'display_name': $select.search }">
         <span ng-bind-html="supplier.display_name | highlight:$select.search"></span>
       </ui-select-choices>
     </ui-select>

--- a/server/controllers/inventory/reports/purchases.receipt.handlebars
+++ b/server/controllers/inventory/reports/purchases.receipt.handlebars
@@ -32,7 +32,7 @@
       <span class="text-capitalize">{{translate "FORM.LABELS.SUPPLIER"}}</span>: <strong>{{purchase.supplier}}</strong> <br>
       <span class="text-capitalize">{{translate "FORM.LABELS.DATE"}}</span>: {{date purchase.date}} <br>
       <span class="text-capitalize">{{translate "FORM.LABELS.REFERENCE"}}</span>: {{purchase.reference}} <br>
-      <span class="text-capitalize">{{translate "FORM.LABELS.NOTES"}}</span>: <strong>{{purchase.note}}</strong> <br>
+      <span>{{translate "FORM.LABELS.NOTES"}}</span>: <strong>{{purchase.note}}</strong> <br>
       <span class="text-capitalize">{{translate 'TABLE.COLUMNS.RESPONSIBLE'}}</span>: <strong>{{purchase.author}}</strong>
     </div>
   </div>

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -13,6 +13,13 @@ CREATE TABLE `stock_adjustment_log` (
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
 
+/**
+@author: jniles
+@date: 2021-03-18
+@description: add edited flag to the purchase order.
+*/
+CALL add_column_if_missing('purchase', 'edited', 'BOOLEAN NOT NULL DEFAULT FALSE');
+
 DROP TABLE IF EXISTS `integration`;
 
 /**

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -19,6 +19,7 @@ CREATE TABLE `stock_adjustment_log` (
 @description: add edited flag to the purchase order.
 */
 CALL add_column_if_missing('purchase', 'edited', 'BOOLEAN NOT NULL DEFAULT FALSE');
+CALL add_column_if_missing('purchase', 'updated_at', 'TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP');
 
 DROP TABLE IF EXISTS `integration`;
 
@@ -31,3 +32,4 @@ CALL drop_column_if_exists('lots', 'delay');
 CALL drop_column_if_exists('lots', 'initial_quantity');
 CALL drop_column_if_exists('lots', 'quantity');
 CALL drop_column_if_exists('lots', 'entry_date');
+

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1386,6 +1386,7 @@ CREATE TABLE `purchase` (
   `user_id`         SMALLINT(5) UNSIGNED NOT NULL,
   `payment_method`  TEXT,
   `note`            TEXT,
+  `edited`          BOOLEAN NOT NULL DEFAULT FALSE,
   `status_id`       TINYINT(3) UNSIGNED NOT NULL DEFAULT 1,
   PRIMARY KEY (`uuid`),
   UNIQUE KEY `purchase_1` (`project_id`, `reference`),

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1383,6 +1383,7 @@ CREATE TABLE `purchase` (
   `supplier_uuid`   BINARY(16) DEFAULT NULL,
   `date`            DATETIME NOT NULL,
   `created_at`      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`      TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
   `user_id`         SMALLINT(5) UNSIGNED NOT NULL,
   `payment_method`  TEXT,
   `note`            TEXT,

--- a/test/data.sql
+++ b/test/data.sql
@@ -591,7 +591,7 @@ UPDATE debtor_group SET price_list_uuid = HUID('75e09694-dd5c-11e5-a8a2-6c299557
 
 SET @purchase_order = HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588');
 INSERT INTO `purchase` VALUES
-  (@purchase_order, 1, 1, 300, 2, HUID('3ac4e83c-65f2-45a1-8357-8b025003d793'), DATE_ADD(CURRENT_DATE, INTERVAL -1725 DAY), CURRENT_TIMESTAMP, 1, NULL, NULL, 1);
+  (@purchase_order, 1, 1, 300, 2, HUID('3ac4e83c-65f2-45a1-8357-8b025003d793'), DATE_ADD(CURRENT_DATE, INTERVAL -1725 DAY), CURRENT_TIMESTAMP, 1, NULL, NULL, FALSE, 1);
 
 INSERT INTO `purchase_item` VALUES
   (HUID('fca58822-b1b2-11e8-9103-7782f63484ff'), @purchase_order, @quinine, 1, 200, 200),
@@ -600,7 +600,7 @@ INSERT INTO `purchase_item` VALUES
 -- confirmed purchase order
 SET @purchase = HUID('8027d1c8-dd68-4686-9f4c-8860f856f8ba');
 INSERT INTO `purchase` VALUES
-  (@purchase, 1, 2, (1000 * 0.05), 2, HUID('3ac4e83c-65f2-45a1-8357-8b025003d793'), DATE_ADD(CURRENT_DATE, INTERVAL -1321 DAY), CURRENT_TIMESTAMP, 1, NULL, 'Purchase Order Confirmed', 2);
+  (@purchase, 1, 2, (1000 * 0.05), 2, HUID('3ac4e83c-65f2-45a1-8357-8b025003d793'), DATE_ADD(CURRENT_DATE, INTERVAL -1321 DAY), CURRENT_TIMESTAMP, 1, NULL, 'Purchase Order Confirmed', FALSE, 2);
 
 INSERT INTO `purchase_item` VALUES
   (HUID('1fcc1316-b1b3-11e8-b276-bfdbdae020fb'), @purchase, @prednisone, 1000, 0.05, (1000 * 0.05));

--- a/test/data.sql
+++ b/test/data.sql
@@ -590,8 +590,9 @@ INSERT INTO `price_list_item` VALUES
 UPDATE debtor_group SET price_list_uuid = HUID('75e09694-dd5c-11e5-a8a2-6c29955775b0') WHERE uuid = HUID('4de0fe47-177f-4d30-b95f-cff8166400b4');
 
 SET @purchase_order = HUID('e07ceadc-82cf-4ae2-958a-6f6a78c87588');
-INSERT INTO `purchase` VALUES
-  (@purchase_order, 1, 1, 300, 2, HUID('3ac4e83c-65f2-45a1-8357-8b025003d793'), DATE_ADD(CURRENT_DATE, INTERVAL -1725 DAY), CURRENT_TIMESTAMP, 1, NULL, NULL, FALSE, 1);
+INSERT INTO `purchase`
+  (uuid, project_id, reference, cost, currency_id, supplier_uuid, date, user_id, payment_method, status_id) VALUES
+  (@purchase_order, 1, 1, 300, 2, HUID('3ac4e83c-65f2-45a1-8357-8b025003d793'), DATE_ADD(CURRENT_DATE, INTERVAL -1725 DAY), 1, NULL, 1);
 
 INSERT INTO `purchase_item` VALUES
   (HUID('fca58822-b1b2-11e8-9103-7782f63484ff'), @purchase_order, @quinine, 1, 200, 200),
@@ -599,8 +600,8 @@ INSERT INTO `purchase_item` VALUES
 
 -- confirmed purchase order
 SET @purchase = HUID('8027d1c8-dd68-4686-9f4c-8860f856f8ba');
-INSERT INTO `purchase` VALUES
-  (@purchase, 1, 2, (1000 * 0.05), 2, HUID('3ac4e83c-65f2-45a1-8357-8b025003d793'), DATE_ADD(CURRENT_DATE, INTERVAL -1321 DAY), CURRENT_TIMESTAMP, 1, NULL, 'Purchase Order Confirmed', FALSE, 2);
+INSERT INTO `purchase` (uuid, project_id, reference, cost, currency_id, supplier_uuid, date, user_id, payment_method, note, status_id) VALUES
+  (@purchase, 1, 2, (1000 * 0.05), 2, HUID('3ac4e83c-65f2-45a1-8357-8b025003d793'), DATE_ADD(CURRENT_DATE, INTERVAL -1321 DAY), 1, NULL, 'Purchase Order Confirmed', 2);
 
 INSERT INTO `purchase_item` VALUES
   (HUID('1fcc1316-b1b3-11e8-b276-bfdbdae020fb'), @purchase, @prednisone, 1000, 0.05, (1000 * 0.05));

--- a/test/end-to-end/purchases/purchases.spec.js
+++ b/test/end-to-end/purchases/purchases.spec.js
@@ -1,9 +1,7 @@
 /* global by */
 const moment = require('moment');
-const chai = require('chai');
+const { expect } = require('chai');
 const helpers = require('../shared/helpers');
-
-const { expect } = chai;
 
 const FU = require('../shared/FormUtils');
 const PurchaseOrderPage = require('./purchases.page.js');

--- a/test/server-unit/purchases/purchases.spec.js
+++ b/test/server-unit/purchases/purchases.spec.js
@@ -17,7 +17,7 @@ function PurchaseUnitTests() {
     await db.exec(`
       INSERT INTO purchase VALUES
         (HUID('${puid}'), 2, 1, 300, 2, HUID('3ac4e83c-65f2-45a1-8357-8b025003d793'),
-        DATE_ADD(CURRENT_DATE, INTERVAL -1725 DAY), CURRENT_TIMESTAMP, 1, NULL, NULL, FALSE, 1);
+        DATE_ADD(CURRENT_DATE, INTERVAL -1725 DAY), CURRENT_TIMESTAMP, NULL, 1, NULL, NULL, FALSE, 1);
     `);
 
     // create a purchase item linked to the above purchase order.

--- a/test/server-unit/purchases/purchases.spec.js
+++ b/test/server-unit/purchases/purchases.spec.js
@@ -17,7 +17,7 @@ function PurchaseUnitTests() {
     await db.exec(`
       INSERT INTO purchase VALUES
         (HUID('${puid}'), 2, 1, 300, 2, HUID('3ac4e83c-65f2-45a1-8357-8b025003d793'),
-        DATE_ADD(CURRENT_DATE, INTERVAL -1725 DAY), CURRENT_TIMESTAMP, 1, NULL, NULL, 1);
+        DATE_ADD(CURRENT_DATE, INTERVAL -1725 DAY), CURRENT_TIMESTAMP, 1, NULL, NULL, FALSE, 1);
     `);
 
     // create a purchase item linked to the above purchase order.


### PR DESCRIPTION
This commit implements the ability to update non-confirmed purchase orders.  If a purchase order has been confirmed, the only thing that should be updated is the status (canceled).  This is yet to be discussed.

To modify a purchase order, one must go to the purchase registry and select "edit" on the purchase orders that is non yet confirmed.  This will take you to the regular purchase order creation page with all values filled out.

Closes #5489.

Here is what it looks like:

![sXzDxvsomU](https://user-images.githubusercontent.com/896472/111638135-599d8000-87fa-11eb-9864-128e0c10e437.gif)


Note that this implementation breaks updating the status.  I'd like some help figuring out which status we should allow.  I'll fix that before a merge.