### PR TITLE
feat(stock): link stock movement transaction

### DIFF
--- a/client/src/modules/journal/journal.service.js
+++ b/client/src/modules/journal/journal.service.js
@@ -119,6 +119,7 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
     { key : 'hrReference', label : 'TABLE.COLUMNS.REFERENCE' },
     { key : 'hrEntity', label : 'TABLE.COLUMNS.RECIPIENT' },
     { key : 'comment', label : 'FORM.LABELS.COMMENT' },
+    { key : 'stockReference', label : 'FORM.LABELS.REFERENCE_STOCK_MOVEMENT' },
   ]);
 
   if (filterCache.filters) {
@@ -136,7 +137,7 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
     // assign default period filter
     const periodDefined = service.util.arrayIncludes(
       assignedKeys,
-      ['period', 'custom_period_start', 'custom_period_end']
+      ['period', 'custom_period_start', 'custom_period_end'],
     );
 
     if (!periodDefined) {

--- a/client/src/modules/stock/movements/templates/action.cell.html
+++ b/client/src/modules/stock/movements/templates/action.cell.html
@@ -42,6 +42,12 @@
       </a>
     </li>
 
+    <li ng-if="grid.appScope.hasAutoStockAccounting">
+      <a data-method="view-transactions" href ui-sref="journal({ filters : [{ key : 'period', value : 'allTime' }, { key : 'stockReference', value : row.entity.document_uuid, displayValue: row.entity.documentReference, cacheable:false }, { key : 'includeNonPosted', value : 1 }]})">
+        <span class="fa fa-file-text-o"></span> <span translate>TRANSACTIONS.VIEW_TRANSACTIONS</span>
+      </a>
+    </li>
+
     <li bh-has-permission="grid.appScope.actions.DELETE_STOCK_MOVEMENT" class="divider"></li>
 
     <li bh-has-permission="grid.appScope.actions.DELETE_STOCK_MOVEMENT">

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -108,7 +108,9 @@ function naiveTransactionSearch(options, includeNonPosted) {
 // if posted ONLY return posted transactions
 // if not posted ONLY return non-posted transactions
 function buildTransactionQuery(options, posted) {
-  db.convert(options, ['uuid', 'record_uuid', 'uuids', 'record_uuids', 'reference_uuid']);
+  db.convert(options, [
+    'uuid', 'record_uuid', 'uuids', 'record_uuids', 'reference_uuid', 'entity_uuid', 'stockReference',
+  ]);
 
   const filters = new FilterParser(options, { tableAlias : 'p' });
 
@@ -160,6 +162,8 @@ function buildTransactionQuery(options, posted) {
   filters.equals('hrEntity', 'text', 'em');
   filters.equals('hrRecord', 'text', 'dm1');
   filters.equals('hrReference', 'text', 'dm2');
+  filters.equals('entity_uuid');
+  filters.equals('stockReference', 'reference_uuid', 'p');
   filters.custom('currency_id', 'c.id=?');
 
   filters.custom('transaction_type_id', 'p.transaction_type_id IN (?)', options.transaction_type_id);


### PR DESCRIPTION
Adds the ability to link stock movements with the journal if the automated stock accounting is working.  This makes it easy to correlate the financial writings with the stock ones.

Closes #5276.

Here it is in action:

![CEzSYAON20](https://user-images.githubusercontent.com/896472/116095822-a9e0eb00-a6a0-11eb-8a50-e4646bad640a.gif)