### PR TITLE
chore: improve find transfer/purchase modals

### DIFF
--- a/client/src/modules/stock/entry/modals/findPurchase.modal.html
+++ b/client/src/modules/stock/entry/modals/findPurchase.modal.html
@@ -1,24 +1,19 @@
-<form 
+<form
   name="FindForm"
   bh-submit="$ctrl.submit(FindForm)"
   novalidate>
 
   <div class="modal-header space-between">
-    <div class="headercrumb">
-      <i class="fa fa-search"></i> 
-      <span translate>FORM.LABELS.SEARCH</span> 
-      <span translate>STOCK.ENTRY_PURCHASE</span>
-    </div>
+    <ol class="headercrumb">
+      <li class="static">
+        <i class="fa fa-search"></i>
+        <span translate>FORM.LABELS.SEARCH</span>
+      </li>
+      <li class="title" translate>STOCK.ENTRY_PURCHASE</li>
+    </ol>
 
     <div class="toolbar text-right">
-      <div class="toolbar-item">
-        <button type="button"
-          ng-click="$ctrl.toggleFilter()"
-          class="btn btn-sm btn-default"
-          ng-class="{ 'btn-info' : $ctrl.filterEnabled }">
-          <span class="fa fa-filter"></span>
-        </button>
-      </div>
+      <bh-filter-toggle on-toggle="$ctrl.toggleFilter()"></bh-filter-toggle>
     </div>
   </div>
 
@@ -50,5 +45,4 @@
       <span translate>FORM.BUTTONS.SUBMIT</span>
     </bh-loading-button>
   </div>
-
 </form>

--- a/client/src/modules/stock/entry/modals/findTransfer.modal.html
+++ b/client/src/modules/stock/entry/modals/findTransfer.modal.html
@@ -1,14 +1,16 @@
 <form
   name="FindForm"
-  ng-submit="$ctrl.submit(FindForm)"
+  bh-submit="$ctrl.submit(FindForm)"
   novalidate>
 
   <div class="modal-header space-between">
-    <div class="headercrumb">
-      <i class="fa fa-search"></i>
-      <span translate>FORM.LABELS.SEARCH</span>
-      <span translate>STOCK.ENTRY_TRANSFER</span>
-    </div>
+    <ol class="headercrumb">
+      <li class="static">
+        <i class="fa fa-search"></i>
+        <span translate>FORM.LABELS.SEARCH</span>
+      </li>
+      <li class="title" translate> STOCK.ENTRY_TRANSFER </li>
+    </ol>
 
     <div class="toolbar text-right">
       <bh-filter-toggle
@@ -51,8 +53,8 @@
       FORM.BUTTONS.CLOSE
     </button>
 
-    <button class="btn btn-primary" type="submit" data-method="submit" ng-disabled="$ctrl.loading" translate>
-      FORM.BUTTONS.SUBMIT
-    </button>
+    <bh-loading-button loading-state="FindForm.$loading">
+      <span translate>FORM.BUTTONS.SUBMIT</span>
+    </bh-loading-button>
   </div>
 </form>

--- a/client/src/modules/stock/entry/modals/templates/document_reference.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/document_reference.tmpl.html
@@ -1,3 +1,0 @@
-<div class="ui-grid-cell-contents">
-  <a ng-click="grid.appScope.showReceipt(row.entity.document_uuid)" href>{{ row.entity.document_reference }}</a>
-</div>


### PR DESCRIPTION
This PR tightens up the code of both transfer modals for stock entry.  Their behavior should be nearly identical.

Here are the improvements:
 1. Both use the headercrumb properly so their formatting looks like other modules.
 2. Both use the `bh-filter-toggle` directive for toggling the grid's filtering.
 3. Both have a submit button that shows a loading indicator while submitting.
 4. Neither listen on every grid change and update the selectedRow.  Instead, that information is only queried on submit.
 5. Both use receipt components for their receipts instead of importing the ReceiptModal service.