### PR TITLE
feat(journal): edit cost centers

### DIFF
--- a/client/src/i18n/en/vouchers.json
+++ b/client/src/i18n/en/vouchers.json
@@ -15,6 +15,7 @@
       "ERROR_TOTALS": "The totals are not balanced",
       "ERROR_PRECISION": "The amounts entered cannot have more than 4 decimal places in precision",
       "ERROR_NEGATIVE_NUMBERS": "There are negative numbers detected",
+      "ERROR_COST_CENTER_ON_OTHER_ACCOUNT" : "There are cost centers on non-income/expense accounts",
       "INVALID_VALUES": "There are invalid values detected",
       "PATIENT_INVOICE": "Patient Invoice",
       "REFERENCE": "Reference",

--- a/client/src/i18n/fr/vouchers.json
+++ b/client/src/i18n/fr/vouchers.json
@@ -15,6 +15,7 @@
       "ERROR_PRECISION": "Les quantités saisies ne peuvent pas avoir plus de 4 décimales dans la précision",
       "ERROR_TOTALS": "Les totaux ne sont pas balancés",
       "ERROR_NEGATIVE_NUMBERS": "Détection des nombres négatives",
+      "ERROR_COST_CENTER_ON_OTHER_ACCOUNT" : "Il existe des centres de coûts sur les comptes hors revenus/dépenses",
       "INVALID_VALUES": "Détection des valeurs invalides",
       "PATIENT_INVOICE": "Facture du patient",
       "REFERENCE": "Référence",

--- a/client/src/js/filters/bytes.js
+++ b/client/src/js/filters/bytes.js
@@ -1,5 +1,5 @@
 angular.module('bhima.filters')
-.filter('bytes', BytesFilter);
+  .filter('bytes', BytesFilter);
 
 BytesFilter.$inject = ['$translate'];
 
@@ -8,16 +8,13 @@ BytesFilter.$inject = ['$translate'];
  * Format bytes size to human readable format
  */
 function BytesFilter($translate) {
-	return function(bytes, precision) {
-		if (isNaN(parseFloat(bytes)) || !isFinite(bytes)) { return '-'; }
-		if (typeof precision === 'undefined') { precision = 1; }
-		var units = ['SIZE_BYTES', 'SIZE_KB', 'SIZE_MB', 'SIZE_GB', 'SIZE_TB', 'SIZE_TB'],
-				number = Math.floor(Math.log(bytes) / Math.log(1024));
+  return function bytesfilter(bytes, precision = 1) {
+    if (Number.isNaN(parseFloat(bytes)) || !Number.isFinite(bytes)) { return '-'; }
+    let units = ['SIZE_BYTES', 'SIZE_KB', 'SIZE_MB', 'SIZE_GB', 'SIZE_TB', 'SIZE_TB'];
+    const number = Math.floor(Math.log(bytes) / Math.log(1024));
 
-		units = units.map(function (unit) {
-			return $translate.instant('FORM.LABELS.' + unit);
-		});
+    units = units.map((unit) => $translate.instant(`FORM.LABELS.${unit}`));
 
-		return (bytes / Math.pow(1024, Math.floor(number))).toFixed(precision) +  ' ' + units[number];
-	};
+    return `${(bytes / (1024 ** Math.floor(number))).toFixed(precision)} ${units[number]}`;
+  };
 }

--- a/client/src/js/services/TransactionService.js
+++ b/client/src/js/services/TransactionService.js
@@ -1,9 +1,9 @@
 angular.module('bhima.services')
   .service('TransactionService', TransactionService);
 
-TransactionService.$inject = ['$http', 'util', '$uibModal'];
+TransactionService.$inject = ['$http', 'util', '$uibModal', 'AccountService'];
 
-function TransactionService($http, util, Modal) {
+function TransactionService($http, util, Modal, Accounts) {
   const service = this;
   const baseUrl = '/transactions/';
 
@@ -79,6 +79,7 @@ function TransactionService($http, util, Modal) {
   const ERROR_SINGLE_ROW_TRANSACTION = 'TRANSACTIONS.SINGLE_ROW_TRANSACTION';
   const ERROR_INVALID_DEBITS_AND_CREDITS = 'VOUCHERS.COMPLEX.ERROR_AMOUNT';
   const ERROR_NEGATIVE_NUMBERS = 'VOUCHERS.COMPLEX.ERROR_NEGATIVE_NUMBERS';
+  const ERROR_COST_CENTER_ON_OTHER_ACCOUNT = 'VOUCHERS.COMPLEX.ERROR_COST_CENTER_ON_OTHER_ACCOUNT';
 
   /**
    * @function offlineValidation
@@ -122,6 +123,11 @@ function TransactionService($http, util, Modal) {
       const hasSingleNumericValue = !util.xor(Boolean(row.debit), Boolean(row.credit));
       if (hasSingleNumericValue) {
         return ERROR_INVALID_DEBITS_AND_CREDITS;
+      }
+
+      const hasCostCenters = row.cost_center_id || row.principal_center_id;
+      if (hasCostCenters && !Accounts.isIncomeOrExpenseAccountTypeId(row.account_type_id)) {
+        return ERROR_COST_CENTER_ON_OTHER_ACCOUNT;
       }
 
       credits += row.credit;

--- a/client/src/modules/accounts/AccountStoreService.js
+++ b/client/src/modules/accounts/AccountStoreService.js
@@ -17,7 +17,6 @@ function AccountStoreService($q, Accounts, AccountTypes, Store) {
   let initTypeLoad = true;
   service.accounts = accountStore;
   service.types = typeStore;
-
   const accounts = new Store();
   const accountTypes = new Store();
 

--- a/client/src/modules/accounts/accounts.service.js
+++ b/client/src/modules/accounts/accounts.service.js
@@ -16,7 +16,7 @@ function AccountService(Api, bhConstants, HttpCache) {
   const baseUrl = '/accounts/';
   const service = new Api(baseUrl);
 
-  // debounce the read() method by 250 milliseconds to avoid needless GET requests
+  // debounce the read() method by 250 milliseconds to avoid needless GET requests service.read = read;
   service.read = read;
   service.label = label;
 
@@ -27,6 +27,7 @@ function AccountService(Api, bhConstants, HttpCache) {
   service.filterAccountByType = filterAccountsByType;
   service.downloadAccountsTemplate = downloadAccountsTemplate;
   service.redCreditCell = redCreditCell;
+  service.isIncomeOrExpenseAccountTypeId = isIncomeOrExpenseAccountTypeId;
 
   /**
    * @method getOpeningBalance
@@ -100,6 +101,11 @@ function AccountService(Api, bhConstants, HttpCache) {
     return accounts.filter(account => {
       return account.type_id !== type;
     });
+  }
+
+  // return true if the account is an income or expense
+  function isIncomeOrExpenseAccountTypeId(typeId) {
+    return [bhConstants.accounts.INCOME, bhConstants.accounts.EXPENSE].includes(typeId);
   }
 
   /**

--- a/client/src/modules/journal/ui-grid-edit-account.directive.js
+++ b/client/src/modules/journal/ui-grid-edit-account.directive.js
@@ -6,40 +6,38 @@ uiGridEditAccount.$inject = ['uiGridEditConstants', 'AccountService', 'uiGridCon
 function uiGridEditAccount(uiGridEditConstants, Accounts, uiGridConstants, $timeout) {
   return {
     restrict : 'A',
-    template : function () {
-      var templ =
-        '<div style="display: table; margin-right: auto; margin-left: auto; width:95%">' +
-        '  <input type="text" autofocus ' +
-        '    style="width:100%" ' +
-        '    ng-model="accountInputValue" ' +
-        '    uib-typeahead="account.id as account.hrlabel for account in accounts | filter:{\'hrlabel\':$viewValue} | limitTo:8" ' +
-        '    typeahead-min-length="1" ' +
-        '    typeahead-editable ="false" ' +
-        '    typeahead-append-to-body="true" ' +
-        '    typeahead-on-select="setAccountOnRow(row.entity, $item)" />' +
-        '</div>';
-
-      return templ;
+    template() {
+      return `
+<div style="display: table; margin-right: auto; margin-left: auto; width:95%">'
+  <input type="text" autofocus '
+    style="width:100%" '
+    ng-model="accountInputValue" '
+    uib-typeahead="account.id as account.hrlabel for account in accounts | filter:{'hrlabel':$viewValue} | limitTo:8" '
+    typeahead-min-length="1" '
+    typeahead-editable ="false" '
+    typeahead-append-to-body="true" '
+    typeahead-on-select="setAccountOnRow(row.entity, $item)" />'
+</div>`;
     },
     require : ['?^uiGrid', '?^uiGridRenderContainer'],
     scope   : true,
-    compile : function () {
+    compile() {
       return {
-        post : function ($scope, $elm, $attrs, controllers) {
-          var uiGridCtrl = controllers[0];
-          var renderContainerCtrl = controllers[1];
+        post($scope, $elm, $attrs, controllers) {
+          const uiGridCtrl = controllers[0];
+          const renderContainerCtrl = controllers[1];
 
           Accounts.read()
-            .then(function (accounts) {
+            .then((accounts) => {
               $scope.accounts = Accounts.filterTitleAccounts(accounts);
             });
 
           // checks to see if a click landed in a dropdown menu - if so, it's probably the typeahead's.
           // if not, it is external and we should end the edit session
-          var onWindowClick = function (evt) {
-            var classNamed = angular.element(evt.target).attr('class');
+          const onWindowClick = function (evt) {
+            const classNamed = angular.element(evt.target).attr('class');
             if (classNamed) {
-              var isAccountTypeaheadElement = (classNamed.indexOf('dropdown-menu') > -1);
+              const isAccountTypeaheadElement = (classNamed.indexOf('dropdown-menu') > -1);
               if (!isAccountTypeaheadElement && evt.target.nodeName !== 'INPUT') {
                 $scope.stopEdit(evt);
               }
@@ -48,33 +46,32 @@ function uiGridEditAccount(uiGridEditConstants, Accounts, uiGridConstants, $time
             }
           };
 
-          var onCellClick = function (evt) {
+          const onCellClick = function (evt) {
             angular.element(document.querySelectorAll('.ui-grid-cell-contents')).off('click', onCellClick);
             $scope.stopEdit(evt);
           };
 
-          $scope.stopEdit = function(evt) {
+          $scope.stopEdit = function stopEdit() {
             $scope.$emit(uiGridEditConstants.events.END_CELL_EDIT);
           };
 
-          $scope.$on('$destroy', function () {
+          $scope.$on('$destroy', () => {
             angular.element(window).off('click', onWindowClick);
           });
 
-          $scope.setAccountOnRow = function (row, account) {
+          $scope.setAccountOnRow = function setAccountOnRow(row, account) {
             row.account_id = account.id;
             row.account_name = account.label;
             row.account_number = account.number;
             row.account_label = account.label;
+            row.account_type_id = account.type_id;
           };
 
-          $scope.$on(uiGridEditConstants.events.BEGIN_CELL_EDIT, function () {
+          $scope.$on(uiGridEditConstants.events.BEGIN_CELL_EDIT, () => {
             $scope.accountInputValue = '';
 
             if (uiGridCtrl.grid.api.cellNav) {
-              uiGridCtrl.grid.api.cellNav.on.navigate($scope, function (newRowCol, oldRowCol) {
-                $scope.stopEdit();
-              });
+              uiGridCtrl.grid.api.cellNav.on.navigate($scope, (/* newRowCol, oldRowCol */) => { $scope.stopEdit(); });
             } else {
               angular.element(document.querySelectorAll('.ui-grid-cell-contents')).on('click', onCellClick);
             }
@@ -84,16 +81,16 @@ function uiGridEditAccount(uiGridEditConstants, Accounts, uiGridConstants, $time
           });
 
           function focusTypeaheadInput() {
-            var $input = $elm.querySelectorAll('input')[0];
+            const $input = $elm.querySelectorAll('input')[0];
             $input.focus();
           }
 
-          $elm.on('keydown', function(evt) {
-            switch (evt.keyCode) {
-              case uiGridConstants.keymap.ESC:
-                evt.stopPropagation();
-                $scope.$emit(uiGridEditConstants.events.CANCEL_CELL_EDIT);
-                break;
+          $elm.on('keydown', (evt) => {
+            switch (evt.keyCode) { // eslint-disable-line
+            case uiGridConstants.keymap.ESC:
+              evt.stopPropagation();
+              $scope.$emit(uiGridEditConstants.events.CANCEL_CELL_EDIT);
+              break;
             }
 
             if (uiGridCtrl && uiGridCtrl.grid.api.cellNav) {
@@ -102,7 +99,7 @@ function uiGridEditAccount(uiGridEditConstants, Accounts, uiGridConstants, $time
                 $scope.stopEdit(evt);
               }
             } else {
-              switch (evt.keyCode) {
+              switch (evt.keyCode) {  // eslint-disable-line
               case uiGridConstants.keymap.ENTER:
               case uiGridConstants.keymap.TAB:
                 evt.stopPropagation();
@@ -118,4 +115,3 @@ function uiGridEditAccount(uiGridEditConstants, Accounts, uiGridConstants, $time
     },
   };
 }
-

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -185,8 +185,8 @@ function buildTransactionQuery(options, posted) {
       BUID(p.reference_uuid) AS reference_uuid, dm2.text AS hrReference,
       p.comment, p.transaction_type_id, p.user_id, pro.abbr,
       pro.name AS project_name, tp.text AS transaction_type_text,
-      a.number AS account_number, a.label AS account_label, p.trans_id_reference_number,
-      p.cost_center_id, cc.label as costCenterLabel,
+      a.number AS account_number, a.type_id AS account_type_id, a.label AS account_label,
+      p.trans_id_reference_number, p.cost_center_id, cc.label as costCenterLabel,
       p.principal_center_id, cp.label as principalCenterLabel,
       u.display_name ${includeExchangeRate}
     FROM ${table} p

--- a/test/client-unit/services/TransactionService.spec.js
+++ b/test/client-unit/services/TransactionService.spec.js
@@ -2,7 +2,7 @@
 /* eslint no-unused-expressions:off */
 describe('TransactionService', () => {
 
-  beforeEach(module('angularMoment', 'bhima.services', 'ui.bootstrap'));
+  beforeEach(module('angularMoment', 'bhima.services', 'ui.bootstrap', 'bhima.constants'));
 
   let Transactions;
   beforeEach(inject(TransactionService => {
@@ -223,7 +223,6 @@ describe('TransactionService', () => {
     const message = Transactions.offlineValidation(rows);
     expect(message).to.equal('TRANSACTIONS.SINGLE_ACCOUNT_TRANSACTION');
   });
-
 
   it('#offlineValidation() should error if there is not a transaction type per row', () => {
     const rows = angular.copy(dataset);


### PR DESCRIPTION
Implements the ability to edit cost centers directly in the posting journal with the following rules:
  1. Only income/expense accounts can have cost centers attached to them.
  2. If the user changes the account, the cost center is cleared.
  3. An error is shown on the account edit modal if the first rule is violated.

The user can also remove cost centers by simply selecting the blank "null" cost center in the top of the list of cost centers.

Here is what it looks like:

![ENljaFH2sq](https://user-images.githubusercontent.com/896472/134491746-124b0d12-73d1-4a2c-afcd-f5e9ae60ad63.gif)

Closes #5934.