### PR TITLE
fix(stock): only consumable items for entry

### DIFF
--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -275,7 +275,7 @@ function StockEntryController(
   function loadInventories() {
     setupStock();
 
-    Inventory.read()
+    Inventory.read(null, { consumable : 1 })
       .then((inventories) => {
         vm.inventories = inventories;
         inventoryStore = new Store({ identifier : 'uuid', data : inventories });

--- a/client/src/modules/stock/requisition/modals/action.modal.js
+++ b/client/src/modules/stock/requisition/modals/action.modal.js
@@ -133,7 +133,7 @@ function ActionRequisitionModalController(
       autoSuggestInventories();
     }
 
-    Inventories.read()
+    Inventories.read(null, { consumable : 1 })
       .then(rows => {
         vm.selectableInventories = rows;
       })


### PR DESCRIPTION
Filters the lookups for the stock requisitions and entries on consumable items so that services/non-consumable items do not show up in the search.

Closes #5665.
Closes #5667.