### PR TITLE
Filter null cost center

### DIFF
--- a/client/src/i18n/en/cost_center.json
+++ b/client/src/i18n/en/cost_center.json
@@ -16,6 +16,7 @@
     "EDIT_ALLOCATION_KEYS" : "Edit Allocation Keys",
     "EDIT_COST_CENTER" : "Update the Cost Center Information",
     "PRINCIPAL": "Principal Cost Center",
+    "NO_COST_CENTER_DEFINED": "** Cost Center Not Defined **",
     "SELECT_ALLOCATION_BASIS": "Select allocation basis",
     "STEP_DOWN_COST_ALLOCATION": "Step-down cost allocation",
     "ONLY_FOR_EXPLOITATION_ACCOUNTS": "Only for operating accounts (income and expenses). For others accounts, the cost center will not be considered"

--- a/client/src/i18n/en/transactions.json
+++ b/client/src/i18n/en/transactions.json
@@ -1,6 +1,7 @@
 {
   "TRANSACTIONS":{
     "NO_COST_CENTER_TRANSACTION": "Transactions without cost center",
+    "ONLY_EXPLOITATION_ACCOUNTS": "Only for income and expense accounts",
     "SHOW_ONLY_TRANSACTION_WITH_NULL_COST_CENTER": "Only display transactions that do not have a cost center",
     "VERIFIED_TRANSACTIONS": "Verified Transactions",
     "VIEW_TRANSACTIONS" : "View Transactions",

--- a/client/src/i18n/en/transactions.json
+++ b/client/src/i18n/en/transactions.json
@@ -1,5 +1,7 @@
 {
   "TRANSACTIONS":{
+    "NO_COST_CENTER_TRANSACTION": "Transactions without cost center",
+    "SHOW_ONLY_TRANSACTION_WITH_NULL_COST_CENTER": "Only display transactions that do not have a cost center",
     "VERIFIED_TRANSACTIONS": "Verified Transactions",
     "VIEW_TRANSACTIONS" : "View Transactions",
     "INCLUDE_POSTED_TRANSACTIONS_DETAIL": "Include posted transactions in search",

--- a/client/src/i18n/fr/cost_center.json
+++ b/client/src/i18n/fr/cost_center.json
@@ -16,6 +16,7 @@
     "EDIT_ALLOCATION_KEYS" : "Modifier les clés de répartition",
     "EDIT_COST_CENTER" : "Mise à jour des informations du centre de coût",
     "PRINCIPAL": "Centre de coût Principal",
+    "NO_COST_CENTER_DEFINED": "** Aucun centre de cout **",
     "SELECT_ALLOCATION_BASIS": "Sélectionnez la base d'allocation",
     "STEP_DOWN_COST_ALLOCATION": "Allocation séquentielle des coûts",
     "ONLY_FOR_EXPLOITATION_ACCOUNTS": "Uniquement pour les comptes d'exploitations (produits et charges). Pour les autres comptes, le centre de cout ne sera pas pris en compte"

--- a/client/src/i18n/fr/transactions.json
+++ b/client/src/i18n/fr/transactions.json
@@ -1,5 +1,7 @@
 {
   "TRANSACTIONS": {
+    "NO_COST_CENTER_TRANSACTION": "Transactions sans centre de coût",
+    "SHOW_ONLY_TRANSACTION_WITH_NULL_COST_CENTER": "Afficher uniquement les transactions n'ayant pas de centre de coût",
     "VERIFIED_TRANSACTIONS": "Transactions Postées",
     "VIEW_TRANSACTIONS" : "Voir les transactions",
     "INCLUDE_POSTED_TRANSACTIONS_DETAIL": "Inclure les transactions postées dans la recherche",

--- a/client/src/i18n/fr/transactions.json
+++ b/client/src/i18n/fr/transactions.json
@@ -1,6 +1,7 @@
 {
   "TRANSACTIONS": {
     "NO_COST_CENTER_TRANSACTION": "Transactions sans centre de coût",
+    "ONLY_EXPLOITATION_ACCOUNTS": "Seulement pour les comptes de produit et de charge",
     "SHOW_ONLY_TRANSACTION_WITH_NULL_COST_CENTER": "Afficher uniquement les transactions n'ayant pas de centre de coût",
     "VERIFIED_TRANSACTIONS": "Transactions Postées",
     "VIEW_TRANSACTIONS" : "Voir les transactions",

--- a/client/src/js/components/bhCostCenterSelect/bhCostCenterSelect.html
+++ b/client/src/js/components/bhCostCenterSelect/bhCostCenterSelect.html
@@ -1,4 +1,4 @@
-<div ng-form="CostCenterForm" bh-cost-center-select>
+<div ng-form="CostCenterForm" bh-cost-center-select ng-model-options="{ updateOn: 'default' }">
   <div
     class="form-group"
     ng-class="{ 'has-error' : CostCenterForm.$submitted && CostCenterForm.costCenterId.$invalid }">

--- a/client/src/js/components/bhCostCenterSelect/bhCostCenterSelect.html
+++ b/client/src/js/components/bhCostCenterSelect/bhCostCenterSelect.html
@@ -7,6 +7,8 @@
       {{ $ctrl.label }}
     </label>
 
+    <ng-transclude></ng-transclude>
+
     <p ng-if="$ctrl.helpText" class="text-info">
       <i class="fa fa-info-circle"></i>&nbsp;
       <span translate>{{ $ctrl.helpText }}</span>

--- a/client/src/js/components/bhCostCenterSelect/bhCostCenterSelect.js
+++ b/client/src/js/components/bhCostCenterSelect/bhCostCenterSelect.js
@@ -37,8 +37,9 @@ function CostCenterSelectController(CostCenters, Notify) {
   }
 
   $ctrl.$onInit = () => {
+    $ctrl.required = !!($ctrl.required);
     $ctrl.label = $ctrl.label || 'COST_CENTER.TITLE';
-    $ctrl.costCenterId = +$ctrl.costCenterId;
+    $ctrl.costCenterId = $ctrl.costCenterId ? +$ctrl.costCenterId : null;
     loadCostCenters();
   };
 

--- a/client/src/js/components/bhCostCenterSelect/bhCostCenterSelect.js
+++ b/client/src/js/components/bhCostCenterSelect/bhCostCenterSelect.js
@@ -12,10 +12,11 @@ angular.module('bhima.components')
       disabled         : '<?',
       label            : '@?',
       helpText         : '@?',
+      enableNull       : '<?',
     },
   });
 
-CostCenterSelectController.$inject = ['CostCenterService', 'NotifyService'];
+CostCenterSelectController.$inject = ['CostCenterService', 'NotifyService', '$translate'];
 
 /**
  * @function CostCenterSelectionController
@@ -23,7 +24,7 @@ CostCenterSelectController.$inject = ['CostCenterService', 'NotifyService'];
  * @description
  * CostCenter selection component
  */
-function CostCenterSelectController(CostCenters, Notify) {
+function CostCenterSelectController(CostCenters, Notify, $translate) {
   const $ctrl = this;
 
   function loadCostCenters() {
@@ -32,6 +33,14 @@ function CostCenterSelectController(CostCenters, Notify) {
         $ctrl.costCenters = $ctrl.filter
           ? costCenters.filter(item => ($ctrl.principal ? item.is_principal : !item.is_principal))
           : costCenters;
+
+        if ($ctrl.enableNull) {
+          const nullCC = {
+            id : -1,
+            label : $translate.instant('COST_CENTER.NO_COST_CENTER_DEFINED'),
+          };
+          $ctrl.costCenters = [nullCC].concat($ctrl.costCenters);
+        }
       })
       .catch(Notify.handleError);
   }

--- a/client/src/modules/journal/journal.service.js
+++ b/client/src/modules/journal/journal.service.js
@@ -121,6 +121,8 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
     { key : 'comment', label : 'FORM.LABELS.COMMENT' },
     { key : 'stockReference', label : 'FORM.LABELS.REFERENCE_STOCK_MOVEMENT' },
     { key : 'showOnlyNullCostCenter', label : 'TRANSACTIONS.NO_COST_CENTER_TRANSACTION' },
+    { key : 'cost_center_id', label : 'COST_CENTER.TITLE' },
+    { key : 'principal_center_id', label : 'COST_CENTER.PRINCIPAL' },
   ]);
 
   if (filterCache.filters) {

--- a/client/src/modules/journal/journal.service.js
+++ b/client/src/modules/journal/journal.service.js
@@ -120,6 +120,7 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
     { key : 'hrEntity', label : 'TABLE.COLUMNS.RECIPIENT' },
     { key : 'comment', label : 'FORM.LABELS.COMMENT' },
     { key : 'stockReference', label : 'FORM.LABELS.REFERENCE_STOCK_MOVEMENT' },
+    { key : 'showOnlyNullCostCenter', label : 'TRANSACTIONS.NO_COST_CENTER_TRANSACTION' },
   ]);
 
   if (filterCache.filters) {

--- a/client/src/modules/journal/modals/search.modal.html
+++ b/client/src/modules/journal/modals/search.modal.html
@@ -148,6 +148,20 @@
           </div>
         </div>
 
+        <!-- cost center -->
+        <bh-cost-center-select
+          label="COST_CENTER.TITLE"
+          cost-center-id="ModalCtrl.searchQueries.cost_center_id"
+          on-select-callback="ModalCtrl.onCostCenterSelect(costCenter)">
+        </bh-cost-center-select>
+
+        <!-- principal center -->
+        <bh-cost-center-select
+          label="COST_CENTER.PRINCIPAL"
+          cost-center-id="ModalCtrl.searchQueries.principal_center_id"
+          on-select-callback="ModalCtrl.onPrincipalCenterSelect(costCenter)">
+        </bh-cost-center-select>
+
         <bh-currency-select
           required="false"
           currency-id="ModalCtrl.searchQueries.currency_id"

--- a/client/src/modules/journal/modals/search.modal.html
+++ b/client/src/modules/journal/modals/search.modal.html
@@ -154,6 +154,7 @@
 
         <!-- cost center -->
         <bh-cost-center-select
+          enable-null="true"
           label="COST_CENTER.TITLE"
           cost-center-id="ModalCtrl.searchQueries.cost_center_id"
           on-select-callback="ModalCtrl.onCostCenterSelect(costCenter)">
@@ -162,6 +163,7 @@
 
         <!-- principal center -->
         <bh-cost-center-select
+          enable-null="true"
           label="COST_CENTER.PRINCIPAL"
           cost-center-id="ModalCtrl.searchQueries.principal_center_id"
           on-select-callback="ModalCtrl.onPrincipalCenterSelect(costCenter)">

--- a/client/src/modules/journal/modals/search.modal.html
+++ b/client/src/modules/journal/modals/search.modal.html
@@ -142,6 +142,10 @@
           <label class="control-label" translate>TRANSACTIONS.NO_COST_CENTER_TRANSACTION</label>
           <bh-clear on-clear="ModalCtrl.clear('showOnlyNullCostCenter')"></bh-clear>
           <div class="checkbox">
+            <p class="text-info">
+              <i class="fa fa-info-circle"></i>
+              <span translate>TRANSACTIONS.ONLY_EXPLOITATION_ACCOUNTS</span>
+            </p>
             <label>
               <input ng-model="ModalCtrl.searchQueries.showOnlyNullCostCenter" ng-true-value="1" ng-false-value="0" type="checkbox"> <span translate>TRANSACTIONS.SHOW_ONLY_TRANSACTION_WITH_NULL_COST_CENTER</span>
             </label>
@@ -153,6 +157,7 @@
           label="COST_CENTER.TITLE"
           cost-center-id="ModalCtrl.searchQueries.cost_center_id"
           on-select-callback="ModalCtrl.onCostCenterSelect(costCenter)">
+          <bh-clear on-clear="ModalCtrl.clear('cost_center_id')"></bh-clear>
         </bh-cost-center-select>
 
         <!-- principal center -->
@@ -160,6 +165,7 @@
           label="COST_CENTER.PRINCIPAL"
           cost-center-id="ModalCtrl.searchQueries.principal_center_id"
           on-select-callback="ModalCtrl.onPrincipalCenterSelect(costCenter)">
+          <bh-clear on-clear="ModalCtrl.clear('principal_center_id')"></bh-clear>
         </bh-cost-center-select>
 
         <bh-currency-select

--- a/client/src/modules/journal/modals/search.modal.html
+++ b/client/src/modules/journal/modals/search.modal.html
@@ -137,6 +137,17 @@
           </div>
         </div>
 
+        <!-- search for null cost center -->
+        <div class="form-group">
+          <label class="control-label" translate>TRANSACTIONS.NO_COST_CENTER_TRANSACTION</label>
+          <bh-clear on-clear="ModalCtrl.clear('showOnlyNullCostCenter')"></bh-clear>
+          <div class="checkbox">
+            <label>
+              <input ng-model="ModalCtrl.searchQueries.showOnlyNullCostCenter" ng-true-value="1" ng-false-value="0" type="checkbox"> <span translate>TRANSACTIONS.SHOW_ONLY_TRANSACTION_WITH_NULL_COST_CENTER</span>
+            </label>
+          </div>
+        </div>
+
         <bh-currency-select
           required="false"
           currency-id="ModalCtrl.searchQueries.currency_id"

--- a/client/src/modules/journal/modals/search.modal.js
+++ b/client/src/modules/journal/modals/search.modal.js
@@ -22,7 +22,8 @@ function JournalSearchModalController(
   const searchQueryOptions = [
     'description', 'user_id', 'account_id', 'project_id', 'amount', 'trans_id',
     'transaction_type_id', 'includeNonPosted', 'hrRecord', 'hrEntity', 'comment',
-    'hrReference', 'currency_id', 'showOnlyNullCostCenter',
+    'hrReference', 'currency_id', 'showOnlyNullCostCenter', 'cost_center_id',
+    'principal_center_id',
   ];
 
   const changes = new Store({ identifier : 'key' });
@@ -119,6 +120,16 @@ function JournalSearchModalController(
     });
 
     displayValues.transaction_type_id = types.join(' / ');
+  };
+
+  vm.onCostCenterSelect = cc => {
+    vm.searchQueries.cost_center_id = cc.id;
+    displayValues.cost_center_id = cc.label;
+  };
+
+  vm.onPrincipalCenterSelect = cc => {
+    vm.searchQueries.principal_center_id = cc.id;
+    displayValues.principal_center_id = cc.label;
   };
 
   // default filter limit - directly write to changes list

--- a/client/src/modules/journal/modals/search.modal.js
+++ b/client/src/modules/journal/modals/search.modal.js
@@ -22,7 +22,7 @@ function JournalSearchModalController(
   const searchQueryOptions = [
     'description', 'user_id', 'account_id', 'project_id', 'amount', 'trans_id',
     'transaction_type_id', 'includeNonPosted', 'hrRecord', 'hrEntity', 'comment',
-    'hrReference', 'currency_id',
+    'hrReference', 'currency_id', 'showOnlyNullCostCenter',
   ];
 
   const changes = new Store({ identifier : 'key' });

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -226,8 +226,11 @@ function buildTransactionQuery(options, posted) {
   filters.equals('stockReference', 'reference_uuid', 'p');
   filters.custom('currency_id', 'c.id=?');
 
-  filters.custom('transaction_type_id', 'p.transaction_type_id IN (?)', options.transaction_type_id);
+  // null cost center for only income and expense accounts
+  const nullCC = 'p.cost_center_id IS NULL AND p.principal_center_id IS NULL AND (a.type_id IN (4, 5))';
+  filters.custom('showOnlyNullCostCenter', nullCC, 'p');
 
+  filters.custom('transaction_type_id', 'p.transaction_type_id IN (?)', options.transaction_type_id);
   filters.custom('uuids', 'p.uuid IN (?)', [options.uuids]);
   filters.custom('record_uuids', 'p.record_uuid IN (?)', [options.record_uuids]);
   filters.custom('accounts_id', 'p.account_id IN (?)', [options.accounts_id]);

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -215,8 +215,18 @@ function buildTransactionQuery(options, posted) {
   filters.equals('record_uuid');
   filters.equals('reference_uuid');
   filters.equals('currency_id');
-  filters.equals('cost_center_id');
-  filters.equals('principal_center_id');
+
+  if (options.cost_center_id > -1) {
+    filters.equals('cost_center_id');
+  } else {
+    filters.custom('cost_center_id', 'p.cost_center_id IS NULL', 'p');
+  }
+
+  if (options.principal_center_id > -1) {
+    filters.equals('principal_center_id');
+  } else {
+    filters.custom('principal_center_id', 'p.principal_center_id IS NULL', 'p');
+  }
 
   filters.equals('comment');
   filters.equals('hrEntity', 'text', 'em');


### PR DESCRIPTION
This PR is related to #5970 

- Adds a way to search transactions with null cost_center_id or principal_center_id
- Adds a way to search by cost_center_id and principal_center_id
- Enhances the `bhCostCenterSelect` to correctly handle `is_required` property and transclude

Closes #5970.