### PR TITLE
fix(cash): fix incorrect error msg key

### DIFF
--- a/client/src/modules/cash/cash.js
+++ b/client/src/modules/cash/cash.js
@@ -121,7 +121,7 @@ function CashController(
     // if the this is not a caution payment, but no invoices are selected,
     // raise an error.
     if (!isCaution && !hasInvoices) {
-      return Notify.danger('CASH.VOUCHER.NO_INVOICES_ASSIGNED');
+      return Notify.danger('CASH.VOUCHER.CASHBOXES.NO_INVOICES_ASSIGNED');
     }
 
     return $q.resolve()


### PR DESCRIPTION
Fixes the error message i18n key for the cash payments form when the user hasn't selected any invoices.  The previous key didn't point to anything.