### PR TITLE
fix(reports): ensure red background on RUMER lines

### DIFF
--- a/client/src/i18n/en/tree.json
+++ b/client/src/i18n/en/tree.json
@@ -139,7 +139,7 @@
     "ROLE_MANAGEMENT" : "Role Management",
     "ROOT" : "Root",
     "RUBRIC_MANAGEMENT" : "Rubrics Management",
-    "RUMER_REPORT" : "Rumer",
+    "RUMER_REPORT" : "RUMER",
     "SERVICE" : "Services",
     "SIMPLE_VOUCHER" : "Simple Voucher",
     "STAFFING_INDICES_MANAGEMENT" : "Staffing indices management",

--- a/client/src/i18n/fr/tree.json
+++ b/client/src/i18n/fr/tree.json
@@ -139,7 +139,7 @@
     "ROLE_MANAGEMENT":"Gestion des rôles",
     "ROOT":"Racine",
     "RUBRIC_MANAGEMENT":"Gestion Rubriques",
-    "RUMER_REPORT" : "Rumer",
+    "RUMER_REPORT" : "RUMER",
     "SERVICE":"Services",
     "SIMPLE_VOUCHER":"Bordereau de transfert",
     "STAFFING_INDICES_MANAGEMENT" : "Gestion des indices de paie",

--- a/server/controllers/stock/reports/rumer.report.handlebars
+++ b/server/controllers/stock/reports/rumer.report.handlebars
@@ -1,5 +1,13 @@
 {{> head title="REPORT.MONTHLY_CONSUMPTION.TITLE" }}
 
+<style>
+  .bg-danger-important {
+    color: #a94442 !important;
+    background-color: #f2dede !important;
+    border-color: #ebccd1 !important;
+  }
+</style>
+
 <body class="container-fluid">
   {{> header}}
 
@@ -32,7 +40,7 @@
 
           <tbody>
             {{#each configurationData}}
-              <tr {{#lt quantityEnding 0 }}class="bg-danger"{{/lt}}>
+              <tr {{#lt quantityEnding 0 }}class="bg-danger-important"{{/lt}}>
               <td> {{ inventoryText }} </td>
               <td class="text-right"><strong> {{ quantityOpening }} </strong></td>
               <td class="text-right"><strong>{{ quantityTotalEntry }}</strong></td>


### PR DESCRIPTION
The table-striped directive was overriding the RUMER's red warning class
for rows ending in negative values.  Thus, the red label would sometimes
not show up.  This commit fixes that issue by creating a custom
background class with !important CSS rules.

Closes #5638.

![image](https://user-images.githubusercontent.com/896472/117931855-fdd60b80-b2ff-11eb-9328-eba819d813f5.png)
