### PR TITLE
fix: do not crash on no account references

### DIFF
--- a/server/controllers/finance/distributionFeeCenter/configuration.js
+++ b/server/controllers/finance/distributionFeeCenter/configuration.js
@@ -12,6 +12,7 @@ const fiscal = require('../fiscal');
 async function configuration(req, res, next) {
   try {
     const { query } = req;
+
     const params = {
       typeFeeCenter : query.typeFeeCenter,
       fee_center_id : query.fee_center_id,
@@ -20,6 +21,11 @@ async function configuration(req, res, next) {
     const accounts = await referenceAccount.auxilliary(params);
     const refAccounts = accounts;
     const accountsId = accounts.map(account => account.account_id);
+
+    if (accountsId.length === 0) {
+      res.status(200).json([]);
+      return;
+    }
 
     const options = {
       accounts_id : accountsId,
@@ -40,6 +46,7 @@ async function configuration(req, res, next) {
     if (query.fee_center_id || query.trans_id) {
       delete options.limit;
     }
+
     const rows = await generalLedger.findTransactions(options);
 
     rows.forEach(item => {

--- a/server/controllers/finance/distributionFeeCenter/proceed.js
+++ b/server/controllers/finance/distributionFeeCenter/proceed.js
@@ -5,7 +5,7 @@
 * of a profit or a cost, of an auxiliary center towards the main centers
 */
 const db = require('../../../lib/db');
-const BadRequest = require('../../../lib/errors/BadRequest');
+const { BadRequest } = require('../../../lib/errors');
 
 function proceed(req, res, next) {
   const { data } = req.body;

--- a/server/controllers/finance/distributionFeeCenter/setting.js
+++ b/server/controllers/finance/distributionFeeCenter/setting.js
@@ -1,27 +1,31 @@
 /**
 * Distribution Fee Center Controller
 *
-* This function is used to set the various distribution keys of the ancillary cost centers to the Main center.
+* This function is used to set the various distribution keys of the auxiliary cost centers to the main cost center.
 */
 
 const db = require('../../../lib/db');
 
 function setting(req, res, next) {
   const { data } = req.body;
+
   const dataValues = data.values;
+
   data.user_id = req.session.user.id;
+
   const distributionKey = [];
 
-  Object.entries(dataValues).forEach(([principalCenterId, rateDistribution]) => {
-    if (rateDistribution) {
-      distributionKey.push([
-        data.auxiliary_fee_center_id,
-        principalCenterId,
-        rateDistribution,
-        data.user_id,
-      ]);
-    }
-  });
+  Object.entries(dataValues)
+    .forEach(([principalCenterId, rateDistribution]) => {
+      if (rateDistribution) {
+        distributionKey.push([
+          data.auxiliary_fee_center_id,
+          principalCenterId,
+          rateDistribution,
+          data.user_id,
+        ]);
+      }
+    });
 
   const delDistribution = `DELETE FROM distribution_key WHERE auxiliary_fee_center_id = ?`;
 


### PR DESCRIPTION
This commit prevents an invalid SQL request from being executed when no account references exist.