### PR TITLE
5553: sort stock movements in decreasing order

### DIFF
--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -93,7 +93,6 @@ function StockMovementsController(
       field : 'fluxName',
       displayName : 'STOCK.FLUX',
       headerCellFilter : 'translate',
-      // cellTemplate : 'modules/stock/movements/templates/flux.cell.html',
     }, {
       field : 'cost',
       type : 'number',

--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -90,10 +90,10 @@ function StockMovementsController(
       headerCellFilter : 'translate',
       cellTemplate : 'modules/stock/movements/templates/io.cell.html',
     }, {
-      field : 'flux_id',
+      field : 'fluxName',
       displayName : 'STOCK.FLUX',
       headerCellFilter : 'translate',
-      cellTemplate : 'modules/stock/movements/templates/flux.cell.html',
+      // cellTemplate : 'modules/stock/movements/templates/flux.cell.html',
     }, {
       field : 'cost',
       type : 'number',
@@ -228,8 +228,10 @@ function StockMovementsController(
     // the column must be filtered on the translated text
     row.io = $translate.instant(row.is_exit === 0 ? 'STOCK.INPUT' : 'STOCK.OUTPUT');
 
+    const fluxName = $translate.instant(getFluxName(row.flux_id));
     // compute the fluxName from its ID
-    row.fluxName = getFluxName(row.flux_id);
+    row.fluxName = fluxName.concat(row.target ? ` - ${row.target}` : '').trim();
+
   }
 
   function toggleLoading() {

--- a/client/src/modules/stock/movements/templates/flux.cell.html
+++ b/client/src/modules/stock/movements/templates/flux.cell.html
@@ -1,3 +1,0 @@
-<div class="ui-grid-cell-contents" ng-if="!row.groupHeader">
-    {{ row.entity.fluxName }}
-</div>

--- a/client/src/modules/stock/movements/templates/flux.cell.html
+++ b/client/src/modules/stock/movements/templates/flux.cell.html
@@ -1,3 +1,3 @@
-<div class="ui-grid-cell-contents" ng-if="!row.groupHeader" translate>
+<div class="ui-grid-cell-contents" ng-if="!row.groupHeader">
     {{ row.entity.fluxName }}
 </div>

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -469,7 +469,7 @@ async function getMovements(depotUuid, params) {
   `;
 
   const finalClause = 'GROUP BY document_uuid, is_exit';
-  const orderBy = 'ORDER BY d.text, m.date';
+  const orderBy = 'ORDER BY d.text, m.date DESC';
   const movements = await getLots(sql, params, finalClause, orderBy);
 
   return movements;

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -456,7 +456,7 @@ async function getMovements(depotUuid, params) {
     m.flux_id, BUID(m.entity_uuid) AS entity_uuid, SUM(m.unit_cost * m.quantity) AS cost,
     f.label AS flux_label, BUID(m.invoice_uuid) AS invoice_uuid, dm.text AS documentReference,
     BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.text AS document_requisition,
-    u.display_name AS userName
+    u.display_name AS userName, IFNULL(em.text, IFNULL(serv.name, dp.text)) AS target
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
@@ -464,8 +464,12 @@ async function getMovements(depotUuid, params) {
     JOIN flux f ON f.id = m.flux_id
     JOIN user u ON u.id = m.user_id
     LEFT JOIN document_map dm ON dm.uuid = m.document_uuid
+    LEFT JOIN entity_map em ON em.uuid = m.entity_uuid
     LEFT JOIN service AS serv ON serv.uuid = m.entity_uuid
+    LEFT JOIN depot AS dp ON dp.uuid = m.entity_uuid
     LEFT JOIN document_map sr_m ON sr_m.uuid = m.stock_requisition_uuid
+
+
   `;
 
   const finalClause = 'GROUP BY document_uuid, is_exit';

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -456,7 +456,7 @@ async function getMovements(depotUuid, params) {
     m.flux_id, BUID(m.entity_uuid) AS entity_uuid, SUM(m.unit_cost * m.quantity) AS cost,
     f.label AS flux_label, BUID(m.invoice_uuid) AS invoice_uuid, dm.text AS documentReference,
     BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.text AS document_requisition,
-    u.display_name AS userName, IFNULL(em.text, IFNULL(serv.name, dp.text)) AS target
+    u.display_name AS userName, IFNULL(em.text, IFNULL(serv.name, IFNULL(dm2.text, dp.text))) AS target
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
@@ -467,6 +467,7 @@ async function getMovements(depotUuid, params) {
     LEFT JOIN entity_map em ON em.uuid = m.entity_uuid
     LEFT JOIN service AS serv ON serv.uuid = m.entity_uuid
     LEFT JOIN depot AS dp ON dp.uuid = m.entity_uuid
+    LEFT JOIN document_map dm2 ON dm2.uuid = m.entity_uuid
     LEFT JOIN document_map sr_m ON sr_m.uuid = m.stock_requisition_uuid
 
 


### PR DESCRIPTION
This PR does two things:

 1. Sorts the stock movements in decreasing order
 2. Adds in the reason for the stock movement to the registry.  This has a performance penalty, but in my tests it has been negligible.  There are ways to speed it up, but it will make the code more difficult to parse and think about.  If this becomes an issue, I can propose it.
 
 Some screenshots:
 
![image](https://user-images.githubusercontent.com/896472/129332262-53210ced-bb18-4389-8ccb-7a9cefcd5a79.png)
_Finding a particular patient by their ID_

![image](https://user-images.githubusercontent.com/896472/129332371-715f8162-42ed-45a5-b338-5d11895c9b55.png)
_All interactions (entries + exits) to pharmacies with PAX in the name_

![image](https://user-images.githubusercontent.com/896472/129332469-bffe404e-ba2d-41c2-b8b7-10513665dc72.png)
_Defaults to most recent to most ancient_

Closes #5553.
Partially addresses #5424.