### PR TITLE
chore(inventory): skip tags where possible

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,8 @@
     "array-bracket-spacing" : "warn",
     "prefer-arrow-callback" : "warn",
     "class-methods-use-this" : "off",
+    "function-call-argument-newline" : "off",
+    "function-paren-newline" : "off",
     "indent" : ["error", 2],
     "comma-dangle" : ["error", "always-multiline"],
     "key-spacing" : ["warn", {

--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -802,7 +802,7 @@
             "TURNOVER": "Turnover",
             "TYPE": "Type",
             "UNCONFIGURED": "Unconfigured",
-            "UNCONSUMABLE": "Non-consummable",
+            "UNCONSUMABLE": "Non-consumable",
             "UNDEFINED": "Undefined",
             "UNIT": "Unit",
             "UNITS": "Units",

--- a/client/src/js/components/bhInventorySelect.js
+++ b/client/src/js/components/bhInventorySelect.js
@@ -24,9 +24,11 @@ function InventorySelectController(Inventory, Notify) {
   $ctrl.$onInit = function onInit() {
     // fired when an inventory has been selected
 
-    const params = $ctrl.onlyConsumable
-      ? { consumable : 1 }
-      : {};
+    const params = { skipTags : 1 };
+
+    if ($ctrl.onlyConsumable) {
+      Object.assign(params, { consumable : 1 });
+    }
 
     // load all inventories
     Inventory.read(null, params)

--- a/client/src/js/components/bhInventorySelect.js
+++ b/client/src/js/components/bhInventorySelect.js
@@ -24,7 +24,7 @@ function InventorySelectController(Inventory, Notify) {
   $ctrl.$onInit = function onInit() {
     // fired when an inventory has been selected
 
-    const params = { skipTags : 1 };
+    const params = { skipTags : true };
 
     if ($ctrl.onlyConsumable) {
       Object.assign(params, { consumable : 1 });

--- a/client/src/modules/invoices/patientInvoiceForm.service.js
+++ b/client/src/modules/invoices/patientInvoiceForm.service.js
@@ -102,7 +102,7 @@ function PatientInvoiceFormService(
       });
 
     // set up the inventory
-    Inventory.read(null, { detailed : 1, locked : 0 })
+    Inventory.read(null, { detailed : 1, locked : 0, skipTags : true })
       .then(data => {
         if (data.length === 0) {
           Notify.danger('INVENTORY.NO_INVENTORY_REGISTERED');

--- a/client/src/modules/prices/modal/createItems.js
+++ b/client/src/modules/prices/modal/createItems.js
@@ -8,7 +8,7 @@ PriceListItemsModalController.$inject = [
 
 function PriceListItemsModalController(
   data, Instance, Inventory, util,
-  Notify, AppCache, PriceList, Modal
+  Notify, AppCache, PriceList, Modal,
 ) {
   const vm = this;
 
@@ -29,7 +29,7 @@ function PriceListItemsModalController(
 
   function startUp() {
     init();
-    Inventory.read()
+    Inventory.read(null, { skipTags : true })
       .then((inventory) => {
         // gather all used uuids in a flat array
         inventory.forEach(item => {
@@ -106,7 +106,6 @@ function PriceListItemsModalController(
   vm.gridOptions.onRegisterApi = gridApi => {
     vm.gridApi = gridApi;
   };
-
 
   // check if the price list item is valid
   function isValidItem() {

--- a/client/src/modules/purchases/create/PurchaseOrderForm.js
+++ b/client/src/modules/purchases/create/PurchaseOrderForm.js
@@ -42,7 +42,7 @@ function PurchaseOrderFormService(Inventory, AppCache, Store, Pool, PurchaseOrde
     this._ready = $q.defer();
 
     // set up the inventory
-    Inventory.read(null, { locked : 0 })
+    Inventory.read(null, { locked : 0, skipTags : true })
       .then((data) => {
 
         // zero out price so that users don't automatically use the sale price.

--- a/client/src/modules/purchases/purchases.service.js
+++ b/client/src/modules/purchases/purchases.service.js
@@ -15,8 +15,15 @@ PurchaseOrderService.$inject = [
  * Connects client controllers with the purchase order backend.
  */
 function PurchaseOrderService(
-  $uibModal, Filters, AppCache, Periods, Api, $httpParamSerializer,
-  Languages, bhConstants, Session,
+  $uibModal,
+  Filters,
+  AppCache,
+  Periods,
+  Api,
+  $httpParamSerializer,
+  Languages,
+  bhConstants,
+  Session,
 ) {
   const baseUrl = '/purchases/';
   const service = new Api(baseUrl);

--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -275,7 +275,7 @@ function StockEntryController(
   function loadInventories() {
     setupStock();
 
-    Inventory.read(null, { consumable : 1 })
+    Inventory.read(null, { consumable : 1, skipTags : true })
       .then((inventories) => {
         vm.inventories = inventories;
         inventoryStore = new Store({ identifier : 'uuid', data : inventories });

--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -295,7 +295,7 @@ function StockExitController(
     Stock.inventories.read(null, {
       depot_uuid : depot.uuid,
       dateTo,
-      skipTags : 1,
+      skipTags : true,
       is_expired : loadExpiredOnlyForLoss,
     })
       .then(inventories => {
@@ -316,7 +316,7 @@ function StockExitController(
 
   function loadCurrentInventories(depot, dateTo = new Date()) {
     vm.loading = true;
-    Stock.lots.read(null, { depot_uuid : depot.uuid, dateTo, skipTags : 1 })
+    Stock.lots.read(null, { depot_uuid : depot.uuid, dateTo, skipTags : true })
       .then(lots => {
         vm.currentInventories = lots.filter(item => item.quantity > 0);
       })

--- a/server/controllers/inventory/index.js
+++ b/server/controllers/inventory/index.js
@@ -222,7 +222,7 @@ async function getInventoryItems(req, res, next) {
     `;
 
     // if we have an empty set, do not query tags.
-    if (data.length !== 0) {
+    if (data.length !== 0 && !params.skipTags) {
       const inventoryUuids = data.map(row => db.bid(row.uuid));
       const tags = await db.exec(queryTags, [inventoryUuids]);
 
@@ -249,7 +249,7 @@ async function getInventoryItems(req, res, next) {
 function getInventoryItemsById(req, res, next) {
   const { uuid } = req.params;
 
-  core.getItemsMetadataById(uuid)
+  core.getItemsMetadataById(uuid, req.query)
     .then((row) => {
       res.status(200).json(row);
     })

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -330,7 +330,7 @@ function remove(_uuid) {
 * @param {String} uuid The inventory item identifier
 * @return {Promise} Returns a database query promise
 */
-async function getItemsMetadataById(uid) {
+async function getItemsMetadataById(uid, query = {}) {
   const sql = `
     SELECT BUID(i.uuid) as uuid, i.code, i.text AS label, i.price, iu.abbr AS unit,
       it.text AS type, ig.name AS groupName, BUID(ig.uuid) AS group_uuid,
@@ -354,8 +354,11 @@ async function getItemsMetadataById(uid) {
   `;
 
   const response = await db.one(sql, [db.bid(uid), uid, 'inventory']);
-  const tags = await db.exec(queryTags, [db.bid(uid)]);
-  response.tags = tags;
+
+  if (!query.skipTags) {
+    response.tags = await db.exec(queryTags, [db.bid(uid)]);
+  }
+
   return response;
 }
 

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -910,6 +910,7 @@ async function listLotsDepot(req, res, next) {
     // if no data is returned or if the skipTags flag is set, we don't need to do any processing
     // of tags.  Skip the SQL query and JS loops.
     if (data.length !== 0 && !params.skipTags) {
+
       const queryTags = `
         SELECT BUID(t.uuid) uuid, t.name, t.color, BUID(lt.lot_uuid) lot_uuid
         FROM tags t

--- a/test/client-unit/services/PatientInvoiceForm.spec.js
+++ b/test/client-unit/services/PatientInvoiceForm.spec.js
@@ -60,7 +60,7 @@ describe('PatientInvoiceForm', () => {
     httpBackend.when('GET', '/services/')
       .respond(200, Mocks.services());
 
-    httpBackend.when('GET', '/inventory/metadata/?detailed=1&locked=0')
+    httpBackend.when('GET', '/inventory/metadata/?detailed=1&locked=0&skipTags=true')
       .respond(200, Mocks.inventories());
 
     form = new PatientInvoiceForm('InvoiceTestKey');

--- a/test/client-unit/services/PurchaseOrderFormService.spec.js
+++ b/test/client-unit/services/PurchaseOrderFormService.spec.js
@@ -42,7 +42,7 @@ describe('PurchaseOrderForm', () => {
 
     httpBackend = $httpBackend;
 
-    httpBackend.when('GET', '/inventory/metadata/?locked=0')
+    httpBackend.when('GET', '/inventory/metadata/?locked=0&skipTags=true')
       .respond(200, Mocks.inventories());
 
     httpBackend.when('GET', '/inventory/d03e7870-0c8e-47d4-a7a8-a17a9924b3f4/unit_cost')


### PR DESCRIPTION
This commit ensures that the `bhInventorySelect` doesn't trigger the tag search path, since it isn't needed.

To test:
On `master`
1. Build the default test database via the integration tests.
2. Add "DEBUG=db*" to the .env file
2. Navigate to the "stock sheet" report and notice that a lot of tags are queried on initial load.

On this branch:
1. Repeat the steps above.
2. Notice that the tags are not queried.