### PR TITLE
fix(depots): improve performance on permissions modal

### DIFF
--- a/client/src/modules/users/UserDepotManagementModal.html
+++ b/client/src/modules/users/UserDepotManagementModal.html
@@ -13,9 +13,7 @@
 
     <div class="form-group" ng-class="{ 'has-error' : UserForm.$submitted && UserForm.display_name.$invalid }">
       <label class="control-label" translate>FORM.LABELS.USERNAME</label>
-      <div>
-        <h4><i> {{ UsersDepotModalCtrl.user.display_name }} </i></h4>
-      </div>
+      <p class="form-control-static">{{ UsersDepotModalCtrl.user.display_name }}<p>
     </div>
 
     <span translate> FORM.INFO.USER_DEPOT </span>
@@ -25,7 +23,7 @@
         <strong class="text-capitalize" translate>FORM.LABELS.CHECK_ALL</strong>
       </label>
     </div>
-    
+
     <div class="panel panel-default" style="margin-bottom : 0px;">
       <div class="panel-heading">
         <a href ng-click="UsersDepotModalCtrl.toggleFilter()">
@@ -36,12 +34,12 @@
       <input ng-model="UsersDepotModalCtrl.filter" ng-show="UsersDepotModalCtrl.filterActive" class="form-control" placeholder="{{'FORM.PLACEHOLDERS.FILTER_NAME' | translate }}" style="border-radius: 0"/>
     </div>
 
-    <div ng-if="!UsersDepotModalCtrl.loading" ng-repeat="depot in UsersDepotModalCtrl.depotsData | filter : { text : UsersDepotModalCtrl.filter }">
-      <div style="margin-left: calc({{depot.$$treeLevel}} * 15px)" class="list-unstyled">
+    <div ng-if="!UsersDepotModalCtrl.loading" ng-repeat="depot in UsersDepotModalCtrl.depotsData | filter : { text : UsersDepotModalCtrl.filter } track by depot.uuid">
+      <div style="margin-left: calc({{::depot.$$treeLevel}} * 15px)" class="list-unstyled">
         <div class="checkbox">
-          <label data-label="{{child._label}}">
-            <input type="checkbox" id="{{depot.uuid}}" ng-model="depot._checked" ng-change="UsersDepotModalCtrl.setNodeValue(depot.children, depot)" />
-            <span translate>{{depot.text}}</span>
+          <label data-label="{{::child._label}}">
+            <input type="checkbox" id="{{::depot.uuid}}" ng-model="depot._checked" ng-change="UsersDepotModalCtrl.setNodeValue(depot.children, depot)" />
+            <span>{{::depot.text}}</span>
           </label>
         </div>
       </div>

--- a/client/src/modules/users/UserDepotManagementModal.js
+++ b/client/src/modules/users/UserDepotManagementModal.js
@@ -67,10 +67,7 @@ function UsersDepotManagementController($state, Users, Notify, AppCache, Depots,
 
   // submit the data to the server from all two forms (update, create)
   function submit(userForm) {
-    const filterChecked = vm.depotsData.filter((item) => {
-      return item._checked;
-    });
-
+    const filterChecked = vm.depotsData.filter((item) => item._checked);
     const userDepots = filterChecked.map(depot => depot.uuid);
 
     if (userForm.$invalid || !vm.user.id) { return 0; }


### PR DESCRIPTION
Marginally improves the performance of the depot permission modal by using track by and one-time bindings, as a best practice.  I tried measuring the result with my browser recording, but ultimately, I'm not sure this makes a huge difference in the initial paint (though it should during selection).  Ultimately, we probably should use a ng-repeat for this and either use a custom directive with better performance or change the way we do permissions.

Addesses #5699.