### PR TITLE
fix(requisition): auto-populate depot in modal

### DIFF
--- a/client/src/modules/stock/StockModal.service.js
+++ b/client/src/modules/stock/StockModal.service.js
@@ -111,7 +111,7 @@ function StockModalService(Modal) {
     return instance.result;
   }
 
-  /** create stock assign */
+  /** create stock requisition */
   function openActionStockRequisition(request) {
     const params = angular.extend(modalParameters, {
       templateUrl  : 'modules/stock/requisition/modals/action.modal.html',

--- a/client/src/modules/stock/requisition/modals/action.modal.js
+++ b/client/src/modules/stock/requisition/modals/action.modal.js
@@ -3,12 +3,12 @@ angular.module('bhima.controllers')
 
 // dependencies injections
 ActionRequisitionModalController.$inject = [
-  '$state', 'Store', 'InventoryService', 'NotifyService',
-  '$uibModalInstance', 'StockService', 'ReceiptModal',
+  'Store', 'InventoryService', 'NotifyService',
+  '$uibModalInstance', 'StockService', 'ReceiptModal', 'data',
 ];
 
 function ActionRequisitionModalController(
-  $state, Store, Inventories, Notify, Modal, Stock, Receipts,
+  Store, Inventories, Notify, Modal, Stock, Receipts, data,
 ) {
   const vm = this;
   const store = new Store({ data : [] });
@@ -50,8 +50,7 @@ function ActionRequisitionModalController(
     flatEntityAccess : true,
   };
 
-  vm.model = {};
-  vm.model.date = new Date();
+  vm.model = { date : new Date() };
 
   vm.addItem = addItem;
   vm.removeItem = removeItem;
@@ -122,9 +121,9 @@ function ActionRequisitionModalController(
   }
 
   function startup() {
-    if ($state.params.depot && $state.params.depot.uuid) {
+    if (data.depot && data.depot.uuid) {
       const DEPOT_REQUESTOR_TYPE = 2;
-      const { depot } = $state.params;
+      const { depot } = data;
 
       vm.model.requestor_type_id = DEPOT_REQUESTOR_TYPE;
       vm.model.requestor_uuid = depot.uuid;
@@ -171,7 +170,7 @@ function ActionRequisitionModalController(
   }
 
   function cancel() {
-    Modal.dismiss('cancel');
+    Modal.dismiss();
   }
 
   startup();

--- a/client/src/modules/stock/requisition/registry.html
+++ b/client/src/modules/stock/requisition/registry.html
@@ -4,7 +4,7 @@
       <li class="static" translate>TREE.STOCK</li>
       <li class="static" translate>REQUISITION.STOCK_REQUISITION</li>
       <li class="title" ng-if="StockCtrl.depot.uuid">
-        <span>{{ StockCtrl.depot.text }}</span>
+        {{ StockCtrl.depot.text }}
       </li>
     </ol>
 

--- a/client/src/modules/stock/requisition/registry.js
+++ b/client/src/modules/stock/requisition/registry.js
@@ -17,6 +17,7 @@ function StockRequisitionController(
   uiGridConstants, StockModal,
   GridState, Columns,
 ) {
+
   const vm = this;
   const cacheKey = 'stock-requisition-grid';
   const stockRequisitionFilters = Stock.filter.requisition;

--- a/client/src/modules/stock/stock.routes.js
+++ b/client/src/modules/stock/stock.routes.js
@@ -84,7 +84,7 @@ angular.module('bhima.routes')
           creating : { value : true },
           filters : [],
         },
-        onEnter : ['$state', 'StockModalService', onEnterFactory('create', 'stockAssign')],
+        onEnter : ['$state', 'StockModalService', '$transition$', onEnterFactory('create', 'stockAssign')],
         onExit : ['$uibModalStack', closeModals],
       })
 
@@ -98,12 +98,8 @@ angular.module('bhima.routes')
       })
       .state('stockRequisition.create', {
         url : '/create',
-        params : {
-          creating : { value : true },
-          filters : [],
-          depot : null,
-        },
-        onEnter : ['$state', 'StockModalService', onEnterFactory('create', 'stockRequisition')],
+        onEnter : ['$state', 'StockModalService', '$transition$', onEnterFactory('create', 'stockRequisition')],
+        params : { depot : null },
         onExit : ['$uibModalStack', closeModals],
       })
 
@@ -111,8 +107,7 @@ angular.module('bhima.routes')
         url         : '/stock/setting',
         controller  : 'StockSettingsController as StockSettingsCtrl',
         templateUrl : 'modules/stock/settings/stock-settings.html',
-        params : {
-        },
+        params : { },
       })
 
       .state('stockAggregatedConsumption', {
@@ -133,14 +128,15 @@ function closeModals($uibModalStack) {
 function onEnterFactory(stateType, state) {
   const isCreateState = stateType === 'create';
 
-  return function onEnter($state, StockModal) {
+  return function onEnter($state, StockModal, $transition) {
+    const transitionParams = $transition.params('to');
     const mapAction = {
       stockAssign : StockModal.openActionStockAssign,
       stockRequisition : StockModal.openActionStockRequisition,
     };
 
     const instance = mapAction[state];
-    instance()
+    instance(transitionParams)
       .then((_uuid) => {
         const params = { uuid : _uuid };
 


### PR DESCRIPTION
Fixes a ui-router state issue where the depot was not available in the modal on subsequent runs.  We explicitly inject the depot into the modal now to prevent issues with `$state`.

I also checked stock assignment and it shouldn't be affected.

Closes #5670.