### PR TITLE
Fix currency xls export

### DIFF
--- a/server/lib/renderers/html.js
+++ b/server/lib/renderers/html.js
@@ -86,6 +86,13 @@ async function renderHTML(data, template, options = {}) {
   debug(`rendering HTML file`);
 
   const html = await hbs.render(template, data);
+
+  // set back the default currency after the rendering
+  if (options.skipCurrencyRendering) {
+    hbs.helpers.currency = finance.currency;
+    hbs.helpers.debcred = finance.currency;
+  }
+
   return inlineSource(html, {
     attribute : false, rootpath : '/', compress : false, swallowErrors : true,
   });


### PR DESCRIPTION
This PR fixes the currency symbol deleted after the export to Xls.

The deletion of the currency symbol has been made intentionally to allow calculation in Excel, the issue was that the currency symbol was removed entirely in the entire BHIMA after export to Excel. With this PR we set back the default currency after the render of the Excel file.

Close #5798 