### PR TITLE
Add status as part of the requistion selection dropdown

### DIFF
--- a/client/src/modules/templates/bhRequisitionSelect.tmpl.html
+++ b/client/src/modules/templates/bhRequisitionSelect.tmpl.html
@@ -15,7 +15,7 @@
       on-select="$ctrl.onSelect($item, $model)">
       <ui-select-match placeholder="{{ 'FORM.SELECT.REFERENCE_REQUISITION' | translate }}"><span>{{$select.selected.reference}}</span></ui-select-match>
       <ui-select-choices ui-select-focus-patch repeat="requisition.uuid as requisition in $ctrl.requisitions | filter: { 'reference': $select.search }">
-        <span ng-bind-html="requisition.reference | highlight:$select.search"></span>
+        <span ng-bind-html="requisition.reference | highlight:$select.search"></span> - <span translate>{{requisition.title_key}}</span>
       </ui-select-choices>
     </ui-select>
 


### PR DESCRIPTION
Adds the requisition status as part of the requisition selection drop down when selecting a requisition for a stock exit.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5679

**TESTING**
- Use a supply depot as depot "A" below
- Check depot "A" to find an item with a reasonable number of some specific inventory item in stock
- Create a requisition from depot A to depot B 
   - To make things clearer, delete all items except one
   - Create the requisition with the inventory item found above
- Go to the stock exit page
  - Change the depot to depot A
  - Select the stock exit option
  - On the popup dialog, select depot B
  - Select  "Yes" on the "do you have a requisition" question
  - In the drop down to select the requisition, notice that the status of the requisition will be "In progress"
  - Complete the stock exit for part of the number in the requisition
  - Repeat the process, but note when selecting the requisition has changed to "Partially delivered".
