### PR TITLE
Enable editing lot expiration dates during stock entry

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -295,6 +295,8 @@
   "LOTS" : {
     "REGISTRY" : "Lots Registry",
     "MERGED_LOTS_AUTOMATICALLY": "Automatically merged {{numLots}} lots for {{numInventories}} articles of inventory",
+    "ENABLE_CORRECTING_LOT_EXPIRATION_DATES": "Enable correction of lot expiration dates",
+    "ENABLE_CORRECTING_LOT_EXPIRATION_DATES_DESCRIPTION": "Enable correction of the expiration dates for existing lots.",
     "ENABLE_FAST_INSERT": "Enable fast lots insertions",
     "ENABLE_FAST_INSERT_DESCRIPTION": "This option will automatically select the next blank row's serial/lot number in the entry table. If necessary, it adds a new row. Useful for quickly inserting with a barcode reader",
     "EXCLUDE_EXHAUSTED_LOTS": "Exclude exhausted lots",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -296,6 +296,8 @@
   "LOTS" : {
     "REGISTRY" : "Registre des lots",
     "MERGED_LOTS_AUTOMATICALLY": "{{NumLots}} lots fusionnés automatiquement pour {{numInventories}} articles d'inventaire",
+    "ENABLE_CORRECTING_LOT_EXPIRATION_DATES": "Permettre la correction des dates d'expiration des lots",
+    "ENABLE_CORRECTING_LOT_EXPIRATION_DATES_DESCRIPTION": "Permettre la correction des dates d'expiration des lots existants.",
     "ENABLE_FAST_INSERT": "Activer les insertions rapides",
     "ENABLE_FAST_INSERT_DESCRIPTION": "Cette option selectionne automatiquement une nouvelle ligne de lot lorsque vous finissez d'introduire un libellé de lot ou numéro de serie. C'est très utile lorsque vous utilisez un lecteur de code barre",
     "EXCLUDE_EXHAUSTED_LOTS": "Exclure les lots de stocks épuisés",

--- a/client/src/modules/stock/entry/modals/lots.modal.html
+++ b/client/src/modules/stock/entry/modals/lots.modal.html
@@ -1,5 +1,6 @@
 <form
   name="FindForm"
+  bh-submit="$ctrl.submit(FindForm)"
   ng-model-options="{ 'debounce' : { 'default' : 200, 'blur' : 0 }}"
   novalidate>
 
@@ -17,7 +18,7 @@
       <div class="col-xs-12">
         <div>
           <span class="text-bold" translate>STOCK.ENTRY_DATE</span> :
-          {{ $ctrl.entryDate | date:$ctrl.Constants.dates.format }}
+          {{ $ctrl.entryDate | date:$ctrl.bhConstants.dates.format }}
         </div>
       </div>
     </div>
@@ -73,7 +74,22 @@
         <p class="help-block" translate>LOTS.ENABLE_FAST_INSERT_DESCRIPTION</p>
       </div>
 
-      <bh-add-item callback="$ctrl.form.addItem()" disable="true">
+      <div style="margin-bottom: 5px;" bh-has-permission="$ctrl.bhConstants.actions.EDIT_LOT">
+        <div class="checkbox">
+          <label>
+            <input
+              id="editExpirationDates"
+              type="checkbox"
+              ng-model="$ctrl.editExpirationDates"
+              ng-change="$ctrl.onExpDateEditable()"
+              ng-true-value="1"
+              ng-false-value="0">
+            <span translate>LOTS.ENABLE_CORRECTING_LOT_EXPIRATION_DATES</span>
+          </label>
+          <p class="help-block" translate>LOTS.ENABLE_CORRECTING_LOT_EXPIRATION_DATES_DESCRIPTION</p>
+        </div>
+
+        <bh-add-item callback="$ctrl.form.addItem()" disable="true">
       </bh-add-item>
     </div>
 
@@ -105,8 +121,8 @@
       FORM.BUTTONS.CLOSE
     </button>
 
-    <button type="submit" class="btn btn-primary" ng-click="$ctrl.submit(FindForm, $event)" data-method="submit" translate>
-      FORM.BUTTONS.SUBMIT
-    </button>
+    <bh-loading-button loading-state="FindForm.$loading">
+      <span translate>FORM.BUTTONS.SUBMIT</span>
+    </bh-loading-button>
   </div>
 </form>

--- a/client/src/modules/stock/entry/modals/templates/lot.expiration.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/lot.expiration.tmpl.html
@@ -2,7 +2,7 @@
   <bh-date-picker
     date="row.entity.expiration_date"
     on-change="grid.appScope.onDateChange(date, row.entity)"
-    disabled="row.entity.disabled"
+    disabled="row.entity.editExpDateDisabled"
     required="true">
   </bh-date-picker>
 </div>


### PR DESCRIPTION
Enable editing lot expiration dates during stock entry for users with the "EDIT_LOT" action permission.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5741

NOTE:  Rather than do this on a line by line basis, I made it for all lots selected.   It seemed cumbersome to do this on every line.  However I'm willing to reconsider this if reviewers feel that we need the extra protection on each line to avoid date entry errors.  However, anyone who does not have the EDIT_LOT action permission will not be able to edit the expiration dates during stock entry in any case.   So if we trust someone to edit any of the lot expiration dates, perhaps we can trust them not to accidentally edit lot expiration dates.

*TESTING*
- The following procedure assumes bhima_test, but production databases should work as well.  Just check the Lot registry for suitable lots.
- Make sure that the "Edit lot information" action is permitted for your user.
- Go to Stock > Entry
- Use the entry mode of your choice (I tested it with Integration, but it should not matter).
- Add DINJ_TRIB1A2_0 : Vitamines B1+B6+B12, 100+50+0.5mg/2ml, Amp, Unité
- Select lots
   - Note the new option to enable editing of expiration dates (do not click it yet)
   - Select one of the existing lots
   - Notice that you cannot change the expiration date
   - Now, click on the option above to enable editing of lot expiration dates
   - Change the date
   - Save the modal
   - Save the Entry
   - Notice the new date in the PDF report that comes up
- Try repeating the stock entry and do not change the date and notice the expiration date does not change
- Disable the EDIT_LOTS action and repeat the test above
   - Note that the option to enable editing lot expiration dates is no longer available.
