### PR TITLE
Fixed missing code in previous update

### DIFF
--- a/server/controllers/finance/reports/debtors/openDebtors.handlebars
+++ b/server/controllers/finance/reports/debtors/openDebtors.handlebars
@@ -43,7 +43,7 @@
               <td>{{debtor.display_name }}</td>
               {{#if ../details.showDetailedView}}<td>{{date debtor.latestInvoiceDate}}</td>{{/if}}
               {{#if ../details.showDetailedView}}<td>{{date debtor.latestCashDate}}</td>{{/if}}
-              <td class="text-right">{{currency debtor.balance ../metadata.enterprise.currency_id}}</td>
+              <td class="text-right">{{currency (multiply debtor.balance ../rate) ../currencyId}}</td>
             </tr>
           {{else}}
             {{> emptyTable columns=5}}
@@ -54,7 +54,7 @@
             <tr style="background-color: #ddd;">
               <th colspan="2">{{translate "TABLE.COLUMNS.TOTAL"}} {{aggregates.numDebtors}} {{translate "TABLE.AGGREGATES.RECORDS"}}</th>
               {{#if details.showDetailedView}}<th colspan="2"></th>{{/if}}
-              <th class="text-right">{{currency aggregates.balance metadata.enterprise.currency_id}}</th>
+              <th class="text-right">{{currency (multiply aggregates.balance rate) currencyId}}</th>
             </tr>
           </tfoot>
         {{/if}}


### PR DESCRIPTION
Fix an error in PR https://github.com/IMA-WorldHealth/bhima/pull/6243.
Somehow, code that was in the handlebars file got lost in the version that got released.  This fix adds that code back in.

**TESTING**
- Use production database
- Try the report: Finance > Report > Open Debtors
   - Try it in the enterprise currency (default), and note a few numbers including the final total at the bottom of the report.   Also, no exchange rate should be listed under the title.
   - Try it with some other currency and verify that the new numbers are correct.  The exchange rate used should be listed at the top of the report (under the title).