### PR TITLE
Update server report CSS rules to simplify and unify report title format

### DIFF
--- a/server/controllers/inventory/reports/changes.handlebars
+++ b/server/controllers/inventory/reports/changes.handlebars
@@ -4,11 +4,11 @@
   <!-- header  -->
  {{> header}}
 
+  <h2 class="text-center">
+    {{ translate 'REPORT.INVENTORY_CHANGE.TITLE' }}
+  </h2>
   <h3 class="text-center">
-    <u>{{ translate 'REPORT.INVENTORY_CHANGE.TITLE' }} </u>
-  </h3>
-  <h3 class="text-center">
-    <small>{{date dateFrom }} - {{date dateTo}}</small>
+    {{date dateFrom }} - {{date dateTo}}
   </h3>
 
   <table class="table table-report table-condensed">

--- a/server/lib/template/partials/head.handlebars
+++ b/server/lib/template/partials/head.handlebars
@@ -6,6 +6,30 @@
   <script src="{{nodeModulesPath}}/jsbarcode/dist/JsBarcode.all.min.js"></script>
   <style>
 
+    h2 {
+      font-size : 1.75em;
+      font-weight: bold;
+      margin-bottom: 0.25em;
+    }
+
+    h3 {
+      font-size : 1.5em;
+      margin-top : 0.1em;
+      margin-bottom: 0.25em;
+    }
+
+    h4 {
+      font-size : 1.25em;
+      margin-top : 0.1em;
+      margin-bottom: 0.25em;
+    }
+
+    h5 {
+      font-size : 1em;
+      margin-top : 0.1em;
+      margin-bottom: 0.25em;
+    }
+
     thead {
       display : table-header-group;
     }
@@ -25,9 +49,14 @@
     .row, .col-lg-12, .col-xs-12 {
        width :100%;
     }
+
     /* sourced from jimmybonney.com.  Thank you! */
     .table-header-rotated th.row-header{
       width: auto;
+    }
+
+    .table-report {
+      margin-top: 1em;
     }
 
     table, td, th{


### PR DESCRIPTION
I've updated the default rules in the CSS used by reports to fix up the font sizes for the title lines.  To use these, simply  update the report title and subtitles to use simple 'h2', 'h3', 'h4', and 'h5' without additional 'underline' or 'small' font html tags.  

This PR partially addresses Issue https://github.com/IMA-WorldHealth/bhima/issues/6148.

Here is the way the titles should come out:

  'h2' - the main title  (will be bold)
  'h3' - most subtitles
  'h4' - for a smaller subtitle
  'h5' - for normal font size (eg, descriptions)

I've updated the Inventory > Report > Inventory Change Report to use this convention.  Here is what the code and resulting output look like:
![image](https://user-images.githubusercontent.com/62145/146245832-40120e93-abad-4a98-970d-f9ef80a20650.png)

![image](https://user-images.githubusercontent.com/62145/146246180-eaa4adc4-ab09-44f2-aa62-4be341d0a6ab.png)
