### PR TITLE
Add 'unused stock' status warning token to Articles in Stock display

### DIFF
--- a/client/src/css/structure.css
+++ b/client/src/css/structure.css
@@ -926,6 +926,11 @@ a[disabled] {
   background-color: #FFFF00 !important;
 }
 
+.unused-stock-status {
+  color: black !important;
+  background-color: #FF00FF !important;
+}
+
 .out-of-stock {
   /* text-decoration : line-through; */
   background-color: #cc00ff8f !important;

--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -222,13 +222,14 @@
     "SERVICE"         : "Service",
     "STATUS"          : {
       "IN_STOCK"      : "In Stock",
+      "IS_IN_RISK_OF_EXPIRATION" : "At risk of expiration",
       "LABEL"         : "Status",
       "MAXIMUM"       : "Maximum Stock Reached",
       "MINIMUM"       : "Low Stock",
       "OVER_MAX"      : "Over Maximum",
       "SECURITY"      : "Critical Stock",
-      "STOCK_OUT"      : "Stock Out",
-      "IS_IN_RISK_OF_EXPIRATION" : "At risk of expiration"
+      "STOCK_OUT"     : "Stock Out",
+      "UNUSED_STOCK"  : "Unused stock"
     },
     "STOCK_MOVEMENT"  : "View Stock Movement",
     "STOCK_MOVEMENTS" : "View Stock Movements",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -223,13 +223,14 @@
     "SERVICE"         : "Service",
     "STATUS"          : {
       "IN_STOCK"      : "Disponible",
+      "IS_IN_RISK_OF_EXPIRATION" : "A risque d'expiration",
       "LABEL"         : "État",
       "MAXIMUM"       : "Stock Max Atteint",
       "MINIMUM"       : "Stock faible",
       "OVER_MAX"      : "Stock Max Depassé",
       "SECURITY"      : "Stock Critique",
       "STOCK_OUT"     : "Rupture de stock",
-      "IS_IN_RISK_OF_EXPIRATION" : "A risque d'expiration"
+      "UNUSED_STOCK"  : "Produits non utilisé"
     },
     "STOCK_MOVEMENT"  : "Voir le mouvement de Stock",
     "STOCK_MOVEMENTS" : "Les Mouvements de Stock",

--- a/client/src/js/constants/bhConstants.js
+++ b/client/src/js/constants/bhConstants.js
@@ -108,11 +108,12 @@ function constantConfig() {
       completed_status : 6,
     },
     stockStatus : {
-      IS_STOCK_OUT          : 'stock_out',
+      IS_STOCK_OUT         : 'stock_out',
       IS_IN_STOCK          : 'in_stock',
       HAS_SECURITY_WARNING : 'security_reached',
       HAS_MINIMUM_WARNING  : 'minimum_reached',
       HAS_OVERAGE_WARNING  : 'over_maximum',
+      UNUSED_STOCK         : 'unused_stock',
     },
     reports : {
       AGED_DEBTOR    : 'AGED_DEBTOR',

--- a/client/src/js/services/StockService.js
+++ b/client/src/js/services/StockService.js
@@ -83,6 +83,7 @@ function StockService(Api, StockFilterer, HttpCache, util, Periods) {
     security_reached  : 'STOCK.STATUS.SECURITY',
     minimum_reached   : 'STOCK.STATUS.MINIMUM',
     over_maximum      : 'STOCK.STATUS.OVER_MAX',
+    unused_stock      : 'STOCK.STATUS.UNUSED_STOCK',
   };
 
   // Filter service

--- a/client/src/modules/stock/inventories/registry.js
+++ b/client/src/modules/stock/inventories/registry.js
@@ -207,6 +207,7 @@ function StockInventoriesController(
     item.hasSecurityWarning = item.status === bhConstants.stockStatus.HAS_SECURITY_WARNING;
     item.hasMinimumWarning = item.status === bhConstants.stockStatus.HAS_MINIMUM_WARNING;
     item.hasOverageWarning = item.status === bhConstants.stockStatus.HAS_OVERAGE_WARNING;
+    item.isUnusedStock = item.status === bhConstants.stockStatus.UNUSED_STOCK;
   }
 
   // on remove one filter

--- a/client/src/modules/stock/inventories/templates/status.cell.html
+++ b/client/src/modules/stock/inventories/templates/status.cell.html
@@ -7,6 +7,14 @@
       STOCK.STATUS.STOCK_OUT
     </div>
 
+    <div ng-if="row.entity.isUnusedStock" class="label unused-stock-status"
+      uib-tooltip="{{'STOCK.STATUS.UNUSED_STOCK' | translate}}"
+      tooltip-append-to-body="true"
+      tooltip-placement="left"
+      translate>
+      STOCK.STATUS.UNUSED_STOCK
+    </div>
+
     <div ng-if="row.entity.hasSecurityWarning" class="label critical-stock-status"
       uib-tooltip="{{'STOCK.STATUS.SECURITY' | translate}}"
       tooltip-append-to-body="true"

--- a/server/config/constants.js
+++ b/server/config/constants.js
@@ -68,11 +68,12 @@ module.exports = {
     completed_status : 6,
   },
   stockStatus : {
-    IS_STOCK_OUT          : 'stock_out',
+    IS_STOCK_OUT         : 'stock_out',
     IS_IN_STOCK          : 'in_stock',
     HAS_SECURITY_WARNING : 'security_reached',
     HAS_MINIMUM_WARNING  : 'minimum_reached',
     HAS_OVERAGE_WARNING  : 'over_maximum',
+    UNUSED_STOCK         : 'unused_stock',
   },
   reports : {
     AGED_DEBTOR    : 'AGED_DEBTOR',

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -525,6 +525,8 @@ function computeInventoryIndicators(inventories) {
     if (Q <= 0) {
       inventory.status = 'stock_out';
       inventory.stock_out_date = inventory.last_movement_date;
+    } else if (Q > 0 && inventory.NO_CONSUMPTION) {
+      inventory.status = 'unused_stock';
     } else if (Q > 0 && Q <= inventory.S_SEC) {
       inventory.status = 'security_reached';
     } else if (Q > inventory.S_SEC && Q <= inventory.S_MIN) {

--- a/server/controllers/stock/reports/stock_inventories.report.handlebars
+++ b/server/controllers/stock/reports/stock_inventories.report.handlebars
@@ -62,6 +62,7 @@
               {{#equal status 'security_reached'}}{{translate 'STOCK.STATUS.SECURITY'}}{{/equal}}
               {{#equal status 'minimum_reached'}}{{translate 'STOCK.STATUS.MINIMUM'}}{{/equal}}
               {{#equal status 'over_maximum'}}{{translate 'STOCK.STATUS.OVER_MAX'}}{{/equal}}
+              {{#equal status 'unused_stock'}}{{translate 'STOCK.STATUS.UNUSED_STOCK'}}{{/equal}}
             </td>
             <td class="text-right">{{avg_consumption}}</td>
             <td class="text-right">{{S_MONTH}}</td>


### PR DESCRIPTION
This PR adds a 'Unused Stock' warking token to the status column in the Articles in Stock report.

I chose "magenta" for the color of the "Unused Stock" item, but could change it if anyone has a better suggestion.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5323

**TESTING**
- Suggest using a production database
- Try the Stock > Articles in Stock page
   - Notice that items with CMM=0 show the magenta "Unused Stock" token in the Status column
   - Change the default search to allow exhausted lots
   - Refresh the Articles in Stock page and notice that items with "stock out" show that token instead of the "Unused Stock" token, even if their CMM=0.   I think that "Unused Stock" implies that there is stock to be used but it was not used.  If there is no stock ("stock out") then it is not obvious why no stock was used (it could be used if it had been in stock, or it is obsolete).
- Try the Stock > Report > Stock Inventories report and verify that the "Unsed Stock" labels are shown in the report.