### PR TITLE
fix(purchase): use client-generated uuid

### DIFF
--- a/client/src/js/services/uuid.js
+++ b/client/src/js/services/uuid.js
@@ -1,10 +1,11 @@
+/* eslint-disable */
 angular.module('bhima.services')
-.service('uuid', function () {
-  return function () {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = Math.random() * 16 | 0,
-      v = c === 'x' ? r : (r & 0x3 | 0x8);
-      return v.toString(16);
-    });
-  };
-});
+  .service('uuid', () => {
+    return () => {
+      return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+        const r = Math.random() * 16 | 0;
+        const v = c === 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+      });
+    };
+  });

--- a/client/src/modules/purchases/create/PurchaseOrderForm.js
+++ b/client/src/modules/purchases/create/PurchaseOrderForm.js
@@ -3,6 +3,7 @@ angular.module('bhima.services')
 
 PurchaseOrderFormService.$inject = [
   'InventoryService', 'AppCache', 'Store', 'Pool', 'PurchaseOrderItemService', '$q',
+  'uuid',
 ];
 
 /**
@@ -13,7 +14,7 @@ PurchaseOrderFormService.$inject = [
  * associated with purchase order creation.  The developer must specify a cacheKey
  * to enable the class to be instantiated correctly.
  */
-function PurchaseOrderFormService(Inventory, AppCache, Store, Pool, PurchaseOrderItem, $q) {
+function PurchaseOrderFormService(Inventory, AppCache, Store, Pool, PurchaseOrderItem, $q, uuid) {
   /**
    * @constructor
    *
@@ -81,6 +82,7 @@ function PurchaseOrderFormService(Inventory, AppCache, Store, Pool, PurchaseOrde
     // clear previous data
     this.setup();
 
+    this.details.uuid = uuid();
     this.details.date = new Date(order.date);
     this.details.cost = order.cost;
     this.details.currency_id = order.currency_id;


### PR DESCRIPTION
Ensures that the client generates a uuid for the purchase order to prevent issues such as #5503 from happening again.

Closes #5503.