### PR TITLE
Fix purchase registry template path

### DIFF
--- a/client/src/modules/purchases/purchases.routes.js
+++ b/client/src/modules/purchases/purchases.routes.js
@@ -12,6 +12,6 @@ angular.module('bhima.routes')
       .state('purchasesList', {
         url         : '/purchases',
         controller  : 'PurchaseListController as PurchaseListCtrl',
-        templateUrl : 'modules/purchases/list/list.html',
+        templateUrl : 'modules/purchases/registry/registry.html',
       });
   }]);


### PR DESCRIPTION
This PR is a about the path template of the purchase registry which was not correct.

![TGUfGIKq2V](https://user-images.githubusercontent.com/5445251/112716820-e3c7a180-8ee8-11eb-938f-5c5c84bebb07.gif)
