### PR TITLE
chore: update houndci eslint version

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,11 +1,9 @@
 eslint:
   enabled: true
   config_file: .eslintrc.json
-  version: 5.7.0
+  version: 8.1.0
 
 scss:
   enabled: false
 
 fail_on_violations: true
-
-


### PR DESCRIPTION
This commit updates the houndci eslint version so it recognizes newer JS rules.