### PR TITLE
fix(depots): filter before limit in depot select

### DIFF
--- a/client/src/modules/stock/depot-selection.modal.html
+++ b/client/src/modules/stock/depot-selection.modal.html
@@ -35,7 +35,7 @@
     <ul style="margin-bottom: 2px;" class="list-group">
       <li
         class="list-group-item"
-        ng-repeat="depot in $ctrl.depots  | limitTo: $ctrl.displayLimit | filter: $ctrl.search track by depot.uuid"
+        ng-repeat="depot in $ctrl.depots | filter: $ctrl.search | limitTo: $ctrl.displayLimit track by depot.uuid"
         ng-class="{'active' : $ctrl.depot.uuid === depot.uuid}"
         ng-click="$ctrl.selectDepot(depot.uuid)"
         style="cursor:pointer;">


### PR DESCRIPTION
This commit switches the order of filtering/limiting to ensure we filter before limiting the view.  This brings values into the view as needed instead of the previous behavior where you were forced to click "see more".

Here is the result:

![nhdCNQBVCu](https://user-images.githubusercontent.com/896472/119546290-09abde00-bd94-11eb-83e1-5b5725ad1767.gif)


Closes #5694.