### PR TITLE
Fix(Exchange rate) display in a friendly user format

### DIFF
--- a/client/src/modules/home/home.ctrl.js
+++ b/client/src/modules/home/home.ctrl.js
@@ -23,7 +23,7 @@ function HomeController(Currencies, Rates, Session, Notify, Fiscal, DashboardSer
   vm.today = new Date();
 
   vm.primaryExchange = [];
-
+  vm.correctDisplay = []; // just for displaying exchange rate in a friendly format
   // this limits the number of places that the page displays for the exchange rate
   vm.EXCHANGE_RATE_DISPLAY_SIZE = 6;
 
@@ -44,21 +44,20 @@ function HomeController(Currencies, Rates, Session, Notify, Fiscal, DashboardSer
     })
     .then(() => {
       vm.currencies.forEach((currency) => {
-        /*
-          currency.isFirstCurencyLabel is used to check the exchange Rate
-          is lower then 1  the program show display something
-          much better for reading
-        */
-        currency.isFirstCurencyLabel = false;
         const exchange = Rates.getCurrentExchange(currency.id);
         currency.rate = exchange.rate;
         currency.date = exchange.date;
         currency.formattedDate = new Moment(currency.date).format('LL');
+        vm.correctDisplay.push({
+          curerency_rate : currency.rate < 1 ? 1 : currency.rate,
+          curerency_symbol : currency.symbol,
+          curerency_date : currency.formattedDate,
+          entreprice_currency : currency.rate < 1 ? (1 / currency.rate).toFixed(2) : 1,
+          entreprice_currency_symbol : vm.enterprise.currencySymbol,
+        });
       });
-
       // @TODO Method for selecting primary exchange
       vm.primaryExchange = vm.currencies;
-
     })
     .catch(err => {
       if (err.message === 'EXCHANGE.MUST_DEFINE_RATES_FIRST') {
@@ -70,7 +69,7 @@ function HomeController(Currencies, Rates, Session, Notify, Fiscal, DashboardSer
 
   Fiscal.getFiscalYearByDate({ date : vm.today })
     .then(([year]) => {
-      vm.year = year;
+      vm.year = year || {};
       vm.year.percentage *= 100;
     })
     .catch(Notify.handleError);

--- a/client/src/modules/home/home.html
+++ b/client/src/modules/home/home.html
@@ -59,25 +59,27 @@
         </div>
       </div>
 
+      
       <div class="col-md-4">
 
         <div class="panel panel-default segment ima-stat-card">
           <div class="panel-body text-center" style="min-height: 124px;">
             <div class="segment-title" translate>TABLE.COLUMNS.EXCHANGE_RATE</div>
             <div 
-              ng-repeat="currency in HomeCtrl.primaryExchange"
+              ng-repeat="row in HomeCtrl.correctDisplay"
               class="col-sm-12" title="{{ HomeCtrl.primaryExchange.rate}} ({{ currency.symbol }})">
 
               <div class="exchange-rate">
-              {{ currency.rate | limitTo:HomeCtrl.EXCHANGE_RATE_DISPLAY_SIZE }} {{ currency.symbol }} = 
-              1 {{HomeCtrl.enterprise.currencySymbol}}
+              {{ row.curerency_rate | limitTo:HomeCtrl.EXCHANGE_RATE_DISPLAY_SIZE }} {{ row.curerency_symbol }} = 
+               {{row.entreprice_currency}} {{row.entreprice_currency_symbol}}
               </div>
 
-              <div><span translate>HOME.EXCHANGE_SET</span> {{ currency.formattedDate }}</div>
+              <div><span translate>HOME.EXCHANGE_SET</span> {{ row.curerency_date }}</div>
             </div>
           </div>
         </div>
       </div>
+    </div>
     </div>
 
     <div class="row">


### PR DESCRIPTION
Here is my proposal for a friendly exchange rate format.

![exhange rate](https://user-images.githubusercontent.com/25838121/148356200-718bd9b8-2271-404a-aa26-1a2e2e1a7ca9.jpeg)



closes #6250
