### PR TITLE
Fix editing of purchase orders.

### DIFF
--- a/client/src/i18n/en/errors.json
+++ b/client/src/i18n/en/errors.json
@@ -20,6 +20,7 @@
     "OVERPAID_INVOICE" : "You have overpaid the invoices.",
     "ER_DUP_KEY" : "A key collided in a unique database field.  Please retry your action.  If the problem persists, contact the developers.",
     "ER_DUP_ENTRY" : "You have duplicated a value in a unique field!  Please make sure that the necessary values are unique.",
+    "ER_DUP_PURCHASE_ORDER_ITEM" : "You have duplicate items for an inventory item (shown in red).  Please delete it and update the previous item with that inventory item.",
     "ER_EXPIRED_STOCK_LOTS" : "Some stock lots are expired",
     "ER_STOCK_LOT_IS_EXPIRED" : "Stock lot '{{label}}' cannot be selected because it is expired",
     "ER_BAD_FIELD_ERROR" : "Column does not exist in database.",

--- a/client/src/i18n/fr/errors.json
+++ b/client/src/i18n/fr/errors.json
@@ -20,6 +20,7 @@
     "OVERPAID_INVOICE" : "Vous avez payé trop aux factures.",
     "ER_DUP_KEY" : "Il ya déjà un enregistrement avec cette clé. Veuillez réessayer votre action. Si le problème persiste, contactez les développeurs.",
     "ER_DUP_ENTRY" : "Vous avez dupliqué une valeur dans un champ unique! Assurez-vous que les valeurs nécessaires sont uniques.",
+    "ER_DUP_PURCHASE_ORDER_ITEM" : "Vous avez des éléments en double pour un article d'inventaire (indiqué en rouge).  Veuillez le supprimer et mettre à jour l'élément précédent avec cet élément d'inventaire.",
     "ER_EXPIRED_STOCK_LOTS" : "Certains lots de stock sont expirés",
     "ER_STOCK_LOT_IS_EXPIRED" : "Le lot de stock '{{label}}' ne peut être sélectionné car il est expiré",
     "ER_BAD_FIELD_ERROR" : "Vous avez entré un champ qui ne peut pas être stocké dans la base de données.",

--- a/client/src/modules/purchases/create/createUpdate.html
+++ b/client/src/modules/purchases/create/createUpdate.html
@@ -210,10 +210,19 @@
               type="button"
               class="btn btn-default"
               ng-click="PurchaseCtrl.clear(PurchaseOrderForm)"
-              data-method="clear" translate>
+              data-method="clear"
+              ng-show="!PurchaseCtrl.isUpdateState"
+              translate>
               FORM.BUTTONS.CLEAR
             </button>
-            <p
+            <button
+              type="button"
+              class="btn btn-default"
+              ng-click="PurchaseCtrl.cancel()"
+              data-method="cancel">
+              <span ng-show="PurchaseCtrl.isUpdateState" translate>FORM.BUTTONS.CANCEL_EDIT</span>
+              <span ng-show="!PurchaseCtrl.isUpdateState" translate>FORM.BUTTONS.CANCEL</span>
+            </button>            <p
               class="text-danger"
               ng-show="PurchaseCtrl.order._invalid && PurchaseOrderForm.$submitted">
               <span class="fa fa-exclamation-circle"></span>

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -53,6 +53,7 @@ const multiplePayroll = require('../controllers/payroll/multiplePayroll');
 const multiplePayrollIndice = require('../controllers/payroll/multiplePayrollIndice');
 const staffingIndices = require('../controllers/payroll/staffingIndices');
 const staffingIndicesReport = require('../controllers/payroll/staffingIndices/report');
+
 // medical routes
 const patients = require('../controllers/medical/patients');
 const patientGroups = require('../controllers/medical/patientGroups');

--- a/server/controllers/finance/purchases.js
+++ b/server/controllers/finance/purchases.js
@@ -303,7 +303,14 @@ async function update(req, res, next) {
   }
 
   const sql = 'UPDATE purchase SET ? WHERE uuid = ?;';
-  const itemSQL = 'UPDATE purchase_item SET ? WHERE uuid = ?';
+
+  const updateItemSql = 'UPDATE purchase_item SET ? WHERE uuid = ?';
+  const createItemSql = `
+  INSERT INTO purchase_item
+    (uuid, inventory_uuid, quantity, unit_price, total, purchase_uuid)
+  VALUES ?
+  `;
+  const deleteItemSql = 'DELETE FROM purchase_item WHERE uuid = ?';
 
   try {
 
@@ -312,15 +319,15 @@ async function update(req, res, next) {
     }
 
     // these statuses are able to be canceled
-    // TODO(@jniles) - are we sure that you should be able to cancel a confirmed purchase
-    // order?
+    // TODO(@jniles) - are we sure that you should be able to cancel a confirmed purchase order?
     const statusCanCancel = [
       PURCHASE_STATUS_CONFIRMED_ID,
       PURCHASE_STATUS_WAITING_CONFIRMATION,
     ];
 
     const data = db.convert(req.body, ['supplier_uuid']);
-    const purchase = await db.one('SELECT * FROM purchase WHERE uuid = ?', [db.bid(req.params.uuid)]);
+    const poUuid = db.bid(req.params.uuid);
+    const purchase = await db.one('SELECT * FROM purchase WHERE uuid = ?', [poUuid]);
 
     // lazy check to allow cancelling confirmed or awaiting confirmation purchase orders.
     // FIXME(@jniles) - we need a better process for this.  Probably a whole new modal to have
@@ -339,17 +346,43 @@ async function update(req, res, next) {
     data.edited = true;
 
     const items = req.body.items || [];
+    const itemUuids = items.map(x => x.uuid);
+
     delete req.body.items;
+
+    // Get the Uuids for the previous purchase order items
+    const rawUuids = await db.exec('SELECT HEX(uuid) as uuid FROM purchase_item WHERE purchase_uuid = ?', [poUuid]);
+    const oldItemUuids = rawUuids.map(x => x.uuid);
 
     const txn = db.transaction();
 
     txn.addQuery(sql, [req.body, db.bid(req.params.uuid)]);
+
+    // Process updated and new purchase items
     items.forEach(item => {
+      // See if it is an existing item
       const uid = db.bid(item.uuid);
-      delete item.uuid;
-      db.convert(item, ['inventory_uuid']);
-      txn.addQuery(itemSQL, [item, uid]);
+      if (oldItemUuids.includes(item.uuid)) {
+        // Update existing purchase items
+        delete item.uuid;
+        db.convert(item, ['inventory_uuid']);
+        txn.addQuery(updateItemSql, [item, uid]);
+      } else {
+        // Create a new purchase item
+        const newItems = linkPurchaseItems([item], poUuid);
+        txn.addQuery(createItemSql, [newItems]);
+      }
     });
+
+    // Delete any removed purchase items
+    // (only if any items were updated)
+    if (items.length > 0) {
+      oldItemUuids.forEach(duid => {
+        if (!itemUuids.includes(duid)) {
+          txn.addQuery(deleteItemSql, [db.bid(duid)]);
+        }
+      });
+    }
 
     // run the transaction
     await txn.execute();


### PR DESCRIPTION
This PR fixes issues with editing purchase orders.  In particular items added while editing are handled correctly.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5736

**TESTING**
- The following functions should be tested
- Creating a new purchase order
- Editing an existing purchase order
   - Deleting an existing item
   - Changing the quantity of an existing item
   - Adding a new item
   - Entering a duplicate of an existing item with the same inventory item, the form will complain.  Please double-check the French translation of the new error message.