### PR TITLE
fix(stock): do not hang on requisition search

### DIFF
--- a/client/src/js/components/bhHasRequisitionVoucher/bhHasRequisitionVoucher.html
+++ b/client/src/js/components/bhHasRequisitionVoucher/bhHasRequisitionVoucher.html
@@ -1,4 +1,4 @@
-<form name="HasRequisitionForm" class="form-group">
+<ng-form name="HasRequisitionForm">
   <bh-yes-no-radios
     label="REQUISITION.DOES_REQUISITION_EXIST"
     value="$ctrl.requisitionVoucherExist"
@@ -15,6 +15,7 @@
       requisition-uuid="$ctrl.requisitionReference"
       requestor-uuid="$ctrl.requestor"
       required="true"
+      disabled="$ctrl.requisitionDisabled"
       on-select-callback="$ctrl.onSelectRequisition(requisition)">
     </bh-requisition-select>
 
@@ -22,4 +23,4 @@
       <p ng-class="$ctrl.classeLabel" translate>{{ $ctrl.message }}</p>
     </div>
   </div>
-</form>
+</ng-form>

--- a/client/src/js/components/bhHasRequisitionVoucher/bhHasRequisitionVoucher.js
+++ b/client/src/js/components/bhHasRequisitionVoucher/bhHasRequisitionVoucher.js
@@ -18,12 +18,15 @@ function bhHasRequisitionVoucherController() {
 
   $ctrl.$onInit = function onInit() {
     $ctrl.requisitionVoucherExist = 0;
+    $ctrl.requisitionDisabled = true;
   };
 
   $ctrl.$onChanges = function onChanges(changes) {
     if (changes.requestor && changes.requestor.currentValue) {
       $ctrl.requisitionVoucherExist = 0;
+      $ctrl.requisitionDisabled = false;
     }
+
   };
 
   $ctrl.onChangeVoucherExist = value => {

--- a/client/src/js/components/bhRequisitionSelect.js
+++ b/client/src/js/components/bhRequisitionSelect.js
@@ -9,6 +9,7 @@ angular.module('bhima.components')
       onSelectCallback : '&',
       required : '@?',
       label : '@?',
+      disabled : '<?',
     },
   });
 

--- a/client/src/modules/stock/exit/modals/findDepot.modal.html
+++ b/client/src/modules/stock/exit/modals/findDepot.modal.html
@@ -2,14 +2,13 @@
   name="FindForm"
   bh-submit="$ctrl.submit(FindForm)"
   novalidate>
-
   <div class="modal-header">
     <ol class="headercrumb">
-      <li class="static"> <i class="fa fa-search"></i> </li>
-      <li class="title">
+      <li class="static">
+        <i class="fa fa-search"></i>
         <span translate>FORM.LABELS.SEARCH</span>
-        <span translate>STOCK.DEPOT</span>
       </li>
+      <li class="title" translate>STOCK.DEPOT</li>
     </ol>
   </div>
 

--- a/client/src/modules/stock/exit/modals/findDepot.modal.js
+++ b/client/src/modules/stock/exit/modals/findDepot.modal.js
@@ -8,6 +8,7 @@ StockFindDepotModalController.$inject = [
 
 function StockFindDepotModalController(Instance, Depot, Notify, Data, Stock, Session, RequisitionHelpers) {
   const vm = this;
+
   const enableStrictDepotDistribution = Session.stock_settings.enable_strict_depot_distribution;
 
   // global
@@ -29,11 +30,8 @@ function StockFindDepotModalController(Instance, Depot, Notify, Data, Stock, Ses
       .then(depots => {
         // set defined the previous selected depot
         if (Data.entity_uuid) {
-          const currentDepot = depots.filter(item => {
-            return item.uuid === Data.entity_uuid;
-          });
-
-          vm.selected = currentDepot.length > 0 ? currentDepot[0] : {};
+          const currentDepot = depots.find(item => item.uuid === Data.entity_uuid);
+          vm.selected = currentDepot || {};
         }
 
         // forbid to distribute to the same depot
@@ -52,13 +50,13 @@ function StockFindDepotModalController(Instance, Depot, Notify, Data, Stock, Ses
 
   // submit
   function submit(form) {
+
     if (vm.reference) {
       return RequisitionHelpers.lookupRequisitionByReference(vm.reference)
         .then(requisition => RequisitionHelpers.isRequisitionForDepot(requisition, Data.depot))
         .then(depotDetails)
         .then(assignDepotRequisition)
         .catch(err => {
-
           // bind the error flags as needed
           vm.requisitionMessage = err.message;
           vm.requisitionLabel = err.label;
@@ -66,7 +64,8 @@ function StockFindDepotModalController(Instance, Depot, Notify, Data, Stock, Ses
         });
     }
 
-    if (form.$invalid && !vm.requisition.uuid) { return null; }
+    if (form.$invalid && (vm.requisition && !vm.requisition.uuid)) { return null; }
+
     return Instance.close(vm.selected);
   }
 

--- a/client/src/modules/templates/bhRequisitionSelect.tmpl.html
+++ b/client/src/modules/templates/bhRequisitionSelect.tmpl.html
@@ -6,11 +6,12 @@
     <label class="control-label" translate>
       {{$ctrl.label}}
     </label>
-    
+
     <ng-transclude></ng-transclude>
-    <ui-select name="requisition_uuid" 
+    <ui-select name="requisition_uuid"
       ng-required ="$ctrl.required"
       ng-model="$ctrl.requisitionUuid"
+      ng-disabled="$ctrl.disabled"
       on-select="$ctrl.onSelect($item, $model)">
       <ui-select-match placeholder="{{ 'FORM.SELECT.REFERENCE_REQUISITION' | translate }}"><span>{{$select.selected.reference}}</span></ui-select-match>
       <ui-select-choices ui-select-focus-patch repeat="requisition.uuid as requisition in $ctrl.requisitions | filter: { 'reference': $select.search }">


### PR DESCRIPTION
This commit prevents the stock exit to requisition from hanging.  It
does this in two ways - first, it removes the typo that is causing the
infinite hang.  Second, it causes the requisition select to be disabled
if the depot isn't selected.  This should show users that they have a
problem and drive them to look up the depot.

Generally, the best way would be to improve the hasRequisitionVoucher
code, but it can't be done quickly.  Hence this quick fix.

Closes #5642.