### PR TITLE
Show voucher information on the stock receipt

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -1,6 +1,7 @@
 {
   "STOCK" : {
     "ALERT" : "Alert",
+    "DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP":"Does not exist because the movement of stock was made before the implementation of stock accounting",
     "ADJUSTMENT"      : "Adjustment",
     "ADJUSTMENT_TYPE" : "Adjustment Type",
     "AGGREGATED_STOCK_CONSUMPTION": {

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -1,6 +1,7 @@
 {
   "STOCK" : {
     "ALERT"  : "Alert",
+    "DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP":"N'existe pas car le mouvement de stock a été fait avant la mise en place de la comptabilité de stock",
     "ADJUSTMENT"      : "Ajustement",
     "ADJUSTMENT_TYPE" : "Type d'Ajustement",
     "AGGREGATED_STOCK_CONSUMPTION": {

--- a/server/controllers/stock/reports/stock/adjustment_receipt.js
+++ b/server/controllers/stock/reports/stock/adjustment_receipt.js
@@ -11,6 +11,7 @@ const {
  */
 async function stockAdjustmentReceipt(documentUuid, session, options) {
   const optionReport = _.extend(options, { filename : 'STOCK.REPORTS.ADJUSTMENT' });
+  const autoStockAccountingEnabled = session.stock_settings.enable_auto_stock_accounting;
 
   const FLUX_TYPE = [
     Stock.flux.FROM_ADJUSTMENT,
@@ -72,6 +73,7 @@ async function stockAdjustmentReceipt(documentUuid, session, options) {
     document_reference : line.document_reference,
     barcode : barcode.generate(key, line.document_uuid),
     voucher_reference : voucherReference,
+    autoStockAccountingEnabled,
   };
 
   data.rows = rows;

--- a/server/controllers/stock/reports/stock/entry_donation_receipt.js
+++ b/server/controllers/stock/reports/stock/entry_donation_receipt.js
@@ -13,6 +13,7 @@ const {
 async function stockEntryDonationReceipt(documentUuid, session, options) {
   const data = {};
   const optionReport = _.extend(options, { filename : 'STOCK.RECEIPTS.ENTRY_DONATION' });
+  const autoStockAccountingEnabled = session.stock_settings.enable_auto_stock_accounting;
 
   // set up the report with report manager
   const report = new ReportManager(STOCK_ENTRY_DONATION_TEMPLATE, session, optionReport);
@@ -65,6 +66,7 @@ async function stockEntryDonationReceipt(documentUuid, session, options) {
     document_reference    : line.document_reference,
     barcode               : barcode.generate(key, line.document_uuid),
     voucher_reference     : voucherReference,
+    autoStockAccountingEnabled,
   };
 
   data.rows = rows;

--- a/server/controllers/stock/reports/stock/entry_integration_receipt.js
+++ b/server/controllers/stock/reports/stock/entry_integration_receipt.js
@@ -15,6 +15,7 @@ const {
 async function stockEntryIntegrationReceipt(documentUuid, session, options) {
   const data = {};
   const optionReport = _.extend(options, { filename : 'STOCK.RECEIPTS.ENTRY_INTEGRATION' });
+  const autoStockAccountingEnabled = session.stock_settings.enable_auto_stock_accounting;
 
   // set up the report with report manager
   const report = new ReportManager(STOCK_ENTRY_INTEGRATION_TEMPLATE, session, optionReport);
@@ -65,6 +66,7 @@ async function stockEntryIntegrationReceipt(documentUuid, session, options) {
     project_display_name  : line.project_display_name,
     barcode : barcode.generate(key, line.document_uuid),
     voucher_reference     : voucherReference,
+    autoStockAccountingEnabled,
   };
 
   data.rows = rows;

--- a/server/controllers/stock/reports/stock/entry_purchase_receipt.js
+++ b/server/controllers/stock/reports/stock/entry_purchase_receipt.js
@@ -13,6 +13,7 @@ const {
 async function stockEntryPurchaseReceipt(documentUuid, session, options) {
   const data = {};
   const optionReport = _.extend(options, { filename : 'STOCK.RECEIPTS.ENTRY_PURCHASE' });
+  const autoStockAccountingEnabled = session.stock_settings.enable_auto_stock_accounting;
 
   // set up the report with report manager
   const report = new ReportManager(STOCK_ENTRY_PURCHASE_TEMPLATE, session, optionReport);
@@ -72,6 +73,7 @@ async function stockEntryPurchaseReceipt(documentUuid, session, options) {
     supplier_display_name : line.supplier_display_name,
     barcode               : barcode.generate(key, line.document_uuid),
     voucher_reference     : voucherReference,
+    autoStockAccountingEnabled,
   };
   data.rows = rows;
   return report.render(data);

--- a/server/controllers/stock/reports/stock/exit_aggregate_consumption_receipt.js
+++ b/server/controllers/stock/reports/stock/exit_aggregate_consumption_receipt.js
@@ -13,6 +13,7 @@ const {
 async function stockExitAggregateConsumptionReceipt(documentUuid, session, options) {
   const data = {};
   const optionReport = _.extend(options, { filename : 'STOCK.RECEIPTS.AGGREGATE_CONSUMPTION' });
+  const autoStockAccountingEnabled = session.stock_settings.enable_auto_stock_accounting;
 
   // set up the report with report manager
   const report = new ReportManager(STOCK_AGGREGATE_CONSUMPTION_TEMPLATE, session, optionReport);
@@ -66,6 +67,7 @@ async function stockExitAggregateConsumptionReceipt(documentUuid, session, optio
     document_reference    : line.document_reference,
     barcode               : barcode.generate(key, line.document_uuid),
     voucher_reference     : voucherReference,
+    autoStockAccountingEnabled,
   };
 
   data.rows = rows;

--- a/server/controllers/stock/reports/stock/exit_loss_receipt.js
+++ b/server/controllers/stock/reports/stock/exit_loss_receipt.js
@@ -16,6 +16,7 @@ const {
 async function stockExitLossReceipt(documentUuid, session, options) {
   const data = {};
   const optionReport = _.extend(options, { filename : 'STOCK.REPORTS.EXIT_LOSS' });
+  const autoStockAccountingEnabled = session.stock_settings.enable_auto_stock_accounting;
 
   let template = STOCK_EXIT_LOSS_TEMPLATE;
 
@@ -67,6 +68,7 @@ async function stockExitLossReceipt(documentUuid, session, options) {
     document_reference : line.document_reference,
     barcode : barcode.generate(key, line.document_uuid),
     voucher_reference : voucherReference,
+    autoStockAccountingEnabled,
   };
 
   data.rows = rows;

--- a/server/controllers/stock/reports/stock/exit_patient_receipt.js
+++ b/server/controllers/stock/reports/stock/exit_patient_receipt.js
@@ -16,6 +16,7 @@ const {
 async function stockExitPatientReceipt(documentUuid, session, options) {
   const data = {};
   const optionReport = _.extend(options, { filename : 'STOCK.REPORTS.EXIT_PATIENT' });
+  const autoStockAccountingEnabled = session.stock_settings.enable_auto_stock_accounting;
 
   let template = STOCK_EXIT_PATIENT_TEMPLATE;
 
@@ -79,6 +80,7 @@ async function stockExitPatientReceipt(documentUuid, session, options) {
     barcode : barcode.generate(key, line.document_uuid),
     voucher_reference : voucherReference,
     hasInvoiceReference : false,
+    autoStockAccountingEnabled,
   };
 
   // let get the invoice ref(document ref) is it exists

--- a/server/controllers/stock/reports/stock_adjustment.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_adjustment.receipt.handlebars
@@ -31,8 +31,14 @@
       <div class="col-xs-6">
         <span class="text-capitalize">{{translate 'STOCK.DEPOT'}}</span>: <strong>{{details.depot_name}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.DOCUMENT'}}</span>: <strong>{{details.document_reference}}</strong> <br>
-        {{#if details.voucher_reference}}
-          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: <strong>{{details.voucher_reference}}</strong> <br>
+        {{#if details.autoStockAccountingEnabled}}
+          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: 
+          {{#if details.voucher_reference}}
+            <strong>{{details.voucher_reference}}</strong>
+          {{else}}
+            <i>{{translate 'STOCK.DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP'}}</i>
+          {{/if}}
+          <br>
         {{/if}}
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date details.date}} <br>
         <span class="text-capitalize">{{translate "TABLE.COLUMNS.CREATED_BY"}}</span>: {{details.user_display_name}}

--- a/server/controllers/stock/reports/stock_aggregate_consumption.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_aggregate_consumption.receipt.handlebars
@@ -21,8 +21,14 @@
       <div class="col-xs-6">
         <span class="text-capitalize">{{translate 'STOCK.DEPOT'}}</span>: <strong>{{details.depot_name}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.DOCUMENT'}}</span>: <strong>{{details.document_reference}}</strong> <br>
-        {{#if details.voucher_reference}}
-          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: <strong>{{details.voucher_reference}}</strong> <br>
+        {{#if details.autoStockAccountingEnabled}}
+          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: 
+          {{#if details.voucher_reference}}
+            <strong>{{details.voucher_reference}}</strong>
+          {{else}}
+            <i>{{translate 'STOCK.DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP'}}</i>
+          {{/if}}
+          <br>
         {{/if}}
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date details.date}} <br>
         <span class="text-capitalize">{{translate "TABLE.COLUMNS.CREATED_BY"}}</span>: {{details.user_display_name}}

--- a/server/controllers/stock/reports/stock_entry_donation.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_entry_donation.receipt.handlebars
@@ -22,8 +22,14 @@
         <h4>{{translate 'STOCK.TO'}}</h4>
         <span class="text-capitalize">{{translate 'STOCK.DEPOT'}}</span>: <strong>{{details.depot_name}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.DOCUMENT'}}</span>: <strong>{{details.document_reference}}</strong> <br>
-        {{#if details.voucher_reference}}
-          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: <strong>{{details.voucher_reference}}</strong> <br>
+        {{#if details.autoStockAccountingEnabled}}
+          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: 
+          {{#if details.voucher_reference}}
+            <strong>{{details.voucher_reference}}</strong>
+          {{else}}
+            <i>{{translate 'STOCK.DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP'}}</i>
+          {{/if}}
+          <br>
         {{/if}}
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date details.date}} <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.COST'}}</span>: {{currency (sum rows 'total') enterprise.currency_id}} <br>

--- a/server/controllers/stock/reports/stock_entry_integration.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_entry_integration.receipt.handlebars
@@ -24,8 +24,14 @@
         <h4>{{translate 'STOCK.TO'}}</h4>
         <span class="text-capitalize">{{translate 'STOCK.DEPOT'}}</span>: <strong>{{details.depot_name}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.DOCUMENT'}}</span>: <strong>{{details.document_reference}}</strong> <br>
-        {{#if details.voucher_reference}}
-          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: <strong>{{details.voucher_reference}}</strong> <br>
+        {{#if details.autoStockAccountingEnabled}}
+          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: 
+          {{#if details.voucher_reference}}
+            <strong>{{details.voucher_reference}}</strong>
+          {{else}}
+            <i>{{translate 'STOCK.DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP'}}</i>
+          {{/if}}
+          <br>
         {{/if}}
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date details.date}} <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.COST'}}</span>: {{currency (sum rows 'total') enterprise.currency_id}} <br>

--- a/server/controllers/stock/reports/stock_entry_purchase.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_entry_purchase.receipt.handlebars
@@ -26,8 +26,14 @@
         <h4>{{translate 'STOCK.TO'}}</h4>
         <span class="text-capitalize">{{translate 'STOCK.DEPOT'}}</span>: <strong>{{details.depot_name}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.DOCUMENT'}}</span>: <strong>{{details.document_reference}}</strong> <br>
-        {{#if details.voucher_reference}}
-          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: <strong>{{details.voucher_reference}}</strong> <br>
+        {{#if details.autoStockAccountingEnabled}}
+          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: 
+          {{#if details.voucher_reference}}
+            <strong>{{details.voucher_reference}}</strong>
+          {{else}}
+            <i>{{translate 'STOCK.DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP'}}</i>
+          {{/if}}
+          <br>
         {{/if}}
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date details.date}} <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.COST'}}</span>: {{currency (sum rows 'total') enterprise.currency_id}} <br>

--- a/server/controllers/stock/reports/stock_exit_loss.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_exit_loss.receipt.handlebars
@@ -21,8 +21,14 @@
       <div class="col-xs-6">
         <span class="text-capitalize">{{translate 'STOCK.DEPOT'}}</span>: <strong>{{details.depot_name}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.DOCUMENT'}}</span>: <strong>{{details.document_reference}}</strong> <br>
-        {{#if details.voucher_reference}}
-          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: <strong>{{details.voucher_reference}}</strong> <br>
+        {{#if details.autoStockAccountingEnabled}}
+          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: 
+          {{#if details.voucher_reference}}
+            <strong>{{details.voucher_reference}}</strong>
+          {{else}}
+            <i>{{translate 'STOCK.DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP'}}</i>
+          {{/if}}
+          <br>
         {{/if}}
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date details.date}} <br>
         <span class="text-capitalize">{{translate "TABLE.COLUMNS.CREATED_BY"}}</span>: {{details.user_display_name}}

--- a/server/controllers/stock/reports/stock_exit_loss.receipt.pos.handlebars
+++ b/server/controllers/stock/reports/stock_exit_loss.receipt.pos.handlebars
@@ -13,6 +13,15 @@
 <p style="margin-top: 0px">
   <span class="text-capitalize">{{translate 'STOCK.DEPOT'}}</span> : <strong>{{details.depot_name}}</strong> <br>
   <span class="text-capitalize">{{translate 'FORM.LABELS.REFERENCE'}}</span> : <strong>{{details.document_reference}}</strong> <br>
+  {{#if details.autoStockAccountingEnabled}}
+    <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: 
+    {{#if details.voucher_reference}}
+      <strong>{{details.voucher_reference}}</strong>
+    {{else}}
+      <i>{{translate 'STOCK.DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP'}}</i>
+    {{/if}}
+    <br>
+  {{/if}}
   {{date details.date}} {{translate 'FORM.LABELS.BY'}} {{details.user_display_name}}
 </p>
 

--- a/server/controllers/stock/reports/stock_exit_patient.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_exit_patient.receipt.handlebars
@@ -28,8 +28,14 @@
         <span class="text-capitalize">{{translate 'STOCK.DEPOT'}}</span>: <strong>{{details.depot_name}}</strong> <br>
         <span class="text-capitalize">{{translate 'FORM.LABELS.DOCUMENT'}}</span>: <strong>{{details.document_reference}}</strong> <br>
 
-        {{#if details.voucher_reference}}
-          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: <strong>{{details.voucher_reference}}</strong> <br>
+        {{#if details.autoStockAccountingEnabled}}
+          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: 
+          {{#if details.voucher_reference}}
+            <strong>{{details.voucher_reference}}</strong>
+          {{else}}
+            <i>{{translate 'STOCK.DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP'}}</i>
+          {{/if}}
+          <br>
         {{/if}}
 
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date details.date}} <br>

--- a/server/controllers/stock/reports/stock_exit_patient.receipt.pos.handlebars
+++ b/server/controllers/stock/reports/stock_exit_patient.receipt.pos.handlebars
@@ -12,6 +12,15 @@
 <p style="margin-top: 0px">
   <span class="text-capitalize">{{translate 'STOCK.DEPOT'}}</span> : <strong>{{details.depot_name}}</strong> <br>
   <span class="text-capitalize">{{translate 'FORM.LABELS.REFERENCE'}}</span> : <strong>{{details.document_reference}}</strong> <br>
+  {{#if details.autoStockAccountingEnabled}}
+    <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: 
+    {{#if details.voucher_reference}}
+      <strong>{{details.voucher_reference}}</strong>
+    {{else}}
+      <i>{{translate 'STOCK.DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP'}}</i>
+    {{/if}}
+    <br>
+  {{/if}}
   {{date details.date}} {{translate 'FORM.LABELS.BY'}} {{details.user_display_name}}
 </p>
 

--- a/server/controllers/stock/reports/stock_exit_service.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_exit_service.receipt.handlebars
@@ -23,6 +23,15 @@
         {{#if details.document_requisition}}
           <span>{{translate 'FORM.LABELS.REQUISITION_REFERENCE'}}</span>: <strong>{{details.document_requisition}}</strong> <br>
         {{/if}}
+        {{#if details.autoStockAccountingEnabled}}
+          <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: 
+          {{#if details.voucher_reference}}
+            <strong>{{details.voucher_reference}}</strong>
+          {{else}}
+            <i>{{translate 'STOCK.DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP'}}</i>
+          {{/if}}
+          <br>
+        {{/if}}
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date details.date}} <br>
         <span class="text-capitalize">{{translate "TABLE.COLUMNS.CREATED_BY"}}</span>: {{details.user_display_name}}
       </div>

--- a/server/controllers/stock/reports/stock_exit_service.receipt.pos.handlebars
+++ b/server/controllers/stock/reports/stock_exit_service.receipt.pos.handlebars
@@ -16,6 +16,15 @@
   {{#if details.document_requisition}}
     <span>{{translate 'FORM.LABELS.REQUISITION_REFERENCE'}}</span>: <strong>{{details.document_requisition}}</strong> <br>
   {{/if}}
+  {{#if details.autoStockAccountingEnabled}}
+    <span class="text-capitalize">{{translate 'FORM.LABELS.VOUCHER'}}</span>: 
+    {{#if details.voucher_reference}}
+      <strong>{{details.voucher_reference}}</strong>
+    {{else}}
+      <i>{{translate 'STOCK.DO_NOT_EXIST_BEFORE_ACCOUNTING_SETUP'}}</i>
+    {{/if}}
+    <br>
+  {{/if}}
   {{date details.date}} {{translate 'FORM.LABELS.BY'}} {{details.user_display_name}}
 </p>
 


### PR DESCRIPTION
This PR is related to #5510 and adds information about voucher on the stock receipt.

If the movement was made before the setup of stock accounting, and then the stock accounting has been activated we have now the message : 

![image](https://user-images.githubusercontent.com/5445251/121700942-513aa580-cac8-11eb-9fda-ea1aa45e5d57.png)

For all other stock movement after the setup of stock accounting, we have the voucher reference on the receipt

![image](https://user-images.githubusercontent.com/5445251/121701141-81824400-cac8-11eb-8aa3-96af8d601de0.png)

This information is defined for : 
- stock exit to patient
- stock exit to service
- stock exit to loss
- stock entry from purchase
- stock entry from integration
- stock entry from donation
- stock adjustment

Close #5510 
