### PR TITLE
Remove lots flags structure

### DIFF
--- a/client/src/modules/stock/lots/templates/lifetime.cell.html
+++ b/client/src/modules/stock/lots/templates/lifetime.cell.html
@@ -1,5 +1,5 @@
 <div class="ui-grid-cell-contents text-right">
-  <span ng-if="row.entity.hasExpirationDate && !row.entity.flags.expired">
+  <span ng-if="row.entity.hasExpirationDate && !row.entity.expired">
     {{ row.entity.lifetime }} <span translate>FORM.LABELS.DAYS</span>
   </span>
 </div>

--- a/client/src/modules/stock/lots/templates/risk.cell.html
+++ b/client/src/modules/stock/lots/templates/risk.cell.html
@@ -1,5 +1,5 @@
 <div class="ui-grid-cell-contents text-right" ng-class="{'text-danger': row.entity.S_RISK > 0}">
-  <span ng-if="row.entity.hasExpirationDate && !row.entity.flags.expired && row.entity.avg_consumption > 0">
+  <span ng-if="row.entity.hasExpirationDate && !row.entity.expired && row.entity.avg_consumption > 0">
     {{ row.entity.S_RISK }} <span translate>FORM.LABELS.DAYS</span>
   </span>
 </div>

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -297,11 +297,11 @@ async function getLotsDepot(depotUuid, params, finalClause) {
   // after the comparison with the CMM, reason why the filtering
   // is not carried out with an SQL request
   if (parseInt(params.is_expiry_risk, 10) === 1) {
-    inventoriesWithLotsProcessed = inventoriesWithLotsProcessed.filter(lot => lot.flags.near_expiration);
+    inventoriesWithLotsProcessed = inventoriesWithLotsProcessed.filter(lot => lot.near_expiration);
   }
 
   if (parseInt(params.is_expiry_risk, 10) === 0) {
-    inventoriesWithLotsProcessed = inventoriesWithLotsProcessed.filter(lot => !lot.flags.near_expiration);
+    inventoriesWithLotsProcessed = inventoriesWithLotsProcessed.filter(lot => !lot.near_expiration);
   }
 
   return inventoriesWithLotsProcessed;
@@ -852,14 +852,6 @@ function computeLotIndicators(inventories) {
         // TODO(@jniles): does this make sense?
         lot.at_risk_of_stock_out = !lot.expired
           && (lot.status === 'minimum_reached' || lot.status === 'security_reached');
-
-        // attach flags after computation for use on client
-        lot.flags = {
-          expired : lot.expired,
-          near_expiration : lot.near_expiration,
-          exhausted : lot.exhausted,
-          at_risk_of_stock_out : lot.at_risk_of_stock_out,
-        };
 
         flattenLots.push(lot);
       });

--- a/server/controllers/stock/reports/stock/expiration_report.js
+++ b/server/controllers/stock/reports/stock/expiration_report.js
@@ -50,7 +50,7 @@ async function stockExpirationReport(req, res, next) {
     const risky = lots.filter(lot => (lot.near_expiration && lot.lifetime > 0));
 
     // get expired lots
-    const expired = lots.filter(lot => lot.flags.expired);
+    const expired = lots.filter(lot => lot.expired);
 
     // merge risky and expired
     const riskyAndExpiredLots = risky.concat(expired);


### PR DESCRIPTION
Removed the 'flags' sub-object from lots.  This was an unnecessary level of indirection for the lot flags (eg, expiration, etc) and it was not consistently being used.  Removing it makes the logic cleaner.

**Testing**
This should be completely transparent to the user.  The main pages that might be affected are the lots registry page and the Stock expiration report.   If those work normally for you, then it is probably okay.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5460