### PR TITLE
feat(stock): add currency to stock exit report

### DIFF
--- a/client/src/modules/reports/generate/stock_exit/stock_exit.config.js
+++ b/client/src/modules/reports/generate/stock_exit/stock_exit.config.js
@@ -3,10 +3,10 @@ angular.module('bhima.controllers')
 
 StockExitConfigController.$inject = [
   '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
-  'LanguageService',
+  'LanguageService', 'SessionService',
 ];
 
-function StockExitConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Languages) {
+function StockExitConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Languages, Session) {
   const vm = this;
   const cache = new AppCache('configure_stock_exit_report');
   const reportUrl = 'reports/stock/exit';
@@ -21,6 +21,8 @@ function StockExitConfigController($sce, Notify, SavedReports, AppCache, reportD
   vm.previewGenerated = false;
   vm.onExitTypeChange = onExitTypeChange;
 
+  vm.currency_id = Session.enterprise.currency_id;
+
   // check cached configuration
   checkCachedConfiguration();
 
@@ -29,6 +31,10 @@ function StockExitConfigController($sce, Notify, SavedReports, AppCache, reportD
 
   vm.onSelectDepot = depot => {
     vm.depot = depot;
+  };
+
+  vm.onSelectCurrency = currency => {
+    vm.currency_id = currency.id;
   };
 
   vm.clear = key => {
@@ -53,6 +59,7 @@ function StockExitConfigController($sce, Notify, SavedReports, AppCache, reportD
       depotUuid : vm.depot.uuid,
       dateFrom : vm.dateFrom,
       dateTo : vm.dateTo,
+      currencyId : vm.currency_id,
       includePatientExit : vm.includePatientExit,
       includeServiceExit : vm.includeServiceExit,
       includeGroupedServiceExit : vm.includeGroupedServiceExit,

--- a/client/src/modules/reports/generate/stock_exit/stock_exit.html
+++ b/client/src/modules/reports/generate/stock_exit/stock_exit.html
@@ -39,6 +39,11 @@
             required="true">
           </bh-date-interval>
 
+          <bh-currency-select
+            currency-id="ReportConfigCtrl.currency_id"
+            on-change="ReportConfigCtrl.onSelectCurrency(currency)" >
+          </bh-currency-select>
+
           <!-- stock exit type -->
           <div ng-class="{'has-error': ConfigForm.$submitted && !ReportConfigCtrl.hasOneChecked}">
             <div class="checkbox">

--- a/server/controllers/stock/reports/stock/exit/exitToPatient.js
+++ b/server/controllers/stock/reports/stock/exit/exitToPatient.js
@@ -1,5 +1,4 @@
 const db = require('../../../../../lib/db');
-const identifiers = require('../../../../../config/identifiers');
 
 const IS_EXIT = 1;
 const EXIT_TO_PATIENT_ID = 9;
@@ -16,8 +15,7 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     SUM(m.quantity) as quantity, m.date, m.description,
     u.display_name AS user_display_name, p.display_name AS patient_display_name,
     dm.text AS document_reference, d.text AS depot_name,
-    CONCAT_WS('.', '${identifiers.PATIENT.key}', proj.abbr, p.reference) AS patient_reference,
-    dm2.text AS invoice_reference
+    em.text AS patient_reference, dm2.text AS invoice_reference
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
@@ -29,6 +27,7 @@ function fetch(depotUuid, dateFrom, dateTo, showDetails) {
     JOIN document_map dm ON dm.uuid = m.document_uuid
     LEFT JOIN invoice iv ON iv.uuid = m.invoice_uuid
     LEFT JOIN document_map dm2 ON dm2.uuid = iv.uuid
+    LEFT JOIN entity_map em ON em.uuid = p.uuid
   WHERE m.is_exit = ${IS_EXIT} AND m.flux_id = ${EXIT_TO_PATIENT_ID} AND d.uuid = ?
     AND (DATE(m.date) BETWEEN DATE(?) AND DATE(?))
   GROUP BY i.uuid`;

--- a/server/controllers/stock/reports/stock_exit.report.handlebars
+++ b/server/controllers/stock/reports/stock_exit.report.handlebars
@@ -20,6 +20,12 @@
         {{date dateFrom}} - {{date dateTo}}
       </h4>
 
+      {{#unless isEnterpriseCurrency}}
+        <div class="alert alert-warning">
+          <p>{{translate "REPORT.REPORT_ACCOUNTS.WARN_CURRENCY"}}</p>
+        </div>
+      {{/unless}}
+
       <br/>
 
       <!-- stock exit to patient -->
@@ -28,15 +34,15 @@
           <thead>
             <tr style="background-color: #EFEFEF;">
               <th colspan="5">{{translate 'STOCK.RECEIPT.EXIT_PATIENTS'}}</th>
-              <th colspan="2" class="text-right">{{currency exitToPatient.cost metadata.enterprise.currency_id}}</th>
+              <th colspan="2" class="text-right">{{currency exitToPatient.cost currencyId}}</th>
             </tr>
           </thead>
           {{#each exitToPatient.data as | data |}}
             <thead>
               <tr>
-                <th colspan="4">{{ data.inventory_name }}</th>
-                <th class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
-                <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../metadata.enterprise.currency_id}}</th>
+                <th colspan="3">{{ data.inventory_name }}</th>
+                <th colspan="2" class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
+                <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../currencyId}}</th>
               </tr>
             </thead>
 
@@ -45,7 +51,7 @@
                 {{#each data.inventory_stock_exit_data as | item |}}
                   <tr>
                     <td style="border:none; width: 20%; padding-left: 30px;"><b>{{ document_reference }}</b></td>
-                    <td class="text-left" style="border:none; width: 40%;">{{ patient_reference }} {{ patient_display_name }}</td>
+                    <td class="text-left" style="border:none; width: 40%;">({{ patient_reference }}) {{ patient_display_name }}</td>
                     <td class="text-left" style="border:none; width: 15%">
                       {{#if invoice_reference}}
                         {{translate 'FORM.LABELS.INVOICE' }}: <b>{{ invoice_reference }}</b>
@@ -53,8 +59,8 @@
                     </td>
                     <td style="border:none;">{{date date }}</td>
                     <td class="text-right" style="border:none;">{{ quantity }} {{ unit_text }}</td>
-                    <td class="text-right" style="border:none;">{{currency unit_cost ../../metadata.enterprise.currency_id}}</td>
-                    <td class="text-right" style="border:none;">{{currency cost ../../metadata.enterprise.currency_id}}</td>
+                    <td class="text-right" style="border:none;">{{currency unit_cost ../../currencyId}}</td>
+                    <td class="text-right" style="border:none;">{{currency cost ../../currencyId}}</td>
                   </tr>
                 {{/each}}
               </tbody>
@@ -77,15 +83,15 @@
           <thead>
             <tr style="background-color: #EFEFEF;">
               <th colspan="5">{{translate 'STOCK.RECEIPT.EXIT_SERVICES'}} <small>{{translate 'STOCK.BY_INVENTORY'}}</small></th>
-              <th colspan="2" class="text-right">{{currency exitToService.cost metadata.enterprise.currency_id}}</th>
+              <th colspan="2" class="text-right">{{currency exitToService.cost currencyId}}</th>
             </tr>
           </thead>
           {{#each exitToService.data as | data |}}
             <thead>
               <tr>
-                <th colspan="4">{{ data.inventory_name }}</th>
-                <th class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
-                <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../metadata.enterprise.currency_id}}</th>
+                <th colspan="3">{{ data.inventory_name }}</th>
+                <th colspan="2" class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
+                <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../currencyId}}</th>
               </tr>
             </thead>
 
@@ -98,8 +104,8 @@
                     <td class="text-left" style="border:none; width: 15%">&nbsp;</td>
                     <td style="border:none;">{{date date }}</td>
                     <td class="text-right" style="border:none;">{{ quantity }} {{ unit_text }}</td>
-                    <td class="text-right" style="border:none;">{{currency unit_cost ../../metadata.enterprise.currency_id}}</td>
-                    <td class="text-right" style="border:none;">{{currency cost ../../metadata.enterprise.currency_id}}</td>
+                    <td class="text-right" style="border:none;">{{currency unit_cost ../../currencyId}}</td>
+                    <td class="text-right" style="border:none;">{{currency cost ../../currencyId}}</td>
                   </tr>
                 {{/each}}
               </tbody>
@@ -122,23 +128,23 @@
           <thead>
             <tr style="background-color: #EFEFEF;">
               <th colspan="5">{{translate 'STOCK.RECEIPT.EXIT_SERVICES'}} <small>{{translate 'STOCK.BY_SERVICE'}}</small></th>
-              <th colspan="2" class="text-right">{{currency exitToServiceGrouped.cost metadata.enterprise.currency_id}}</th>
+              <th colspan="2" class="text-right">{{currency exitToServiceGrouped.cost currencyId}}</th>
             </tr>
           </thead>
           {{#each exitToServiceGrouped.data as | data |}}
             <thead>
               <tr>
                 <th colspan="5">{{ data.inventory_name }}</th>
-                <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../metadata.enterprise.currency_id}}</th>
+                <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../currencyId}}</th>
               </tr>
             </thead>
 
             {{#each data.subset.data as | newData |}}
               <thead>
                 <tr>
-                  <th style="padding-left: 30px;" colspan="4">{{ newData.inventory_name }}</th>
-                  <th class="text-right">{{ newData.inventory_stock_exit_quantity }} {{ newData.inventory_unit }}</th>
-                  <th colspan="2" class="text-right">{{currency newData.inventory_stock_exit_cost ../../metadata.enterprise.currency_id}}</th>
+                  <th style="padding-left: 30px;" colspan="3">{{ newData.inventory_name }}</th>
+                  <th colspan="2" class="text-right">{{ newData.inventory_stock_exit_quantity }} {{ newData.inventory_unit }}</th>
+                  <th colspan="2" class="text-right">{{currency newData.inventory_stock_exit_cost ../../currencyId}}</th>
                 </tr>
               </thead>
 
@@ -151,8 +157,8 @@
                       <td class="text-left" style="border:none; width: 15%">&nbsp;</td>
                       <td style="border:none;">{{date date }}</td>
                       <td class="text-right" style="border:none;">{{ quantity }} {{ unit_text }}</td>
-                      <td class="text-right" style="border:none;">{{currency unit_cost ../../../metadata.enterprise.currency_id}}</td>
-                      <td class="text-right" style="border:none;">{{currency cost ../../../metadata.enterprise.currency_id}}</td>
+                      <td class="text-right" style="border:none;">{{currency unit_cost ../../../currencyId}}</td>
+                      <td class="text-right" style="border:none;">{{currency cost ../../../currencyId}}</td>
                     </tr>
                   {{/each}}
                 </tbody>
@@ -176,15 +182,15 @@
           <thead>
             <tr style="background-color: #EFEFEF;">
               <th colspan="5">{{translate 'STOCK.RECEIPT.EXIT_DEPOT'}}</th>
-              <th colspan="2" class="text-right">{{currency exitToDepot.cost metadata.enterprise.currency_id}}</th>
+              <th colspan="2" class="text-right">{{currency exitToDepot.cost currencyId}}</th>
             </tr>
           </thead>
           {{#each exitToDepot.data as | data |}}
             <thead>
               <tr>
-                <th colspan="4">{{ data.inventory_name }}</th>
-                <th class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
-                <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../metadata.enterprise.currency_id}}</th>
+                <th colspan="3">{{ data.inventory_name }}</th>
+                <th colspan="2" class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
+                <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../currencyId}}</th>
               </tr>
             </thead>
 
@@ -197,8 +203,8 @@
                     <td class="text-left" style="border:none; width: 15%">&nbsp;</td>
                     <td style="border:none;">{{date date }}</td>
                     <td class="text-right" style="border:none;">{{ quantity }} {{ unit_text }}</td>
-                    <td class="text-right" style="border:none;">{{currency unit_cost ../../metadata.enterprise.currency_id}}</td>
-                    <td class="text-right" style="border:none;">{{currency cost ../../metadata.enterprise.currency_id}}</td>
+                    <td class="text-right" style="border:none;">{{currency unit_cost ../../currencyId}}</td>
+                    <td class="text-right" style="border:none;">{{currency cost ../../currencyId}}</td>
                   </tr>
                 {{/each}}
               </tbody>
@@ -221,15 +227,15 @@
           <thead>
             <tr style="background-color: #EFEFEF;">
               <th colspan="5">{{translate 'STOCK.RECEIPT.EXIT_LOSS'}}</th>
-              <th colspan="2" class="text-right">{{currency exitToLoss.cost metadata.enterprise.currency_id}}</th>
+              <th colspan="2" class="text-right">{{currency exitToLoss.cost currencyId}}</th>
             </tr>
           </thead>
           {{#each exitToLoss.data as | data |}}
             <thead>
               <tr>
-                <th colspan="4">{{ data.inventory_name }}</th>
-                <th class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
-                <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../metadata.enterprise.currency_id}}</th>
+                <th colspan="3">{{ data.inventory_name }}</th>
+                <th colspan="2" class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
+                <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../currencyId}}</th>
               </tr>
             </thead>
 
@@ -242,8 +248,8 @@
                     <td class="text-left" style="border:none; width: 15%">&nbsp;</td>
                     <td style="border:none;">{{date date }}</td>
                     <td class="text-right" style="border:none;">{{ quantity }} {{ unit_text }}</td>
-                    <td class="text-right" style="border:none;">{{currency unit_cost ../../metadata.enterprise.currency_id}}</td>
-                    <td class="text-right" style="border:none;">{{currency cost ../../metadata.enterprise.currency_id}}</td>
+                    <td class="text-right" style="border:none;">{{currency unit_cost ../../currencyId}}</td>
+                    <td class="text-right" style="border:none;">{{currency cost ../../currencyId}}</td>
                   </tr>
                 {{/each}}
               </tbody>
@@ -266,15 +272,15 @@
           <thead>
             <tr style="background-color: #EFEFEF;">
               <th colspan="5">{{translate 'STOCK.RECEIPT.AGGREGATE_CONSUMPTION'}}</th>
-              <th colspan="2" class="text-right">{{currency exitAggregateConsumption.cost metadata.enterprise.currency_id}}</th>
+              <th colspan="2" class="text-right">{{currency exitAggregateConsumption.cost currencyId}}</th>
             </tr>
           </thead>
           {{#each exitAggregateConsumption.data as | data |}}
             <thead>
               <tr>
-                <th colspan="4">{{ data.inventory_name }}</th>
-                <th class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
-                <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../metadata.enterprise.currency_id}}</th>
+                <th colspan="3">{{ data.inventory_name }}</th>
+                <th colspan="2" class="text-right">{{ data.inventory_stock_exit_quantity }} {{ data.inventory_unit }}</th>
+                <th colspan="2" class="text-right">{{currency data.inventory_stock_exit_cost ../currencyId}}</th>
               </tr>
             </thead>
 
@@ -287,8 +293,8 @@
                     <td class="text-left" style="border:none; width: 15%">&nbsp;</td>
                     <td style="border:none;">{{date date }}</td>
                     <td class="text-right" style="border:none;">{{ quantity }} {{ unit_text }}</td>
-                    <td class="text-right" style="border:none;">{{currency unit_cost ../../metadata.enterprise.currency_id}}</td>
-                    <td class="text-right" style="border:none;">{{currency cost ../../metadata.enterprise.currency_id}}</td>
+                    <td class="text-right" style="border:none;">{{currency unit_cost ../../currencyId}}</td>
+                    <td class="text-right" style="border:none;">{{currency cost ../../currencyId}}</td>
                   </tr>
                 {{/each}}
               </tbody>


### PR DESCRIPTION
Adds a currency picker to the stock exit report so that users can see the value of stock in whatever currency they desire at the exchange rate of today.

Here is what it looks like:

![image](https://user-images.githubusercontent.com/896472/119487683-fc71fd80-bd59-11eb-829b-d4439ab5e2c9.png)


Closes #5348.