### PR TITLE
Fix migration script on production

### DIFF
--- a/client/src/modules/cost_center/modals/cost_center.modal.html
+++ b/client/src/modules/cost_center/modals/cost_center.modal.html
@@ -66,7 +66,7 @@
               name="auxiliary"
               ng-value="1"
               ng-model="CostCenterModalCtrl.costCenter.is_cost"
-              ng-click="CostCenterModalCtrl.costCenter(true)"
+              ng-click="CostCenterModalCtrl.setCostCenterMeta(true)"
               id="is_cost"
               >
             <span translate>FORM.LABELS.COST_CENTER </span>
@@ -78,7 +78,7 @@
               name="auxiliary"
               ng-value="0"
               ng-model="CostCenterModalCtrl.costCenter.is_cost"
-              ng-click="CostCenterModalCtrl.costCenter(false)"
+              ng-click="CostCenterModalCtrl.setCostCenterMeta(false)"
               id="is_profit"
               >
             <span translate>FORM.LABELS.PROFIT_CENTER </span>

--- a/client/src/modules/cost_center/modals/edit_allocation_basis.modal.js
+++ b/client/src/modules/cost_center/modals/edit_allocation_basis.modal.js
@@ -68,6 +68,7 @@ function AllocationBasisEditController(CostCenter, AllocationBasisService, Modal
     field : 'name',
     displayName : 'TABLE.COLUMNS.NAME',
     headerCellFilter : 'translate',
+    cellFilter : 'translate',
     width : '25%',
   }, {
     field : 'description',

--- a/client/src/modules/reports/generate/cost_center_step_down/cost_center_step_down.config.js
+++ b/client/src/modules/reports/generate/cost_center_step_down/cost_center_step_down.config.js
@@ -1,19 +1,19 @@
 angular.module('bhima.controllers')
-  .controller('cost_center_step_downController', FeeCenterStepdownReportConfigController);
+  .controller('cost_center_step_downController', CostCenterStepdownReportConfigController);
 
-FeeCenterStepdownReportConfigController.$inject = [
+CostCenterStepdownReportConfigController.$inject = [
   '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
 ];
 
 /**
- * @function FeeCenterStepdownReportConfigController
+ * @function CostCenterStepdownReportConfigController
  *
  * @description
  * This function renders the cost_center_step_down report.
  */
-function FeeCenterStepdownReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function CostCenterStepdownReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
-  const cache = new AppCache('FeeCenterStepdownReport');
+  const cache = new AppCache('CostCenterStepdownReport');
   const reportUrl = 'reports/finance/cost_center_step_down';
 
   vm.previewGenerated = false;

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -141,7 +141,7 @@ description: Add cost basis items
 INSERT IGNORE INTO `cost_center_allocation_basis` VALUES
   (1, 'ALLOCATION_BASIS_DIRECT_COST', '', 'ALLOCATION_BASIS_DIRECT_COST_DESCRIPTION', 1),
   (2, 'ALLOCATION_BASIS_NUM_EMPLOYEES', '', 'ALLOCATION_BASIS_NUM_EMPLOYEES_DESCRIPTION', 1),
-  (3, 'ALLOCATION_BASIS_AREA_USED', 'm�', 'ALLOCATION_BASIS_AREA_USED_DESCRIPTION', 1),
+  (3, 'ALLOCATION_BASIS_AREA_USED', 'm²', 'ALLOCATION_BASIS_AREA_USED_DESCRIPTION', 1),
   (4, 'ALLOCATION_BASIS_ELECTRICITY_CONSUMED', 'kWh', 'ALLOCATION_BASIS_ELECTRICITY_CONSUMED_DESCRIPTION', 1),
   (5, 'ALLOCATION_BASIS_NUM_COMPUTERS', '', 'ALLOCATION_BASIS_NUM_COMPUTERS_DESCRIPTION', 1),
   (6, 'ALLOCATION_BASIS_NUM_LABOR_HOURS', 'h', 'ALLOCATION_BASIS_NUM_LABOR_HOURS_DESCRIPTION', 1);
@@ -195,7 +195,7 @@ INSERT IGNORE INTO `unit` VALUES
 
 INSERT IGNORE INTO `report` (`report_key`, `title_key`) VALUES
    ('lost_stock_report', 'LOST_STOCK_REPORT');
-   
+
 /**
  * @author: mbayopanda
  * @desc: fix allocation bases link and report
@@ -203,12 +203,3 @@ INSERT IGNORE INTO `report` (`report_key`, `title_key`) VALUES
 UPDATE `unit` SET `path` = '/cost_center/allocation_bases' WHERE id = 299;
 INSERT IGNORE INTO `report` (`report_key`, `title_key`) VALUES
   ('cost_center_step_down', 'TREE.COST_CENTER_STEPDOWN');
-
-/**
- * @author: mbayopanda
- * @desc: add predefined allocation basis
- */
-INSERT INTO `cost_center_allocation_basis` (`id`, `name`, `units`, `description`, `is_predefined`) VALUES
-  (1, 'ALLOCATION_BASIS_DIRECT_COST', '', 'ALLOCATION_BASIS_DIRECT_COST_DESCRIPTION', 1),
-  (2, 'ALLOCATION_BASIS_NUM_EMPLOYEES', '', 'ALLOCATION_BASIS_NUM_EMPLOYEES_DESCRIPTION', 1),
-  (3, 'ALLOCATION_BASIS_AREA_USED', 'm²', 'ALLOCATION_BASIS_AREA_USED_DESCRIPTION', 1);

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -203,3 +203,12 @@ INSERT IGNORE INTO `report` (`report_key`, `title_key`) VALUES
 UPDATE `unit` SET `path` = '/cost_center/allocation_bases' WHERE id = 299;
 INSERT IGNORE INTO `report` (`report_key`, `title_key`) VALUES
   ('cost_center_step_down', 'TREE.COST_CENTER_STEPDOWN');
+
+/**
+ * @author: mbayopanda
+ * @desc: add predefined allocation basis
+ */
+INSERT INTO `cost_center_allocation_basis` (`id`, `name`, `units`, `description`, `is_predefined`) VALUES
+  (1, 'ALLOCATION_BASIS_DIRECT_COST', '', 'ALLOCATION_BASIS_DIRECT_COST_DESCRIPTION', 1),
+  (2, 'ALLOCATION_BASIS_NUM_EMPLOYEES', '', 'ALLOCATION_BASIS_NUM_EMPLOYEES_DESCRIPTION', 1),
+  (3, 'ALLOCATION_BASIS_AREA_USED', 'm²', 'ALLOCATION_BASIS_AREA_USED_DESCRIPTION', 1);

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -195,3 +195,11 @@ INSERT IGNORE INTO `unit` VALUES
 
 INSERT IGNORE INTO `report` (`report_key`, `title_key`) VALUES
    ('lost_stock_report', 'LOST_STOCK_REPORT');
+   
+/**
+ * @author: mbayopanda
+ * @desc: fix allocation bases link and report
+ */
+UPDATE `unit` SET `path` = '/cost_center/allocation_bases' WHERE id = 299;
+INSERT IGNORE INTO `report` (`report_key`, `title_key`) VALUES
+  ('cost_center_step_down', 'TREE.COST_CENTER_STEPDOWN');


### PR DESCRIPTION
This PR fixes migration script on a production data base by :
- Updating the cost center allocation bases path in the unit table
- Adding an entry for the cost center allocation report in the report table

Also, some fix : 
- Old FeeCenter reference
- Translation in grid cell