### PR TITLE
Updated the 'until date' label

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -240,7 +240,7 @@
     },
     "STOCK": {
       "TITLE": "Articles in Stock Report",
-      "DESCRIPTION": "This report shows the stock of products, their average monthly consumption and indicates if a reorder is needed.  The items are ordered by inventory group, then by their name.  By default, all products in every depot is displayed, but these can be filtered by specifying an individual product or depot.",
+      "DESCRIPTION": "This report shows the stock of products, their average monthly consumption and indicates if a reorder is needed at the specified date.  The items are ordered by inventory group, then by their name.  By default, all products in every depot is displayed, but these can be filtered by specifying an individual product or depot.",
       "ALL_DEPOTS": "All Depots",
       "ONE_DEPOT": "One Specific Depot",
       "ALL_INVENTORIES": "All Inventories",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -242,7 +242,7 @@
     },
     "STOCK":{
       "TITLE" : "Rapport de stock",
-      "DESCRIPTION" : "Ce rapport montre le stock de produits, leur consommation mensuelle moyenne et indique si une commande supplémentaire est nécessaire à la date spécifiée.  Les articles sont classés par groupe de stock, puis par leur nom.  Par défaut, tous les produits de chaque dépôt sont affichés, mais il est possible de les filtrer en spécifiant un produit ou un dépôt individuel.",
+      "DESCRIPTION" : "Ce rapport indique le stock des produits, leur consommation mensuelle moyenne et indique si une commande est nécessaire à la date spécifiée. Les articles sont classés par groupe d'inventaire, puis par leur nom. Par défaut, tous les produits de chaque dépôt sont affichés, mais ceux-ci peuvent être filtrés en spécifiant un produit ou un dépôt individuel.",
       "ALL_DEPOTS" : "Tous les dépôts",
       "ONE_DEPOT" : "Un dépôt en particulier",
       "ALL_INVENTORIES" : "Tous les articles",
@@ -259,7 +259,7 @@
       "EXIT_REPORT" : "Rapport des sorties de stocks",
       "EXIT_REPORT_DESCRIPTION" : "Ce rapport affiche les sorties de stock qui ont eu lieu dans different dépôts",
       "INCLUDE_AGGREGATE_CONSUMPTION": "Inclure les consommations agrégées",
-	  "INCLUDE_INFORMATION" : "Information à inclure",
+      "INCLUDE_INFORMATION" : "Information à inclure",
       "INCLUDE_PATIENT_EXIT" : "Inclure les distributions vers les patients",
       "INCLUDE_SERVICE_EXIT" : "Inclure les distributions vers les services",
       "INCLUDE_GROUPED_SERVICE_EXIT" : "Inclure les distributions groupées par services",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -242,7 +242,7 @@
     },
     "STOCK":{
       "TITLE" : "Rapport de stock",
-      "DESCRIPTION" : "Ce rapport affiche les stocks de produits ansi que leur moyenne de consommation et état",
+      "DESCRIPTION" : "Ce rapport montre le stock de produits, leur consommation mensuelle moyenne et indique si une commande supplémentaire est nécessaire à la date spécifiée.  Les articles sont classés par groupe de stock, puis par leur nom.  Par défaut, tous les produits de chaque dépôt sont affichés, mais il est possible de les filtrer en spécifiant un produit ou un dépôt individuel.",
       "ALL_DEPOTS" : "Tous les dépôts",
       "ONE_DEPOT" : "Un dépôt en particulier",
       "ALL_INVENTORIES" : "Tous les articles",

--- a/client/src/modules/reports/generate/inventory_report/inventory_report.html
+++ b/client/src/modules/reports/generate/inventory_report/inventory_report.html
@@ -26,7 +26,7 @@
 
           <!-- choose date until  -->
           <bh-date-editor
-            label="FORM.LABELS.UNTIL_DATE"
+            label="FORM.LABELS.DATE"
             date-value="ReportConfigCtrl.dateTo"
             on-change="ReportConfigCtrl.onSelectDate(date)">
           </bh-date-editor>


### PR DESCRIPTION
Fixes the "until" label in the report: Stock > Inventories (Stock > Articles en Stock).

Closes https://github.com/IMA-WorldHealth/bhima/issues/5703

Includes a small adjustment to the English description in the report creation page.   The French translation was updated accordingly (and needs review).