### PR TITLE
fix(stock): properly exchange stock value

### DIFF
--- a/server/controllers/stock/reports/stock/value.js
+++ b/server/controllers/stock/reports/stock/value.js
@@ -83,10 +83,11 @@ async function reporting(_options, session) {
       const isExit = item.is_exit ? (-1) : 1;
 
       if (!item.is_exit && (quantityInStock > 0)) {
-        weightedAverageUnitCost = ((quantityInStock * weightedAverageUnitCost) + (item.quantity * item.unit_cost))
-          / (item.quantity + quantityInStock);
+        weightedAverageUnitCost = (
+          (quantityInStock * weightedAverageUnitCost) + (item.quantity * (item.unit_cost * rate))
+        ) / (item.quantity + quantityInStock);
       } else if (!item.is_exit && (quantityInStock === 0)) {
-        weightedAverageUnitCost = item.unit_cost;
+        weightedAverageUnitCost = (item.unit_cost * rate);
       }
 
       quantityInStock += (item.quantity * isExit);
@@ -95,9 +96,9 @@ async function reporting(_options, session) {
     });
 
     stock.stockQtt = quantityInStock;
-    stock.stockUnitCost = weightedAverageUnitCost * rate;
-    stock.stockValue = (quantityInStock * weightedAverageUnitCost) * rate;
-    stockTotal += (stock.stockValue * rate);
+    stock.stockUnitCost = weightedAverageUnitCost;
+    stock.stockValue = (quantityInStock * weightedAverageUnitCost);
+    stockTotal += (stock.stockValue);
   });
 
   const stockValueElements = options.exclude_zero_value


### PR DESCRIPTION
The stock value report was updated to include exchanged values so that
the report could be viewed in $USD at Vanga.  However, the exchange rate
was incorrectly applied, causing bugs in the Weighted Average Cost
algorithm.  To fix this, we apply only the rate to the `unit_cost` and
carry that forward via sums.