### PR TITLE
Set type=number for numeric fields in tabular grids to fix sorting

### DIFF
--- a/client/src/modules/grades/grades.js
+++ b/client/src/modules/grades/grades.js
@@ -41,6 +41,7 @@ function GradeManagementController(Grades, Modals, Notify, uiGridConstants, $sta
       displayName : 'FORM.LABELS.BASIC_SALARY',
       headerCellFilter : 'translate',
       cellFilter : 'currency:'.concat(Session.enterprise.currency_id),
+      type : 'number',
     }, {
       field : 'action',
       width : 80,

--- a/client/src/modules/holidays/holidays.js
+++ b/client/src/modules/holidays/holidays.js
@@ -23,21 +23,44 @@ function HolidayManagementController(Holidays, ModalService, Notify, uiGridConst
   vm.gridApi = {};
   vm.filterEnabled = false;
 
-  var gridColumn =
-    [
-      { field : 'display_name', displayName : 'FORM.LABELS.EMPLOYEE_NAME', headerCellFilter : 'translate' },
-      { field : 'label', displayName : 'FORM.LABELS.DESIGNATION', headerCellFilter : 'translate' },
-      { field : 'dateFrom', displayName : 'FORM.LABELS.DATE_FROM', cellFilter : 'date:"mediumDate"', headerCellFilter : 'translate' },
-      { field : 'dateTo', displayName : 'FORM.LABELS.DATE_TO', cellFilter : 'date:"mediumDate"', headerCellFilter : 'translate' },
-      { field : 'percentage', displayName : 'FORM.LABELS.PERCENTAGE', headerCellFilter : 'translate' },
-      { field : 'action',
-        width : 80,
-        displayName : '',
-        cellTemplate : '/modules/holidays/templates/action.tmpl.html',
-        enableSorting : false,
-        enableFiltering : false,
-      },
-    ];
+  const gridColumn = [
+    {
+      field : 'display_name',
+      displayName : 'FORM.LABELS.EMPLOYEE_NAME',
+      headerCellFilter : 'translate',
+    },
+    {
+      field : 'label',
+      displayName : 'FORM.LABELS.DESIGNATION',
+      headerCellFilter : 'translate',
+    },
+    {
+      field : 'dateFrom',
+      displayName : 'FORM.LABELS.DATE_FROM',
+      cellFilter : 'date:"mediumDate"',
+      headerCellFilter : 'translate',
+    },
+    {
+      field : 'dateTo',
+      displayName : 'FORM.LABELS.DATE_TO',
+      cellFilter : 'date:"mediumDate"',
+      headerCellFilter : 'translate',
+    },
+    {
+      field : 'percentage',
+      displayName : 'FORM.LABELS.PERCENTAGE',
+      headerCellFilter : 'translate',
+      type : 'number',
+    },
+    {
+      field : 'action',
+      width : 80,
+      displayName : '',
+      cellTemplate : '/modules/holidays/templates/action.tmpl.html',
+      enableSorting : false,
+      enableFiltering : false,
+    },
+  ];
 
   // options for the UI grid
   vm.gridOptions = {

--- a/client/src/modules/invoices/patientInvoice.js
+++ b/client/src/modules/invoices/patientInvoice.js
@@ -63,16 +63,19 @@ function PatientInvoiceController(
       displayName : 'TABLE.COLUMNS.QUANTITY',
       headerCellFilter : 'translate',
       cellTemplate : 'modules/invoices/templates/grid/quantity.tmpl.html',
+      type : 'number',
     }, {
       field : 'transaction_price',
       displayName : 'FORM.LABELS.UNIT_PRICE',
       headerCellFilter : 'translate',
       cellTemplate : 'modules/invoices/templates/grid/unit.tmpl.html',
+      type : 'number',
     }, {
       field : 'amount',
       displayName : 'TABLE.COLUMNS.AMOUNT',
       headerCellFilter : 'translate',
       cellTemplate : 'modules/invoices/templates/grid/amount.tmpl.html',
+      type : 'number',
     }, {
       field : 'actions',
       width : 25,

--- a/client/src/modules/invoicing-fees/invoicing-fees.ctrl.js
+++ b/client/src/modules/invoicing-fees/invoicing-fees.ctrl.js
@@ -39,6 +39,7 @@ function InvoicingFeesController($state, InvoicingServices, Notify, bhConstants,
     headerCellFilter : 'translate',
     cellFilter : 'percentage',
     cellClass : 'text-right',
+    type : 'number',
   }, {
     field : 'created_at',
     displayName : 'TABLE.COLUMNS.DATE',

--- a/client/src/modules/locations/village/village.js
+++ b/client/src/modules/locations/village/village.js
@@ -68,11 +68,13 @@ function VillageController($state, locationService, util, Notify,
     field : 'longitude',
     displayName : 'FORM.LABELS.LONGITUDE',
     headerCellFilter : 'translate',
+    type : 'number',
   },
   {
     field : 'latitude',
     displayName : 'FORM.LABELS.LATITUDE',
     headerCellFilter : 'translate',
+    type : 'number',
   },
   {
     field : 'actions',

--- a/client/src/modules/multiple_payroll/multiple_payroll.js
+++ b/client/src/modules/multiple_payroll/multiple_payroll.js
@@ -58,6 +58,7 @@ function MultiplePayrollController(
     cellClass : 'text-right',
     aggregationType  : uiGridConstants.aggregationTypes.sum,
     cellFilter : 'currency:row.entity.currency_id',
+    type : 'number',
   }, {
     field : 'balance',
     displayName : 'FORM.LABELS.BALANCE',
@@ -65,6 +66,7 @@ function MultiplePayrollController(
     cellClass : 'text-right',
     aggregationType  : uiGridConstants.aggregationTypes.sum,
     cellFilter : 'currency:row.entity.currency_id',
+    type : 'number',
   }, {
     field : 'status_id',
     displayName : 'FORM.LABELS.STATUS',

--- a/client/src/modules/offdays/offdays.js
+++ b/client/src/modules/offdays/offdays.js
@@ -28,7 +28,9 @@ function OffdayManagementController(Offdays, ModalService, Notify, uiGridConstan
     {
       field : 'date', displayName : 'FORM.LABELS.DATE', cellFilter : 'date', headerCellFilter : 'translate',
     },
-    { field : 'percent_pay', displayName : 'FORM.LABELS.PERCENTAGE', headerCellFilter : 'translate' },
+    {
+      field : 'percent_pay', displayName : 'FORM.LABELS.PERCENTAGE', headerCellFilter : 'translate', type : 'number',
+    },
     {
       field : 'action',
       width : 80,

--- a/client/src/modules/patients/registry/modals/findDuplicatePatients.modal.js
+++ b/client/src/modules/patients/registry/modals/findDuplicatePatients.modal.js
@@ -53,6 +53,7 @@ function FindDuplicatePatientsModalController(Patients, Instance) {
     field : 'num_patients',
     displayName : 'TABLE.COLUMNS.TOTAL',
     headerCellFilter : 'translate',
+    type : 'number',
   }, {
     field : 'display_name',
     displayName : 'TABLE.COLUMNS.NAME',

--- a/client/src/modules/payroll/staffing_indice/modal/functionIndiceModal.js
+++ b/client/src/modules/payroll/staffing_indice/modal/functionIndiceModal.js
@@ -24,6 +24,7 @@ function FunctionIndiceModalController($state, StaffingIndice, Notify, Instance,
       displayName : 'FORM.LABELS.VALUE',
       headerCellFilter : 'translate',
       cellClass : 'text-right',
+      type : 'number',
     },
     {
       field : 'actions',

--- a/client/src/modules/payroll/staffing_indice/modal/gradeIndiceModal.js
+++ b/client/src/modules/payroll/staffing_indice/modal/gradeIndiceModal.js
@@ -24,6 +24,7 @@ function GradeIndiceModalController($state, StaffingIndice, Notify, Instance, Mo
       displayName : 'FORM.LABELS.VALUE',
       headerCellFilter : 'translate',
       cellClass : 'text-right',
+      type : 'number',
     },
     {
       field : 'actions',

--- a/client/src/modules/prices/modal/createItems.js
+++ b/client/src/modules/prices/modal/createItems.js
@@ -86,6 +86,7 @@ function PriceListItemsModalController(
     displayName : 'FORM.LABELS.VALUE',
     headerCellFilter : 'translate',
     cellTemplate : `/modules/prices/templates/price_item_value.tmpl.html`,
+    type : 'number',
     width : 70,
   }, {
     field : 'actions',

--- a/client/src/modules/prices/prices.js
+++ b/client/src/modules/prices/prices.js
@@ -48,6 +48,7 @@ function PriceListController(
       displayName : 'FORM.LABELS.ITEMS',
       headerCellFilter : 'translate',
       cellTemplate : `/modules/prices/templates/itemsNumber.cell.html`,
+      type : 'number',
     },
     {
       field : 'subcribedGroupsNumber',

--- a/client/src/modules/purchases/create/createUpdate.js
+++ b/client/src/modules/purchases/create/createUpdate.js
@@ -72,6 +72,7 @@ function PurchaseOrderController(
     displayName : 'TABLE.COLUMNS.QUANTITY',
     headerCellFilter : 'translate',
     cellTemplate : 'modules/purchases/create/templates/quantity.tmpl.html',
+    type : 'number',
   }, {
     field : 'unit_price',
     width : 105,
@@ -79,12 +80,14 @@ function PurchaseOrderController(
     headerCellFilter : 'translate',
     headerCellClass : 'wrappingColHeader',
     cellTemplate : 'modules/purchases/create/templates/price.tmpl.html',
+    type : 'number',
   }, {
     field : 'amount',
     width : 100,
     displayName : 'TABLE.COLUMNS.AMOUNT',
     headerCellFilter : 'translate',
     cellTemplate : 'modules/purchases/create/templates/amount.tmpl.html',
+    type : 'number',
   }, {
     field : 'actions',
     width : 30,

--- a/client/src/modules/purchases/registry/registry.js
+++ b/client/src/modules/purchases/registry/registry.js
@@ -82,14 +82,15 @@ function PurchaseRegistryController(
     footerCellFilter : 'currency:'.concat(Session.enterprise.currency_id),
     aggregationType : uiGridConstants.aggregationTypes.sum,
     aggregationHideLabel : true,
+    type : 'number',
   }, {
     field : 'author',
     displayName : 'FORM.LABELS.AUTHOR',
     headerCellFilter : 'translate',
   }, {
-    cellTemplate : '/modules/purchases/templates/cellStatus.tmpl.html',
     field : 'status',
     displayName : 'FORM.LABELS.STATUS',
+    cellTemplate : '/modules/purchases/templates/cellStatus.tmpl.html',
     headerCellFilter : 'translate',
     enableFiltering : false,
     enableSorting : false,

--- a/client/src/modules/stock/assign/registry.js
+++ b/client/src/modules/stock/assign/registry.js
@@ -63,6 +63,7 @@ function StockLotsAssignController(
       field : 'quantity',
       displayName : 'STOCK.QUANTITY',
       headerCellFilter : 'translate',
+      type : 'number',
     },
 
     {
@@ -83,7 +84,7 @@ function StockLotsAssignController(
 
   const gridFooterTemplate = `
     <div style="padding-left: 10px;">
-      <b>{{ grid.appScope.countGridRows() }}</b> 
+      <b>{{ grid.appScope.countGridRows() }}</b>
       <span translate>TABLE.AGGREGATES.ROWS</span>
     </div>
   `;

--- a/client/src/modules/stock/entry/modals/findPurchase.modal.js
+++ b/client/src/modules/stock/entry/modals/findPurchase.modal.js
@@ -51,6 +51,7 @@ function StockFindPurchaseModalController(
       headerCellFilter : 'translate',
       cellFilter       : `currency:row.entity.currency_id`,
       cellClass        : 'text-right',
+      type             : 'number',
     }, {
       field            : 'author',
       displayName      : 'TABLE.COLUMNS.BY',

--- a/client/src/modules/stock/inventory-adjustment/inventory-adjustment.js
+++ b/client/src/modules/stock/inventory-adjustment/inventory-adjustment.js
@@ -100,6 +100,7 @@ function StockInventoryAdjustmentController(
       cellTemplate : 'modules/stock/inventory-adjustment/templates/quantity.tmpl.html',
       aggregationType : uiGridConstants.aggregationTypes.sum,
       enableFiltering : false,
+      type : 'number',
     }, {
       field : 'difference',
       width : 150,
@@ -108,6 +109,7 @@ function StockInventoryAdjustmentController(
       headerCellFilter : 'translate',
       enableFiltering : false,
       enableSorting : true,
+      type : 'number',
     },
     {
       field : 'expiration_date',

--- a/client/src/modules/stock/requisition/modals/action.modal.js
+++ b/client/src/modules/stock/requisition/modals/action.modal.js
@@ -40,6 +40,7 @@ function ActionRequisitionModalController(
       displayName : 'FORM.LABELS.QUANTITY',
       headerCellFilter : 'translate',
       cellTemplate : 'modules/stock/requisition/templates/quantity.cell.html',
+      type : 'number',
     },
 
     {

--- a/client/src/modules/subsidies/subsidies.js
+++ b/client/src/modules/subsidies/subsidies.js
@@ -37,6 +37,7 @@ function SubsidyController(Subsidy, ModalService, Notify, uiGridConstants, $stat
         field : 'value',
         displayName : 'TABLE.COLUMNS.VALUE',
         headerCellFilter : 'translate',
+        type : 'number',
       },
       {
         field : 'number',

--- a/client/src/modules/templates/modals/findReference.modal.js
+++ b/client/src/modules/templates/modals/findReference.modal.js
@@ -97,6 +97,7 @@ function FindReferenceModalController(
     headerCellFilter : 'translate',
     cellFilter: 'currency:'.concat(Session.enterprise.currency_id),
     cellClass : 'text-right',
+    type : 'number',
   }];
 
   // this function extends the columns list by splicing in the accounts

--- a/client/src/modules/ward/configuration/room/room.js
+++ b/client/src/modules/ward/configuration/room/room.js
@@ -36,6 +36,7 @@ function RoomController(Room, Modal, ModalService, Notify, uiGridConstants, Sess
         field : 'nb_beds',
         displayName : 'BED.NB_BEDS',
         headerCellFilter : 'translate',
+        type : 'number',
       },
       {
         field : 'ward_name',


### PR DESCRIPTION
Updates several client-side tabular grids to set type='number' for numerical columns so that sorting is done correctly (instead of the default, which is lexical sorting).

**TESTING**
The following pages are affected by these changes and should be tested
 - Administration > Grade Management
 - Administration > Holiday Management
 - Administration > Invoicing Fees
 - Administration > Location Management > Village/Township Management
 - Administration > Offdays Management
 - Administration > Price List
 - Administration > Price List > (price list) > Action menu > Details
 - Administration > Subsidy Management
 - Finance > Invoice Registry
 - Hospital > Patient Registry > Menu > Find Duplicate Patients (modal)
 - Human Resources > Multiple Payroll
 - Human Resources > Staffing Indices Management > Menu > Function Bonus (modal)
 - Human Resources > Staffing Indices Management > Menu > Enrollment Bonus (modal)
 - Purchase Orders > Purchase Registry (mixed currencies!)
 - Stock > Stock Assignment
 - Stock > Stock Entry > [PURCHASE] button (modal, note mixed currencies)
 - Stock > Inventory Adjustment (list, before submitting)
 - Stock > Requisition > [New requisition] button (modal, see suggested article list)
 - Ward Management > Settings 