### PR TITLE
fix(patients): properly count stock movements

### DIFF
--- a/client/src/js/components/bhPatientFinancialActivity.js
+++ b/client/src/js/components/bhPatientFinancialActivity.js
@@ -69,11 +69,13 @@ function PatientFinancialActivityCtrl(Patients, moment, Session, Constants, $q) 
           if (index < limitRecent) {
             dataMovement.push(item);
           }
+
           $ctrl.dataMovementTotalValue += item.value;
         });
 
         $ctrl.dataMovement = dataMovement;
         $ctrl.noStockMovement = stockData.length === 0;
+        $ctrl.totalMovementCount = stockData.length;
       }).finally(() => {
         $ctrl.loading = false;
       });

--- a/client/src/modules/patients/record/bh-patient-financial-activity.html
+++ b/client/src/modules/patients/record/bh-patient-financial-activity.html
@@ -120,7 +120,7 @@
                   ]
                 })">
                   <i class="fa fa-link"></i>
-                  <span translate translate-values="{'numMovements':$ctrl.dataMovement.length}">
+                  <span translate translate-values="{'numMovements':$ctrl.totalMovementCount}">
                     PATIENT_RECORDS.VIEW_ALL_MOVEMENTS_TO_PATIENT
                   </span>
                 </a>


### PR DESCRIPTION
Properly count stock movements on the patient overview page.

Closes #5443.

Here is what it looked like before:

![image](https://user-images.githubusercontent.com/896472/117133383-1001f800-ad9c-11eb-9c2f-9d58076aa83c.png)


After:
![image](https://user-images.githubusercontent.com/896472/117133419-1abc8d00-ad9c-11eb-9e28-4aa6a92db4e9.png)
