### PR TITLE
Fix: stock exit disappearing inventory items

### DIFF
--- a/client/src/modules/stock/depot-selection.modal.html
+++ b/client/src/modules/stock/depot-selection.modal.html
@@ -35,7 +35,7 @@
     <ul style="margin-bottom: 2px;" class="list-group">
       <li
         class="list-group-item"
-        ng-repeat="depot in $ctrl.depots  | limitTo: $ctrl.displayLimit | filter: $ctrl.search track by depot.uuid"
+        ng-repeat="depot in $ctrl.depots | filter: $ctrl.search | limitTo: $ctrl.displayLimit track by depot.uuid"
         ng-class="{'active' : $ctrl.depot.uuid === depot.uuid}"
         ng-click="$ctrl.selectDepot(depot.uuid)"
         style="cursor:pointer;">

--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -235,8 +235,17 @@ function StockExitController(
   // remove item
   function removeItem(item) {
     vm.stockForm.removeItem(item.id);
+
+    // restore the inventory to the selectableInventories list
+    // if there are no more copies.
+    if (item.inventory) {
+      const isInList = vm.selectableInventories.some(row => row.uuid === item.inventory.uuid);
+      if (!isInList) { vm.selectableInventories.push(item.inventory); }
+    }
+
     checkValidity();
     refreshSelectedLotsList();
+
   }
 
   // configure item


### PR DESCRIPTION
This commit fixes the "disappearing" inventory items bug by adding the inventory back into the pool if it should be selectable again.

Here is the fix in action:
![zlwEMu3SFb](https://user-images.githubusercontent.com/896472/119548961-0b2ad580-bd97-11eb-9d53-5762835d25e9.gif)


Closes #5696.