### PR TITLE
Added client unit tests for changing currency while creating a purchase order

### DIFF
--- a/test/client-unit/mocks/data.js
+++ b/test/client-unit/mocks/data.js
@@ -56,6 +56,22 @@
       settings :  {},
     });
 
+    service.exchange = () => [{
+      // placeholder
+    }, {
+      currency_id : 1,
+      name : 'FC',
+      rate : 2000.0,
+    }, {
+      currency_id : 2,
+      name : 'USD',
+      rate : 1.0,
+    }, {
+      currency_id : 3,
+      name : 'EUR',
+      rate : 0.84,
+    }];
+
     service.stock_settings = () => ({
       enterprise_id : 1,
       enable_auto_stock_accounting : 0,

--- a/test/client-unit/services/PurchaseOrderFormService.spec.js
+++ b/test/client-unit/services/PurchaseOrderFormService.spec.js
@@ -8,6 +8,10 @@ describe('PurchaseOrderForm', () => {
   let $timeout;
   let form;
 
+  // const FC = 1;
+  // const USD = 2;
+  const EUR = 3;
+
   beforeEach(module(
     'bhima.services',
     'angularMoment',
@@ -40,7 +44,6 @@ describe('PurchaseOrderForm', () => {
 
     httpBackend.when('GET', '/inventory/metadata/?locked=0')
       .respond(200, Mocks.inventories());
-
   }));
 
   beforeEach(() => {
@@ -93,7 +96,7 @@ describe('PurchaseOrderForm', () => {
     expect(form.store.data.length).to.equal(1);
   });
 
-  it('deletes an item when when #removeItem() is callled', () => {
+  it('deletes an item when when #removeItem() is called', () => {
     // Make sure it is empty to start with
     expect(form.store.data.length).to.equal(0);
 
@@ -110,7 +113,7 @@ describe('PurchaseOrderForm', () => {
     expect(form.store.data.length).to.equal(0);
   });
 
-  it('sets totals correctly when #digest() is callled', () => {
+  it('sets totals correctly when #digest() is called', () => {
 
     // Get the UUIDs for a couple of inventory items
     const uuid1 = form.inventory.available.data[0].uuid;
@@ -132,7 +135,7 @@ describe('PurchaseOrderForm', () => {
     form.digest();
     expect(form.details.cost).to.eql(4.6);
 
-    // Add a secpmd PO item to the form
+    // Add a second PO item to the form
     const item2 = form.addItem();
     item2.inventory_uuid = uuid2;
     form.configureItem(item2);
@@ -145,4 +148,72 @@ describe('PurchaseOrderForm', () => {
     form.digest();
     expect(form.details.cost).to.eql(15.1);
   });
+
+  it('verify that currencies are handled correctly with multiple currencies', () => {
+
+    const enterpriseCurrencyId = Mocks.enterprise().currency_id;
+    const enterpriseCurrencyRate = Mocks.exchange()[enterpriseCurrencyId].rate;
+
+    // Get the UUIDs for an inventory item for the test
+    // NOTE: inventory unit prices are always in enterprise currency
+    const invUuid1 = form.inventory.available.data[1].uuid;
+    const unitPrice1 = 2.3;
+    const quantity1 = 10;
+    const invUuid2 = form.inventory.available.data[2].uuid;
+    const unitPrice2 = 3.1;
+    const quantity2 = 20;
+
+    // Fix the price in the inventory
+    form.inventory.available.data[1].price = unitPrice1;
+    form.inventory.available.data[2].price = unitPrice2;
+
+    // Set up and verify the default currency and exchange rate
+    form.setCurrencyId(enterpriseCurrencyId);
+    form.setExchangeRate(enterpriseCurrencyRate);
+    expect(form.details.currency_id).to.equal(enterpriseCurrencyId);
+    expect(form.currentExchangeRate).to.equal(enterpriseCurrencyRate);
+
+    // Add a PO item to the form
+    const item1 = form.addItem();
+    item1.inventory_uuid = invUuid1;
+    item1._valid = true;
+    item1._invalid = !item1._valid;
+    form.configureItem(item1);
+    item1.quantity = quantity1;
+    item1._hasValidAccounts = true;
+    item1._initialised = true;
+
+    // Verify that the cost (in USD)
+    form.digest();
+    expect(form.details.cost).to.be.closeTo(quantity1 * unitPrice1 * enterpriseCurrencyRate, 1e-8);
+
+    // Now change to Euros
+    const euroExchangeRate = Mocks.exchange()[EUR].rate;
+    form.setCurrencyId(EUR);
+    form.setExchangeRate(euroExchangeRate);
+    expect(form.details.currency_id).to.equal(EUR);
+    expect(form.currentExchangeRate).to.equal(euroExchangeRate);
+
+    // Verify that the cost (in USD)
+    form.digest();
+    const expectedCost1 = quantity1 * unitPrice1 * euroExchangeRate;
+    expect(form.details.cost).to.be.closeTo(expectedCost1, 1e-8);
+
+    // Now add another item
+    const item2 = form.addItem();
+    item2.inventory_uuid = invUuid2;
+    item2._valid = true;
+    item2._invalid = !item1._valid;
+    form.configureItem(item2);
+    item2.quantity = quantity2;
+    item2._hasValidAccounts = true;
+    item2._initialised = true;
+
+    // Check the cost
+    form.digest();
+    const expectedCost2 = (quantity1 * unitPrice1 * euroExchangeRate)
+      + (quantity2 * unitPrice2 * euroExchangeRate);
+    expect(form.details.cost).to.be.closeTo(expectedCost2, 1e-8);
+  });
+
 });


### PR DESCRIPTION
Add a client unit test to check the correct recomputation of order costs when changing the currency while creating a purchase order.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5583
