### PR TITLE
feat: add users/stock movements to sys usage

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -708,6 +708,7 @@
             "SET_DATE": "Change Date",
             "SETTINGS": "Settings",
             "SEX": "Sex",
+            "STOCK_MOVEMENTS" : "Stock Movements",
             "SHIPPING_HANDLING_COST": "Shipping and handling costs",
             "INCLUDES_SHIPPING_HANDLING_COST": "Includes shipping & handling costs",
             "SHIPPING_HANDLING_COST_PARTIAL": "Shipping and handling costs (partial)",

--- a/client/src/i18n/en/users.json
+++ b/client/src/i18n/en/users.json
@@ -2,6 +2,7 @@
   "USERS" : {
     "ADDING_USER" : "New User",
     "ADD_USER" : "Add a New User",
+    "ACTIVE_USERS" : "Active users",
     "CREATE" : "Create",
     "CREATED" : "Created",
     "DESCRIPTION" : "User management unit and rights",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -708,6 +708,7 @@
             "SET_DATE": "Changer la Date",
             "SETTINGS": "Paramétrages",
             "SEX": "Sexe",
+            "STOCK_MOVEMENTS" : "Mouvements de stock",
             "SHIPPING_HANDLING_COST": "Frais d'expédition et de manutention",
             "INCLUDES_SHIPPING_HANDLING_COST": "Comprend les frais d'expédition et de manutention",
             "SHIPPING_HANDLING_COST_PARTIAL": "Frais d'expédition et de manutention (partielle)",

--- a/client/src/i18n/fr/users.json
+++ b/client/src/i18n/fr/users.json
@@ -2,6 +2,7 @@
   "USERS" : {
     "ADDING_USER" : "Ajout utilisateur",
     "ADD_USER" : "Ajouter utilisateur",
+    "ACTIVE_USERS" : "Utilisateurs actifs",
     "CREATE" : "Créer",
     "CREATED" : "Crée avec succés",
     "DESCRIPTION" : "Module de gestion des utilisateur et leurs droits",

--- a/server/controllers/finance/reports/systemUsage/index.js
+++ b/server/controllers/finance/reports/systemUsage/index.js
@@ -19,22 +19,33 @@ async function document(req, res, next) {
     const { date } = req.query;
 
     const patientsNbr = `
-      SELECT HOUR(created_at) as 'hour', COUNT(patient.uuid) as 'number'
+      SELECT HOUR(created_at) as 'hour', COUNT(patient.uuid) as 'number',
+        GROUP_CONCAT(DISTINCT user_id ORDER BY user_id) AS users
       FROM patient
       WHERE DATE(created_at) = DATE(?)
       GROUP BY HOUR(created_at)
     `;
 
     const invoicesNbr = `
-      SELECT HOUR(created_at)  as 'hour', COUNT(invoice.uuid) as 'number'
+      SELECT HOUR(created_at) as 'hour', COUNT(invoice.uuid) as 'number',
+        GROUP_CONCAT(DISTINCT user_id ORDER BY user_id) AS users
       FROM invoice
       WHERE DATE(created_at) = DATE(?)
       GROUP BY HOUR(created_at)
     `;
 
     const cashNbr = `
-      SELECT HOUR(created_at)  as 'hour', COUNT(cash.uuid) as 'number'
+      SELECT HOUR(created_at) as 'hour', COUNT(cash.uuid) as 'number',
+        GROUP_CONCAT(DISTINCT user_id ORDER BY user_id) AS users
       FROM cash
+      WHERE DATE(created_at) = DATE(?)
+      GROUP BY HOUR(created_at)
+    `;
+
+    const stockMovementNbr = `
+      SELECT HOUR(created_at) as 'hour', COUNT(DISTINCT document_uuid) as 'number',
+        GROUP_CONCAT(DISTINCT user_id ORDER BY user_id) AS users
+      FROM stock_movement
       WHERE DATE(created_at) = DATE(?)
       GROUP BY HOUR(created_at)
     `;
@@ -43,44 +54,82 @@ async function document(req, res, next) {
       patients,
       invoices,
       cashPayments,
+      stockMovements,
     ] = await Promise.all([
       db.exec(patientsNbr, date),
       db.exec(invoicesNbr, date),
       db.exec(cashNbr, date),
+      db.exec(stockMovementNbr, date),
     ]);
 
     const patientMap = _.groupBy(patients, 'hour');
     const cashPaymentMap = _.groupBy(cashPayments, 'hour');
     const invoicesMap = _.groupBy(invoices, 'hour');
+    const stockMovementsMap = _.groupBy(stockMovements, 'hour');
 
     const pivot = [];
 
     for (let i = 0; i < 25; i++) {
       const index = `${i}`;
       const row = {
-        hour : index, patients : 0, invoices : 0, cashPayments : 0,
+        hour : index, patients : 0, invoices : 0, cashPayments : 0, stockMovements : 0, users : 0,
       };
 
+      let aggregateUsers = '';
+
       if (patientMap[index]) {
-        row.patients = patientMap[index][0].number;
+        const { number, users } = patientMap[index][0];
+        row.patients = number;
+        aggregateUsers += users;
       }
 
       if (invoicesMap[index]) {
-        row.invoices = invoicesMap[index][0].number;
+        const { number, users } = invoicesMap[index][0];
+        row.invoices = number;
+        aggregateUsers += users;
       }
 
       if (cashPaymentMap[index]) {
-        row.cashPayments = cashPaymentMap[index][0].number;
+        const { number, users } = cashPaymentMap[index][0];
+        row.cashPayments = number;
+        aggregateUsers += users;
       }
+
+      if (stockMovementsMap[index]) {
+        const { number, users } = stockMovementsMap[index][0];
+        row.stockMovements = number;
+        aggregateUsers += users;
+      }
+
+      // make a unique array of users and count them
+      const users = aggregateUsers
+        .split(',')
+        .sort()
+        .filter((value, idx, arr) => arr.indexOf(value) === idx)
+        .length;
+
+      row.users = users;
 
       pivot.push(row);
     }
 
-    const cleaned = pivot.filter(row => (row.patients + row.invoices + row.cashPayments > 0));
+    const cleaned = pivot.filter(row => (row.patients + row.invoices + row.cashPayments + row.stockMovements > 0));
+
+    // aggregate all relevant
+    const aggregates = cleaned.reduce((agg, row) => {
+      agg.patients += row.patients;
+      agg.invoices += row.invoices;
+      agg.cashPayments += row.cashPayments;
+      agg.stockMovements += row.stockMovements;
+      return agg;
+    }, {
+      patients : 0, invoices : 0, cashPayments : 0, stockMovements : 0, users : 0,
+    });
 
     const result = await report.render({
       statDate : date,
       pivot : cleaned,
+      aggregates,
     });
 
     res.set(result.headers).send(result.report);

--- a/server/controllers/finance/reports/systemUsage/system.usage.handlebars
+++ b/server/controllers/finance/reports/systemUsage/system.usage.handlebars
@@ -19,23 +19,37 @@
         <thead>
           <tr style="background-color:#ddd;">
             <th class="text-center">{{translate 'FORM.LABELS.HOUR'}}</th>
-             <th class="text-center text-capitalize">{{translate 'FORM.LABELS.PATIENT'}}</th>
+            <th class="text-center text-capitalize">{{translate 'FORM.INFO.PATIENTS'}}</th>
             <th class="text-center">{{translate 'FORM.LABELS.INVOICES'}}</th>
             <th class="text-center ">{{translate 'FORM.LABELS.CASH_PAYMENTS'}}</th>
+            <th class="text-center ">{{translate 'FORM.LABELS.STOCK_MOVEMENTS'}}</th>
+            <th class="text-center text-capitalize">{{translate 'USERS.ACTIVE_USERS'}}</th>
           </tr>
         </thead>
         <tbody>
           {{#each pivot as |row|}}
             <tr>
-              <td  class="text-right">{{ row.hour }}h</td>
-              <td  class="text-right">{{ row.patients }}</td>
-              <td  class="text-right">{{ row.invoices }}</td>
-              <td  class="text-right">{{ row.cashPayments }}</td>
+              <td class="text-right">{{ row.hour }}h</td>
+              <td class="text-right">{{ row.patients }}</td>
+              <td class="text-right">{{ row.invoices }}</td>
+              <td class="text-right">{{ row.cashPayments }}</td>
+              <td class="text-right">{{ row.stockMovements }}</td>
+              <td class="text-right">{{ row.users}}</td>
             </tr>
             {{else}}
-                {{> emptyTable columns=4 }}
+                {{> emptyTable columns=6 }}
             {{/each}}
         </tbody>
+        <tfoot>
+          <tr style="background-color:#ddd;">
+            <th>{{translate "FORM.LABELS.TOTAL"}}</th>
+            <th class="text-right">{{ aggregates.patients }}</th>
+            <th class="text-right">{{ aggregates.invoices }}</th>
+            <th class="text-right">{{ aggregates.cashPayments }}</th>
+            <th class="text-right">{{ aggregates.stockMovements }}</th>
+            <th></th>
+          </tr>
+        </tfoot>
       </table>
     </div>
   </div>


### PR DESCRIPTION
Adds active user counts and stock movements to the system usage report.

Closes #5848.

![image](https://user-images.githubusercontent.com/896472/132200938-bc638c57-c807-400f-b682-632b8f0ed3b0.png)
