### PR TITLE
chore(stock): add pricing to transfer documents

### DIFF
--- a/server/controllers/stock/reports/stock/entry_depot_receipt.js
+++ b/server/controllers/stock/reports/stock/entry_depot_receipt.js
@@ -20,6 +20,7 @@ function stockEntryDepotReceipt(documentUuid, session, options) {
   return getDepotMovement(documentUuid, session.enterprise, false)
     .then(data => {
       const { key } = identifiers.STOCK_ENTRY;
+      data.totals = { cost : data.rows.reduce((agg, row) => agg + row.total, 0) };
       data.entry.details.barcode = barcode.generate(key, data.entry.details.document_uuid);
       return report.render(data);
     });

--- a/server/controllers/stock/reports/stock/exit_depot_receipt.js
+++ b/server/controllers/stock/reports/stock/exit_depot_receipt.js
@@ -27,6 +27,10 @@ function stockExitDepotReceipt(documentUuid, session, options) {
   return getDepotMovement(documentUuid, session.enterprise, true)
     .then(data => {
       const { key } = identifiers.STOCK_EXIT;
+
+      // get the total cost of the movement
+      data.totals = { cost : data.rows.reduce((agg, row) => agg + row.total, 0) };
+
       data.exit.details.barcode = barcode.generate(key, data.exit.details.document_uuid);
       return report.render(data);
     });

--- a/server/controllers/stock/reports/stock_entry_depot.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_entry_depot.receipt.handlebars
@@ -53,6 +53,8 @@
         <th>{{translate 'STOCK.QUANTITY_SENT'}}</th>
         <th>{{translate 'STOCK.QUANTITY_RECEIVED'}}</th>
         <th>{{translate 'STOCK.QUANTITY_DIFFERENCE'}}</th>
+        <th>{{translate 'STOCK.UNIT_COST'}}</th>
+        <th class="text-center">{{translate 'TABLE.COLUMNS.TOTAL_COST'}}</th>
         <th style="width: 30%;">{{translate 'FORM.LABELS.NOTE'}}</th>
       </tr>
     </thead>
@@ -66,12 +68,22 @@
           <td class="text-right">{{quantity_sent}}</td>
           <td class="text-right">{{quantity}}</td>
           <td class="text-right">{{quantity_difference}}</td>
-          <td style="width: 30%;">&nbsp;</td>
+          <td class="text-right">{{currency unit_cost ../metadata.enterprise.currency_id}}</td>
+          <td class="text-right">{{currency total ../metadata.enterprise.currency_id}}</td>
+          <td style="width: 25%;">&nbsp;</td>
         </tr>
       {{else}}
-        {{> emptyTable columns=9}}
+        {{> emptyTable columns=11}}
       {{/each}}
     </tbody>
+    <tfoot>
+      <tr style="font-weight: bold;">
+        <td colspan="11">
+          <span>{{rows.length}} {{translate 'STOCK.ITEMS'}}</span>
+          <span class="pull-right">{{currency totals.cost metadata.enterprise.currency_id}}</span>
+        </td>
+      </tr>
+    </tfoot>
   </table>
 
   <br>

--- a/server/controllers/stock/reports/stock_exit_depot.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_exit_depot.receipt.handlebars
@@ -54,9 +54,11 @@
         <th>{{translate 'STOCK.CODE'}}</th>
         <th>{{translate 'STOCK.INVENTORY'}}</th>
         <th>{{translate 'STOCK.LOT'}}</th>
+        <th>{{translate 'STOCK.INVENTORY_UNIT'}}</th>
         <th>{{translate 'STOCK.EXPIRATION'}}</th>
         <th>{{translate 'STOCK.QUANTITY'}}</th>
-        <th>{{translate 'STOCK.INVENTORY_UNIT'}}</th>
+        <th>{{translate 'STOCK.UNIT_COST'}}</th>
+        <th class="text-center">{{translate 'TABLE.COLUMNS.TOTAL_COST'}}</th>
       </tr>
     </thead>
     <tbody>
@@ -65,17 +67,22 @@
           <td>{{code}}</td>
           <td>{{text}}</td>
           <td>{{label}}</td>
+          <td>{{unit}}</td>
           <td>{{date expiration_date}}</td>
           <td class="text-right">{{quantity}}</td>
-          <td>{{unit}}</td>
+          <td class="text-right">{{currency unit_cost ../metadata.enterprise.currency_id}}</td>
+          <td class="text-right">{{currency total ../metadata.enterprise.currency_id}}</td>
         </tr>
       {{else}}
-        {{> emptyTable columns=6}}
+        {{> emptyTable columns=8}}
       {{/each}}
     </tbody>
     <tfoot>
       <tr style="font-weight: bold;">
-        <td colspan="6">{{rows.length}} {{translate 'STOCK.ITEMS'}}</td>
+        <td colspan="9">
+          <span>{{rows.length}} {{translate 'STOCK.ITEMS'}}</span>
+          <span class="pull-right">{{currency totals.cost metadata.enterprise.currency_id}}</span>
+        </td>
       </tr>
     </tfoot>
   </table>


### PR DESCRIPTION
This commit adds the cost information to the transfer receipts from one depot to another as requested by our users in Tshikaji.

Closes #5643.

Here is what it looks like:
![image](https://user-images.githubusercontent.com/896472/119262226-bc384100-bbda-11eb-9c0e-90e59be34900.png)
