### PR TITLE
Remove selection badge when dates are hand edited

### DIFF
--- a/client/src/js/components/bhDateInterval.js
+++ b/client/src/js/components/bhDateInterval.js
@@ -1,9 +1,9 @@
 /**
  * @name bhDateInterval
  * @description
- * The `bhDateInterval` component provide a mean to select dates plage between
- * two dates. The dates values returned are send to dates models given in
- * date-from and date-to attributes.
+ * The `bhDateInterval` component provide a means to select a date range
+ * between two dates. The dates values returned are sent to dates models
+ * given in date-from and date-to attributes.
  *
  * An optional flag `limit-min-fiscal` can be provided that limits the from and
  * to date inputs to not allow dates before the start of the first enterprise
@@ -48,6 +48,8 @@ function bhDateInterval(bhConstants, Fiscal, Session, PeriodService, $translate)
   // expose to the view
   $ctrl.search = search;
   $ctrl.clear = clear;
+  $ctrl.lastDateFrom = null;
+  $ctrl.lastDateTo = null;
 
   $ctrl.$onInit = () => {
     // specify if clear button can be displayed
@@ -90,6 +92,11 @@ function bhDateInterval(bhConstants, Fiscal, Session, PeriodService, $translate)
     if ($ctrl.onChange) {
       $ctrl.onChange({ dateFrom : $ctrl.dateFrom, dateTo : $ctrl.dateTo });
     }
+    if ($ctrl.dateFrom !== $ctrl.lastDateFrom || $ctrl.dateTo !== $ctrl.lastDateTo) {
+      delete $ctrl.selected;
+      $ctrl.lastDateFrom = $ctrl.dateFrom;
+      $ctrl.lastDateTo = $ctrl.dateTo;
+    }
   };
 
   function search(selection) {
@@ -101,6 +108,8 @@ function bhDateInterval(bhConstants, Fiscal, Session, PeriodService, $translate)
   function setDateInterval(key) {
     $ctrl.dateFrom = new Date(PeriodService.index[key].limit.start());
     $ctrl.dateTo = new Date(PeriodService.index[key].limit.end());
+    $ctrl.lastDateFrom = $ctrl.dateFrom;
+    $ctrl.lastDateTo = $ctrl.dateTo;
   }
 
   function day() {
@@ -133,6 +142,8 @@ function bhDateInterval(bhConstants, Fiscal, Session, PeriodService, $translate)
     delete $ctrl.dateFrom;
     delete $ctrl.dateTo;
     delete $ctrl.selected;
+    $ctrl.lastDateFrom = null;
+    $ctrl.lastDateTo = null;
   }
 
   function startup() {


### PR DESCRIPTION
Fix a bug in the date interval selection component.   When a reconfigured date range is selected (eg, 'This Year') the component puts a little "This Year" badge, in orange, next to the component label.   However when either the start or end dates are hand-edited, the badge is not removed even though it is probably not still correct.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6173

**TESTING**
- Use any database
- Go to the Finance > Reports > Cash Report page
- Select a predefined date range (eg, "This Month")
- Notice the orange "This Month" badge appears
- Manually edit either the start or end dates and the badge should disappear. 
- Try the "Preview" to verify that the date range still works properly in the report generation.

Note: Even if you manually restore the date to the correct range for one of the predefined ranges, the corresponding badge will not appear.  Only click on the predefined date range links will produce the badge.