### PR TITLE
Add optional daily balances to the RUMER report

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -177,9 +177,13 @@
       "TITLE": "Purchase Price Analysis"
     },
     "RUMER": {
+      "BALANCE": "Balance",
       "CONDENSED_REPORT": "Condensed report",
       "DESCRIPTION": "Drug Usage and Recipe Register",
+      "ENTRIES": "Entries",
       "EXCLUDE_OUT_STOCK_ITEMS": "Exclude inventories without movements and out of stock",
+      "INCLUDE_DAILY_BALANCES": "Include daily stock balances and out-of-stock percentage",
+      "PERCENT_STOCK_OUT": "% Stock Out",
       "STOCK_BEGINNING": "Stock at the beginning of the month",
       "STOCK_END": "Stock at the end of the month",
       "TITLE": "RUMER",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -161,9 +161,14 @@
       "TOTAL_ALL_STOCK_MOV": "Total de tous les mouvements de stocks"
     },
     "RUMER": {
+      "BALANCE": "Solde",
       "CONDENSED_REPORT": "Rapport condensé",
       "DESCRIPTION": "Registre d’utilisation des médicaments et recettes",
+      "ENTRIES": "Entrées",
       "EXCLUDE_OUT_STOCK_ITEMS": "Exclure les inventaires sans mouvements et en rupture de stock",
+      "INCLUDE_DAILY_BALANCES": "Inclure les soldes quotidiens des stocks et le pourcentage de rupture de stock",
+      "INCOMING": "Entrant",
+      "PERCENT_STOCK_OUT": "% de rupture de stock",
       "STOCK_BEGINNING": "Stock au début du mois",
       "STOCK_END": "Stock à la fin du mois",
       "TITLE": "RUMER",

--- a/client/src/modules/reports/generate/rumer_report/rumer_report.config.js
+++ b/client/src/modules/reports/generate/rumer_report/rumer_report.config.js
@@ -36,6 +36,14 @@ function rumerReportController($sce, Notify, SavedReports, AppCache, reportData,
     vm.reportDetails.year = period.year;
   };
 
+  vm.onDailyBalances = () => {
+    vm.reportDetails.condensed_report = false;
+  };
+
+  vm.onCondensedReport = () => {
+    vm.reportDetails.include_daily_balances = false;
+  };
+
   vm.clear = key => {
     delete vm[key];
   };

--- a/client/src/modules/reports/generate/rumer_report/rumer_report.html
+++ b/client/src/modules/reports/generate/rumer_report/rumer_report.html
@@ -51,7 +51,20 @@
 
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.consensed_report" ng-true-value="1" ng-false-value="0">
+              <input type="checkbox"
+                ng-model="ReportConfigCtrl.reportDetails.include_daily_balances"
+                ng-change="ReportConfigCtrl.onDailyBalances()"
+                ng-true-value="1" ng-false-value="0">
+              <span translate>REPORT.RUMER.INCLUDE_DAILY_BALANCES</span>
+            </label>
+          </div>
+
+          <div class="checkbox">
+            <label>
+              <input type="checkbox"
+                ng-model="ReportConfigCtrl.reportDetails.condensed_report"
+                ng-change="ReportConfigCtrl.onCondensedReport()"
+                ng-true-value="1" ng-false-value="0">
               <span translate>REPORT.RUMER.CONDENSED_REPORT</span>
             </label>
           </div>

--- a/server/controllers/stock/reports/rumer.report.handlebars
+++ b/server/controllers/stock/reports/rumer.report.handlebars
@@ -6,6 +6,10 @@
     background-color: #f2dede !important;
     border-color: #ebccd1 !important;
   }
+  td.bg-danger-out-of-stock {
+    color: #a94442 !important;
+    background-color: #f2dede !important;
+  }
 </style>
 
 <body class="container-fluid">
@@ -24,7 +28,7 @@
       <h3 class="text-center">{{params.depot_text}}</h3>
       <h4 class="text-center">{{translate params.translate_key}} - {{params.year}} </h4>
 
-      <table class="table table-striped table-condensed table-report table-bordered">
+      <table class="table table-condensed {{#if params.include_daily_balances}}{{else}}table-striped{{/if}} table-report table-bordered">
         <thead>
           <tr style="background-color:#ddd;">
             <th style="min-width:100px;">{{translate 'FORM.LABELS.INVENTORY'}}</th>
@@ -35,23 +39,44 @@
             {{/each}}
             <th style="width: 7.5%;" class="text-center">{{translate 'REPORT.RUMER.TOTAL_EXITS'}} </th>
             <th style="width: 7.5%;" class="text-center">{{translate 'REPORT.RUMER.STOCK_END'}}</th>
+            <th style="width: 7.5%;" class="text-center">{{translate 'STOCK.DAYS_OF_STOCK_OUT'}}</th>
+            <th style="width: 7.5%;" class="text-center">{{translate 'REPORT.RUMER.PERCENT_STOCK_OUT'}}</th>
           </tr>
         </thead>
 
           <tbody>
             {{#each configurationData}}
-              <tr {{#lt quantityEnding 0 }}class="bg-danger-important"{{/lt}}>
-              <td> {{ inventoryText }} </td>
-              <td class="text-right"><strong> {{ quantityOpening }} </strong></td>
-              <td class="text-right"><strong>{{ quantityTotalEntry }}</strong></td>
-              {{#each dailyConsumption }}
+              <tr {{#lt quantityEnding 0 }}class="bg-danger-important"{{/lt}}
+                {{#if ../params.include_daily_balances}}style="background-color: #f9f9f9; border-bottom: 1px solid gray;"{{/if}}>
+                <td> {{ inventoryText }} </td>
+                <td class="text-right"><strong> {{ quantityOpening }} </strong></td>
+                <td class="text-right"><strong>{{ quantityTotalEntry }}</strong></td>
+                {{#each dailyConsumption }}
                 <td class="text-right">
-                {{#if value}} {{ value }} {{/if}}
+                  {{#if consumed}} {{ consumed }} {{/if}}
                 </td>
-              {{/each}}
-              <td class="text-right"><strong> {{ quantityTotalExit }} </strong></td>
-              <td class="text-right"><strong> {{ quantityEnding }} </strong></td>
-            </tr>
+                {{/each}}
+                <td class="text-right"><strong> {{ quantityTotalExit }} </strong></td>
+                <td class="text-right"><strong> {{ quantityEnding }} </strong></td>
+                <td class="text-right"><strong> {{ numStockOutDays }} </strong></td>
+                <td class="text-right"><strong> {{ percentStockOut }}% </strong></td>
+              </tr>
+              {{#if ../params.include_daily_balances}}
+              <tr style="border-top: 0; border-bottom: 0;">
+                <td class="text-right" colspan="3">{{translate 'REPORT.RUMER.ENTRIES'}}</td>
+                {{#each dailyConsumption }}
+                <td class="text-right"> {{#if incoming}} {{ incoming }} {{/if}} </td>
+                {{/each}}
+                <td colspan="4"></td>
+              </tr>
+              <tr style="border-top: 0; border-bottom: 2px solid black;">
+                <td class="text-right" colspan="3">{{translate 'REPORT.RUMER.BALANCE'}}</td>
+                {{#each dailyConsumption }}
+                <td {{#lt balance 1 }}class="text-right bg-danger-out-of-stock"{{else}}class="text-right"{{/lt}}> {{ balance }} </td>
+                {{/each}}
+                <td colspan="4"></td>
+              </tr>
+              {{/if}}
             {{/each}}
           </tbody>
       </table>

--- a/server/controllers/stock/reports/rumer_condensed.report.handlebars
+++ b/server/controllers/stock/reports/rumer_condensed.report.handlebars
@@ -19,15 +19,18 @@
       <table class="table table-striped table-condensed table-report table-bordered">
         <thead>
           <tr style="background-color:#ddd;">
-            <th style="min-width:31%;">{{translate 'FORM.LABELS.INVENTORY'}}</th>
-            <th style="width: 11.5%;" class="text-center"> {{translate 'REPORT.RUMER.STOCK_BEGINNING'}} </th>
-            <th style="width: 11.5%;" class="text-center"> {{translate 'REPORT.RUMER.TOTAL_ENTRIES'}} </th>
+            <th style="min-width:25%;">{{translate 'FORM.LABELS.INVENTORY'}}</th>
+            <th style="width: 10%;" class="text-center"> {{translate 'REPORT.RUMER.STOCK_BEGINNING'}} </th>
+            <th style="width: 10%;" class="text-center"> {{translate 'REPORT.RUMER.TOTAL_ENTRIES'}} </th>
 
-            <th style="width: 11.5%;" class="text-center"> {{translate 'REPORT.RUMER.TOTAL_QUANTITIES_CONSUMED'}} </th>
-            <th style="width: 11.5%;" class="text-center"> {{translate 'REPORT.RUMER.TOTAL_QUANTITIES_LOST'}} </th>
+            <th style="width: 10%;" class="text-center"> {{translate 'REPORT.RUMER.TOTAL_QUANTITIES_CONSUMED'}} </th>
+            <th style="width: 10%;" class="text-center"> {{translate 'REPORT.RUMER.TOTAL_QUANTITIES_LOST'}} </th>
 
-            <th style="width: 11.5%;" class="text-center">{{translate 'REPORT.RUMER.TOTAL_EXITS'}} </th>
-            <th style="width: 11.5%;" class="text-center">{{translate 'REPORT.RUMER.STOCK_END'}}</th>
+            <th style="width: 10%;" class="text-center">{{translate 'REPORT.RUMER.TOTAL_EXITS'}} </th>
+            <th style="width: 10%;" class="text-center">{{translate 'REPORT.RUMER.STOCK_END'}}</th>
+
+            <th style="width: 7.5%;" class="text-center">{{translate 'STOCK.DAYS_OF_STOCK_OUT'}}</th>
+            <th style="width: 7.5%;" class="text-center">{{translate 'REPORT.RUMER.PERCENT_STOCK_OUT'}}</th>
           </tr>
         </thead>
 
@@ -43,6 +46,9 @@
 
               <td class="text-right"><strong> {{ quantityTotalExit }} </strong></td>
               <td class="text-right"><strong> {{ quantityEnding }} </strong></td>
+
+              <td class="text-right"><strong> {{ numStockOutDays }} </strong></td>
+              <td class="text-right"><strong> {{ percentStockOut }}% </strong></td>
             </tr>
             {{/each}}
           </tbody>

--- a/server/controllers/stock/reports/stock/rumer.js
+++ b/server/controllers/stock/reports/stock/rumer.js
@@ -30,9 +30,10 @@ async function report(req, res, next) {
   const params = req.query;
 
   params.exclude_out_stock = parseInt(params.exclude_out_stock, 10);
-  params.consensed_report = parseInt(params.consensed_report, 10);
+  params.include_daily_balances = parseInt(params.include_daily_balances, 10);
+  params.condensed_report = parseInt(params.condensed_report, 10);
 
-  const template = params.consensed_report ? TEMPLATE2 : TEMPLATE1;
+  const template = params.condensed_report ? TEMPLATE2 : TEMPLATE1;
 
   const data = {};
   const headerReport = [];
@@ -72,15 +73,16 @@ async function report(req, res, next) {
 
     const sqlDailyConsumption = `
       SELECT BUID(sms.inventory_uuid) AS uuid, inv.code, inv.text AS inventory_text,
-      (sms.out_quantity_consumption + sms.out_quantity_exit) AS quantity, sms.date
-        FROM stock_movement_status AS sms
-        JOIN inventory AS inv ON inv.uuid = sms.inventory_uuid
+        (sms.out_quantity_consumption + sms.out_quantity_exit) AS quantity,
+        sms.in_quantity, sms.quantity_delta, sms.date
+      FROM stock_movement_status AS sms
+      JOIN inventory AS inv ON inv.uuid = sms.inventory_uuid
       WHERE sms.depot_uuid = ? AND sms.date >= DATE(?) AND sms.date <= DATE(?)
     `;
 
     const sqlMonthlyConsumption = `
       SELECT BUID(sms.inventory_uuid) AS uuid, inv.code, inv.text AS inventory_text, sms.date,
-        SUM(sms.out_quantity_consumption + sms.out_quantity_exit) AS quantityTotalExit, 
+        SUM(sms.out_quantity_consumption + sms.out_quantity_exit) AS quantityTotalExit,
         SUM(sms.in_quantity) AS quantityTotalEntry,
         SUM(sms.out_quantity_consumption) AS outQuantityConsumption,
         SUM(sms.out_quantity_exit) AS outQuantityExit
@@ -116,32 +118,7 @@ async function report(req, res, next) {
     });
 
     configurationData.forEach(inventory => {
-      const dailyConsumption = [];
-      for (let i = startDate; i <= endDate; i++) {
-        dailyConsumption.push({ value : 0, index : i });
-      }
-
-      inventoriesConsumed.forEach(consumed => {
-        if (inventory.inventoryUuid === consumed.uuid) {
-          const dateConsumption = parseInt(moment(consumed.date).format('DD'), 10);
-          dailyConsumption.forEach(d => {
-            if (d.index === dateConsumption) {
-              d.value = consumed.quantity;
-            }
-          });
-        }
-      });
-
-      inventory.dailyConsumption = dailyConsumption;
-
-      if (inventoriesOpening.length) {
-        inventoriesOpening.forEach(opening => {
-          if (inventory.inventoryUuid === opening.inventory_uuid) {
-            inventory.quantityOpening = opening.quantity;
-          }
-        });
-      }
-
+      // First populate the monthly stats
       if (monthlyConsumption.length) {
         monthlyConsumption.forEach(row => {
           if (inventory.inventoryUuid === row.uuid) {
@@ -152,6 +129,51 @@ async function report(req, res, next) {
           }
         });
       }
+      // Add the opening balance for each inventory article
+      if (inventoriesOpening.length) {
+        inventoriesOpening.forEach(opening => {
+          if (inventory.inventoryUuid === opening.inventory_uuid) {
+            inventory.quantityOpening = opening.quantity;
+          }
+        });
+      }
+
+      const dailyConsumption = [];
+      for (let i = startDate; i <= endDate; i++) {
+        dailyConsumption.push({ index : i, consumed : 0 });
+      }
+
+      // Construct a consumed inventories data set for this inventory item
+      // to simplify the logic for constructing balances.
+      const invDailyConsumed = inventoriesConsumed.filter(item => item.uuid === inventory.inventoryUuid);
+      invDailyConsumed.forEach(item => {
+        item.dayNum = parseInt(moment(item.date).format('DD'), 10);
+      });
+      invDailyConsumed.sort((a, b) => a.date > b.date);
+      let lastBalance = inventory.quantityOpening;
+      let numStockOutDays = 0;
+      dailyConsumption.forEach(d => {
+        const consumed = invDailyConsumed.find(item => item.dayNum === d.index);
+        if (consumed) {
+          d.consumed = consumed.quantity;
+          d.incoming = consumed.in_quantity;
+          d.balance = lastBalance + consumed.quantity_delta;
+        } else {
+          d.balance = lastBalance;
+        }
+
+        // Save the balance for the next day
+        lastBalance = d.balance;
+
+        if (d.balance === 0) {
+          numStockOutDays += 1;
+        }
+      });
+
+      inventory.numStockOutDays = numStockOutDays;
+      inventory.percentStockOut = Number(100 * (numStockOutDays / dailyConsumption.length)).toFixed(1);
+
+      inventory.dailyConsumption = dailyConsumption;
     });
 
     data.configurationData = configurationData;


### PR DESCRIPTION
Add an option to the RUMER report to all adding extra rows to show the daily stock entries and balances.  

Added a column on the far right indicating the percent of days of stock out for each stock article.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6064

I tested this against the Vanga database and it seems to work correctly.  I spot-checked against the example spreadsheet sent to us by the Vanga medical director and it matched except in a few cases where the database data I downloaded earlier this week is different than the earlier data they had.   Also note that the example spreadsheet is done manually and it is possible there are some errors there as well.

The numbers made sense for the VANGA Stock Pharmacy.  However there are some cases in the Usage Pharmacy where the daily balances are negative.  This not the fault of this PR but is most likely related to units issues that they are having problems with there.

**TESTING**
- Use the Vanga dataset
- Stock > Reports > RUMER
   - Select: Stock Pharmacy
   - Select: 2021
   - Select:  October
   - Try the report with and without the new "Include daily balances" option.
   - The version without the daily balances should match the previous report


