### PR TITLE
feat: add created_at exports to registries

### DIFF
--- a/client/src/modules/cash/payments/registry.js
+++ b/client/src/modules/cash/payments/registry.js
@@ -60,6 +60,13 @@ function CashPaymentRegistryController(
     cellTemplate : '/modules/cash/payments/templates/date.cell.html',
     type : 'date',
   }, {
+    field : 'created_at',
+    type : 'date',
+    displayName : 'FORM.LABELS.SERVER_DATE',
+    headerCellFilter : 'translate',
+    cellTemplate : 'modules/journal/templates/created_at.cell.html',
+    visible : false,
+  }, {
     name : 'patientName',
     displayName : 'TABLE.COLUMNS.CLIENT',
     headerCellFilter : 'translate',

--- a/client/src/modules/invoices/registry/registry.js
+++ b/client/src/modules/invoices/registry/registry.js
@@ -60,6 +60,13 @@ function InvoiceRegistryController(
     type : 'date',
     cellTemplate : '/modules/invoices/registry/templates/date.cell.html',
   }, {
+    field : 'created_at',
+    type : 'date',
+    displayName : 'FORM.LABELS.SERVER_DATE',
+    headerCellFilter : 'translate',
+    cellTemplate : 'modules/journal/templates/created_at.cell.html',
+    visible : false,
+  }, {
     name : 'patientName',
     displayName : 'TABLE.COLUMNS.PATIENT',
     headerCellFilter : 'translate',

--- a/client/src/modules/journal/journal.js
+++ b/client/src/modules/journal/journal.js
@@ -332,6 +332,13 @@ function JournalController(
     displayName : 'FORM.LABELS.COMMENT',
     headerCellFilter : 'translate',
     visible : false,
+  }, {
+    field : 'created_at',
+    type : 'date',
+    displayName : 'FORM.LABELS.SERVER_DATE',
+    headerCellFilter : 'translate',
+    cellTemplate : 'modules/journal/templates/created_at.cell.html',
+    visible : false,
   }];
 
   vm.gridOptions.columnDefs = columns;

--- a/client/src/modules/journal/templates/created_at.cell.html
+++ b/client/src/modules/journal/templates/created_at.cell.html
@@ -1,0 +1,6 @@
+<div
+  class="ui-grid-cell-contents text-right"
+  uib-tooltip="{{ row.entity.created_at | date : 'MMM dd, yyyy - HH:mm:ss' }}"
+  tooltip-placement="right">
+  <span>{{ row.entity.created_at | date:'dd/MM/yyyy HH:mm:ss'}}</span>
+</div>

--- a/client/src/modules/patients/registry/registry.js
+++ b/client/src/modules/patients/registry/registry.js
@@ -85,6 +85,13 @@ function PatientRegistryController(
     displayName : 'TABLE.COLUMNS.DATE_REGISTERED',
     headerCellFilter : 'translate',
   }, {
+    field : 'created_at',
+    type : 'date',
+    displayName : 'FORM.LABELS.SERVER_DATE',
+    headerCellFilter : 'translate',
+    cellTemplate : 'modules/journal/templates/created_at.cell.html',
+    visible : false,
+  }, {
     field : 'last_visit',
     cellFilter : 'date',
     displayName : 'TABLE.COLUMNS.LAST_VISIT',

--- a/client/src/modules/purchases/registry/registry.js
+++ b/client/src/modules/purchases/registry/registry.js
@@ -67,6 +67,13 @@ function PurchaseRegistryController(
     headerCellFilter : 'translate',
     cellFilter : 'date',
   }, {
+    field : 'created_at',
+    type : 'date',
+    displayName : 'FORM.LABELS.SERVER_DATE',
+    headerCellFilter : 'translate',
+    cellTemplate : 'modules/journal/templates/created_at.cell.html',
+    visible : false,
+  }, {
     field : 'supplier',
     displayName : 'FORM.LABELS.SUPPLIER',
     headerCellFilter : 'translate',

--- a/client/src/modules/stock/requisition/registry.js
+++ b/client/src/modules/stock/requisition/registry.js
@@ -59,15 +59,18 @@ function StockRequisitionController(
       displayName : 'FORM.LABELS.DATE',
       headerCellFilter : 'translate',
       cellFilter : 'date: \'dd MMM yyyy - HH:mm:ss\'',
-    },
-
-    {
+    }, {
+      field : 'created_at',
+      type : 'date',
+      displayName : 'FORM.LABELS.SERVER_DATE',
+      headerCellFilter : 'translate',
+      cellTemplate : 'modules/stock/movements/templates/created_at.cell.html',
+      visible : false,
+    }, {
       field : 'user_display_name',
       displayName : 'FORM.LABELS.USER',
       headerCellFilter : 'translate',
-    },
-
-    {
+    }, {
       field : 'status_key',
       displayName : 'FORM.LABELS.STATUS',
       headerCellFilter : 'translate',

--- a/client/src/modules/vouchers/voucher-registry.ctrl.js
+++ b/client/src/modules/vouchers/voucher-registry.ctrl.js
@@ -81,6 +81,17 @@ function VoucherController(
     type : 'date',
     cellTemplate : 'modules/vouchers/templates/date.cell.html',
   }, {
+    field : 'created_at',
+    type : 'date',
+    displayName : 'FORM.LABELS.SERVER_DATE',
+    headerCellFilter : 'translate',
+    cellTemplate : 'modules/journal/templates/created_at.cell.html',
+    visible : false,
+  }, {
+    name : 'patientName',
+    displayName : 'TABLE.COLUMNS.PATIENT',
+    headerCellFilter : 'translate',
+  }, {
     field : 'description',
     displayName : 'TABLE.COLUMNS.DESCRIPTION',
     headerCellFilter : 'translate',

--- a/server/controllers/finance/cash.js
+++ b/server/controllers/finance/cash.js
@@ -135,7 +135,7 @@ function find(options) {
       cash.date, cash.created_at,  BUID(cash.debtor_uuid) AS debtor_uuid, cash.currency_id,
       cash.amount, cash.description, cash.cashbox_id, cash.is_caution, cash.user_id,
       cash.reversed, d.text AS debtor_name, cb.label AS cashbox_label, u.display_name,
-      p.display_name AS patientName, em.text AS patientReference, cash.edited
+      p.display_name AS patientName, em.text AS patientReference, cash.edited, cash.created_at
     FROM cash
       JOIN document_map dm ON dm.uuid = cash.uuid
       JOIN project ON cash.project_id = project.id

--- a/server/controllers/finance/journal/index.js
+++ b/server/controllers/finance/journal/index.js
@@ -186,7 +186,7 @@ function buildTransactionQuery(options, posted) {
       p.comment, p.transaction_type_id, p.user_id, pro.abbr,
       pro.name AS project_name, tp.text AS transaction_type_text,
       a.number AS account_number, a.type_id AS account_type_id, a.label AS account_label,
-      p.trans_id_reference_number, p.cost_center_id, cc.label as costCenterLabel,
+      p.trans_id_reference_number, p.cost_center_id, cc.label as costCenterLabel, p.created_at,
       u.display_name ${includeExchangeRate}
     FROM ${table} p
       JOIN project pro ON pro.id = p.project_id

--- a/server/controllers/finance/patientInvoice.js
+++ b/server/controllers/finance/patientInvoice.js
@@ -237,7 +237,8 @@ function find(options) {
       patient.display_name as patientName, invoice.cost, invoice.description,
       BUID(invoice.debtor_uuid) as debtor_uuid, dm.text AS reference,
       em.text AS patientReference, service.name as serviceName, proj.name AS project_name,
-      user.display_name, invoice.user_id, invoice.reversed, invoice.edited, invoice.posted
+      user.display_name, invoice.user_id, invoice.reversed, invoice.edited, invoice.posted,
+      invoice.created_at
     FROM invoice
     JOIN patient FORCE INDEX(debtor_uuid) ON invoice.debtor_uuid = patient.debtor_uuid
     ${debtorJoin}

--- a/server/controllers/finance/purchases.js
+++ b/server/controllers/finance/purchases.js
@@ -448,7 +448,7 @@ function find(options) {
         p.cost, p.shipping_handling, p.date, s.display_name  AS supplier,
         p.user_id, p.note,
         BUID(p.supplier_uuid) as supplier_uuid, u.display_name AS author,
-        p.currency_id, p.status_id, ps.text AS status
+        p.currency_id, p.status_id, ps.text AS status, p.created_at
       FROM purchase AS p
       JOIN document_map dm ON p.uuid = dm.uuid
       JOIN supplier AS s ON s.uuid = p.supplier_uuid

--- a/server/controllers/finance/reports/invoices/index.js
+++ b/server/controllers/finance/reports/invoices/index.js
@@ -53,7 +53,6 @@ async function report(req, res, next) {
   }
 }
 
-
 async function reporting(_options, session) {
   const filters = shared.formatFilters(_options);
   _.extend(_options, {
@@ -120,7 +119,6 @@ function receipt(req, res, next) {
   const currencyId = options.currency || req.session.enterprise.currency_id;
   const invoiceResponse = {};
   invoiceResponse.lang = options.lang;
-
 
   let template = RECEIPT_TEMPLATE;
 

--- a/server/controllers/finance/reports/shared.js
+++ b/server/controllers/finance/reports/shared.js
@@ -201,6 +201,10 @@ const filters = [{
   displayName : 'PERIODS.END',
   isDate : true,
   comparitor : '<',
+}, {
+  field : 'created_at',
+  displayName : 'FORM.LABELS.SERVER_DATE',
+  isDate : true,
 }];
 
 // translation key mappings for dynamic filters

--- a/server/controllers/finance/vouchers.js
+++ b/server/controllers/finance/vouchers.js
@@ -131,7 +131,7 @@ function find(options) {
       BUID(v.uuid) as uuid, v.date, v.project_id, v.currency_id, v.amount,
       v.description, v.user_id, v.type_id, u.display_name, transaction_type.text,
       dm.text AS reference, v.edited, BUID(v.reference_uuid) AS reference_uuid,
-      p.name AS project_name, v.reversed
+      p.name AS project_name, v.reversed, v.created_at
     FROM voucher v
     JOIN document_map dm ON v.uuid = dm.uuid
     JOIN project p ON p.id = v.project_id

--- a/server/controllers/medical/patients/index.js
+++ b/server/controllers/medical/patients/index.js
@@ -815,7 +815,7 @@ function patientEntityQuery(detailed) {
       BUID(p.uuid) AS uuid, p.project_id, em.text AS reference, p.display_name, BUID(p.debtor_uuid) as debtor_uuid,
       p.sex, p.dob, p.dob_unknown_date, p.registration_date, BUID(d.group_uuid) as debtor_group_uuid, p.hospital_no,
       p.health_zone, p.health_area, u.display_name as userName, originVillage.name as originVillageName, dg.color,
-      originSector.name as originSectorName, dg.name AS debtorGroupName, proj.name AS project_name,
+      originSector.name as originSectorName, dg.name AS debtorGroupName, proj.name AS project_name, p.created_at,
       originProvince.name as originProvinceName ${detailedColumns}
     FROM patient AS p
       JOIN project AS proj ON p.project_id = proj.id

--- a/server/controllers/stock/requisition/requisition.js
+++ b/server/controllers/stock/requisition/requisition.js
@@ -15,7 +15,7 @@ const SELECT_QUERY = `
     sr.requestor_type_id, sr.description, sr.date, sr.user_id, sr.project_id, sr.status_id,
     u.display_name AS user_display_name, d.text AS depot_text,
     s.name service_requestor, dd.text depot_requestor,
-    dm.text reference, stat.title_key, stat.status_key, stat.class_style
+    dm.text reference, stat.title_key, stat.status_key, stat.class_style, sr.created_at
   FROM stock_requisition sr
   JOIN user u ON u.id = sr.user_id
   JOIN depot d ON d.uuid = sr.depot_uuid
@@ -305,10 +305,11 @@ exports.deleteRequisition = async (req, res, next) => {
     const transaction = db.transaction();
     const uuid = db.bid(req.params.uuid);
 
-    transaction.addQuery('DELETE FROM stock_requisition_item WHERE requisition_uuid = ?;', [uuid]);
-    transaction.addQuery('DELETE FROM stock_requisition WHERE uuid = ?;', [uuid]);
+    await transaction
+      .addQuery('DELETE FROM stock_requisition_item WHERE requisition_uuid = ?;', [uuid])
+      .addQuery('DELETE FROM stock_requisition WHERE uuid = ?;', [uuid])
+      .execute();
 
-    await transaction.execute();
     res.sendStatus(204);
   } catch (error) {
     next(error);

--- a/server/lib/filter.js
+++ b/server/lib/filter.js
@@ -135,7 +135,7 @@ class FilterParser {
     }
   }
 
-  equals(filterKey, columnAlias = filterKey, tableAlias = this._tableAlias, isArray) {
+  equals(filterKey, columnAlias = filterKey, tableAlias = this._tableAlias, isArray = false) {
     const tableString = this._formatTableAlias(tableAlias);
 
     if (this._filters[filterKey]) {

--- a/server/lib/renderers/xlsxReport.js
+++ b/server/lib/renderers/xlsxReport.js
@@ -15,7 +15,6 @@ const { find, headers, setValue } = require('./xlsx');
 
 const i18n = require('../helpers/translate');
 
-
 exports.render = render;
 exports.find = find;
 exports.extension = '.xlsx';

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -134,7 +134,6 @@ function execp(cmd) {
   return deferred.promise;
 }
 
-
 /**
  * @function roundDecimal
  *
@@ -145,7 +144,7 @@ function execp(cmd) {
  * @param {Number} precision
  */
 function roundDecimal(number, precision = 4) {
-  const base = Math.pow(10, precision);
+  const base = 10 ** precision;
   return Math.round(number * base) / base;
 }
 
@@ -240,13 +239,11 @@ function calculateAge(dob) {
   return moment().diff(dob, 'years');
 }
 
-
 function createDirectory(dirPath) {
   if (!fs.existsSync(dirPath)) {
     fs.mkdirSync(dirPath);
   }
 }
-
 
 function getRandomColor() {
   const r = Math.floor(Math.random() * 255);

--- a/test/integration/stock/requisition.js
+++ b/test/integration/stock/requisition.js
@@ -9,6 +9,7 @@ describe('(/stock/requisition) The Stock Assign HTTP API', () => {
     'uuid', 'requestor_uuid', 'requestor_type_id', 'description', 'date',
     'user_id', 'project_id', 'user_display_name', 'depot_uuid', 'depot_text', 'service_requestor',
     'depot_requestor', 'reference', 'items', 'status_key', 'title_key', 'class_style', 'status_id',
+    'created_at',
   ];
 
   // create new stock requisition on "Depot Principal" from a servicedelete stock requisition


### PR DESCRIPTION
This commit adds created_at exports to the remaining registries under the title "server date".

Closes #6061.