### PR TITLE
refactor(stock): change "cost" to "value"

### DIFF
--- a/server/controllers/stock/reports/stock_entry_purchase.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_entry_purchase.receipt.handlebars
@@ -36,7 +36,7 @@
           <br>
         {{/if}}
         <span class="text-capitalize">{{translate 'FORM.LABELS.DATE'}}</span>: {{date details.date}} <br>
-        <span class="text-capitalize">{{translate 'FORM.LABELS.COST'}}</span>: {{currency (sum rows 'total') enterprise.currency_id}} <br>
+        <span class="text-capitalize">{{translate 'FORM.LABELS.VALUE'}}</span>: {{currency (sum rows 'total') enterprise.currency_id}} <br>
         <span class="text-capitalize">{{translate 'STOCK.INVENTORY'}}</span>: {{rows.length}} {{translate 'STOCK.ITEMS'}} <br>
         <span class="text-capitalize">{{translate "TABLE.COLUMNS.CREATED_BY"}}</span>: {{details.user_display_name}} <br>
       </div>


### PR DESCRIPTION
This commit changes the wording of "cost" to "value" in the stock entry
form to better represent that the stock is _valued_ at that amount,
regardless of what the enterprise paid for it.

Closes #5746.