### PR TITLE
fix(reports): filter untracked lots from expiration report

### DIFF
--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -108,6 +108,7 @@ function getLotFilters(parameters) {
   filters.equals('invoice_uuid', 'invoice_uuid', 'm');
   filters.equals('purchase_uuid', 'entity_uuid', 'm');
   filters.equals('tag_uuid', 'tags', 't');
+  filters.equals('trackingExpiration', 'tracking_expiration');
   filters.equals('stock_requisition_uuid', 'stock_requisition_uuid', 'm');
 
   // filter on the underlying voucher t

--- a/server/controllers/stock/reports/stock/expiration_report.js
+++ b/server/controllers/stock/reports/stock/expiration_report.js
@@ -14,15 +14,14 @@ async function stockExpirationReport(req, res, next) {
   const today = new Date();
 
   try {
-    const params = { includeEmptyLot : 0, ...req.query };
+    const options = { trackingExpiration : 1, includeEmptyLot : 0, ...req.query };
 
-    const optionReport = _.extend(params, {
+    const optionReport = _.extend(options, {
       filename : 'REPORT.STOCK_EXPIRATION_REPORT.TITLE',
     });
 
     // set up the report with report manager
     const report = new ReportManager(STOCK_EXPIRATION_REPORT_TEMPLATE, req.session, optionReport);
-    const options = params;
 
     if (req.session.stock_settings.enable_strict_depot_permission) {
       options.check_user_id = req.session.user.id;


### PR DESCRIPTION
Filters out lots for which we are not tracking the expiration date from the expiration report.

Closes #5649.

_before_: 
![image](https://user-images.githubusercontent.com/896472/119255031-d7468900-bbb9-11eb-86ca-92976d20c17d.png)

_after_:
![image](https://user-images.githubusercontent.com/896472/119255053-f0e7d080-bbb9-11eb-99d6-1c1a2d717174.png)
