### PR TITLE
fix(reports): require depots for stock changes

### DIFF
--- a/client/src/modules/reports/generate/stock_changes/stock_changes.html
+++ b/client/src/modules/reports/generate/stock_changes/stock_changes.html
@@ -42,8 +42,8 @@
             <!-- select depot -->
             <bh-depot-select
               depot-uuid="ReportConfigCtrl.reportDetails.depot_uuid"
-              on-select-callback="ReportConfigCtrl.onSelectDepot(depot)">
-              <bh-clear on-clear="ReportConfigCtrl.clear('depot_uuid')"></bh-clear>
+              on-select-callback="ReportConfigCtrl.onSelectDepot(depot)"
+              required="true">
             </bh-depot-select>
 
             <!-- preview -->


### PR DESCRIPTION
Makes the depot field a required field for viewing the stock changes report.

Closes #6154.

![image](https://user-images.githubusercontent.com/896472/148118962-873611eb-465f-462f-a346-2bb634c2d405.png)
