### PR TITLE
fix(stock): allow delete movements

### DIFF
--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -273,7 +273,7 @@ function StockMovementsController(
   vm.hasAutoStockAccounting = Session.stock_settings.enable_auto_stock_accounting;
 
   vm.deleteMovement = documentUuid => {
-    ModalService.confirm()
+    return ModalService.confirm()
       .then(ans => {
         if (!ans) { return null; }
 

--- a/client/src/modules/stock/movements/templates/action.cell.html
+++ b/client/src/modules/stock/movements/templates/action.cell.html
@@ -48,9 +48,9 @@
       </a>
     </li>
 
-    <li bh-has-permission="grid.appScope.actions.DELETE_STOCK_MOVEMENT" class="divider"></li>
+    <li bh-has-permission="grid.appScope.bhConstants.actions.DELETE_STOCK_MOVEMENT" class="divider"></li>
 
-    <li bh-has-permission="grid.appScope.actions.DELETE_STOCK_MOVEMENT">
+    <li bh-has-permission="grid.appScope.bhConstants.actions.DELETE_STOCK_MOVEMENT">
       <a data-method="delete" ng-click="grid.appScope.deleteMovement(row.entity.document_uuid)" href>
         <span class="text-danger"><i class="fa fa-trash"></i> <span translate>FORM.BUTTONS.DELETE_RECORD</span></span>
       </a>


### PR DESCRIPTION
Fix a typo that caused the delete option to never show on stock movements.