### PR TITLE
fix(movements): improve mobile registry view

### DIFF
--- a/client/src/modules/stock/movements/registry.html
+++ b/client/src/modules/stock/movements/registry.html
@@ -62,8 +62,8 @@
             ng-disabled="!StockCtrl.selectedGroup.label">
             <span>
               <i class="fa fa-object-group"></i>
-              <span ng-hide="StockCtrl.selectedGroup.label" translate>STOCK.GROUPING</span>
-              <span ng-show="StockCtrl.selectedGroup.label" translate>
+              <span class="hidden-xs" ng-hide="StockCtrl.selectedGroup.label" translate>STOCK.GROUPING</span>
+              <span class="hidden-xs" ng-show="StockCtrl.selectedGroup.label" translate>
                 {{ StockCtrl.selectedGroup.label }}
               </span>
             </span>


### PR DESCRIPTION
Somewhat improves the mobile registry view of the stock movements registry.  It doesn't fix it completely, but it makes progress so it is at least usable.

![image](https://user-images.githubusercontent.com/896472/119255369-b5e69c80-bbbb-11eb-82ce-df7a26a0ae27.png)


Closes #5594.