### PR TITLE
Fixed count in merge duplicate lots modal

### DIFF
--- a/client/src/modules/stock/lots/modals/duplicates.modal.html
+++ b/client/src/modules/stock/lots/modals/duplicates.modal.html
@@ -19,7 +19,7 @@
       <span translate>LOTS.NO_LOTS_FOUND</span>
     </div>
     <div ng-if="$ctrl.lots.length > 1">
-      <span translate translate-values="{'N':$ctrl.lots.length - 1}">LOTS.FOUND_N_LOTS</span>
+      <span translate translate-values="{'N':$ctrl.lots.length}">LOTS.FOUND_N_LOTS</span>
 
       <div>
         <input type="checkbox" ng-model="$ctrl.allSelected" ng-change="$ctrl.selectAll()" />


### PR DESCRIPTION
Fixes the number of matching/duplicate lots in the merge duplicate lots modal.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5739

**TESTING**
- Use IMCK/Vanga db
- Enable all role permissions for testing
- Run Stock > Find Duplicate Lots
   - Pick a row and note the number of duplicates (next to last column)
   - Use the action menu for that item and "Find duplicate lots"
   - Note that the number of matching lots (at the top of the pop-up merge lots modal) matches the previous number now and matches the number of rows.
- Double-check for no matches
   - Go to the lots registry (Stock > Lots)
   - Use the action menu and "Find duplicate lots" 
   - If the lot has no duplicates, the pop-up modal should show that clearly
   - If it does have duplicates, the number of rows should match the count in the description (and number of rows).  Try again until you find one that has no duplicates.
