### PR TITLE
fix: add new fiscal year

### DIFF
--- a/test/data.sql
+++ b/test/data.sql
@@ -374,6 +374,9 @@ CALL CreateFiscalYear(1, @fiscalYear2019, @superUser, 'Fiscal Year 2020', 12, DA
 SET @fiscalYear2021 = 0;
 CALL CreateFiscalYear(1, @fiscalYear2020, @superUser, 'Fiscal Year 2021', 12, DATE('2021-01-01'), DATE('2021-12-31'), 'Notes for 2021', @fiscalYear2021);
 
+SET @fiscalYear2022 = 0;
+CALL CreateFiscalYear(1, @fiscalYear2021, @superUser, 'Fiscal Year 2022', 12, DATE('2022-01-01'), DATE('2022-12-31'), 'Notes for 2022', @fiscalYear2022);
+
 -- give test permission to all projects
 INSERT INTO `project_permission` VALUES (1, 1, 1),(2, 1, 2),(3, 2, 1),(4, 4, 1);
 

--- a/test/integration/fiscalYear.js
+++ b/test/integration/fiscalYear.js
@@ -5,9 +5,9 @@ const helpers = require('./helpers');
 
 describe('(/fiscal) Fiscal Year', () => {
   const newFiscalYear = {
-    label : 'A New Fiscal Year 2022',
-    start_date : new Date('2022-01-01 01:00'),
-    end_date : new Date('2021-11-31 01:00'),
+    label : 'A New Fiscal Year 2023',
+    start_date : new Date('2023-01-01 01:00'),
+    end_date : new Date('2023-12-31 01:00'),
     number_of_months : 12,
     note : 'Fiscal Year for Integration Test',
     closing_account : 111, // 1311 - Résusltat net : Bénéfice *
@@ -47,24 +47,22 @@ describe('(/fiscal) Fiscal Year', () => {
   it('GET /fiscal returns a list of fiscal_years', () => {
     return agent.get('/fiscal')
       .then(res => {
-        helpers.api.listed(res, 8);
+        helpers.api.listed(res, 9);
         const firstYearPeriods = res.body[0].periods;
         expect(firstYearPeriods).to.be.equal(undefined);
       })
       .catch(helpers.handler);
   });
 
-
   it('GET /fiscal returns a list of fiscal_years width their periods', () => {
     return agent.get('/fiscal?includePeriods=1')
       .then(res => {
-        helpers.api.listed(res, 8);
+        helpers.api.listed(res, 9);
         const firstYearPeriods = res.body[0].periods;
         expect(firstYearPeriods).to.not.be.empty;
       })
       .catch(helpers.handler);
   });
-
 
   it('GET /fiscal/:id returns one fiscal year', () => {
     return agent.get(`/fiscal/${newFiscalYear.id}`)


### PR DESCRIPTION
This commit fixes our integration tests for 2022.  One day, we'll remember to do this _before_ the start of the new year.