### PR TITLE
Create report for stock lost during inter-depot transfers.

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -140,6 +140,17 @@
       "TITLE" : "Inventory Changes Report",
       "DESCRIPTION": "This reports shows changes occured on inventory items during a period."
     },
+    "LOST_STOCK_REPORT": {
+      "TITLE": "Lost Stock Report",
+      "DEPOT_ROLE": "List stock transfer losses for this depot as",
+      "DESCRIPTION": "This report lists stock that was lost while transferring stock from one depot to another",
+      "DESTINATION": "Destination",
+      "DESTINATION_DEPOT" : "Destination Depot",
+      "EITHER": "Either",
+      "LOSS": "Loss",
+      "SOURCE": "Source",
+      "SOURCE_DEPOT" : "Source Depot"
+    },
     "MONTHLY_CONSUMPTION" : {
       "TITLE": "Monthly consumption",
       "DESCRIPTION": "Monthly consumption report by deposit for a given period"
@@ -186,12 +197,10 @@
       "TITLE" : "Stock Consumption's graph report",
       "DESCRIPTION" : "This report graphically shows the consumption of stock during a period for a depot or inventory"
     },
-
     "STOCK_MOVEMENT_REPORT" : {
       "TITLE" : "Stock Movement Graph",
       "DESCRIPTION" : "This report displays a graph of stock movements made during a period"
     },
-
     "PREVIOUS_MONTHS": "Previous Months",
     "PERIOD_START": "Start",
     "PERIOD_STOP": "Stop",
@@ -203,6 +212,7 @@
     "NULL" : "Null",
     "SIXTY_TO_NINETY_DAYS": "60 to 90 Days",
     "THIRTY_TO_SIXTY_DAYS": "30 to 60 Days",
+    "TOTALS": "Totals",
     "VIEW_ACCOUNT_STATEMENT": "View in Account Statement",
     "VIEW_CREDIT_NOTE": "View Credit Note",
     "VIEW_INVOICE": "View Invoices",
@@ -275,7 +285,7 @@
       "EXIT_REPORT": "Stock Exit Report",
       "EXIT_REPORT_DESCRIPTION": "This report shows stock exits which had occurred in different depots",
       "INCLUDE_AGGREGATE_CONSUMPTION": "Include aggregate consumption",
-	  "INCLUDE_INFORMATION": "Information to include",
+      "INCLUDE_INFORMATION": "Information to include",
       "INCLUDE_PATIENT_EXIT": "Include stock exit to patient",
       "INCLUDE_SERVICE_EXIT": "Include stock exit to service",
       "INCLUDE_GROUPED_SERVICE_EXIT" : "Include stock exit grouped by services",

--- a/client/src/i18n/en/tree.json
+++ b/client/src/i18n/en/tree.json
@@ -98,6 +98,7 @@
     "JOURNAL_LOG":"Journal Log",
     "JOURNAL_VOUCHER" : "Journal Voucher",
     "LOCATION" : "Location Management",
+    "LOST_STOCK_REPORT" : "Lost Stock Report",
     "MONTHLY_BALANCE": "Monthly Balance",
     "MONTHLY_CONSUMPTION" : "[Stock] Monthly consumption",
     "MULTI_PAYROLL_INDICE" : "Multiple Payroll (index-based)",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -136,7 +136,17 @@
       "TITLE" : "Rapport de changement d'inventaire",
       "DESCRIPTION": "Ce rapport montre les changements survenus sur les articles en stock au cours d'une période"
     },
-
+    "LOST_STOCK_REPORT": {
+      "TITLE": "Rapport sur les stocks perdus",
+      "DEPOT_ROLE": "Lister les pertes de transfert de stock pour ce dépôt comme",
+      "DESCRIPTION": "Ce rapport répertorie les stocks perdus lors du transfert de stock d'un dépôt à un autre.",
+      "DESTINATION": "Destination",
+      "DESTINATION_DEPOT" : "Dépôt de destination",
+      "EITHER": "L'un ou l'autre",
+      "LOSS": "Perte",
+      "SOURCE": "Source",
+      "SOURCE_DEPOT" : "Dépôt de source"
+    },
     "OPENING_BALANCE": "Balance d'ouverture",
     "ORDER": {
       "LAST_TRANSACTION": "Date de la dernière transaction",
@@ -197,6 +207,7 @@
     "SINCE": "Depuis",
     "SIXTY_TO_NINETY_DAYS": "60 a 90 jours",
     "THIRTY_TO_SIXTY_DAYS": "30 a 60 jours",
+    "TOTALS": "Totaux",
     "VIEW_ACCOUNT_STATEMENT": "Voir le Rélevé de Compte",
     "VIEW_CREDIT_NOTE": "Voir la note de credit",
     "VIEW_INVOICE": "Voir les factures",

--- a/client/src/i18n/fr/tree.json
+++ b/client/src/i18n/fr/tree.json
@@ -97,6 +97,7 @@
     "IPR_TAX_CONFIGURATION": "Configuration de la taxe IPR",
     "JOURNAL_VOUCHER":"Ajout Transactions",
     "LOCATION":"Localisations",
+    "LOST_STOCK_REPORT": "Rapport sur les stocks perdus",
     "MONTHLY_BALANCE": "Analyse mensuel de la Balance",
     "MONTHLY_CONSUMPTION" : "[Stock] Consommations mensuelles",
     "MULTI_PAYROLL" : "Payroll Multiple",

--- a/client/src/modules/reports/generate/lost_stock_report/lost_stock_report.html
+++ b/client/src/modules/reports/generate/lost_stock_report/lost_stock_report.html
@@ -1,0 +1,98 @@
+<bh-report-preview
+  ng-if="ReportConfigCtrl.previewGenerated"
+  source-document="ReportConfigCtrl.previewResult"
+  on-clear-callback="ReportConfigCtrl.clearPreview()"
+  on-save-callback="ReportConfigCtrl.requestSaveAs()">
+</bh-report-preview>
+
+<div ng-show="!ReportConfigCtrl.previewGenerated">
+  <div class="row">
+    <div class="col-md-12">
+      <h3 translate>REPORT.LOST_STOCK_REPORT.TITLE</h3>
+      <p class="text-info" translate>REPORT.LOST_STOCK_REPORT.DESCRIPTION</p>
+    </div>
+  </div>
+
+  <div class="row" style="margin-top : 10px">
+    <div class="col-md-6">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <span translate>REPORT.UTIL.OPTIONS</span>
+        </div>
+
+        <div class="panel-body">
+
+        <form name="ConfigForm" bh-submit="ReportConfigCtrl.preview(ConfigForm)" novalidate autocomplete="off">
+
+          <!-- select depot -->
+          <bh-depot-select
+            depot-uuid="ReportConfigCtrl.reportDetails.depot_uuid"
+            on-select-callback="ReportConfigCtrl.onSelectDepot(depot)"
+            required="true">
+          </bh-depot-select>
+
+          <div class="form-group">
+            <label class="control-label" translate>REPORT.LOST_STOCK_REPORT.DEPOT_ROLE</label>
+            <div class="radio" style="margin-top: 0">
+              <label class="radio-inline">
+                <input
+                  type="radio"
+                  name="depot_mode"
+                  value="destination"
+                  ng-model="ReportConfigCtrl.reportDetails.depotRole"
+                  ng-click="ReportConfigCtrl.onSelectDepotMode('destination')"
+                  id="depot_is_destination"
+                  required>
+                <span translate>REPORT.LOST_STOCK_REPORT.DESTINATION</span>
+              </label>
+
+              <label class="radio-inline">
+                <input
+                  type="radio"
+                  name="depot_mode"
+                  value="source"
+                  ng-model="ReportConfigCtrl.reportDetails.depotRole"
+                  ng-click="ReportConfigCtrl.onSelectDepotMode('source')"
+                  id="depot_is_source"
+                  required>
+                <span translate>REPORT.LOST_STOCK_REPORT.SOURCE</span>
+              </label>
+
+              <label class="radio-inline">
+                <input
+                  type="radio"
+                  name="depot_mode"
+                  value="either"
+                  ng-model="ReportConfigCtrl.reportDetails.depotRole"
+                  ng-click="ReportConfigCtrl.onSelectDepotMode('either')"
+                  id="depot_is_eithere"
+                  required>
+                <span translate>REPORT.LOST_STOCK_REPORT.EITHER</span>
+              </label>
+            </div>
+          </div>
+
+          <!-- date interval -->
+          <bh-date-interval
+            date-from="ReportConfigCtrl.reportDetails.dateFrom"
+            date-to="ReportConfigCtrl.reportDetails.dateTo"
+            limit-min-fiscal
+            required="true">
+          </bh-date-interval>
+
+          <bh-currency-select
+            currency-id="ReportConfigCtrl.reportDetails.currencyId"
+            on-change="ReportConfigCtrl.onSelectCurrency(currency)"
+            required="true">
+          </bh-currency-select>
+
+           <!-- preview -->
+          <bh-loading-button loading-state="ConfigForm.$loading">
+            <span translate>REPORT.UTIL.PREVIEW</span>
+          </bh-loading-button>
+        </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/client/src/modules/reports/generate/lost_stock_report/lost_stock_report.js
+++ b/client/src/modules/reports/generate/lost_stock_report/lost_stock_report.js
@@ -1,0 +1,87 @@
+angular.module('bhima.controllers')
+  .controller('lost_stock_reportController', LostStockConfigController);
+
+LostStockConfigController.$inject = [
+  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+  'LanguageService', 'SessionService',
+];
+
+function LostStockConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Languages, Session) {
+  const vm = this;
+  const cache = new AppCache('configure_lost_stock_report');
+  const reportUrl = 'reports/stock/lost';
+
+  vm.reportDetails = {};
+
+  vm.previewGenerated = false;
+
+  vm.reportDetails.currencyId = Session.enterprise.currency_id;
+
+  // check cached configuration
+  checkCachedConfiguration();
+
+  vm.onSelectDepot = depot => {
+    vm.reportDetails.depot_uuid = depot.uuid;
+  };
+
+  vm.onSelectDepotMode = role => {
+    vm.reportDetails.depotRole = role;
+  };
+
+  vm.onSelectCurrency = currency => {
+    vm.reportDetails.currencyId = currency.id;
+  };
+
+  vm.clear = key => {
+    delete vm[key];
+  };
+
+  vm.clearPreview = () => {
+    vm.previewGenerated = false;
+    vm.previewResult = null;
+  };
+
+  vm.preview = form => {
+    if (form.$invalid) {
+      return 0;
+    }
+
+    // update cached configuration
+    cache.reportDetails = angular.copy(vm.reportDetails);
+    angular.extend(vm.reportDetails, { lang : Languages.key });
+
+    return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
+      .then((result) => {
+        vm.previewGenerated = true;
+        vm.previewResult = $sce.trustAsHtml(result);
+      })
+      .catch(Notify.handleError);
+  };
+
+  vm.requestSaveAs = function requestSaveAs() {
+    const options = {
+      url : reportUrl,
+      report : reportData,
+      reportOptions : angular.copy(vm.reportDetails),
+    };
+
+    return SavedReports.saveAsModal(options)
+      .then(() => {
+        $state.go('reportsBase.reportsArchive', { key : options.report.report_key });
+      })
+      .catch(Notify.handleError);
+  };
+
+  function checkCachedConfiguration() {
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
+
+    // Set the defaults
+    if (!angular.isDefined(vm.reportDetails.currencyId)) {
+      vm.reportDetails.currencyId = Session.enterprise.currency_id;
+    }
+    if (!angular.isDefined(vm.reportDetails.depotRole)) {
+      vm.reportDetails.depotRole = 'destination';
+    }
+  }
+
+}

--- a/client/src/modules/reports/reports.routes.js
+++ b/client/src/modules/reports/reports.routes.js
@@ -21,6 +21,7 @@ angular.module('bhima.routes')
       'income_expense_by_year',
       'stock_sheet',
       'inventory_report',
+      'lost_stock_report',
       'ohada_balance_sheet_report',
       'ohada_profit_loss',
       'open_debtors',

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -846,6 +846,7 @@ exports.configure = function configure(app) {
   app.get('/reports/stock/exit', stockReports.stockExitReport);
   app.get('/reports/stock/entry', stockReports.stockEntryReport);
   app.get('/reports/stock/consumption_graph', stockReports.consumptionGraph);
+  app.get('/reports/stock/lost', stockReports.lostStockReport);
   app.get('/reports/stock/movement_report', stockReports.movementReport);
   app.get('/reports/stock/expiration_report', stockReports.expirationReport);
   app.get('/reports/stock/changes', stockReports.stockChangesReport);

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -49,6 +49,7 @@ module.exports = {
   getLotsDepot,
   getLotsMovements,
   listStatus,
+  listLostStock,
   // stock consumption
   getInventoryQuantityAndConsumption,
   getInventoryMovements,
@@ -469,8 +470,6 @@ async function getMovements(depotUuid, params) {
     LEFT JOIN depot AS dp ON dp.uuid = m.entity_uuid
     LEFT JOIN document_map dm2 ON dm2.uuid = m.entity_uuid
     LEFT JOIN document_map sr_m ON sr_m.uuid = m.stock_requisition_uuid
-
-
   `;
 
   const finalClause = 'GROUP BY document_uuid, is_exit';
@@ -478,6 +477,61 @@ async function getMovements(depotUuid, params) {
   const movements = await getLots(sql, params, finalClause, orderBy);
 
   return movements;
+}
+
+/**
+ * @function listLostStock
+ *
+ * This function returns a list of stock lost between purchase and delivery
+ */
+function listLostStock(params) {
+  const sql = `
+    SELECT
+      BUID(dest.uuid) as uuid, dest.date, dest.description, dest.period_id,
+      dest.document_uuid, dest.depot_uuid, dest.unit_cost,
+      dd.text AS destDepot, od.text AS srcDepot,
+      dest.quantity AS quantityRecd, ex.quantity AS quantitySent,
+      IFNULL((ex.quantity - dest.quantity), 0) AS quantityDifference,
+      i.code AS inventory_code, i.text AS inventory_name,
+      l.label AS lotLabel, l.expiration_date AS expirationDate,
+      dest.unit_cost, (dest.quantity * dest.unit_cost) AS total_cost
+    FROM stock_movement dest
+    JOIN depot dd ON dd.uuid = dest.depot_uuid
+    JOIN depot od ON od.uuid = dest.entity_uuid
+    JOIN lot l ON l.uuid = dest.lot_uuid
+    JOIN inventory i ON i.uuid = l.inventory_uuid
+    JOIN (
+      SELECT m.document_uuid, m.lot_uuid, m.quantity, m.unit_cost
+      FROM stock_movement m
+      WHERE m.is_exit = 1 AND m.flux_id = ${flux.TO_OTHER_DEPOT}
+    ) ex ON ex.document_uuid = dest.document_uuid AND ex.lot_uuid = dest.lot_uuid
+  `;
+
+  db.convert(params, ['depot_uuid']);
+
+  const { depotRole } = params;
+  delete params.depotRole;
+
+  // Define the pseudo parameter 'enable_quantity_check' to enable the custom quantity check
+  params.enable_quantity_check = true;
+
+  const filters = new FilterParser(params, { tableAlias : 'dest' });
+
+  filters.custom('enable_quantity_check', 'dest.flux_id = (?) AND IFNULL((ex.quantity - dest.quantity), 0) <> 0',
+    flux.FROM_OTHER_DEPOT);
+  filters.dateFrom('dateFrom', 'date');
+  filters.dateTo('dateTo', 'date');
+  if (depotRole === 'destination') {
+    filters.equals('depot_uuid');
+  } else if (depotRole === 'source') {
+    filters.equals('depot_uuid', 'uuid', 'od');
+  }
+  filters.setOrder('ORDER BY dest.date, destDepot');
+
+  const query = filters.applyQuery(sql);
+  const queryParams = filters.parameters();
+
+  return db.exec(query, queryParams);
 }
 
 /**

--- a/server/controllers/stock/reports/common.js
+++ b/server/controllers/stock/reports/common.js
@@ -25,6 +25,7 @@ const STOCK_AGGREGATE_CONSUMPTION_TEMPLATE = `${BASE_PATH}/stock_aggregate_consu
 // reports
 const STOCK_EXIT_REPORT_TEMPLATE = `${BASE_PATH}/stock_exit.report.handlebars`;
 const STOCK_ENTRY_REPORT_TEMPLATE = `${BASE_PATH}/stock_entry.report.handlebars`;
+const STOCK_LOST_STOCK_REPORT_TEMPLATE = `${BASE_PATH}/stock_lost_stock.report.handlebars`;
 const STOCK_LOTS_REPORT_TEMPLATE = `${BASE_PATH}/stock_lots.report.handlebars`;
 const STOCK_MOVEMENTS_REPORT_TEMPLATE = `${BASE_PATH}/stock_movements.report.handlebars`;
 const STOCK_INLINE_MOVEMENTS_REPORT_TEMPLATE = `${BASE_PATH}/stock_inline_movements.report.handlebars`;
@@ -55,7 +56,7 @@ const { formatFilters } = require('../../finance/reports/shared');
  * @param {string} documentUuid
  * @param {object} enterprise
  * @param {boolean} isExit
- * @description return depot movement informations
+ * @description return depot movements information
  * @return {object} data
  */
 async function getDepotMovement(documentUuid, enterprise, isExit) {
@@ -205,6 +206,7 @@ module.exports = {
   STOCK_ADJUSTMENT_TEMPLATE,
   STOCK_EXIT_REPORT_TEMPLATE,
   STOCK_ENTRY_REPORT_TEMPLATE,
+  STOCK_LOST_STOCK_REPORT_TEMPLATE,
   STOCK_LOTS_REPORT_TEMPLATE,
   STOCK_MOVEMENTS_REPORT_TEMPLATE,
   STOCK_INLINE_MOVEMENTS_REPORT_TEMPLATE,

--- a/server/controllers/stock/reports/index.js
+++ b/server/controllers/stock/reports/index.js
@@ -23,6 +23,7 @@ const stockInlineMovementsReport = require('./stock/inline_movements_report');
 const stockInventoriesReport = require('./stock/inventories_report');
 const stockSheetReport = require('./stock/stock_sheet');
 const stockAggregatedConsumptionReport = require('./stock/aggregated_consumption_report');
+const lostStockReport = require('./stock/lost_stock_report');
 
 const stockExitPatientReceipt = require('./stock/exit_patient_receipt');
 const stockExitDepotReceipt = require('./stock/exit_depot_receipt');
@@ -155,6 +156,7 @@ exports.stockAssignReceipt = stockAssignReceipt;
 exports.stockRequisitionReceipt = stockRequisitionReceipt;
 exports.purchaseOrderAnalysis = require('./purchase_order_analysis');
 
+exports.lostStockReport = lostStockReport;
 exports.stockChangesReport = stockChangesReport;
 exports.stockAdjustmentReceipt = stockAdjustmentReceipt;
 exports.stockExitAggregateConsumptionReceipt = stockExitAggregateConsumptionReceipt;

--- a/server/controllers/stock/reports/stock/lost_stock_report.js
+++ b/server/controllers/stock/reports/stock/lost_stock_report.js
@@ -1,0 +1,64 @@
+const {
+  _, ReportManager, Stock, STOCK_LOST_STOCK_REPORT_TEMPLATE,
+} = require('../common');
+
+const Exchange = require('../../../finance/exchange');
+
+/**
+ * @method lostStockReport
+ *
+ * @description
+ * This method builds the stock lots report as either a JSON, PDF, or HTML
+ * file to be sent to the client.
+ *
+ * GET /reports/stock/lost
+ */
+async function lostStockReport(req, res, next) {
+
+  const params = req.query;
+  const { depotRole } = params;
+
+  const enterpriseId = req.session.enterprise.id;
+  const exchangeRate = await Exchange.getExchangeRate(enterpriseId, params.currencyId, new Date());
+  const rate = exchangeRate.rate || 1;
+
+  // set up the report with report manager
+  const optionReport = _.extend(params, { filename : 'TREE.LOST_STOCK_REPORT' });
+  const report = new ReportManager(STOCK_LOST_STOCK_REPORT_TEMPLATE, req.session, optionReport);
+
+  return Stock.listLostStock(params)
+    .then((rows) => {
+      const data = {};
+      const [key] = rows;
+      data.currencyId = Number(params.currencyId);
+      data.dateTo = params.dateTo;
+      data.dateFrom = params.dateFrom;
+      data.isDestDepot = null;
+      data.isSrcDepot = null;
+      if (key && depotRole === 'destination') {
+        data.isDestDepot = true;
+        data.depotName = key.destDepot;
+      } else if (key && depotRole === 'source') {
+        data.isSrcDepot = true;
+        data.depotName = key.srcDepot;
+      }
+      let sumLosses = 0;
+      let totalMissing = 0;
+      rows.forEach(row => {
+        row.unit_cost *= rate;
+        totalMissing += row.quantityDifference;
+        row.loss = row.quantityDifference * row.unit_cost;
+        sumLosses += row.loss;
+      });
+      data.rows = rows;
+      data.totalMissing = totalMissing;
+      data.totalLoss = sumLosses;
+      return report.render(data);
+    })
+    .then((result) => {
+      res.set(result.headers).send(result.report);
+    })
+    .catch(next);
+}
+
+module.exports = lostStockReport;

--- a/server/controllers/stock/reports/stock_lost_stock.report.handlebars
+++ b/server/controllers/stock/reports/stock_lost_stock.report.handlebars
@@ -1,0 +1,79 @@
+{{> head title="REPORT.LOST_STOCK_REPORT.TITLE" }}
+
+<body>
+
+  <div class="container">
+  {{> header}}
+    <!-- body  -->
+    <div class="row">
+      <div class="col-xs-12">
+
+        <h2 class="text-center text-uppercase">
+          <strong>{{translate 'REPORT.LOST_STOCK_REPORT.TITLE'}}</strong> <br>
+          <small>{{date dateFrom}} - {{date dateTo}}</small>
+        </h2>
+
+        <h3 class="text-center">
+          {{#if isDestDepot}}{{translate 'REPORT.LOST_STOCK_REPORT.DESTINATION_DEPOT'}}: {{depotName}}{{/if}}
+          {{#if isSrcDepot}}{{translate 'REPORT.LOST_STOCK_REPORT.SOURCE_DEPOT'}}: {{depotName}}{{/if}}
+        </h3>
+
+        <br>
+
+        <!-- list of data  -->
+        <table class="table table-condensed table-report">
+          <thead>
+            <tr style="background-color:#ddd;">
+              <th>{{translate 'TABLE.COLUMNS.DATE'}}</th>
+              <th>{{translate 'STOCK.CODE'}}</th>
+              <th>{{translate 'STOCK.INVENTORY'}}</th>
+              <th>{{translate 'STOCK.LOT'}}</th>
+              <th>{{translate 'STOCK.EXPIRATION'}}</th>
+              <th>{{translate 'REPORT.LOST_STOCK_REPORT.DESTINATION_DEPOT'}}</th>
+              <th>{{translate 'REPORT.LOST_STOCK_REPORT.SOURCE_DEPOT'}}</th>
+              <th>{{translate 'STOCK.QUANTITY_SENT'}}</th>
+              <th>{{translate 'STOCK.QUANTITY_RECEIVED'}}</th>
+              <th>{{translate 'STOCK.QUANTITY_DIFFERENCE'}}</th>
+              <th>{{translate 'STOCK.UNIT_COST'}}</th>
+              <th class="text-center">{{translate 'REPORT.LOST_STOCK_REPORT.LOSS'}}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each rows}}
+            <tr {{#if hasWarning}}class="text-danger bg-danger"{{/if}} >
+              <td class="text-right">{{date date}}</td>
+              <td>{{inventory_code}}</td>
+              <td>{{inventory_name}}</td>
+              <td>{{lotLabel}}</td>
+              <td class="text-right">{{date expirationDate}}</td>
+              <td>{{destDepot}}</td>
+              <td>{{srcDepot}}</td>
+              <td class="text-right">{{quantitySent}}</td>
+              <td class="text-right">{{quantityRecd}}</td>
+              <td class="text-right">{{quantityDifference}}</td>
+              <td class="text-right">{{currency unit_cost ../currencyId 4}}</td>
+              <td class="text-right">{{currency loss ../currencyId 2}}</td>
+            </tr>
+            {{else}}
+              {{> emptyTable columns=12}}
+            {{/each}}
+          </tbody>
+          <tfoot>
+            <tr style="font-weight: bold;">
+              <td colspan="9">
+                 <span class="pull-right">{{translate 'REPORT.TOTALS'}}</span>
+              </td>
+              <td class="text-right">
+                {{totalMissing}}
+              </td>
+              <td></td>
+              <td class="text-right">{{currency totalLoss currencyId 2}}</td>
+            </tr>
+          </tfoot>
+          </table>
+
+      </div>
+    </div>
+  </div>
+</body>
+

--- a/server/models/bhima.sql
+++ b/server/models/bhima.sql
@@ -172,7 +172,8 @@ INSERT INTO unit VALUES
   (296, 'Agg. Stock Consumption Report','REPORT.AGGREGATED_STOCK_CONSUMPTION.TITLE','Aggregated consumption', 282, '/reports/aggregated_stock_consumption'),
   (297, 'Journal Log','TREE.JOURNAL_LOG','The Journal log module', 5,'/journal/log'),
   (298, 'Cost Center Step-down','TREE.COST_CENTER_STEPDOWN','The fee center report with step-down algorithm', 286,'/reports/cost_center_step_down'),
-  (299, 'Allocation Bases','TREE.COST_CENTER_ALLOCATION_KEYS','List cost center allocation bases with values', 218,'/cost_center/allocation_bases');
+  (299, 'Allocation Bases','TREE.COST_CENTER_ALLOCATION_KEYS','List cost center allocation bases with values', 218,'/cost_center/allocation_bases'),
+  (300, 'Lost Stock Reprot','TREE.LOST_STOCK_REPORT','Report on stock lost during depot transfers', 282,'/reports/lost_stock_report');
 
 
 -- Reserved system account type
@@ -246,7 +247,8 @@ INSERT INTO `report` (`report_key`, `title_key`) VALUES
   ('stock_changes', 'REPORT.STOCK_CHANGES.TITLE'),
   ('aggregated_stock_consumption', 'REPORT.AGGREGATED_STOCK_CONSUMPTION.TITLE'),
   ('rumer_report', 'REPORT.RUMER.TITLE'),
-  ('cost_center_step_down', 'TREE.COST_CENTER_STEPDOWN');
+  ('cost_center_step_down', 'TREE.COST_CENTER_STEPDOWN'),
+  ('lost_stock_report', 'TREE.LOST_STOCK_REPORT');
 
 -- Supported Languages
 INSERT INTO `language` VALUES

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -139,6 +139,9 @@ date: 2021-09-15
 description: Add cost basis items
 */
 INSERT IGNORE INTO `cost_center_allocation_basis` VALUES
+  (1, 'ALLOCATION_BASIS_DIRECT_COST', '', 'ALLOCATION_BASIS_DIRECT_COST_DESCRIPTION', 1),
+  (2, 'ALLOCATION_BASIS_NUM_EMPLOYEES', '', 'ALLOCATION_BASIS_NUM_EMPLOYEES_DESCRIPTION', 1),
+  (3, 'ALLOCATION_BASIS_AREA_USED', 'm�', 'ALLOCATION_BASIS_AREA_USED_DESCRIPTION', 1),
   (4, 'ALLOCATION_BASIS_ELECTRICITY_CONSUMED', 'kWh', 'ALLOCATION_BASIS_ELECTRICITY_CONSUMED_DESCRIPTION', 1),
   (5, 'ALLOCATION_BASIS_NUM_COMPUTERS', '', 'ALLOCATION_BASIS_NUM_COMPUTERS_DESCRIPTION', 1),
   (6, 'ALLOCATION_BASIS_NUM_LABOR_HOURS', 'h', 'ALLOCATION_BASIS_NUM_LABOR_HOURS_DESCRIPTION', 1);
@@ -153,7 +156,7 @@ INSERT IGNORE INTO `unit` VALUES
 
 ALTER TABLE `cost_center_allocation_basis_value`
   ADD CONSTRAINT unique_allocation_cost_center_basis UNIQUE (`cost_center_id`, `basis_id`);
-  
+
 
 /**
 author: @lomamech
@@ -181,3 +184,14 @@ ALTER TABLE `account_reference` MODIFY COLUMN `description` VARCHAR(200) NOT NUL
  * @desc: stock setting for cost center to use in case of stock loss
  */
 ALTER TABLE `stock_setting` ADD COLUMN `default_cost_center_for_loss` MEDIUMINT(8) NULL;
+
+/**
+* author: @jmcameron
+* date: 2021-09-24
+* description: Add lost stock report menu item
+*/
+INSERT IGNORE INTO `unit` VALUES
+  (300, 'Lost Stock Report', 'TREE.LOST_STOCK_REPORT', 'Report on stock lost during depot transfers', 282, '/reports/lost_stock_report');
+
+INSERT IGNORE INTO `report` (`report_key`, `title_key`) VALUES
+   ('lost_stock_report', 'LOST_STOCK_REPORT');


### PR DESCRIPTION
Creates a new report to tabulate the stock lost during transfers.
The creation dialog allows a depot to be selected and its role in the transfers (destination, source, or either).
The to/from dates apply to the stock entry to the destination depot.

Closes https://github.com/IMA-WorldHealth/bhima/issues/5915

**TESTING**
- To see the lost stock report, you will need some lost stock!   So either use a production database where you know there is lost stock, or use bhima_test and construct the lost stock transfers yourself
- If you use bhima_test or a production database with no losses, try the report first (Stock > Reports > Lost Stock Report) and verify that an empty report is generated.
- To create lost stock incidents:
   - Suppose the destination is Depot B and the source is Depot A.
   - If a requisition does not already exist for the transfer, create it.
   - Exit the desired stock from Depot A (note the quantity)
   - Enter the desired stock into Depot B (with requisition) -- AND do not accept the full count.  This emulates some stock being lost during the transfer.
   - To be most useful for testing, do the same procedure going the opposite direction
- Check the report:   Stock > Reports > Lost Stock Report
- Select Depot B for the depot
- Select the depot role as "Destination"
- Choose to/from date, etc.
- View the report.
- Try the other roles (Source, Either)

**OPEN QUESTION**
- How to handle deliveries with more stock received than sent (ie, miscount at origin depot)

