### PR TITLE
fix(csp): turn useDefaults off in CSP

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -43,6 +43,7 @@ exports.configure = function configure(app) {
   // helmet guards
   app.use(helmet({
     contentSecurityPolicy : {
+      useDefaults : false,
       directives : {
         defaultSrc : ['\'self\'', '\'unsafe-inline\'', 'blob:'],
         fontSrc : ['\'self\'', 'https://fonts.gstatic.com'],


### PR DESCRIPTION
This commit turns the cross-site protection `useDefaults` directive to `false`.  It was flipped to being `true` by default with the last release of `helmet` and wreaks havoc with our app.

See [the helmetjs changelog](https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md) for more information.