### PR TITLE
chore(cost centers): use account table for lookup

### DIFF
--- a/server/models/procedures/cost_centers.sql
+++ b/server/models/procedures/cost_centers.sql
@@ -19,12 +19,7 @@ CREATE FUNCTION GetCostCenterByAccountId(account_id INT)
 RETURNS MEDIUMINT(8) DETERMINISTIC
 BEGIN
   RETURN (
-    SELECT cost_center_id FROM reference_cost_center WHERE account_reference_id IN (
-      SELECT account_reference_id FROM account_reference_item JOIN account_reference
-        ON account_reference_item.account_reference_id = account_reference.id
-        WHERE account_reference_item.account_id = account_id
-          and account_reference.reference_type_id =  1 -- reference_type_id 1 is cost center
-    )
+    SELECT cost_center_id FROM account WHERE account.id = account_id
   );
 END $$
 
@@ -43,15 +38,9 @@ CREATE FUNCTION GetPrincipalCostCenterByAccountId(account_id INT)
 RETURNS MEDIUMINT(8) DETERMINISTIC
 BEGIN
   RETURN (
-    SELECT id FROM cost_center WHERE is_principal = 1 AND id = (
-      SELECT cost_center_id FROM reference_cost_center
-      WHERE account_reference_id IN (
-        SELECT account_reference_id FROM account_reference_item JOIN account_reference
-          ON account_reference_item.account_reference_id = account_reference.id
-          WHERE account_reference_item.account_id = account_id
-            and account_reference.reference_type_id =  1 -- reference_type_id 1 is cost center
-      )
-    )
+    SELECT cost_center_id FROM account
+      JOIN cost_center ON account.cost_center_id = cost_center.id
+    WHERE account.id = account_id AND cost_center.is_principal = 1
   );
 END $$
 

--- a/test/data.sql
+++ b/test/data.sql
@@ -317,6 +317,7 @@ INSERT INTO `account` (`id`, `type_id`, `enterprise_id`, `number`, `label`, `par
 -- set one hidden account 52121010 - BCDC USD
 UPDATE account set hidden = 1 WHERE id = 184;
 
+
 -- attach gain/loss accounts to the enterprise
 UPDATE enterprise SET `gain_account_id` = 267, `loss_account_id` = 134;
 
@@ -838,6 +839,8 @@ INSERT INTO `cost_center` (`id`, `label`, `is_principal`, `allocation_method`, `
   (5, 'Auxiliary 2', 0, 'proportional', 2),
   (6, 'Auxiliary 3', 0, 'flat', 2);
 
+-- set test cost center
+UPDATE account set cost_center_id = 4 WHERE id = 215;
 
 
 -- REFERENCE FEE CENTER


### PR DESCRIPTION
After merging #5967, we can now rewrite these functions to use the account table directly.

Closes #5968.