### PR TITLE
Fix permissions for editing roles actions

### DIFF
--- a/client/src/modules/roles/roles.html
+++ b/client/src/modules/roles/roles.html
@@ -5,7 +5,7 @@
       <li class="title" translate>TREE.ROLE_MANAGEMENT</li>
     </ol>
 
-    <div class="toolbar" ng-show="RolesCtrl.canEditRoles">
+    <div class="toolbar" ng-show="bh-has-permission="grid.appScope.bhConstants.actions.EDIT_ROLES"">
       <div class="toolbar-item">
         <button class="btn btn-default" ng-click="RolesCtrl.createUpdateRoleModal()" data-method="create">
           <span class="fa fa-plus"></span>


### PR DESCRIPTION
This fixes an oversight in the recent refactoring of action permissions.  Now anyone with CAN_EDIT_ROLES should be able to add roles in the Role management interface.

**Testing**
- Run as superuser or other admin account
- Go to Administration > Role Management
- Note that the [Add] role button now appears on the top right of the form.
- You should be able to add, edit, and delete roles