### PR TITLE
feat(invoices): automatically allocate costs

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -666,6 +666,7 @@
             "PRICE": "Price",
             "PRINCIPAL_2": "Principal",
             "PRINCIPAL": "Principal",
+            "PRINCIPAL_COST_CENTER" : "Principal Cost Center",
             "PRINT_ORIENTATION_LANDSCAPE":"Landscape",
             "PRINT_ORIENTATION_PORTRAIT":"Portrait",
             "PRINT_ORIENTATION":"Print Orientation",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -666,6 +666,7 @@
             "PRICE": "Prix",
             "PRINCIPAL_2": "Principal",
             "PRINCIPAL": "Principale",
+            "PRINCIPAL_COST_CENTER" : "Principale centre de coûts",
             "PRINT": "Imprimer",
             "PRINT_ORIENTATION_LANDSCAPE":"Paysage",
             "PRINT_ORIENTATION":"Orientation d'impression",

--- a/client/src/modules/journal/journal.js
+++ b/client/src/modules/journal/journal.js
@@ -318,6 +318,16 @@ function JournalController(
     headerCellFilter : 'translate',
     visible : false,
   }, {
+    field : 'costCenterLabel',
+    displayName : 'FORM.LABELS.COST_CENTER',
+    headerCellFilter : 'translate',
+    visible : false,
+  }, {
+    field : 'principalCenterLabel',
+    displayName : 'FORM.LABELS.PRINCIPAL_COST_CENTER',
+    headerCellFilter : 'translate',
+    visible : false,
+  }, {
     field : 'comment',
     displayName : 'FORM.LABELS.COMMENT',
     headerCellFilter : 'translate',

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -186,6 +186,8 @@ function buildTransactionQuery(options, posted) {
       p.comment, p.transaction_type_id, p.user_id, pro.abbr,
       pro.name AS project_name, tp.text AS transaction_type_text,
       a.number AS account_number, a.label AS account_label, p.trans_id_reference_number,
+      p.cost_center_id, cc.label as costCenterLabel,
+      p.principal_center_id, cp.label as principalCenterLabel,
       u.display_name ${includeExchangeRate}
     FROM ${table} p
       JOIN project pro ON pro.id = p.project_id
@@ -193,6 +195,8 @@ function buildTransactionQuery(options, posted) {
       LEFT JOIN transaction_type tp ON tp.id = p.transaction_type_id
       JOIN user u ON u.id = p.user_id
       JOIN currency c ON c.id = p.currency_id
+      LEFT JOIN cost_center cc ON cc.id = p.cost_center_id
+      LEFT JOIN cost_center cp ON cp.id = p.principal_center_id
       LEFT JOIN entity_map em ON em.uuid = p.entity_uuid
       LEFT JOIN document_map dm1 ON dm1.uuid = p.record_uuid
       LEFT JOIN document_map dm2 ON dm2.uuid = p.reference_uuid
@@ -211,6 +215,8 @@ function buildTransactionQuery(options, posted) {
   filters.equals('record_uuid');
   filters.equals('reference_uuid');
   filters.equals('currency_id');
+  filters.equals('cost_center_id');
+  filters.equals('principal_center_id');
 
   filters.equals('comment');
   filters.equals('hrEntity', 'text', 'em');
@@ -230,8 +236,6 @@ function buildTransactionQuery(options, posted) {
     'amount', '(credit = ? OR debit = ? OR credit_equiv = ? OR debit_equiv = ?)',
     [amount, amount, amount, amount],
   );
-
-  filters.custom('excludes_distributed', 'p.uuid NOT IN (SELECT fc.row_uuid FROM cost_center_allocation AS fc)');
 
   return {
     sql : filters.applyQuery(sql),

--- a/server/models/procedures/cost_center.sql
+++ b/server/models/procedures/cost_center.sql
@@ -16,7 +16,7 @@ BEGIN
 
 
   DROP TEMPORARY TABLE IF EXISTS cost_center_costs_with_indexes;
-  CREATE TEMPORARY TABLE cost_center_costs_with_indexes AS 
+  CREATE TEMPORARY TABLE cost_center_costs_with_indexes AS
     SELECT
         z.id, z.label AS cost_center_label,
         z.allocation_basis_id,
@@ -24,8 +24,8 @@ BEGIN
         z.step_order,
         z.`value` AS direct_cost,
         ccb.name AS cost_center_allocation_basis_label,
-        ccbv.quantity AS cost_center_allocation_basis_value  
-    FROM 
+        ccbv.quantity AS cost_center_allocation_basis_value
+    FROM
     (
         (
           SELECT
@@ -33,7 +33,7 @@ BEGIN
             SUM(cca.debit - cca.credit) AS `value`
           FROM cost_center AS fc
           JOIN cost_center_aggregate cca ON cca.principal_center_id = fc.id
-          JOIN `period` p ON p.id = cca.period_id 
+          JOIN `period` p ON p.id = cca.period_id
           LEFT JOIN cost_center_allocation_basis ccb ON ccb.id = fc.allocation_basis_id
           WHERE DATE(p.start_date) >= DATE(_dateFrom) AND DATE(p.end_date) <= DATE(_dateTo)
           GROUP BY cca.principal_center_id
@@ -45,14 +45,14 @@ BEGIN
             SUM(cca.debit - cca.credit) AS `value`
           FROM cost_center AS fc
           JOIN cost_center_aggregate cca ON cca.cost_center_id = fc.id AND cca.principal_center_id IS NULL
-          JOIN `period` p ON p.id = cca.period_id 
+          JOIN `period` p ON p.id = cca.period_id
           LEFT JOIN cost_center_allocation_basis ccb ON ccb.id = fc.allocation_basis_id
           WHERE DATE(p.start_date) >= DATE(_dateFrom) AND DATE(p.end_date) <= DATE(_dateTo)
           GROUP BY cca.cost_center_id
         )
-    ) AS z 
-    JOIN cost_center_allocation_basis_value ccbv ON ccbv.cost_center_id = z.id 
-    JOIN cost_center_allocation_basis ccb ON ccb.id = ccbv.basis_id 
+    ) AS z
+    JOIN cost_center_allocation_basis_value ccbv ON ccbv.cost_center_id = z.id
+    JOIN cost_center_allocation_basis ccb ON ccb.id = ccbv.basis_id
     ORDER by z.step_order ASC;
 
   SELECT

--- a/server/models/procedures/cost_centers.sql
+++ b/server/models/procedures/cost_centers.sql
@@ -9,10 +9,11 @@ DELIMITER $$
 
 @description
 Retrieves the cost center id for an account by using its account_id. Each account should
-have one and only one cost center.
+have one and only one cost center.  If an account does not have a cost center, NULL will be
+returned.
 
-NOTE(@jniles) - Currently, BHIMA does not guarantee this, but when we do make guarantees,
-we will be able to modify this function to do it.
+NOTE(@jniles) - Currently, BHIMA does not guarantee that only one cost center is associated with an
+account, but when we do make guarantees, we will be able to modify this function to do it.
 */
 CREATE FUNCTION GetCostCenterByAccountId(account_id INT)
 RETURNS MEDIUMINT(8) DETERMINISTIC
@@ -29,10 +30,11 @@ END $$
 
 @description
 Retrieves the cost center id for a service using its service_uuid.  Each service should have one
-and only one cost center assocaited with it.
+and only one cost center assocaited with it.  If a service does not have a cost center, NULL will
+be returned.
 
-NOTE(@jniles) - Currently, BHIMA does not guarantee this, but when we do make guarantees,
-we will be able to modify this function to do it.
+NOTE(@jniles) - Currently, BHIMA does not guarantee that only one cost center is associated with a
+service, but when we do make guarantees, we will be able to modify this function to do it.
 */
 CREATE FUNCTION GetCostCenterByServiceUuid(service_uuid BINARY(16))
 RETURNS MEDIUMINT(8) DETERMINISTIC

--- a/server/models/procedures/invoicing.sql
+++ b/server/models/procedures/invoicing.sql
@@ -7,6 +7,15 @@ DELIMITER $$
   methods.  As temporary tables, they are scoped to the current connection,
   meaning that all other methods _must_ be called in the same database
   transaction.  Once the connection terminates, the tables are cleaned up.
+
+
+  NOTE
+  The CopyInvoiceToPostingJournal procedure also handles cost center allocation by the following logic:
+    a) If a cost center exists for that account, use the account's cost center.
+    b) If no cost center exists for the account, use the cost center of the service selected in the invoice.
+
+  This logic applies to invoice_items, invoicing_fees, and subsidies.  As long as each service is assigned a cost center,
+  every income/expense line in the invoice transaction will have
 */
 
 
@@ -403,6 +412,7 @@ BEGIN
   DECLARE iuserId INT;
   DECLARE idescription TEXT;
   DECLARE iaccountId INT;
+  DECLARE serviceCostCenterId INT;
 
   DECLARE transIdNumberPart INT;
 
@@ -456,8 +466,8 @@ BEGIN
   SET transIdNumberPart = GetTransactionNumberPart(transId, projectId);
 
   -- set the invoice variables
-  SELECT cost, debtor_uuid, date, user_id, description
-    INTO icost, ientityId, idate, iuserId, idescription
+  SELECT cost, debtor_uuid, date, user_id, description, GetCostCenterByServiceUuid(service_uuid)
+    INTO icost, ientityId, idate, iuserId, idescription, serviceCostCenterId
   FROM invoice WHERE invoice.uuid = iuuid;
 
   -- set the transaction variables (account)
@@ -546,12 +556,12 @@ BEGIN
   INSERT INTO posting_journal (
     uuid, project_id, fiscal_year_id, period_id, trans_id, trans_id_reference_number, trans_date,
     record_uuid, description, account_id, debit, credit, debit_equiv,
-    credit_equiv, currency_id, transaction_type_id, user_id
+    credit_equiv, currency_id, transaction_type_id, user_id, cost_center_id
   )
    SELECT
     HUID(UUID()), i.project_id, fiscalYearId, periodId, transId, transIdNumberPart, i.date, i.uuid,
     CONCAT(dm.text,': ', inv.text) as txt, ig.sales_account, ii.debit, ii.credit, ii.debit, ii.credit,
-    currencyId, 11, i.user_id
+    currencyId, 11, i.user_id, IFNULL(GetCostCenterByAccountId(ig.sales_account), serviceCostCenterId)
   FROM invoice AS i JOIN invoice_item AS ii JOIN inventory as inv JOIN inventory_group AS ig JOIN document_map as dm ON
     i.uuid = ii.invoice_uuid AND
     ii.inventory_uuid = inv.uuid AND
@@ -563,11 +573,11 @@ BEGIN
   INSERT INTO posting_journal (
     uuid, project_id, fiscal_year_id, period_id, trans_id, trans_id_reference_number, trans_date,
     record_uuid, description, account_id, debit, credit, debit_equiv,
-    credit_equiv, currency_id, transaction_type_id, user_id
+    credit_equiv, currency_id, transaction_type_id, user_id, cost_center_id
   ) SELECT
     HUID(UUID()), i.project_id, fiscalYearId, periodId, transId, transIdNumberPart, i.date, i.uuid,
     i.description, su.account_id, isu.value, 0, isu.value, 0, currencyId, 11,
-    i.user_id
+    i.user_id,  IFNULL(GetCostCenterByAccountId(su.account_id), serviceCostCenterId)
   FROM invoice AS i JOIN invoice_subsidy AS isu JOIN subsidy AS su ON
     i.uuid = isu.invoice_uuid AND
     isu.subsidy_id = su.id
@@ -577,11 +587,11 @@ BEGIN
   INSERT INTO posting_journal (
     uuid, project_id, fiscal_year_id, period_id, trans_id, trans_id_reference_number, trans_date,
     record_uuid, description, account_id, debit, credit, debit_equiv,
-    credit_equiv, currency_id, transaction_type_id, user_id
+    credit_equiv, currency_id, transaction_type_id, user_id, cost_center_id
   ) SELECT
     HUID(UUID()), i.project_id, fiscalYearId, periodId, transId, transIdNumberPart, i.date, i.uuid,
     i.description, b.account_id, 0, ib.value, 0, ib.value, currencyId, 11,
-    i.user_id
+    i.user_id, IFNULL(GetCostCenterByAccountId(b.account_id), serviceCostCenterId)
   FROM invoice AS i JOIN invoice_invoicing_fee AS ib JOIN invoicing_fee AS b ON
     i.uuid = ib.invoice_uuid AND
     ib.invoicing_fee_id = b.id


### PR DESCRIPTION
This commit implements the automatic cost allocation during invoicing. The logic is that any income/expense account that is associated with a cost center is assigned that cost center when writing to the posting_journal.  If the account is not assigned, we default to the service's cost center.

This applies to all invoice_items, invoicing_fees, and invoice_subsidies.

Note: I haven't implemented the calculation of the cost_center_aggregate because @lomamech did that in his PR.

Closes #5855.

Here is an example of the test dataset with cost centers allocated:
![image](https://user-images.githubusercontent.com/896472/134312745-a841f0ec-153d-426f-920b-4f31d4e1ee88.png)

-----

@mbayopanda @lomamech @jmcameron this shows how we can automatically assign cost centers to transactions made during invoicing.  The same kind of logic will apply to stock exits and payroll.  Please review this code and let me know what your thoughts are.

I haven't used the `principal_center_id` here, and I'm less sure that we need it.  I think directly assigning the income/costs may be enough without the `principal_center_id`.
