### PR TITLE
feat(lots): add barcode server-side API

### DIFF
--- a/client/src/modules/stock/lots/modals/edit.modal.html
+++ b/client/src/modules/stock/lots/modals/edit.modal.html
@@ -1,15 +1,16 @@
 <form name="ActionForm" bh-submit="$ctrl.submit(ActionForm)" novalidate>
     <div class="modal-header">
       <ol class="headercrumb">
+        <li class="static" translate>TREE.STOCK</li>
         <li class="static" translate>LOTS.DETAILS</li>
-        <li class="title">{{$ctrl.model.inventory_code}} - {{$ctrl.model.inventory_text}}</li>
+        <li class="title">{{$ctrl.model.inventory_code}} - {{$ctrl.model.label}}</li>
       </ol>
     </div>
 
     <div class="modal-body">
       <div class="form-group">
         <label class="control-label" translate>FORM.LABELS.INVENTORY</label>
-        <p>{{$ctrl.model.inventory_text}}</p>
+        <p>{{$ctrl.model.inventory_code}} - {{$ctrl.model.inventory_name}}</p>
       </div>
 
       <div class="form-group"

--- a/client/src/modules/stock/lots/modals/edit.modal.js
+++ b/client/src/modules/stock/lots/modals/edit.modal.js
@@ -19,7 +19,6 @@ function EditLotModalController(Data, Session, Lots, Inventory, Notify, Instance
   vm.trackingExpiration = true;
 
   function startup() {
-
     Lots.read(Data.uuid)
       .then(lot => {
         vm.model = lot;
@@ -39,8 +38,9 @@ function EditLotModalController(Data, Session, Lots, Inventory, Notify, Instance
   }
 
   function submit(form) {
-    if (form.$invalid) { return; }
-    Lots.update(Data.uuid, vm.model)
+    if (form.$invalid) { return 0; }
+
+    return Lots.update(Data.uuid, vm.model)
       .then(() => {
         Notify.success('LOTS.SUCCESSFULLY_EDITED');
         Instance.close(true);

--- a/server/config/identifiers.js
+++ b/server/config/identifiers.js
@@ -42,27 +42,22 @@ module.exports = {
     documentPath : '/reports/finance/financial_patient/',
     redirectPath : '/#!/patients/?',
   },
-  DOCUMENT : {
-    key : 'DO',
-  },
   STOCK_ASSIGN : {
     key : 'SA',
     table : 'stock_assign',
   },
-  STOCK_ENTRY : {
-    key : 'SN',
-  },
-  STOCK_EXIT : {
-    key : 'SX',
-  },
+  STOCK_ENTRY : { key : 'SN' }, // TODO - make these both just SM
+  STOCK_EXIT : { key : 'SX' }, // TODO - make these both just SM
   STOCK_MOVEMENT : {
     key : 'SM',
     table : 'stock_movement',
     documentPath : '/receipts/stock/',
     redirectPath : '/#/stock/movements',
   },
-  STOCK_LOT : {
-    key : 'SL',
+  LOT : {
+    key : 'LT',
+    table : 'lot',
+    redirectPath : '/#/stock/lots',
   },
   INVENTORY_ITEM : {
     key   : 'II',

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -54,6 +54,7 @@ module.exports = {
   getInventoryQuantityAndConsumption,
   getInventoryMovements,
   getDailyStockConsumption,
+  lookupLotByUuid,
 };
 
 /**
@@ -162,6 +163,11 @@ function getLotFilters(parameters) {
   filters.equals('user_id', 'user_id', 'm');
 
   return filters;
+}
+
+async function lookupLotByUuid(uid) {
+  const [lot] = await getLots(null, { uuid : uid });
+  return lot;
 }
 
 /**

--- a/server/lib/barcode.js
+++ b/server/lib/barcode.js
@@ -13,6 +13,7 @@ const { lookupInvoice } = require('../controllers/finance/patientInvoice');
 const lookupCashPayment = require('../controllers/finance/cash').lookup;
 const { lookupVoucher } = require('../controllers/finance/vouchers');
 const lookupPurchaseOrder = require('../controllers/finance/purchases').lookup;
+const { lookupLotByUuid } = require('../controllers/stock/core');
 
 const identifiersIndex = {};
 indexIdentifiers();
@@ -85,4 +86,5 @@ function indexIdentifiers() {
   identifiers.CASH_PAYMENT.lookup = lookupCashPayment;
   identifiers.VOUCHER.lookup = lookupVoucher;
   identifiers.PURCHASE_ORDER.lookup = lookupPurchaseOrder;
+  identifiers.LOT.lookup = lookupLotByUuid;
 }

--- a/test/integration/barcodes.js
+++ b/test/integration/barcodes.js
@@ -6,6 +6,7 @@ const helpers = require('./helpers');
 describe('(/barcode) Barcode Reverse Lookup', () => {
   const validPatientBarcode = 'PA81af634f';
   const invalidPatientBarcode = 'PAnotvalid';
+  const validLotBarcode = 'LT064ab1d9';
 
   const invalidBarcodeType = 'ZZinvalidcode';
 
@@ -19,6 +20,21 @@ describe('(/barcode) Barcode Reverse Lookup', () => {
         expect(res.body).to.contain.keys(patientKeys);
       })
       .catch(helpers.handler);
+  });
+
+  it(`/barcode/:key looks up a barcode for a lot ${validLotBarcode}`, () => {
+    return agent.get(`/barcode/${validLotBarcode}`)
+      .then((res) => {
+        const lotKeys = ['uuid', 'label', 'code', 'text', 'expiration_date', 'unit_cost'];
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+
+        const lot = res.body;
+        expect(lot).to.contain.keys(lotKeys);
+        expect(lot.uuid).to.equal('064AB1D952464402AE8A958FCDB07B35');
+      })
+      .catch(helpers.handler);
+
   });
 
   it('/barcode/invalid returns 404 for valid PA document type, invalid UUID', () => {


### PR DESCRIPTION
Adds the server-side API to lookup lots by their barcode.  Note, we don't actually display the lot's barcode anywhere yet.

Also fixes a few bugs with the lot edit modal.

Closes #6055.