### PR TITLE
Automatically add number of employees to cost centers in step-down cost allocation reports

### DIFF
--- a/client/src/i18n/en/cost_center.json
+++ b/client/src/i18n/en/cost_center.json
@@ -3,6 +3,7 @@
     "TITLE" : "Cost Centers",
     "ADD_ALLOCATION_KEYS" : "Add Allocation Keys",
     "ADD_COST_CENTER" : "Add a Cost Center",
+    "ADD_ALLOCATION_BASIS_TOOLTIP": "Add a new cost allocation basis",
     "ALLOCATION_BASES":"Allocation Bases",
     "ALLOCATION_BASIS": "Allocation basis",
     "ALLOCATION_BASIS_TABLE": "Table of allocation bases",
@@ -19,7 +20,9 @@
     "NO_COST_CENTER_DEFINED": "** Cost Center Not Defined **",
     "SELECT_ALLOCATION_BASIS": "Select allocation basis",
     "STEP_DOWN_COST_ALLOCATION": "Step-down cost allocation",
-    "ONLY_FOR_EXPLOITATION_ACCOUNTS": "Only for operating accounts (income and expenses). For others accounts, the cost center will not be considered"
+    "ONLY_FOR_EXPLOITATION_ACCOUNTS": "Only for operating accounts (income and expenses). For others accounts, the cost center will not be considered",
+    "UPDATE_ALLOCATION_QUANTITIES": "Update",
+    "UPDATE_ALLOCATION_QUANTITIES_TOOLTIP": "Update system-computed cost center allocation quantities"
   },
   "ALLOCATION_METHOD": "Allocation method",
   "ALLOCATION_METHOD_FLAT": "Flat",

--- a/client/src/i18n/fr/cost_center.json
+++ b/client/src/i18n/fr/cost_center.json
@@ -3,6 +3,7 @@
     "TITLE" : "Centres de coût",
     "ADD_ALLOCATION_KEYS" : "Ajouter les clés de répartition",
     "ADD_COST_CENTER" : "Ajouter un centre de coût",
+    "ADD_ALLOCATION_BASIS_TOOLTIP": "Ajouter une nouvelle base d'allocation",
     "ALLOCATION_BASES":"Les bases d'allocation",
     "ALLOCATION_BASIS": "Base d'allocation",
     "ALLOCATION_BASIS_TABLE": "Tableau des bases d'allocation'",
@@ -19,7 +20,9 @@
     "NO_COST_CENTER_DEFINED": "** Aucun centre de cout **",
     "SELECT_ALLOCATION_BASIS": "Sélectionnez la base d'allocation",
     "STEP_DOWN_COST_ALLOCATION": "Allocation séquentielle des coûts",
-    "ONLY_FOR_EXPLOITATION_ACCOUNTS": "Uniquement pour les comptes d'exploitations (produits et charges). Pour les autres comptes, le centre de cout ne sera pas pris en compte"
+    "ONLY_FOR_EXPLOITATION_ACCOUNTS": "Uniquement pour les comptes d'exploitations (produits et charges). Pour les autres comptes, le centre de cout ne sera pas pris en compte",
+    "UPDATE_ALLOCATION_QUANTITIES": "Mettre à jour",
+    "UPDATE_ALLOCATION_QUANTITIES_TOOLTIP": "Mettre à jour les quantités d'allocation des centres de coûts calculées par le système"
   },
   "ALLOCATION_METHOD": "Méthode d'allocation séquentielle des coûts",
   "ALLOCATION_METHOD_FLAT": "Uniform",

--- a/client/src/modules/cost_center/allocation_bases/allocation_bases.html
+++ b/client/src/modules/cost_center/allocation_bases/allocation_bases.html
@@ -8,8 +8,18 @@
 
     <div class="toolbar">
       <div class="toolbar-item">
-        <button class="btn btn-default text-capitalize" ui-sref="cost_center_allocation_bases.create" data-method="create">
+        <button class="btn btn-default text-capitalize"
+          ui-sref="cost_center_allocation_bases.create"
+          uib-tooltip="{{'COST_CENTER.ADD_ALLOCATION_BASIS_TOOLTIP' | translate}}"
+          tooltip-append-to-body="true" tooltip-placement="left"
+          data-method="create">
           <span class="fa fa-plus"></span> <span translate>FORM.LABELS.ADD</span>
+        </button>
+        <button class="btn btn-default text-capitalize"
+          uib-tooltip="{{'COST_CENTER.UPDATE_ALLOCATION_QUANTITIES_TOOLTIP' | translate}}"
+          tooltip-append-to-body="true" tooltip-placement="left"
+          ng-click="CostCenterAllocationBasesCtrl.updateComputableQuantities()">
+          <span class="fa fa-plus"></span> <span translate>COST_CENTER.UPDATE_ALLOCATION_QUANTITIES</span>
         </button>
       </div>
     </div>

--- a/client/src/modules/cost_center/allocation_bases/allocation_bases.js
+++ b/client/src/modules/cost_center/allocation_bases/allocation_bases.js
@@ -22,6 +22,7 @@ function CostCenterAllocationBasesController(
   vm.gridApi = {};
   vm.editAllocationBasis = editAllocationBasis;
   vm.removeAllocationBasis = removeAllocationBasis;
+  vm.updateComputableQuantities = updateComputableQuantities;
 
   // options for the UI grid
   vm.gridOptions = {
@@ -47,6 +48,18 @@ function CostCenterAllocationBasesController(
       .then(() => {
         Notify.success('FORM.INFO.DELETE_SUCCESS');
         $state.go('cost_center_allocation_bases', null, { reload : true });
+      });
+  }
+
+  function updateComputableQuantities() {
+    vm.loading = true;
+    AllocationBasisQuantity.updateQuantities()
+      .then(() => {
+        Notify.success('FORM.INFO.SUCCESS');
+        $state.go('cost_center_allocation_bases', null, { reload : true });
+      })
+      .finally(() => {
+        vm.loading = false;
       });
   }
 

--- a/client/src/modules/cost_center/allocation_basis_quantity.service.js
+++ b/client/src/modules/cost_center/allocation_basis_quantity.service.js
@@ -17,6 +17,7 @@ function AllocationBasisQuantityService(Api) {
   service.bulkInsert = bulkInsert;
   service.bulkDelete = bulkDelete;
   service.bulkUpdate = bulkUpdate;
+  service.updateQuantities = updateQuantities;
 
   function bulkDetails(id) {
     const url = `/cost_center_allocation_basis_quantity/bulk/${id}`;
@@ -39,6 +40,12 @@ function AllocationBasisQuantityService(Api) {
   function bulkDelete(id) {
     const url = `/cost_center_allocation_basis_quantity/bulk/${id}`;
     return service.$http.delete(url)
+      .then(service.util.unwrapHttpResponse);
+  }
+
+  function updateQuantities() {
+    const url = `/cost_center_allocation_basis_quantities_update`;
+    return service.$http.put(url)
       .then(service.util.unwrapHttpResponse);
   }
 

--- a/client/src/modules/cost_center/cost_center.service.js
+++ b/client/src/modules/cost_center/cost_center.service.js
@@ -39,5 +39,11 @@ function CostCenterService(Api, $uibModal) {
       .then(service.util.unwrapHttpResponse);
   };
 
+  service.getAllocationQuantities = (options) => {
+    const url = `/cost_center/allocation_quantities`;
+    return service.$http.get(url, { params : options })
+      .then(service.util.unwrapHttpResponse);
+  };
+
   return service;
 }

--- a/server/config/constants.js
+++ b/server/config/constants.js
@@ -21,6 +21,15 @@ module.exports = {
     EXPENSE : 5,
     TITLE : 6,
   },
+  allocationBasis : {
+    /* NOTE: Must match values in bhima.sql */
+    ALLOCATION_BASIS_DIRECT_COST : 1,
+    ALLOCATION_BASIS_NUM_EMPLOYEES : 2,
+    ALLOCATION_BASIS_AREA_USED : 3,
+    ALLOCATION_BASIS_ELECTRICITY_CONSUMED : 4,
+    ALLOCATION_BASIS_NUM_COMPUTERS : 5,
+    ALLOCATION_BASIS_NUM_LABOR_HOURS : 6,
+  },
   settings : {
     CONTACT_EMAIL : 'developers@imaworldhealth.org',
   },

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -953,6 +953,7 @@ exports.configure = function configure(app) {
   app.post('/cost_center_allocation_basis_quantity', costAllocationBasisQuantity.create);
   app.put('/cost_center_allocation_basis_quantity/:id', costAllocationBasisQuantity.update);
   app.delete('/cost_center_allocation_basis_quantity/:id', costAllocationBasisQuantity.delete);
+  app.put('/cost_center_allocation_basis_quantities_update', costAllocationBasisQuantity.updateQuantities);
 
   // Distribution Fees Centers API
   app.get('/allocation_cost_center', distributionConfiguration.configuration);

--- a/server/models/bhima.sql
+++ b/server/models/bhima.sql
@@ -486,21 +486,20 @@ INSERT INTO `analysis_tool_type` (`label`, `is_balance_sheet`, `rank`) VALUES
   ('FORM.LABELS.ANALYSIS_TOOLS.DEBTS', 1, 1);
 
 -- Cost Center basis info
+-- NOTE: 'id' field must match values assigned to the corresponding allocation
+--       basis items in server/config/constants.js (search for allocationBasis)
 INSERT INTO `cost_center_allocation_basis`
-  (`id`, `name`, `units`, `description`, `is_predefined`, `is_currency`, `decimal_places`)
+  (`id`, `name`, `units`, `description`, `is_predefined`, `is_currency`, `decimal_places`, `is_computed`)
   VALUES
   (1, 'ALLOCATION_BASIS_DIRECT_COST', '',
-      'ALLOCATION_BASIS_DIRECT_COST_DESCRIPTION', 1, 1, 2),
+      'ALLOCATION_BASIS_DIRECT_COST_DESCRIPTION', 1, 1, 2, 0),
   (2, 'ALLOCATION_BASIS_NUM_EMPLOYEES', '',
-      'ALLOCATION_BASIS_NUM_EMPLOYEES_DESCRIPTION', 1, 0, 0),
+      'ALLOCATION_BASIS_NUM_EMPLOYEES_DESCRIPTION', 1, 0, 0, 1),
   (3, 'ALLOCATION_BASIS_AREA_USED', 'ALLOCATION_BASIS_AREA_USED_UNITS',
-      'ALLOCATION_BASIS_AREA_USED_DESCRIPTION', 1, 0, 1),
+      'ALLOCATION_BASIS_AREA_USED_DESCRIPTION', 1, 0, 1, 0),
   (4, 'ALLOCATION_BASIS_ELECTRICITY_CONSUMED', 'ALLOCATION_BASIS_ELECTRICITY_CONSUMED_UNITS',
-      'ALLOCATION_BASIS_ELECTRICITY_CONSUMED_DESCRIPTION', 1, 0, 1),
+      'ALLOCATION_BASIS_ELECTRICITY_CONSUMED_DESCRIPTION', 1, 0, 1, 0),
   (5, 'ALLOCATION_BASIS_NUM_COMPUTERS', '',
-      'ALLOCATION_BASIS_NUM_COMPUTERS_DESCRIPTION', 1, 0, 0),
+      'ALLOCATION_BASIS_NUM_COMPUTERS_DESCRIPTION', 1, 0, 0, 0),
   (6, 'ALLOCATION_BASIS_NUM_LABOR_HOURS', 'ALLOCATION_BASIS_NUM_LABOR_HOURS_UNITS',
-      'ALLOCATION_BASIS_NUM_LABOR_HOURS_DESCRIPTION', 1, 0, 1);
-
-
-
+      'ALLOCATION_BASIS_NUM_LABOR_HOURS_DESCRIPTION', 1, 0, 1, 0);

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -138,7 +138,7 @@ author: @jmcameron
 date: 2021-09-15
 description: Add cost basis items
 */
-INSERT IGNORE INTO `cost_center_allocation_basis` VALUES
+INSERT IGNORE INTO `cost_center_allocation_basis` (`id`, `name`, `units`, `description`, `is_predefined`) VALUES
   (1, 'ALLOCATION_BASIS_DIRECT_COST', '', 'ALLOCATION_BASIS_DIRECT_COST_DESCRIPTION', 1),
   (2, 'ALLOCATION_BASIS_NUM_EMPLOYEES', '', 'ALLOCATION_BASIS_NUM_EMPLOYEES_DESCRIPTION', 1),
   (3, 'ALLOCATION_BASIS_AREA_USED', 'm²', 'ALLOCATION_BASIS_AREA_USED_DESCRIPTION', 1),
@@ -205,7 +205,7 @@ UPDATE `unit` SET `path` = '/cost_center/allocation_bases' WHERE id = 299;
 INSERT IGNORE INTO `report` (`report_key`, `title_key`) VALUES
   ('cost_center_step_down', 'TREE.COST_CENTER_STEPDOWN');
 
-   
+
 /*
  * @author: jmcameron
  * @date: 2021-09-29
@@ -218,10 +218,11 @@ ALTER TABLE `cost_center_allocation_basis` MODIFY COLUMN `units` VARCHAR(200) DE
 UPDATE `cost_center_allocation_basis` SET `decimal_places` = 2, `is_currency` = 1 WHERE id = 1;
 UPDATE `cost_center_allocation_basis` SET `decimal_places` = 1, `units` = 'ALLOCATION_BASIS_AREA_USED_UNITS' WHERE id = 3;
 UPDATE `cost_center_allocation_basis` SET `decimal_places` = 1, `units` = 'ALLOCATION_BASIS_ELECTRICITY_CONSUMED_UNITS' WHERE id = 4;
-UPDATE `cost_center_allocation_basis` SET `decimal_places` = 1, `units` = 'ALLOCATION_BASIS_NUM_LABOR_HOURS_UNITS',  WHERE id = 6;
+UPDATE `cost_center_allocation_basis` SET `decimal_places` = 1, `units` = 'ALLOCATION_BASIS_NUM_LABOR_HOURS_UNITS'  WHERE id = 6;
 
 UPDATE `unit` SET `key` = 'TREE.DISTRIBUTION_KEYS_MANAGEMENT' WHERE id = 223;
 UPDATE `unit` SET `name` = 'Allocation Bases', `key` = 'TREE.COST_CENTER_ALLOCATION_KEYS', `description` = 'List cost center allocation bases with values' WHERE `id` = 299;
+
 
 /*
  * @author: mbayopanda
@@ -229,3 +230,12 @@ UPDATE `unit` SET `name` = 'Allocation Bases', `key` = 'TREE.COST_CENTER_ALLOCAT
  */
 CALL add_column_if_missing('account', 'cost_center_id', 'MEDIUMINT(8) UNSIGNED NULL');
 CALL add_constraint_if_missing('account', 'account__cost_center', 'FOREIGN KEY (`cost_center_id`) REFERENCES `cost_center` (`id`)');
+
+
+/*
+ * @author: jmcameron
+ * @date: 2021-10-01
+ * @desc: auto generation of number of employees
+ */
+CALL add_column_if_missing('cost_center_allocation_basis', 'is_computed', 'BOOLEAN NOT NULL DEFAULT 0 AFTER `decimal_places`');
+UPDATE `cost_center_allocation_basis` SET `is_computed` = 1 WHERE id = 2;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -983,7 +983,6 @@ CREATE TABLE `price_list_item` (
 
 -- TODO write schema change (transactions) INTo SQL update script
 DROP TABLE IF EXISTS `patient`;
-
 CREATE TABLE `patient` (
   `uuid`                 BINARY(16) NOT NULL,
   `project_id`           SMALLINT(5) UNSIGNED NOT NULL,
@@ -2267,6 +2266,7 @@ CREATE TABLE `cost_center_allocation_basis` (
   `is_predefined` BOOLEAN NOT NULL DEFAULT 0,
   `is_currency` BOOLEAN NOT NULL DEFAULT 0,
   `decimal_places` TINYINT(2) NOT NULL DEFAULT 0,
+  `is_computed` BOOLEAN NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY  (`name`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;


### PR DESCRIPTION
This PR adds/updates the number of employees for each cost center based on the query proposed by @jniles in its issue:

Closes https://github.com/IMA-WorldHealth/bhima/issues/5962

I think I was able to verify that computes the correct number of employees for each cost center both in bhima_test and in the vanga dataset (after applying the employees and cost center update scripts from @jniles and @lomamech (respectively).

To use:  Go to the "Allocation Keys" page and click on the [Update] button.  That will update the cost_center_allocation_base_value table with the items that it can compute (currently only num employees).

This does not work completely yet, because 
- For bhima_test, the sample data does not set appropriate services and link them to cost centers for the new cost centers
- For vanga, the code to construct the data for the step-down cost allocation is producing empty data.  Further work is needed to connect all  the pieces.
- Did not test on imck, etc.