### PR TITLE
feat(cost centers): add grid save state

### DIFF
--- a/client/src/modules/cost_center/cost_center.html
+++ b/client/src/modules/cost_center/cost_center.html
@@ -21,6 +21,21 @@
                 <i class="fa fa-table"></i> <span translate>ALLOCATION_BASES</span>
               </a>
             </li>
+
+            <li role="separator" class="divider"></li>
+
+            <li role="menuitem">
+              <a href data-method="save-state" ng-click="CostCenterCtrl.saveGridState()">
+                <i class="fa fa-save"></i> <span translate>FORM.BUTTONS.SAVE_GRID_CONFIGURATION</span>
+              </a>
+            </li>
+
+            <li role="menuitem">
+              <a href data-method="clear-state" ng-click="CostCenterCtrl.clearGridState()">
+                <i class="fa fa-close"></i> <span translate>FORM.BUTTONS.CLEAR_GRID_CONFIGURATION</span>
+              </a>
+            </li>
+
           </ul>
         </div>
       </div>
@@ -47,6 +62,7 @@
       ui-grid="CostCenterCtrl.gridOptions"
       class="grid-full-height"
       ui-grid-auto-resize
+      ui-grid-save-state
       ui-grid-resize-columns>
 
       <bh-grid-loading-indicator

--- a/client/src/modules/cost_center/cost_center.js
+++ b/client/src/modules/cost_center/cost_center.js
@@ -3,7 +3,7 @@ angular.module('bhima.controllers')
 
 CostCenterController.$inject = [
   'CostCenterService', 'ModalService', 'NotifyService', 'uiGridConstants',
-  '$uibModal', '$translate',
+  '$uibModal', '$translate', 'GridStateService', '$state',
 ];
 
 /**
@@ -13,8 +13,10 @@ CostCenterController.$inject = [
  * It's responsible for creating, editing and updating a Cost Center
  */
 function CostCenterController(CostCenters, ModalService, Notify, uiGridConstants,
-  $uibModal, $translate) {
+  $uibModal, $translate, GridState, $state) {
   const vm = this;
+
+  const cacheKey = 'CostCenterRegistry';
 
   // bind methods
   vm.deleteCostCenter = deleteCostCenter;
@@ -141,6 +143,13 @@ function CostCenterController(CostCenters, ModalService, Notify, uiGridConstants
           .catch(Notify.handleError);
       });
   }
+
+  const state = new GridState(vm.gridOptions, cacheKey);
+  vm.saveGridState = state.saveGridState;
+  vm.clearGridState = function clearGridState() {
+    state.clearGridState();
+    $state.reload();
+  };
 
   function openEditAllocationBasisModal() {
     $uibModal.open({


### PR DESCRIPTION
Adds the save-state configuration to the `ui-grid` to make working with the grid a slight bit easier.

Closes #5959.

![xriQOIuuK4](https://user-images.githubusercontent.com/896472/135984290-1e602a28-cfc6-4b8c-9233-72be078a8225.gif)


**Testing Instructions**
1. Load the cost center registry.
2. Change the sort order.
3. Use the dropdown menu in the top right to save the grid state.
4. Refresh the page
5. Observe that the sort order has been preserved
6. Use the dropdown menu to clear the grid state
7. Observe that the sort order has returned to default.

