### PR TITLE
feat(depots): add loading icon for depot select

### DIFF
--- a/client/src/js/components/bhDepotSelect/bhDepotSelect.js
+++ b/client/src/js/components/bhDepotSelect/bhDepotSelect.js
@@ -45,6 +45,8 @@ function DepotSelectController(Depots, Notify) {
       return null;
     }
 
+    $ctrl.$loading = true;
+
     const options = {
       text : (text || '').toLowerCase(),
       exception : $ctrl.exception,

--- a/client/src/js/components/bhDepotSelect/bhDepotSelect.tmpl.html
+++ b/client/src/js/components/bhDepotSelect/bhDepotSelect.tmpl.html
@@ -1,6 +1,6 @@
 <div ng-form="DepotForm" bh-depot-select ng-model-options="{ updateOn: 'default' }">
   <div
-    class="form-group"
+    class="form-group has-feedback"
     ng-class="{ 'has-error' : DepotForm.$submitted && DepotForm.depot_uuid.$invalid }">
 
     <label class="control-label" translate>
@@ -16,13 +16,15 @@
       name="depot_uuid"
       ng-model="$ctrl.depotText"
       uib-typeahead="depot for depot in $ctrl.searchByName($viewValue)"
-      typeahead-loading="$ctrl.loading"
+      typeahead-loading="$ctrl.$loading"
       typeahead-template-url="/modules/templates/depotList.tmpl.html"
       typeahead-on-select="$ctrl.onSelect($item, $model)"
       typeahead-min-length="0"
       autocomplete="off"
       translate-attr="{ 'placeholder': 'FORM.SELECT.DEPOT' }"
       ng-required="$ctrl.required">
+
+    <span ng-show="$ctrl.$loading" class="glyphicon glyphicon-hourglass form-control-feedback"></span>
 
     <div class="help-block" ng-messages="DepotForm.depot_uuid.$error" ng-show="DepotForm.$submitted">
       <div ng-messages-include="modules/templates/messages.tmpl.html"></div>

--- a/client/src/modules/stock/requisition/modals/action.modal.html
+++ b/client/src/modules/stock/requisition/modals/action.modal.html
@@ -62,14 +62,12 @@
         required="true"
         exception="$ctrl.model.requestor_uuid"
         on-select-callback="$ctrl.onSelectDepot(depot)">
-        <bh-clear on-clear="$ctrl.clear('depot_uuid')"></bh-clear>
       </bh-depot-select>
     </div>
 
     <!-- note -->
     <div class="form-group">
       <label class="control-label" translate>FORM.LABELS.NOTE</label>
-      <bh-clear on-clear="$ctrl.clear('description')"></bh-clear>
       <textarea ng-model="$ctrl.model.description" class="form-control" name="description" id="description"></textarea>
     </div>
   </div>


### PR DESCRIPTION
Adds a loading indicator (hourglass) to the bhDepotSelect so that users are aware that the component is loading, even in a slow connection.

Closes #5704.

Here is what it looks like:
![3KBGXuPPNa](https://user-images.githubusercontent.com/896472/119626041-19b2d480-be0b-11eb-9536-a80cc0d63ce3.gif)
