### PR TITLE
Feat: add aggregate cost center table

### DIFF
--- a/server/models/admin.sql
+++ b/server/models/admin.sql
@@ -272,9 +272,10 @@ BEGIN
   DELETE FROM cost_center_aggregate;
 
   -- regenerate
-  INSERT INTO cost_center_aggregate (period_id, credit, debit, credit, cost_center_id, principal_center_id)
+  INSERT INTO cost_center_aggregate (period_id, credit, debit, cost_center_id, principal_center_id)
     SELECT period_id, SUM(credit_equiv) AS credit, SUM(debit_equiv) AS debit, cost_center_id, principal_center_id
     FROM general_ledger
+    WHERE cost_center_id IS NOT NULL
     GROUP BY cost_center_id, principal_center_id, period_id;
 END $$
 

--- a/server/models/admin.sql
+++ b/server/models/admin.sql
@@ -260,5 +260,22 @@ CREATE PROCEDURE zMergeDepots(
   DELETE FROM depot WHERE uuid =  _old_uuid;
 END$$
 
+/*
+ zRecalculateCostCenterAggregates
+
+ Removes all data from the cost_center_aggregate table and rebuilds it.
+*/
+CREATE PROCEDURE zRecalculateCostCenterAggregates()
+BEGIN
+
+  -- wipe the cost_center_aggregate table
+  DELETE FROM cost_center_aggregate;
+
+  -- regenerate
+  INSERT INTO cost_center_aggregate (period_id, credit, debit, credit, cost_center_id, principal_center_id)
+    SELECT period_id, SUM(credit_equiv) AS credit, SUM(debit_equiv) AS debit, cost_center_id, principal_center_id
+    FROM general_ledger
+    GROUP BY cost_center_id, principal_center_id, period_id;
+END $$
 
 DELIMITER ;

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -1,0 +1,35 @@
+/* migrate v1.21.0 to next */
+
+/**
+author: @jniles
+date: 2021-08-30
+description: adds cost columns and indices to relevant tables
+*/
+
+DROP TABLE IF EXISTS `cost_center_aggregate`;
+CREATE TABLE `cost_center_aggregate` (
+  `period_id`       MEDIUMINT(8) UNSIGNED NOT NULL,
+  `debit`           DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.00,
+  `credit`          DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.00,
+  `cost_center_id`  MEDIUMINT(8) UNSIGNED NOT NULL,
+  `principal_center_id` MEDIUMINT(8) UNSIGNED NULL,
+  KEY `cost_center_id` (`cost_center_id`),
+  KEY `principal_center_id` (`principal_center_id`),
+  KEY `period_id` (`period_id`),
+  CONSTRAINT `cost_center_aggregate__period` FOREIGN KEY (`period_id`) REFERENCES `period` (`id`),
+  CONSTRAINT `cost_center_aggregate__cost_center_id` FOREIGN KEY (`cost_center_id`) REFERENCES `fee_center` (`id`),
+  CONSTRAINT `cost_center_aggregate__principal_center_id` FOREIGN KEY (`principal_center_id`) REFERENCES `fee_center` (`id`)
+) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
+
+CALL add_column_if_missing('posting_journal', 'cost_center_id', 'MEDIUMINT(8) UNSIGNED NULL');
+CALL add_column_if_missing('posting_journal', 'principal_center_id', 'MEDIUMINT(8) UNSIGNED NULL');
+
+ALTER TABLE `posting_journal` ADD CONSTRAINT `pg__cost_center_1` FOREIGN KEY (`cost_center_id`) REFERENCES `fee_center` (`id`) ON UPDATE CASCADE;
+ALTER TABLE `posting_journal` ADD CONSTRAINT `pg__cost_center_2` FOREIGN KEY (`principal_center_id`) REFERENCES `fee_center` (`id`) ON UPDATE CASCADE;
+
+
+CALL add_column_if_missing('general_ledger', 'cost_center_id', 'MEDIUMINT(8) UNSIGNED NULL');
+CALL add_column_if_missing('general_ledger', 'principal_center_id', 'MEDIUMINT(8) UNSIGNED NULL');
+
+ALTER TABLE `general_ledger` ADD CONSTRAINT `general_ledger__cost_center_1` FOREIGN KEY (`cost_center_id`) REFERENCES `fee_center` (`id`) ON UPDATE CASCADE;
+ALTER TABLE `general_ledger` ADD CONSTRAINT `general_ledger__cost_center_2` FOREIGN KEY (`principal_center_id`) REFERENCES `fee_center` (`id`) ON UPDATE CASCADE;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -2580,7 +2580,7 @@ CREATE TABLE `cost_center_aggregate` (
   `debit`           DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.00,
   `credit`          DECIMAL(19,4) UNSIGNED NOT NULL DEFAULT 0.00,
   `cost_center_id`  MEDIUMINT(8) UNSIGNED NOT NULL,
-  `principal_center_id` MEDIUMINT(8) UNSIGNED NOT NULL,
+  `principal_center_id` MEDIUMINT(8) UNSIGNED NULL,
   KEY `cost_center_id` (`cost_center_id`),
   KEY `principal_center_id` (`principal_center_id`),
   KEY `period_id` (`period_id`),


### PR DESCRIPTION
This PR adds the back-end tables for aggregating costs by cost center and the stored procedure for generating it.  It should serve as a reference for how to create the table for step-down analysis.

Closes #5880.
Closes #5881.