### PR TITLE
Add tooltips to status cells in articles in stock

### DIFF
--- a/client/src/modules/stock/inventories/templates/status.cell.html
+++ b/client/src/modules/stock/inventories/templates/status.cell.html
@@ -1,21 +1,41 @@
 <div class="ui-grid-cell-contents">
-    <div ng-if="row.entity.hasStockOut" class="label out-of-stock-status" translate>
+    <div ng-if="row.entity.hasStockOut" class="label out-of-stock-status"
+      uib-tooltip="{{'STOCK.STATUS.STOCK_OUT' | translate}}"
+      tooltip-append-to-body="true"
+      tooltip-placement="left"
+      translate>
       STOCK.STATUS.STOCK_OUT
     </div>
 
-    <div ng-if="row.entity.hasSecurityWarning" class="label critical-stock-status" translate>
+    <div ng-if="row.entity.hasSecurityWarning" class="label critical-stock-status"
+      uib-tooltip="{{'STOCK.STATUS.SECURITY' | translate}}"
+      tooltip-append-to-body="true"
+      tooltip-placement="left"
+      translate>
       STOCK.STATUS.SECURITY
     </div>
 
-    <div ng-if="row.entity.hasMinimumWarning" class="label low-stock-status" translate>
+    <div ng-if="row.entity.hasMinimumWarning" class="label low-stock-status"
+      uib-tooltip="{{'STOCK.STATUS.MINIMUM' | translate}}"
+      tooltip-append-to-body="true"
+      tooltip-placement="left"
+      translate>
       STOCK.STATUS.MINIMUM
     </div>
 
-    <div ng-if="row.entity.isInStock" class="label label-success" translate>
+    <div ng-if="row.entity.isInStock" class="label label-success"
+      uib-tooltip="{{'STOCK.STATUS.IN_STOCK' | translate}}"
+      tooltip-append-to-body="true"
+      tooltip-placement="left"
+      translate>
       STOCK.STATUS.IN_STOCK
     </div>
 
-    <div ng-if="row.entity.hasOverageWarning" class="label label-primary" translate>
+    <div ng-if="row.entity.hasOverageWarning" class="label label-primary"
+      uib-tooltip="{{'STOCK.STATUS.OVER_MAX' | translate}}"
+      tooltip-append-to-body="true"
+      tooltip-placement="left"
+      translate>
       STOCK.STATUS.OVER_MAX
     </div>
 </div>

--- a/client/src/modules/stock/inventories/templates/warning.cell.html
+++ b/client/src/modules/stock/inventories/templates/warning.cell.html
@@ -3,7 +3,7 @@
     ng-if="!row.entity.hasStockOut"
     uib-tooltip-template="'warningLotsMessage.html'"
     tooltip-append-to-body="true"
-    tooltip-placement="right">
+    tooltip-placement="left">
     <i ng-if="row.entity.noAlert"  class="fa fa-check text-success"></i>
     <i ng-if="row.entity.alert" class="fa fa-exclamation-triangle text-danger"></i>
     <i ng-if="row.entity.warning" class="fa fa-exclamation-circle text-warning"></i>


### PR DESCRIPTION
Added tooltips for the status cells in the Articles in Stock page.   
(Tried to position to the right of the cell, but that did not work. So ended up on the left and updated the tooltips for the warning cells to be on the left too for consistency).

#closes https://github.com/IMA-WorldHealth/bhima/issues/5478

**Testing**
- You may want to use a production database to see all the possible status tags
- To see the expired stock, enable that in the Search > Default filters.