### PR TITLE
Fix currency labeling for stock movements from purchase order entries

### DIFF
--- a/server/controllers/stock/reports/stock/entry_purchase_receipt.js
+++ b/server/controllers/stock/reports/stock/entry_purchase_receipt.js
@@ -23,7 +23,7 @@ async function stockEntryPurchaseReceipt(documentUuid, session, options) {
       u.display_name AS user_display_name,
       l.label, l.expiration_date, d.text AS depot_name,
       dm2.text AS purchase_reference, p.note, p.cost, p.date AS purchase_date,
-      p.payment_method, s.display_name AS supplier_display_name,
+      p.payment_method, p.currency_id, s.display_name AS supplier_display_name,
       dm.text as document_reference, ig.tracking_expiration,
       IF(ig.tracking_expiration = 1, TRUE, FALSE) as expires
     FROM stock_movement m
@@ -53,6 +53,7 @@ async function stockEntryPurchaseReceipt(documentUuid, session, options) {
   }
 
   const line = rows[0];
+
   const { key } = identifiers.STOCK_ENTRY;
 
   data.enterprise = session.enterprise;
@@ -67,6 +68,7 @@ async function stockEntryPurchaseReceipt(documentUuid, session, options) {
     purchase_reference    : line.purchase_reference,
     p_note                : line.note,
     p_cost                : line.cost,
+    p_currency_id         : line.currency_id,
     p_date                : line.purchase_date,
     p_method              : line.payment_method,
     supplier_display_name : line.supplier_display_name,

--- a/server/controllers/stock/reports/stock_entry_purchase.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_entry_purchase.receipt.handlebars
@@ -19,7 +19,7 @@
         <span class="text-capitalize">{{translate 'FORM.LABELS.SUPPLIER'}}</span>: <strong>{{details.supplier_display_name}}</strong> <br>
         <span class="text-capitalize">{{translate 'STOCK.PURCHASE_ORDER'}}</span>: <strong>{{details.purchase_reference}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date details.p_date}}<br>
-        <span class="text-capitalize">{{translate 'STOCK.AMOUNT'}}</span>: {{currency details.p_cost enterprise.currency_id}} <br>
+        <span class="text-capitalize">{{translate 'STOCK.AMOUNT'}}</span>: {{currency details.p_cost details.p_currency_id}} <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.PAYMENT_METHOD'}}</span>: {{translate details.p_method}} <br>
       </div>
       <div class="col-xs-6">
@@ -30,7 +30,7 @@
           <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: <strong>{{details.voucher_reference}}</strong> <br>
         {{/if}}
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date details.date}} <br>
-        <span class="text-capitalize">{{translate 'FORM.LABELS.COST'}}</span>: {{currency (sum rows 'total') enterprise.currency_id}} <br>
+        <span class="text-capitalize">{{translate 'FORM.LABELS.COST'}}</span>: {{currency (sum rows 'total') details.p_currency_id}} <br>
         <span class="text-capitalize">{{translate 'STOCK.INVENTORY'}}</span>: {{rows.length}} {{translate 'STOCK.ITEMS'}} <br>
         <span class="text-capitalize">{{translate "TABLE.COLUMNS.CREATED_BY"}}</span>: {{details.user_display_name}} <br>
       </div>
@@ -69,8 +69,8 @@
             <td></td>
           {{/if}}
           <td class="text-right">{{quantity}}</td>
-          <td class="text-right">{{currency unit_cost ../enterprise.currency_id}}</td>
-          <td class="text-right">{{currency total ../enterprise.currency_id}}</td>
+          <td class="text-right">{{currency unit_cost ../details.p_currency_id}}</td>
+          <td class="text-right">{{currency total ../details.p_currency_id}}</td>
         </tr>
       {{else}}
         {{> emptyTable columns=9}}
@@ -79,7 +79,7 @@
     <tfoot>
       <tr style="font-weight: bold;">
         <td colspan="6">{{rows.length}} {{translate 'STOCK.ITEMS'}}</td>
-        <td class="text-right">{{currency (sum rows 'total') enterprise.currency_id}}</td>
+        <td class="text-right">{{currency (sum rows 'total') details.p_currency_id}}</td>
       </tr>
     </tfoot>
   </table>


### PR DESCRIPTION
This PR fixes omissions in the recent selectable-currency purchase order updates whihc 
missed updating stock movements for purchase order entries. 

**TESTING**
- Use any database
- Pick a non-enterprise currency (below I use Euros, but it could be FC too).
- Use the Admin > Exchange rate  and make a note of the current Euro exchange rate
   - If the rate for Euros is not defined, define it now.
- Create a purchase order (PO) in Euros.
   - Confirm the PO if necessary
   - Notice all interactions and the Receipt clearly show Euros (once it is selected in the PO creation)
- Do stock entry for that PO.
- Go to Stock Movements and find just-completed stock movement for the PO
- Notice that the cost for the movement is shown in USD (the enterprise currency) and that the exchange rate has been applied correctly.
- Use the action menu for that movement and look at the report. The PO report should be in the original currency (Euros) and should be similar to the one for that PO (you can check using the PO registry, action menu...)