### PR TITLE
Fixed bugs in merge lots interface

### DIFF
--- a/client/src/modules/stock/lots/modals/duplicates.modal.js
+++ b/client/src/modules/stock/lots/modals/duplicates.modal.js
@@ -38,9 +38,7 @@ function DuplicateLotsModalController(data, Instance, Lots, Notify, $translate) 
     vm.selectedLot = lotSelected;
     vm.lots.forEach(lot => {
       lot.selected = lot.uuid === lotSelected.uuid;
-      if (lot.uuid === lotSelected.uuid) {
-        lot.merge = false;
-      }
+      lot.merge = false;
     });
   }
 

--- a/server/controllers/stock/lots.js
+++ b/server/controllers/stock/lots.js
@@ -139,7 +139,7 @@ function getCandidates(req, res, next) {
 function getDupes(req, res, next) {
   const options = db.convert(req.query, ['inventory_uuid']);
   const filters = new FilterParser(options, { tableAlias : 'l' });
-  filters.fullText('label');
+  filters.equals('label');
   filters.equals('inventory_uuid');
   filters.equals('entry_date');
   filters.equals('expiration_date');


### PR DESCRIPTION
Fixed the bugs in the lots merge interface.
The first problem is because the display of duplicate lots is based on label equality, but the lots shown when the user wants to merge specific lots used SQL "LIKE".
To fix the second issue (hopefully) I whenever the selected lot is changed, I clear the 'merge' attribute for all lots.  That way the flags for 'select' and 'merge' are always compatible.  I was not able to duplicate the problem after this fix.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5802
