### PR TITLE
Update aged debtor and creditor reports

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -813,7 +813,7 @@
             "UNKNOWN": "Unknown",
             "UNLOCKED": "Unlocked",
             "UNTIL_DATE": "Until the date",
-            "UNTIL_PERIOD": "Until the period",
+            "UNTIL_PERIOD": "Through the period",
             "UPDATED": "Updated",
             "UPDATE_GROUP_DEBTOR": "Update Debtor Group",
             "UPDATE_PATIENT_GROUP": "Update Patient Group Subscription",

--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -246,6 +246,7 @@
     "VIEW_RECEIPT": "View Receipt",
     "VIEW_REQUISITION": "View requisition",
     "VIEW_VOUCHER": "View Vouchers",
+    "WARN_PREV_FY_NOT_CLOSED": "Attention! The previous Fiscal Year is not closed. The results in this report may not be accurate until is it closed! ",
     "ZERO_TO_THIRTY_DAYS": "Less Than 30 Days",
     "REPORT_ACCOUNTS": {
       "TITLE": "Account Report",

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -97,8 +97,8 @@
       "FINANCIAL_SITUATION_EMPLOYEE": "Situation financière de l'employé",
 	  "FINANCIAL_SITUATION_EMPLOYEES": "Situation financière des employés",
       "INCLUDE_MEDICAL_CARE_EMPLOYEE": "Inclure les soins médicaux accordé à l'employé",
-      "LIMIT_TO_TIME_INTERVAL": "Limiter à l'intervalle de temps",    
-      "NORMAL_REPORT": "Rapport simple",      
+      "LIMIT_TO_TIME_INTERVAL": "Limiter à l'intervalle de temps",
+      "NORMAL_REPORT": "Rapport simple",
       "REPORT": "Situation financière de l'employé",
       "SEE_SITUATION_ALL_EMPLOYEES": "Voir la situation global de tous les employés",
       "SUMMARY_REPORT": "Rapport synthétique",
@@ -242,6 +242,7 @@
     "VIEW_RECEIPT": "Voir le document",
     "VIEW_REQUISITION": "Voir la réquisition",
     "VIEW_VOUCHER": "Voir les bordereaux",
+    "WARN_PREV_FY_NOT_CLOSED": "Attention ! L'année fiscale précédente n'est pas clôturée. Les résultats de ce rapport peuvent ne pas être exacts tant qu'il n'est pas clôturé !",
     "ZERO_TO_THIRTY_DAYS": "Moins de 30 jours",
     "REPORT_ACCOUNTS": {
       "TITLE": "Rapport de comptes",

--- a/client/src/modules/reports/generate/aged_creditors/aged_creditors.config.js
+++ b/client/src/modules/reports/generate/aged_creditors/aged_creditors.config.js
@@ -2,10 +2,10 @@ angular.module('bhima.controllers')
   .controller('aged_creditorsController', AgedCreditorsConfigController);
 
 AgedCreditorsConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
-function AgedCreditorsConfigController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function AgedCreditorsConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Session) {
   const vm = this;
   const cache = new AppCache('configure_aged_creditors');
   const reportUrl = 'reports/finance/creditors/aged';
@@ -18,6 +18,10 @@ function AgedCreditorsConfigController($sce, Notify, SavedReports, AppCache, rep
   vm.clearPreview = function clearPreview() {
     vm.previewGenerated = false;
     vm.previewResult = null;
+  };
+
+  vm.setCurrency = function setCurrency(currency) {
+    vm.reportDetails.currency_id = currency.id;
   };
 
   vm.onSelectFiscalYear = (fiscalYear) => {
@@ -59,6 +63,11 @@ function AgedCreditorsConfigController($sce, Notify, SavedReports, AppCache, rep
   function checkCachedConfiguration() {
     if (cache.reportDetails) {
       vm.reportDetails = angular.copy(cache.reportDetails);
+    }
+
+    // Set the defaults
+    if (!angular.isDefined(vm.reportDetails.currencyId)) {
+      vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
   }
 }

--- a/client/src/modules/reports/generate/aged_creditors/aged_creditors.html
+++ b/client/src/modules/reports/generate/aged_creditors/aged_creditors.html
@@ -52,6 +52,11 @@
               </label>
             </div>
 
+            <bh-currency-select
+              on-change="ReportConfigCtrl.setCurrency(currency)"
+              currency-id="ReportConfigCtrl.reportDetails.currency_id">
+            </bh-currency-select>
+
             <bh-loading-button loading-state="ConfigForm.$loading">
               <span translate>REPORT.UTIL.PREVIEW</span>
             </bh-loading-button>

--- a/client/src/modules/reports/generate/aged_debtors/aged_debtors.config.js
+++ b/client/src/modules/reports/generate/aged_debtors/aged_debtors.config.js
@@ -2,10 +2,10 @@ angular.module('bhima.controllers')
   .controller('aged_debtorsController', AgedDebtorsConfigController);
 
 AgedDebtorsConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
-function AgedDebtorsConfigController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function AgedDebtorsConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Session) {
   const vm = this;
   const cache = new AppCache('configure_aged_debtors');
   const reportUrl = 'reports/finance/debtors/aged';
@@ -64,6 +64,11 @@ function AgedDebtorsConfigController($sce, Notify, SavedReports, AppCache, repor
   function checkCachedConfiguration() {
     if (cache.reportDetails) {
       vm.reportDetails = angular.copy(cache.reportDetails);
+    }
+
+    // Set the defaults
+    if (!angular.isDefined(vm.reportDetails.currencyId)) {
+      vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
   }
 }

--- a/client/src/modules/reports/generate/aged_debtors/aged_debtors.html
+++ b/client/src/modules/reports/generate/aged_debtors/aged_debtors.html
@@ -44,11 +44,6 @@
               </label>
             </div>
 
-            <bh-currency-select
-              on-change="ReportConfigCtrl.setCurrency(currency)"
-              currency-id="ReportConfigCtrl.reportDetails.currency_id">
-            </bh-currency-select>
-
             <!-- included Total Zeros  -->
             <div class="checkbox">
               <label>
@@ -56,6 +51,11 @@
                 <span translate>FORM.LABELS.INCLUDE_ZEROES</span>
               </label>
             </div>
+
+            <bh-currency-select
+              on-change="ReportConfigCtrl.setCurrency(currency)"
+              currency-id="ReportConfigCtrl.reportDetails.currency_id">
+            </bh-currency-select>
 
             <bh-loading-button loading-state="ConfigForm.$loading">
               <span translate>REPORT.UTIL.PREVIEW</span>

--- a/server/controllers/finance/reports/creditors/aged.handlebars
+++ b/server/controllers/finance/reports/creditors/aged.handlebars
@@ -8,9 +8,15 @@
       <strong>{{translate "REPORT.AGED_CREDITORS.TITLE"}}</strong>
     </h3>
 
-    <h5 class="text-center">
+    <h4 class="text-center">
       <span class="text-capitalize">{{translate "FORM.LABELS.UNTIL_PERIOD"}}</span> <span class="text-capitalize"> {{date dateUntil "MMMM YYYY"}} </span>
-    </h5>
+    </h4>
+
+    {{#unless previousFyClosed}}
+    <div class="alert alert-warning">
+      <p>{{translate "REPORT.WARN_PREV_FY_NOT_CLOSED"}}</p>
+    </div>
+    {{/unless}}
 
     <!-- margin is the cell size -->
     <section>
@@ -59,25 +65,25 @@
               <td class="text-left">{{this.number}}</td>
               <td class="text-right">
                 {{#if this.excess}}
-                  {{debcred this.excess ../metadata.enterprise.currency_id}}
+                  {{debcred this.excess ../currency_id}}
                 {{/if}}
               </td>
               <td class="text-right">
                 {{#if this.ninety}}
-                  {{debcred this.ninety ../metadata.enterprise.currency_id}}
+                  {{debcred this.ninety ../currency_id}}
                 {{/if}}
               </td>
               <td class="text-right">
                 {{#if this.sixty}}
-                  {{debcred this.sixty ../metadata.enterprise.currency_id}}
+                  {{debcred this.sixty ../currency_id}}
                 {{/if}}
               </td>
               <td class="text-right">
                 {{#if this.thirty}}
-                  {{debcred this.thirty ../metadata.enterprise.currency_id}}
+                  {{debcred this.thirty ../currency_id}}
                 {{/if}}
               </td>
-              <td class="text-right">{{debcred this.total ../metadata.enterprise.currency_id}}</td>
+              <td class="text-right">{{debcred this.total ../currency_id}}</td>
             </tr>
           {{else}}
             {{> emptyTable columns=7}}
@@ -87,11 +93,11 @@
           <tfoot>
             <tr style="background-color: #ddd;">
               <th colspan="2">{{translate "TABLE.COLUMNS.TOTAL"}}</th>
-              <th class="text-right">{{debcred aggregates.excess metadata.enterprise.currency_id}}</th>
-              <th class="text-right">{{debcred aggregates.ninety metadata.enterprise.currency_id}}</th>
-              <th class="text-right">{{debcred aggregates.sixty metadata.enterprise.currency_id}}</th>
-              <th class="text-right">{{debcred aggregates.thirty metadata.enterprise.currency_id}}</th>
-              <th class="text-right">{{debcred aggregates.total metadata.enterprise.currency_id}}</th>
+              <th class="text-right">{{debcred aggregates.excess ./currency_id}}</th>
+              <th class="text-right">{{debcred aggregates.ninety ./currency_id}}</th>
+              <th class="text-right">{{debcred aggregates.sixty ./currency_id}}</th>
+              <th class="text-right">{{debcred aggregates.thirty ./currency_id}}</th>
+              <th class="text-right">{{debcred aggregates.total ./currency_id}}</th>
             </tr>
           </tfoot>
         {{/if}}

--- a/server/controllers/finance/reports/creditors/index.js
+++ b/server/controllers/finance/reports/creditors/index.js
@@ -47,6 +47,7 @@ function agedCreditorReport(req, res, next) {
   db.one(sql, [qs.period_id])
     .then(period => {
       qs.date = period.end_date;
+      qs.enterprise_id = metadata.enterprise.id;
       // fire the SQL for the report
       return queryContext(qs);
     })
@@ -74,28 +75,49 @@ async function queryContext(params = {}) {
   // format the dates for MySQL escape
   const dates = _.fill(Array(5), params.date);
   const data = {};
+  const currencyId = db.escape(params.currency_id);
+  const enterpriseId = db.escape(params.enterprise_id);
+
+  const fySql = `
+    SELECT locked FROM fiscal_year
+    WHERE ID = (SELECT previous_FISCAL_year_id from fiscal_year where id = ?)
+  `;
+
+  const previousFy = await db.one(fySql, [params.fiscal_id]);
 
   const groupByMonthColumns = `
-    SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 0, gl.debit_equiv - gl.credit_equiv, 0)) AS thirty,
-    SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 1, gl.debit_equiv - gl.credit_equiv, 0)) AS sixty,
-    SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 2, gl.debit_equiv - gl.credit_equiv, 0)) AS ninety,
-    SUM(IF(MONTH(?) - MONTH(gl.trans_date) > 2, gl.debit_equiv - gl.credit_equiv, 0)) AS excess,
+    SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 0, (gl.debit_equiv - gl.credit_equiv) *
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS thirty,
+    SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 1, (gl.debit_equiv - gl.credit_equiv) *
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS sixty,
+    SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 2, (gl.debit_equiv - gl.credit_equiv) *
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS ninety,
+    SUM(IF(MONTH(?) - MONTH(gl.trans_date) > 2, (gl.debit_equiv - gl.credit_equiv) *
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS excess,
   `;
 
   const groupByRangeColumns = `
-    SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) BETWEEN 0 AND 29, gl.debit_equiv - gl.credit_equiv, 0)) AS thirty,
-    SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) BETWEEN 30 AND 59, gl.debit_equiv - gl.credit_equiv, 0)) AS sixty,
-    SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) BETWEEN 60 AND 89, gl.debit_equiv - gl.credit_equiv, 0)) AS ninety,
-    SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) > 90, gl.debit_equiv - gl.credit_equiv, 0)) AS excess,
+    SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) BETWEEN 0 AND 29, (gl.debit_equiv - gl.credit_equiv) *
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS thirty,
+    SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) BETWEEN 30 AND 59, (gl.debit_equiv - gl.credit_equiv) *
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS sixty,
+    SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) BETWEEN 60 AND 89, (gl.debit_equiv - gl.credit_equiv) *
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS ninety,
+    SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) > 90, (gl.debit_equiv - gl.credit_equiv) *
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS excess,
   `;
 
-  const columns = useMonthGrouping ? groupByMonthColumns : groupByRangeColumns;
+  // switch between grouping by month and grouping by period
+  const columns = useMonthGrouping
+    ? groupByMonthColumns
+    : groupByRangeColumns;
 
   // selects into columns of 30, 60, 90, and >90
   const creditorSql = `
     SELECT BUID(cg.uuid) AS id, cg.name, a.number,
       ${columns}
-      SUM(gl.debit_equiv - gl.credit_equiv) AS total
+      SUM((gl.debit_equiv - gl.credit_equiv) *
+        IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1)) AS total
     FROM creditor_group AS cg
       JOIN general_ledger AS gl ON gl.account_id = cg.account_id
       JOIN account AS a ON a.id = cg.account_id
@@ -110,7 +132,8 @@ async function queryContext(params = {}) {
   const aggregateSql = `
     SELECT
       ${columns}
-      SUM(gl.debit_equiv - gl.credit_equiv) AS total
+      SUM((gl.debit_equiv - gl.credit_equiv) *
+        IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1)) AS total
     FROM creditor_group AS cg
       JOIN general_ledger AS gl ON gl.account_id = cg.account_id
     WHERE DATE(gl.trans_date) <= DATE(?)
@@ -121,6 +144,7 @@ async function queryContext(params = {}) {
   const creditors = await db.exec(creditorSql, [...dates, params.fiscal_id]);
   data.creditors = creditors;
   data.dateUntil = params.date;
+  data.previousFyClosed = previousFy.locked;
 
   // this is specific to grouping by months
   data.firstMonth = params.date;
@@ -131,6 +155,7 @@ async function queryContext(params = {}) {
 
   const [aggregates] = await db.exec(aggregateSql, [...dates, params.fiscal_id]);
   data.aggregates = aggregates;
+  data.currency_id = params.currency_id;
 
   return data;
 }

--- a/server/controllers/finance/reports/debtors/aged.handlebars
+++ b/server/controllers/finance/reports/debtors/aged.handlebars
@@ -8,11 +8,18 @@
       <strong>{{translate "REPORT.AGED_DEBTORS.TITLE"}}</strong>
     </h3>
 
-    <h5 class="text-center">
+    <h4 class="text-center">
       <strong>
         <span class="text-capitalize">{{translate "FORM.LABELS.UNTIL_PERIOD"}}</span> <span class="text-capitalize"> {{date dateUntil "MMMM YYYY"}} </span>
       </strong>
-    </h5>
+    </h4>
+
+    {{#unless previousFyClosed}}
+    <div class="alert alert-warning">
+      <p>{{translate "REPORT.WARN_PREV_FY_NOT_CLOSED"}}</p>
+    </div>
+    {{/unless}}
+
     <!-- margin is the cell size -->
     <section>
       <table class="table table-condensed table-report table-bordered">

--- a/server/controllers/finance/reports/debtors/index.js
+++ b/server/controllers/finance/reports/debtors/index.js
@@ -24,8 +24,8 @@ const db = require('../../../../lib/db');
 const TEMPLATE = './server/controllers/finance/reports/debtors/aged.handlebars';
 
 const DEFAULT_OPTIONS = {
-  csvKey: 'debtors',
-  orientation: 'landscape',
+  csvKey : 'debtors',
+  orientation : 'landscape',
 };
 
 /**
@@ -40,7 +40,6 @@ function agedDebtorReport(req, res, next) {
   const metadata = _.clone(req.session);
 
   let report;
-  let previousFyLocked;
 
   try {
     report = new ReportManager(TEMPLATE, metadata, qs);
@@ -95,31 +94,25 @@ async function queryContext(params = {}) {
   const previousFy = await db.one(fySql, [params.fiscal_id]);
 
   const groupByMonthColumns = `
-    SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 0, (gl.debit_equiv - gl.credit_equiv)*
-     IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS thirty,
-
-     SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 1, (gl.debit_equiv - gl.credit_equiv)*
-     IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS sixty,
-
-     SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 2, (gl.debit_equiv - gl.credit_equiv)*
-     IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS ninety,
-
-     SUM(IF(MONTH(?) - MONTH(gl.trans_date) > 2, (gl.debit_equiv - gl.credit_equiv)*
-     IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS excess,
+    SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 0, (gl.debit_equiv - gl.credit_equiv) *
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS thirty,
+    SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 1, (gl.debit_equiv - gl.credit_equiv) *
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS sixty,
+    SUM(IF(MONTH(?) - MONTH(gl.trans_date) = 2, (gl.debit_equiv - gl.credit_equiv) *
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS ninety,
+    SUM(IF(MONTH(?) - MONTH(gl.trans_date) > 2, (gl.debit_equiv - gl.credit_equiv) *
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS excess,
   `;
 
   const groupByRangeColumns = `
     SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) BETWEEN 0 AND 29, (gl.debit_equiv - gl.credit_equiv) *
-    IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS thirty,
-
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS thirty,
     SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) BETWEEN 30 AND 59, (gl.debit_equiv - gl.credit_equiv) *
-    IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS sixty,
-
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS sixty,
     SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) BETWEEN 60 AND 89, (gl.debit_equiv - gl.credit_equiv) *
-    IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS ninety,
-
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS ninety,
     SUM(IF(DATEDIFF(DATE(?), DATE(gl.trans_date)) > 90, (gl.debit_equiv - gl.credit_equiv) *
-    IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS excess,
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1), 0)) AS excess,
   `;
 
   // switch between grouping by month and grouping by period
@@ -132,7 +125,7 @@ async function queryContext(params = {}) {
     SELECT BUID(dg.uuid) AS id, dg.name, a.number,
       ${columns}
       SUM((gl.debit_equiv - gl.credit_equiv) *
-      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1)) AS total
+        IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1)) AS total
     FROM debtor_group AS dg JOIN debtor AS d ON dg.uuid = d.group_uuid
       LEFT JOIN general_ledger AS gl ON gl.entity_uuid = d.uuid
       JOIN account AS a ON a.id = dg.account_id
@@ -148,7 +141,7 @@ async function queryContext(params = {}) {
     SELECT
       ${columns}
       SUM((gl.debit_equiv - gl.credit_equiv)*
-      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1))AS total
+      IFNULL(GetExchangeRate(${enterpriseId}, ${currencyId}, gl.trans_date), 1)) AS total
     FROM debtor_group AS dg JOIN debtor AS d ON dg.uuid = d.group_uuid
       LEFT JOIN general_ledger AS gl ON gl.entity_uuid = d.uuid
     WHERE DATE(gl.trans_date) <= DATE(?)

--- a/test/integration/reports/finance/aged_creditors.js
+++ b/test/integration/reports/finance/aged_creditors.js
@@ -2,7 +2,10 @@ const RenderingTests = require('../rendering');
 
 const target = '/reports/finance/creditors/aged';
 const options = {
+  fiscal_id : 4,
   period_id : 201802,
+  currency_id : 2,
+  enterprise_id : 1,
 };
 
 describe(`(${target}) Aged Creditors`, RenderingTests(target, null, options));

--- a/test/integration/reports/finance/aged_debtors.js
+++ b/test/integration/reports/finance/aged_debtors.js
@@ -2,7 +2,10 @@ const RenderingTests = require('../rendering');
 
 const target = '/reports/finance/debtors/aged';
 const options = {
+  fiscal_id : 4,
   period_id : 201802,
+  currency_id : 2,
+  enterprise_id : 1,
 };
 
 describe(`(${target}) Aged Debtors`, RenderingTests(target, null, options));


### PR DESCRIPTION
Updated these two reports:

Finance > Report > Aged Creditors Report
- default to enterprise currency
- Minor updates to report format
- Added a warning if the previous fiscal year is not closed

Finance > Report > Aged Debtors Report
- Added multi-currency support
- Minor updates to report format
- Added a warning if the previous fiscal year is not closed

Closes https://github.com/IMA-WorldHealth/bhima/issues/6167
Closes https://github.com/IMA-WorldHealth/bhima/issues/6168

**TESTING**
- Try the two reports above and try the various combinations of group by month, currency, etc, and make sure things work correctly.
- To see the error message, unlock the previous fiscal year via SQL:
   - UPDATE fiscal_year SET locked=0 where id = ???;
     where ??? is the id of the fiscal year you selected on the client interface (not the previous FY)
   - Try both reports again to see the warning message
   - Restore the locked field above to 1 (as appropriate)


