### PR TITLE
fix(xlsx): do not crash on invalid date

### DIFF
--- a/server/lib/renderers/xlsx.js
+++ b/server/lib/renderers/xlsx.js
@@ -117,6 +117,7 @@ function render(data, template, options) {
 
 /**
  * @function find
+ *
  * @description
  * Finds available data to write in the excel file rows is the default key.
  * If nothing is found, this function get look at rowsDataKey it return
@@ -140,7 +141,9 @@ function setValue(ws, x, y, value) {
     return cell.number(value);
   }
 
-  if (_.isDate(value)) {
+  const isValidDate = _.isDate(value) && !Number.isNaN(value.valueOf());
+
+  if (isValidDate) {
     return cell.date(value).style({
       numberFormat : 'yyyy-mm-dd hh:mm:ss',
     });

--- a/test/server-unit/xlsx.spec.js
+++ b/test/server-unit/xlsx.spec.js
@@ -64,13 +64,31 @@ describe('xlsx.js', () => {
         { uuid : '7a9480cc-b2cd-4975-a1dc-e8c167070481', name : 'Alice' },
         { uuid : '1459ce89-5d67-4019-84d8-b2bcb808eacb', name : 'Bob' }],
     };
-    const formatedData = [
+    const formattedData = [
       { name : 'Alice' },
       { name : 'Bob' },
     ];
 
     const options = { rowsDataKey : 'students', ignoredColumns : ['uuid'] };
     const result = xlsx.find(data, options);
-    expect(result).to.deep.equal(formatedData);
+    expect(result).to.deep.equal(formattedData);
+  });
+
+  it('should not crash on an invalid date', () => {
+    const data = {
+      students : [
+        { name : 'Alice', dob : new Date('1980-06-13') },
+        { name : 'Bob', dob : new Date('') },
+      ],
+    };
+
+    const formattedData = [
+      { name : 'Alice', dob : new Date('1980-06-13') },
+      { name : 'Bob', dob : new Date('') },
+    ];
+
+    const options = { rowsDataKey : 'students' };
+    const result = xlsx.find(data, options);
+    expect(result).to.deep.equal(formattedData);
   });
 });


### PR DESCRIPTION
If a date isn't valid, the XLSX renderer would just crash, dumping JSON to the client.  By checking if the date is valid prior to passing it to `excel4node`, we prevent a crash by rendering the invalid date as a string so users can inspect the date and change it.

Closes #5666.