### PR TITLE
fix: remove USD cashbox from Vanga db

### DIFF
--- a/server/models/migrations/next/fix-vanga-usd-aux-cashbox.sql
+++ b/server/models/migrations/next/fix-vanga-usd-aux-cashbox.sql
@@ -1,0 +1,6 @@
+/**
+author: @jniles
+date: 2022-01-04
+description: removes the USD Caisse Auxiliare from Vanga
+*/
+DELETE FROM cash_box_account_currency WHERE id = 2;


### PR DESCRIPTION
Adds a patch SQL file to remove the USD cashbox from the vanga database.

Closes #6238