### PR TITLE
chore(stock): hover for full exp date on stock exit

### DIFF
--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -32,6 +32,7 @@ function StockExitController(
   vm.currentInventories = [];
   vm.reset = reset;
   vm.ROW_ERROR_FLAG = bhConstants.grid.ROW_ERROR_FLAG;
+  vm.DATE_FMT = bhConstants.dates.format;
   vm.overconsumption = [];
 
   vm.onDateChange = date => {

--- a/client/src/modules/stock/exit/templates/expiration.tmpl.html
+++ b/client/src/modules/stock/exit/templates/expiration.tmpl.html
@@ -1,3 +1,6 @@
 <div ng-if="row.entity.lot.uuid" class="ui-grid-cell-contents">
-  <span am-time-ago="row.entity.lot.expiration_date"></span>
+  <span
+    am-time-ago="row.entity.lot.expiration_date"
+    title="{{row.entity.lot.expiration_date | date:grid.appScope.DATE_FMT }}"
+    ></span>
 </div>


### PR DESCRIPTION
Adds the ability to view the entire expiration date by hovering over the "expires" field.

Closes #5637.

Here is what it looks like:

![image](https://user-images.githubusercontent.com/896472/117928378-c5343300-b2fb-11eb-8588-2e3a4f98e63e.png)
