### PR TITLE
fix(stock): disable add entry items on clear

### DIFF
--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -177,6 +177,7 @@ function StockEntryController(
     form.$setPristine();
     form.$setUntouched();
     vm.movement = { date : new Date() };
+    vm.entityAllowAddItems = false;
     vm.resetEntryExitTypes = true;
   }
 


### PR DESCRIPTION
Disables as the "add entry items" in the stock entry page if the user aclicks "clear".  It is reactivated again when the user picks a source.

Closes #5624.