### PR TITLE
chore(purchase): zero out purchase price

### DIFF
--- a/client/src/modules/purchases/create/PurchaseOrderForm.js
+++ b/client/src/modules/purchases/create/PurchaseOrderForm.js
@@ -42,8 +42,15 @@ function PurchaseOrderFormService(Inventory, AppCache, Store, Pool, PurchaseOrde
     this._ready = $q.defer();
 
     // set up the inventory
-    Inventory.read(null, { locked : 0, use_previous_price : 1 })
+    Inventory.read(null, { locked : 0 })
       .then((data) => {
+
+        // zero out price so that users don't automatically use the sale price.
+        data.forEach(row => {
+          row.price = 0;
+        });
+
+
         this.inventory.initialize('uuid', data);
 
         // FIXME(@jniles) - this is a hack. We should actually put a list() method on the

--- a/test/client-unit/services/PurchaseOrderFormService.spec.js
+++ b/test/client-unit/services/PurchaseOrderFormService.spec.js
@@ -38,7 +38,7 @@ describe('PurchaseOrderForm', () => {
 
     httpBackend = $httpBackend;
 
-    httpBackend.when('GET', '/inventory/metadata/?locked=0&use_previous_price=1')
+    httpBackend.when('GET', '/inventory/metadata/?locked=0')
       .respond(200, Mocks.inventories());
 
   }));


### PR DESCRIPTION
This commit zeroes out the purchase price so users are forced to put in
their own purchase price.

Closes #5734.

![image](https://user-images.githubusercontent.com/896472/122100063-c0720b80-cde0-11eb-9c8e-62db47014b65.png)
