### PR TITLE
Display and export created_at timestamps in Stock Movements

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -726,6 +726,7 @@
             "SELECT_ONE": "Select One",
             "SELECT": "Select",
             "SENIORITY_BONUS": "seniority bonus",
+            "SERVER_DATE": "Server Date",
             "SERVICE": "Service",
             "SERVICE_OPTIONAL": "Service (optional)",
             "SERVICES": "Services",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -726,6 +726,7 @@
             "SELECT_ONE": "Sélection Unique",
             "SELECT": "Sélectionner",
             "SENIORITY_BONUS": "Prime d'ancienneté",
+            "SERVER_DATE": "Date du server",
             "SERVICE": "Service",
             "SERVICE_OPTIONAL": "Service (optionnel)",
             "SERVICES": "Services",

--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -109,8 +109,14 @@ function StockMovementsController(
       type : 'date',
       displayName : 'FORM.LABELS.DATE',
       headerCellFilter : 'translate',
-      cellFilter : 'date',
-      cellClass : 'text-right',
+      cellTemplate : 'modules/stock/movements/templates/date.cell.html',
+    }, {
+      field : 'created_at',
+      type : 'date',
+      displayName : 'FORM.LABELS.SERVER_DATE',
+      headerCellFilter : 'translate',
+      cellTemplate : 'modules/stock/movements/templates/created_at.cell.html',
+      visible : false,
     }, {
       field : 'userName',
       displayName : 'FORM.LABELS.USER',

--- a/client/src/modules/stock/movements/templates/created_at.cell.html
+++ b/client/src/modules/stock/movements/templates/created_at.cell.html
@@ -1,0 +1,6 @@
+<div
+  class="ui-grid-cell-contents text-right"
+  uib-tooltip="{{ row.entity.created_at | date : 'MMM dd, yyyy - HH:mm:ss' }}"
+  tooltip-placement="right">
+  <span>{{ row.entity.created_at | date}}</span>
+</div>

--- a/client/src/modules/stock/movements/templates/date.cell.html
+++ b/client/src/modules/stock/movements/templates/date.cell.html
@@ -1,0 +1,6 @@
+<div
+  class="ui-grid-cell-contents text-right"
+  uib-tooltip="{{ row.entity.date | date : 'MMM dd, yyyy - HH:mm:ss' }}"
+  tooltip-placement="left">
+  <span>{{ row.entity.date | date}}</span>
+</div>

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -473,7 +473,8 @@ async function getMovements(depotUuid, params) {
   SELECT
     m.description,
     d.text AS depot_text, IF(is_exit = 1, "OUT", "IN") AS io,
-    BUID(m.depot_uuid) AS depot_uuid, m.is_exit, m.date, BUID(m.document_uuid) AS document_uuid,
+    BUID(m.depot_uuid) AS depot_uuid, m.is_exit, m.date, m.created_at,
+    BUID(m.document_uuid) AS document_uuid,
     m.flux_id, BUID(m.entity_uuid) AS entity_uuid, SUM(m.unit_cost * m.quantity) AS cost,
     f.label AS flux_label, BUID(m.invoice_uuid) AS invoice_uuid, dm.text AS documentReference,
     BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.text AS document_requisition,
@@ -703,7 +704,7 @@ async function getDailyStockConsumption(params) {
       d.text AS depot_name,
       BUID(d.uuid) AS depot_uuid,
       f.id AS flux_id,
-      m.is_exit, 
+      m.is_exit,
       sv.wac
     FROM stock_movement m
     JOIN flux f ON m.flux_id = f.id


### PR DESCRIPTION
Added ability to show the created_at time (shown as "Server Date") in the Stock Movements registry.
Also added tooltips for the date cell and the Server Date (create_at) cell that shows the full time and date (not just the calendar day).

NOTE:  Try this with the Vanga database and notice the large difference between the date and the server date.  It may be necessary to export a more complete time string that includes the time zone.   Also, please review https://github.com/IMA-WorldHealth/bhima/issues/6062 and decide how we should handle this.  Note that this PR could be accepted as is and we can add another issue to fix the export date string (which would probably apply to more than this page).

Closes https://github.com/IMA-WorldHealth/bhima/issues/6221

**TESTING**
- Use any database
- Go to the Stock Movements page
- Note that the "Server Date" is not showing.  Use the Menu->Column modal to enable its display.
- Hover over a Date cell and a Server Date cell to see the full time.
- Try exporting the page and verify that the server date gets exported.
