### PR TITLE
feat(stock): add sale value on stock value report

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -715,6 +715,7 @@
             "SALE_ID": "Sale ID",
             "SALE_RESPONSIBLE": "Seller",
             "SALE": "Sale",
+            "SALE_VALUE" : "Sale Value",
             "SEARCH_QUERIES": "Search Queries",
             "SEARCH": "Search",
             "SECOND_NAME": "Last Name",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -715,6 +715,7 @@
             "SALE_ID": "Vente ID",
             "SALE_RESPONSIBLE": "Responsable des ventes",
             "SALE": "Vente",
+            "SALE_VALUE": "Valeur de vente",
             "SEARCH": "Chercher",
             "SEARCH_QUERIES": "Requêtes de recherche",
             "SECOND_NAME": "Nom",

--- a/server/controllers/stock/reports/stock_value.report.handlebars
+++ b/server/controllers/stock/reports/stock_value.report.handlebars
@@ -29,28 +29,32 @@
             <tr style="background-color:#ddd;">
               <th class="text-center">{{translate 'FORM.LABELS.CODE'}}</th>
               <th class="text-center">{{translate 'FORM.LABELS.INVENTORY'}}</th>
-              <th class="text-center">{{translate 'FORM.LABELS.INVENTORY_PRICE'}}</th>
               <th class="text-center">{{translate 'FORM.LABELS.QUANTITY'}}</th>
               <th class="text-center">{{translate 'STOCK.UNIT_COST'}}</th>
               <th class="text-center">{{translate 'FORM.LABELS.VALUE'}}</th>
+              <th class="text-center">{{translate 'FORM.LABELS.INVENTORY_PRICE'}}</th>
+              <th class="text-center">{{translate 'FORM.LABELS.SALE_VALUE'}}</th>
             </tr>
           </thead>
           <tbody>
             {{#each stockValues}}
-              <tr>
+            <tr {{#if hasWarning}}class="text-danger bg-danger"{{/if}} >
                 <td>{{inventory_code}}</td>
                 <td style="width:50%">{{inventory_name}}</td>
-                <td class="text-right">{{currency inventoryPrice ../currency_id 4}}</td>
                 <td class="text-right">{{stockQtyPurchased}}</td>
                 <td class="text-right">{{currency stockUnitCost ../currency_id 4}}</td>
-                <td class="text-right">{{currency stockValue ../currency_id}}</td>
+                <td class="text-right">{{currency stockValue ../currency_id 2}}</td>
+                <td class="text-right">{{currency inventoryPrice ../currency_id 4}}</td>
+                <td class="text-right">{{currency saleValue ../currency_id 2}}</td>
               </tr>
           {{else}}
-            {{> emptyTable columns=4}}
+            {{> emptyTable columns=7}}
           {{/each}}
           <tr>
             <th colspan="4" class="text-right">{{ translate "FORM.LABELS.VALUE_IN_STOCK"}}</th>
-            <th class="text-right">{{ currency stockTotalValue currency_id }}</th>
+            <th class="text-right">{{currency stockTotalValue currency_id 2}}</th>
+            <th class="text-right">{{ translate "FORM.LABELS.SALE_VALUE"}}</th>
+            <th class="text-right">{{ currency stockTotalSaleValue currency_id 2}}</th>
           </tr>
           </tbody>
         </table>


### PR DESCRIPTION
Adds the stock's sale value on the stock value report.  It also displays a red warning if the sale value is less than the stock's value to alert users of potential mistakes.

Closes #5847.

Here is an example:
![image](https://user-images.githubusercontent.com/896472/134323350-9ecfe3c2-c5e1-4858-b15c-bdc8350d6741.png)
