### PR TITLE
fix(reports): add realized_profit report key

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -106,7 +106,7 @@
 	  "FINANCIAL_SITUATION_EMPLOYEES": "Financial situation of employees",
       "INCLUDE_MEDICAL_CARE_EMPLOYEE": "Include medical care provided to the employee",
       "LIMIT_TO_TIME_INTERVAL": "Limit to time interval",
-      "NORMAL_REPORT": "Normal Report",      
+      "NORMAL_REPORT": "Normal Report",
       "REPORT": "Employee Standing Report",
       "SEE_SITUATION_ALL_EMPLOYEES": "See the overall situation of all employees",
       "SUMMARY_REPORT": "Summary report",
@@ -529,7 +529,7 @@
     },
     "REALIZED_PROFIT" : {
       "TITLE":"Collection on invoices report",
-      "DESCRIPTION":"This report shows incomes made from invoices with remaining debts",
+      "DESCRIPTION":"This report shows revenue made from invoices with remaining debts",
       "REMAINING" : "Remaining",
       "INVOICED" : "Invoiced",
       "PAID" : "Paid"

--- a/client/src/i18n/en/tree.json
+++ b/client/src/i18n/en/tree.json
@@ -139,7 +139,7 @@
     "PURCHASE" : "Purchase",
     "PURCHASE_REGISTRY" : "Purchase Registry",
     "PURCHASING" : "Purchasing",
-    "REALIZED_PROFIT_REPORT": "[Invoicing] Collection on invoices",
+    "REALIZED_PROFIT_REPORT": "Collection on invoices",
     "RECOVERY_CAPACITY_REPORT": "Recovery Capacity",
     "REFERENCE_GROUP" : "Reference Group",
     "REFERENCE" : "Reference",

--- a/server/models/bhima.sql
+++ b/server/models/bhima.sql
@@ -130,7 +130,7 @@ INSERT INTO unit VALUES
   (246,'Client Debts Report','TREE.CLIENT_DEBTS_REPORT','Client debts report',281,'/reports/client_debts'),
   (247,'Client Support Report','TREE.CLIENT_SUPPORT_REPORT','Client support report',281,'/reports/client_support'),
   (248,'Analysis of Cashboxes','REPORT.ANALYSIS_AUX_CASHBOXES.TITLE','Analysis of auxiliary cashboxes',281,'/reports/analysis_auxiliary_cashboxes'),
-  (249,'Realized Profit Report','TREE.REALIZED_PROFIT_REPORT','Realized profit report',281,'/reports/realized_profit'),
+  (249,'Realized Profit Report','TREE.REALIZED_PROFIT_REPORT','Realized profit report / Collection on Invoicies',281,'/reports/realized_profit'),
   (250,'System Usage Statistics','REPORT.SYSTEM_USAGE_STAT.TITLE','System usage statistics',280,'/reports/system_usage_stat'),
   (251,'Indexes','TREE.INDEXES','The payroll index',57,'/PAYROLL_INDEX_FOLDER'),
   (252,'Staffing indexes management','TREE.STAFFING_INDICES_MANAGEMENT','Staffing indices management',251,'/staffing_indices'),

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -32,3 +32,12 @@ DELETE FROM unit WHERE id IN (220, 221, 222, 223, 230, 231, 232);
  * @date: 2021-12-16
  */
 ALTER TABLE `exchange_rate` MODIFY `rate` DOUBLE NOT NULL;
+
+
+/**
+ * @author: jniles
+ * @description: add realized_profit report if it doesn't exist
+ * @date: 2021-12-21
+*/
+INSERT IGNORE INTO `report` (`report_key`, `title_key`) VALUES
+  ('realized_profit', 'REPORT.REALIZED_PROFIT.TITLE');


### PR DESCRIPTION
This commit adds the realized_profit report key to the database migration file.

Closes #6160.

![image](https://user-images.githubusercontent.com/896472/146907254-6a2c033e-7787-4e5d-b543-a7bb907de7a5.png)
