### PR TITLE
fix(cost center): uniquely show auxiliary cost centers in columns

### DIFF
--- a/client/src/modules/cost_center/modals/cost_center.modal.html
+++ b/client/src/modules/cost_center/modals/cost_center.modal.html
@@ -221,7 +221,7 @@
     <hr>
     <div class="radio">
       <p><strong translate>COST_CENTER.STEP_DOWN_COST_ALLOCATION</strong></p>
-      <label class="control-label" style="vertical-align: middle;" translate>ALLOCATION_METHOD</label>:
+      <label class="control-label" style="vertical-align: middle; padding-left:0" translate>ALLOCATION_METHOD</label>:
       <label class="radio-inline" ng-repeat="choice in CostCenterModalCtrl.allocationMethodOptions">
         <input
           type="radio"

--- a/server/controllers/finance/reports/cost_center_step_down/report.handlebars
+++ b/server/controllers/finance/reports/cost_center_step_down/report.handlebars
@@ -29,8 +29,10 @@
               <th>{{translate 'FORM.LABELS.SERVICE'}}</th>
               <th>{{translate 'COST_CENTER.DIRECT_COST'}}</th>
               {{#each data as | service |}}
+                {{#unless service.is_principal}}
                 <th>{{ service.cost_center_label }}</th>
                 <th style="width: 3em;">%</th>
+                {{/unless}}
               {{/each}}
               <th>{{translate 'TABLE.COLUMNS.TOTAL'}}</th>
             </tr>

--- a/server/models/procedures/cost_centers.sql
+++ b/server/models/procedures/cost_centers.sql
@@ -77,8 +77,8 @@ RETURNS MEDIUMINT(8) DETERMINISTIC
 BEGIN
   RETURN (
     SELECT GetCostCenterByServiceUuid(i.service_uuid)
-	FROM invoice i
-	WHERE i.uuid = invoice_uuid
+    FROM invoice i
+    WHERE i.uuid = invoice_uuid
   );
 END $$
 
@@ -97,17 +97,16 @@ BEGIN
       SELECT @full_error AS error_message;
     END;
 
-
   DROP TEMPORARY TABLE IF EXISTS cost_center_costs_with_indexes;
   CREATE TEMPORARY TABLE cost_center_costs_with_indexes AS
     SELECT
-        z.id, z.label AS cost_center_label,
-        z.allocation_basis_id,
-        z.is_principal,
-        z.step_order,
-        z.`value` AS direct_cost,
-        ccb.name AS cost_center_allocation_basis_label,
-        ccbv.quantity AS cost_center_allocation_basis_value
+      z.id, z.label AS cost_center_label,
+      z.allocation_basis_id,
+      z.is_principal,
+      z.step_order,
+      z.`value` AS direct_cost,
+      ccb.name AS cost_center_allocation_basis_label,
+      ccbv.quantity AS cost_center_allocation_basis_value
     FROM
     (
         (


### PR DESCRIPTION
This commit fixes the presentation of the cost center report to only show the allocation ratios for the auxiliary cost centers in the columns.

Closes #5979.

![image](https://user-images.githubusercontent.com/896472/136187131-68d3ed8a-09ed-4938-96d0-25eba5e54fde.png)
