### PR TITLE
Fix issues with the stock lots usage schedule

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -338,6 +338,7 @@
     "NEVER_EXHAUSTED": "Never",
     "NO_LOTS_FOUND": "No lots found that were not expired or exhausted!",
     "PROJECTION_BASIS": "This projection is based on current average consumption of {{avg_consumption}} {{unit_type}} per month.",
+    "REORDER_STOCK_TODAY": "Reorder this stock today!",
     "REORDER_STOCK_DATE": "Suggested date to reorder stock: {{reorder_date | date}}",
     "QUANTITY_USED": "Quantity used",
     "QUANTITY_WASTED": "Quantity wasted",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -339,6 +339,7 @@
     "NO_LOTS_FOUND": "Aucun lot trouvé qui ne soit pas périmé ou épuisé !",
     "PROJECTION_BASIS": "Cette projection est basée sur la consommation moyenne actuelle de {{avg_consumption}} {{unit_type}} par mois.",
     "REORDER_STOCK_DATE": "Date suggérée pour commander plus de stock: {{reorder_date | date}}",
+    "REORDER_STOCK_TODAY": "Commandez ce stock aujourd'hui!",
     "QUANTITY_USED": "Quantité utilisée",
     "QUANTITY_WASTED": "Quantité gaspillée",
     "VALUE_WASTED": "Valeur gaspillée",

--- a/client/src/modules/stock/lots/modals/schedule.modal.html
+++ b/client/src/modules/stock/lots/modals/schedule.modal.html
@@ -6,7 +6,7 @@
   <div class="modal-header">
     <ol class="headercrumb">
       <li translate class="static" style="font-weight: bold;">LOTS_SCHEDULE.TITLE</li>
-      <li class="title"><span translate>FORM.LABELS.FOR</span>: {{$ctrl.inventory_name}}</li>
+      <li class="title"><span translate>FORM.LABELS.FOR</span>: {{$ctrl.inventory_name}} [{{$ctrl.inventory_code}}]</li>
     </ol>
     <p>{{$ctrl.projection_text}}</p>
     <p ng-if="$ctrl.reorderSuggestion">{{$ctrl.reorderSuggestion}}</p>


### PR DESCRIPTION
This PR fixes/improves these issues:
- Prevents rounding errors from indicating articles being wasted when they are actually all used
- Start the lot usage schedule at 00:00AM of "today"
- Improve the message about the suggested date to order if the indicated order date is before today.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5825

Tested on Vanga and IMCK databases.