### PR TITLE
Save purchase order stock movements in enterprise currency

### DIFF
--- a/client/src/modules/purchases/create/createUpdate.js
+++ b/client/src/modules/purchases/create/createUpdate.js
@@ -243,7 +243,7 @@ function PurchaseOrderController(Purchases, PurchaseOrder, Notify,
         // Update the currency/exchange info
         vm.order.setCurrencyId(vm.rate.currency.id);
 
-        return Exchange.read({ limit : 10 });
+        return Exchange.read();
       })
       .then((rates) => {
         vm.rates = rates;

--- a/client/src/modules/stock/entry/modals/findPurchase.modal.js
+++ b/client/src/modules/stock/entry/modals/findPurchase.modal.js
@@ -4,10 +4,12 @@ angular.module('bhima.controllers')
 StockFindPurchaseModalController.$inject = [
   '$uibModalInstance', 'PurchaseOrderService', 'NotifyService',
   'uiGridConstants', 'GridFilteringService', 'bhConstants', 'SessionService',
+  'ExchangeRateService',
 ];
 
 function StockFindPurchaseModalController(
-  Instance, Purchase, Notify, uiGridConstants, Filtering, bhConstants, Session,
+  Instance, Purchase, Notify, uiGridConstants, Filtering,
+  bhConstants, Session, Exchange
 ) {
   const vm = this;
 
@@ -35,7 +37,6 @@ function StockFindPurchaseModalController(
       field            : 'reference',
       displayName      : 'TABLE.COLUMNS.REFERENCE',
       headerCellFilter : 'translate',
-      // cellTemplate     : 'modules/stock/entry/modals/templates/purchase_reference.tmpl.html',
       cellTemplate : purchaseReferenceCellTemplate,
     }, {
       field            : 'date',
@@ -52,7 +53,7 @@ function StockFindPurchaseModalController(
       field            : 'cost',
       displayName      : 'STOCK.AMOUNT',
       headerCellFilter : 'translate',
-      cellFilter       : `currency:${Session.enterprise.currency_id}`,
+      cellFilter       : `currency:row.entity.currency_id`,
       cellClass        : 'text-right',
     },
     { field : 'author', displayName : 'TABLE.COLUMNS.BY', headerCellFilter : 'translate' },
@@ -88,7 +89,10 @@ function StockFindPurchaseModalController(
   /* ======================= End Grid ======================================== */
   function load() {
     vm.loading = true;
-    Purchase.search({ status_id : [CONFIRMED, PARTIALLY_RECEIVED] })
+    Exchange.read()
+      .then(() => {
+        return Purchase.search({ status_id : [CONFIRMED, PARTIALLY_RECEIVED] });
+      })
       .then(purchases => {
         vm.gridOptions.data = purchases;
       })


### PR DESCRIPTION
This PR ensures that stock movements from purchase orders (POs) are saved in the enterprise currency.
The general approach is:
- Purchase orders and related PO items are saved in user-specified currency.  The lot unit price is based on the inventory unit prices with the correct exchange rate applied.
- When entries are done from POs, once the lots are selected and the final [Submit] button is pressed, the stock movement is saved in enterprise currency.

**TESTING**
- use bhima_test
- yarn build:db
- Use the Admin > Exchange rate and make a note of the current Euro, FC exchange rates
   - If the rate for Euros is not defined, define it now as 0.84
- Create three POs ($, FC, and Euros) for 10 of DINJ_TRIB1A2_0 (Vitamines B1+B6+B12...).
- Unit prices should be:
  - $ -> 3.62
  - FC -> 930*3.62 = 3366.6
  - Euro -> 0.84*3.62 = 3.048
- As you create each PO, verify the unit price and totals in the PO Receipt
- In the PO registry confirm each PO (if necessary)
  - Verify the totals for each PO in the registry
- Do stock entry for each of the three POs
  - Note the Search Purchase modal will show totals in the respective currencies.  Verify these are right.
  - For each PO
    - Select the full 10 items in the "Lots" selector
    - In the Lots selector, notice the unit cost is shown in the respective currency
    - When you press [Submit] check the Stock Entry - Purchase receipt.  It should show unit and total in the enterprise currency.
- Review the stock movements for these three entries.  They should be identical and in enterprise currency ($).

