### PR TITLE
Chore: remove testing on MySQL 5.7

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -69,7 +69,6 @@ blocks:
           matrix:
             - env_var: MYSQL_VERSION
               values:
-                - '5.7'
                 - '8'
             - env_var: NODEJS_VERSION
               values:
@@ -127,7 +126,6 @@ blocks:
           matrix:
             - env_var: MYSQL_VERSION
               values:
-                - '5.7'
                 - '8'
             - env_var: NODEJS_VERSION
               values:

--- a/docs/en/for-developers/installing-bhima.md
+++ b/docs/en/for-developers/installing-bhima.md
@@ -10,7 +10,7 @@ This guide will get you up and running with bhima locally. Please note that bhim
 
 Before you begin the installation process, please make sure you have all the bhima dependencies installed locally. We only test on Linux, so your best bet is to use a Linux flavor you are familiar with. Please make sure you have recent version of:
 
-1. [MySQL](http://dev.mysql.com/downloads/) \(5.7 or 8.0\)
+1. [MySQL 8](http://dev.mysql.com/downloads/)
 2. [Redis](https://redis.io)
 3. [curl](https://curl.haxx.se/)
 4. [NodeJS](https://nodejs.org/en/) \(we recommend using [node version manager](https://github.com/creationix/nvm) on linux. Note that we only test on stable and edge\).
@@ -112,7 +112,7 @@ nano .env
 #Run the following commands to create the bhima user in MySQL, so that it can build the database (make sure the user and #password both match what you set in the .env file):
 
 sudo mysql -u root -p
-CREATE USER 'bhima'@'localhost' IDENTIFIED BY 'password';
+CREATE USER 'bhima'@'localhost' IDENTIFIED WITH 'mysql_native_password' BY 'password';
 GRANT ALL PRIVILEGES ON * . * TO 'bhima'@'localhost';
 #Use ctrl + z to get back to the main terminal prompt
 ```
@@ -149,9 +149,7 @@ docker run --name mysql8 -p 3306:3306 \
   -e MYSQL_ROOT_PASSWORD=MyPassword \
   -d mysql:8 \
   --sql-mode='STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION' \
-  --default-authentication-plugin=mysql_native_password \
-  --character-set-server=utf8mb4 \
-  --collation-server=utf8mb4_unicode_ci
+  --default-authentication-plugin=mysql_native_password
 
 # give it a few seconds, and MySQL will be started and listening on port 3306
 ```

--- a/docs/en/for-developers/installing-bhima.md
+++ b/docs/en/for-developers/installing-bhima.md
@@ -207,22 +207,3 @@ Our tests are broken into unit tests, end to end tests, and integration tests. T
 You can run all tests by simply typing `yarn test`.
 
 Enjoy using bhima!
-
----
-
-### Trouble-Shooting
-
-#### MySQL Issues
-If the application fails to run and you get server errors like this:
-
-```
-MySQL 8.0 - Client does not support authentication protocol requested by server; consider upgrading MySQL client
-```
-
-The problem is that MySql by default requires a password-encoding mechanism that the MySQL interface (mysqljs) in Node.js does not support.  You need to instruct MySQL to accept the old-style password encoding.  Run mysql client as `root` and execute this command:
-
-```sql
-ALTER USER bhima IDENTIFIED WITH mysql_native_password BY 'password';
-```
-
-(replace 'password' with your desired password).  Once this is done MySQL should accept the passwords passed to it via Node.js.

--- a/docs/fr/for-developers/installing-bhima.md
+++ b/docs/fr/for-developers/installing-bhima.md
@@ -10,7 +10,7 @@ Ce guide vous permettra de vous familiariser avec bhima localement. Veuillez not
 
 Avant de commencer le processus d'installation, assurez-vous que toutes les dépendances bhima sont installées localement. Nous ne testons que sous Linux. Il est donc préférable d’utiliser une version de Linux que vous connaissez bien. Assurez-vous d'avoir la version récente de:
 
-1. [MySQL](http://dev.mysql.com/downloads/) \(5.7 ou 8.0\)
+1. [MySQL](http://dev.mysql.com/downloads/)
 2. [Redis](https://redis.io)
 3. [curl](https://curl.haxx.se/)
 4. [NodeJS](https://nodejs.org/en/) \(nous vous recommandons d’utiliser le [gestionnaire de version de node](https://github.com/creationix/nvm) sous Linux. Notez que nous ne testons que sur des versions stables. et bord \).
@@ -96,8 +96,8 @@ nano .env
 # Exécutez les commandes suivantes pour créer l'utilisateur bhima dans MySQL afin qu'il puisse construire la base de données (assurez-vous que l'utilisateur et #password correspondent tous les deux à ce que vous avez défini dans le fichier .env):
 
 sudo mysql -u root -p
-CREATE USER 'bhima' @ 'localhost' IDENTIFIED BY 'mot de passe';
-Accordez tous les privilèges sur *. * TO 'bhima' @ 'localhost';
+CREATE USER 'bhima'@'localhost' IDENTIFIED WITH 'mysql_native_password' BY 'mot de passe';
+Accordez tous les privilèges sur *. * TO 'bhima'@'localhost';
 #Utilisez ctrl + z pour revenir à l'invite du terminal principal
 ```
 
@@ -133,9 +133,7 @@ docker run --name mysql8 -p 3306:3306 \
   -e MYSQL_ROOT_PASSWORD=MyPassword \
   -d mysql:8 \
   --sql-mode='STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION' \
-  --default-authentication-plugin=mysql_native_password \
-  --character-set-server=utf8mb4 \
-  --collation-server=utf8mb4_unicode_ci
+  --default-authentication-plugin=mysql_native_password
 
 ```
 

--- a/sh/travis-install-mysql8.sh
+++ b/sh/travis-install-mysql8.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-wget https://repo.mysql.com/mysql-apt-config_0.8.15-1_all.deb
-dpkg -i mysql-apt-config_0.8.15-1_all.deb
-apt-get update -q
-apt-get install -q -y --allow-unauthenticated -o Dpkg::Options::=--force-confnew mysql-server
-systemctl restart mysql
-mysql_upgrade


### PR DESCRIPTION
This commit removes testing on MySQL 5.7 and also removes the documentation tied to MySQL 5.7.  It completes the transition to MySQL 8.

Closes #5364. 

-----
[View rendered docs/en/for-developers/installing-bhima.md](https://github.com/jniles/bhima/blob/chore-remove-testing-on-mysql-5.7/docs/en/for-developers/installing-bhima.md)
[View rendered docs/fr/for-developers/installing-bhima.md](https://github.com/jniles/bhima/blob/chore-remove-testing-on-mysql-5.7/docs/fr/for-developers/installing-bhima.md)