### PR TITLE
fix(reports): monthly analysis of balance cleanup

### DIFF
--- a/client/src/modules/reports/generate/monthly_balance/monthly_balance.config.js
+++ b/client/src/modules/reports/generate/monthly_balance/monthly_balance.config.js
@@ -2,24 +2,16 @@ angular.module('bhima.controllers')
   .controller('monthly_balanceController', monthlyBalanceController);
 
 monthlyBalanceController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'AccountService',
-  'FormatTreeDataService',
+  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
 ];
 
-function monthlyBalanceController($sce, Notify, SavedReports, AppCache, reportData, $state, Accounts, FormatTreeData) {
+function monthlyBalanceController($sce, Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('monthly_balance');
   const reportUrl = 'reports/finance/monthly_balance';
 
   vm.previewGenerated = false;
   vm.reportDetails = {};
-
-  Accounts.read()
-    .then(elements => {
-      // bind the accounts to the controller
-      const accounts = FormatTreeData.order(elements);
-      vm.accounts = accounts;
-    });
 
   vm.onSelectFiscalYear = (fiscalYear) => {
     vm.reportDetails.fiscal_id = fiscalYear.id;
@@ -33,6 +25,10 @@ function monthlyBalanceController($sce, Notify, SavedReports, AppCache, reportDa
   vm.clearPreview = function clearPreview() {
     vm.previewGenerated = false;
     vm.previewResult = null;
+  };
+
+  vm.onSelectAccount = function onSelectAccount(account) {
+    vm.account = account;
   };
 
   vm.preview = function preview(form) {

--- a/client/src/modules/reports/generate/monthly_balance/monthly_balance.html
+++ b/client/src/modules/reports/generate/monthly_balance/monthly_balance.html
@@ -31,7 +31,7 @@
               fiscal-year-id="ReportConfigCtrl.reportDetails.fiscal_id"
               period-id="ReportConfigCtrl.reportDetails.period_id"
               on-select-callback="ReportConfigCtrl.onSelectPeriod(period)">
-            </bh-period-selection>            
+            </bh-period-selection>
 
             <div class="form-group" ng-class="{'has-error' : ConfigForm.$submitted && ConfigForm.allAccount.$invalid }">
               <div class="radio">
@@ -68,27 +68,11 @@
             </div>
 
             <div ng-if="ReportConfigCtrl.reportDetails.allAccount === 0">
-              <div class="form-group"
-                   ng-class="{'has-error' : ConfigForm.account_id.$invalid && ConfigForm.$submitted}">
-                <label class="control-label" translate>FORM.LABELS.ACCOUNT</label>
-
-                <ui-select
-                  name="account_id"
-                  ng-model="ReportConfigCtrl.account"
-                  required>
-                  <ui-select-match placeholder="{{ 'FORM.LABELS.ACCOUNT' | translate }}">
-                    <span><strong>{{$select.selected.number}}</strong> {{$select.selected.label}}</span>
-                  </ui-select-match>
-                  <ui-select-choices ui-select-focus-patch repeat="account in ReportConfigCtrl.accounts | filter:{ 'hrlabel' : $select.search}">
-                    <span ng-bind-html="account.number | highlight:$select.search"></span>
-                    <small ng-bind-html="account.label | highlight:$select.search"></small>
-                  </ui-select-choices>
-                </ui-select>
-
-                <div class="help-block" ng-messages="ConfigForm.account_id.$error" ng-show="ConfigForm.$submitted">
-                  <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
-                </div>
-              </div>
+              <bh-account-select
+                account-id="ReportConfigCtrl.reportDetails.accountId"
+                on-select-callback="ReportConfigCtrl.onSelectAccount(account)"
+                exclude-title-accounts="true">
+              </bh-account-select>
             </div>
 
             <bh-loading-button loading-state="ConfigForm.$loading">

--- a/server/controllers/finance/reports/monthly_balance/report.handlebars
+++ b/server/controllers/finance/reports/monthly_balance/report.handlebars
@@ -1,4 +1,4 @@
-{{> head title="{{translate 'REPORT.MONTHLY_BALANCE.TITLE' }}" }}
+{{> head title="REPORT.MONTHLY_BALANCE.TITLE" }}
 
 <div class="container">
   {{> header}}
@@ -14,44 +14,41 @@
       {{/if}}
 
       <table class="table table-condensed table-report table-bordered">
+        <thead>
+          <th width="10%">{{translate 'FORM.LABELS.ACCOUNT_NUMBER'}}</th>
+          <th>{{translate 'FORM.LABELS.LABEL'}}</th>
+          <th width="10%">{{translate 'FORM.LABELS.DEBIT'}}</th>
+          <th width="10%">{{translate 'FORM.LABELS.CREDIT'}}</th>
+          <th width="10%">{{translate 'FORM.LABELS.AMOUNT'}}</th>
+        </thead>
+
         <tbody>
-          <tr style="padding:0;margin:0;border:none;">
-            <td style="padding:0;margin:0;border:none;">
-              <table class="table table-condensed table-report table-bordered">
-                <thead>
-                  <th width="10%">{{translate 'FORM.LABELS.ACCOUNT_NUMBER'}}</th>
-                  <th width="30%">{{translate 'FORM.LABELS.LABEL'}}</th>
-                  <th width="20%">{{translate 'FORM.LABELS.DEBIT'}}</th>
-                  <th width="20%">{{translate 'FORM.LABELS.CREDIT'}}</th>
-                  <th width="20%">{{translate 'FORM.LABELS.AMOUNT'}}</th>
-                </thead>
-                <tbody>
-                  {{#each this.exploitation}}
-                    {{#if amount}}
-                      <tr>
-                        <td class="text-right">{{number}}</td>
-                        <td {{#if title}}class="text-bold"{{/if}}>
-                          {{label}}
-                        </td>
-                        <td class="text-right">{{debcred debit ../currencyId}}</td>
-                        <td class="text-right">{{debcred credit ../currencyId}}</td>
-                        <td class="text-right">{{debcred amount ../currencyId}}</td>
-                      </tr>
-                    {{/if}}
-                  {{/each}}
-                </tbody>
-                {{#if allAccount}}
-                  <tfoot>
-                    <th class="text-right" colspan="2" width="10%">{{translate 'FORM.LABELS.TOTAL'}}</th>
-                    <th class="text-right" width="20%">{{debcred totalExploitation.debit ./currencyId}}</th>
-                    <th class="text-right" width="20%">{{debcred this.totalExploitation.credit ./currencyId}}</th>
-                    <th class="text-right" width="20%"></th>
-                  </tfoot>
-                {{/if}}  
-              </table>
-            </td>
-          </tr>
+          {{#each this.exploitation}}
+            {{#if amount}}
+              <tr>
+                <td class="text-right">{{number}}</td>
+                <td
+                  {{#if title}}class="text-bold"{{/if}}
+                  style="padding-left: calc(2px + ({{depth}} - 1) * 10px);">
+                  {{label}}
+                </td>
+                <td class="text-right">{{debcred debit ../currencyId}}</td>
+                <td class="text-right">{{debcred credit ../currencyId}}</td>
+                <td class="text-right">{{debcred amount ../currencyId}}</td>
+              </tr>
+            {{/if}}
+          {{/each}}
         </tbody>
+
+        {{#if allAccount}}
+          <tfoot>
+            <th class="text-right" colspan="2">{{translate 'FORM.LABELS.TOTAL'}}</th>
+            <th class="text-right">{{debcred totalExploitation.debit ./currencyId}}</th>
+            <th class="text-right">{{debcred this.totalExploitation.credit ./currencyId}}</th>
+            <th class="text-right"></th>
+          </tfoot>
+        {{/if}}
+
       </table>
     </div>
   </div>


### PR DESCRIPTION
This commit cleans up several items in the monthly analysis of the
balance sheet report.

1. The report is migrated to async/await.
2. Properly uses the tree library for calculation of totals.
3. Uses the `bhAccountSelect` to select accounts.
4. Makes the currency render in the enterprise currency.

Close #5242.

![image](https://user-images.githubusercontent.com/896472/128697729-47399c2d-564a-470a-8dd9-8d5f751c1d8f.png)
