### PR TITLE
Search requisitions by user

### DIFF
--- a/client/src/modules/purchases/registry/registry.js
+++ b/client/src/modules/purchases/registry/registry.js
@@ -111,7 +111,6 @@ function PurchaseRegistryController(
     fastWatch : true,
     onRegisterApi : (api) => { vm.gridApi = api; },
     columnDefs,
-
   };
 
   const columnConfig = new Columns(vm.uiGridOptions, cacheKey);

--- a/client/src/modules/stock/requisition/modals/search.modal.html
+++ b/client/src/modules/stock/requisition/modals/search.modal.html
@@ -46,6 +46,13 @@
             <bh-clear on-clear="$ctrl.clear('depot_uuid')"></bh-clear>
           </bh-depot-select>
 
+          <!-- user -->
+          <bh-user-select
+            user-id="$ctrl.searchQueries.user_id"
+            name="user_id"
+            on-select-callback="$ctrl.onSelectUser(user)">
+            <bh-clear on-clear="$ctrl.clear('user_id')"></bh-clear>
+          </bh-user-select>
         </div>
       </uib-tab>
       <uib-tab index="1" heading="{{ 'FORM.LABELS.DEFAULTS' | translate }}" data-default-filter-tab>

--- a/client/src/modules/stock/requisition/modals/search.modal.js
+++ b/client/src/modules/stock/requisition/modals/search.modal.js
@@ -16,7 +16,7 @@ function SearchStockRequisitionModalController(data, util, Store, Instance, Peri
   vm.defaultQueries = {};
 
   const searchQueryOptions = [
-    'depot_uuid', 'date_from', 'date_to',
+    'depot_uuid', 'date_from', 'date_to', 'user_id',
   ];
 
   const displayValues = {};
@@ -32,6 +32,11 @@ function SearchStockRequisitionModalController(data, util, Store, Instance, Peri
   vm.onSelectDepot = function onSelectDepot(depot) {
     vm.searchQueries.depot_uuid = depot.uuid;
     displayValues.depot_uuid = depot.text;
+  };
+
+  vm.onSelectUser = function onSelectUser(user) {
+    vm.searchQueries.user_id = user.id;
+    displayValues.user_id = user.display_name;
   };
 
   vm.onSelectRequestor = requestor => {


### PR DESCRIPTION
Adds "User" to the search modal to limit listings of requisitions to the specified user.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5692

**TESTING**
- With bhima_test (with other DBs you may not need to hack the reqs)
- Modify one of the Purchase orders to be by a different user
  - In Mysql:
  - select uuid from stock_requisition where reference=3;
  - update stock_requisition set user_id = 2 where uuid=<UUID from previous query>;
- Run bhima,  stock > Requisition
- You should see that Req SREQ.TPA.1 was done by "Regular User"
- Try
   - Super User => 3 reqs
   - Regular User => 1 req
   - Any other user => 0 req
