### PR TITLE
Fix more excel exports

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -150,7 +150,7 @@
       "UPLOAD_SUCCESS" : "Stock imported successfully",
       "UPLOAD_DATE_REQUIRED" : "Define the importation date please"
     },
-    "CMM"             : "CMM",
+    "CMM"             : "AMC",
     "CURRENT_QUANTITY" : "Current Quantity",
     "INPUT"           : "Input",
     "INTEGRATION"     : "Integration",
@@ -199,6 +199,7 @@
     "DIRECTION": " Movement direction",
     "LOSS_DISTRIBUTION" : "Stock Loss",
     "MIN_MONTHS_SECURITY_STOCK" : "Min Months Security Stock",
+    "MONTHS_REMAINING": "Months Remaining",
     "MOTIF"           : "Motive",
     "MOVEMENT"        : "Movement",
     "MOVEMENTS"       : "Movements",
@@ -285,7 +286,8 @@
     "TOGGLE_EXPIRED_STOCK" : "Show expired lots?",
     "TOGGLE_EXPIRED_STOCK_HELP_TEXT" : "This will add a filter on lots that are expired.",
     "TOGGLE_EXPIRY_RISKS" : "Show the lots with expiry risks?",
-    "TOGGLE_EXPIRY_RISKS_HELP_TEXT" : "This will display the lots at risk, whose average monthly consumption will not allow total consumption before the expiration date."
+    "TOGGLE_EXPIRY_RISKS_HELP_TEXT" : "This will display the lots at risk, whose average monthly consumption will not allow total consumption before the expiration date.",
+    "WAC" : "Weighted Avgerage Cost"
   },
   "SETTINGS" : {
     "CONSUMPTION_AND_REORDER_SETTINGS" : "Stock Consumption and Reorder Settings",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -200,6 +200,7 @@
     "DIRECTION": "Direction du  movement",
     "LOSS_DISTRIBUTION" : "Perte de Stock",
     "MIN_MONTHS_SECURITY_STOCK" : "Mois minimum stock de sécurité",
+    "MONTHS_REMAINING": "Mois restants",
     "MOTIF"           : "Motif",
     "MOVEMENT"        : "Mouvement",
     "MOVEMENTS"       : "Mouvements",
@@ -243,7 +244,7 @@
       "EXIT_LOSS"      : "Perte de stock"
     },
     "RECEIVER"        : "Recepteur",
-    "RECEPTION_ASSET_INTEGRATION" : "Entrée des actifs par intégration",    
+    "RECEPTION_ASSET_INTEGRATION" : "Entrée des actifs par intégration",
     "RECEPTION_TRANSFER" : "Transfert",
     "RECEPTION_DESCRIPTION" : "Reception de stock",
     "RECEPTION_INTEGRATION" : "Entrée de stock par intégration",
@@ -286,7 +287,8 @@
     "TOGGLE_EXPIRED_STOCK" : "Afficher le stock expiré?",
     "TOGGLE_EXPIRED_STOCK_HELP_TEXT" : "Ceci ajoutera un filtre sur les lots arrivés à expiration.",
     "TOGGLE_EXPIRY_RISKS" : "Afficher les lots présentant des risques d'expiration?",
-    "TOGGLE_EXPIRY_RISKS_HELP_TEXT" : "Ceci permettra d'afficher les lots à risque, dont la consommation moyenne mensuel ne permettra pas la consommation total avant la date de peremption"
+    "TOGGLE_EXPIRY_RISKS_HELP_TEXT" : "Ceci permettra d'afficher les lots à risque, dont la consommation moyenne mensuel ne permettra pas la consommation total avant la date de peremption",
+    "WAC" : "Cout Unitaire Moyen Pondéré"
   },
   "SETTINGS" : {
     "CONSUMPTION_AND_REORDER_SETTINGS" : "Consommation de stock et de réapprovisionnement",

--- a/client/src/modules/stock/inventories/registry.js
+++ b/client/src/modules/stock/inventories/registry.js
@@ -78,23 +78,20 @@ function StockInventoriesController(
     headerCellFilter : 'translate',
     cellTemplate     : 'modules/stock/inventories/templates/status.cell.html',
   }, {
-    field           : 'avg_consumption',
-    displayName     : 'CMM',
-    enableFiltering : false,
-    enableSorting   : true,
-    cellClass       : 'text-right',
-    type : 'number',
-    cellTemplate     : 'modules/stock/inventories/templates/cmm.cell.html',
-  }, {
-    field            : 'S_MONTH',
-    displayName      : 'MS',
+    field            : 'avg_consumption',
+    displayName      : 'STOCK.CMM',
+    headerTooltip    : 'STOCK.MONTHLY_CONSUMPTION.AVERAGE_MONTHLY_CONSUMPTION',
+    headerCellFilter : 'translate',
     enableFiltering  : false,
-    enableSorting    : false,
+    enableSorting    : true,
     cellClass        : 'text-right',
-    type : 'number',
+    type             : 'number',
+    cellTemplate     : 'modules/stock/inventories/templates/cmm.cell.html',
   }, {
     field           : 'S_SEC',
     displayName     : 'SS',
+    headerCellFilter : 'translate',
+    headerTooltip   : 'STOCK.SECURITY',
     enableFiltering : false,
     enableSorting   : false,
     cellClass       : 'text-right',
@@ -102,6 +99,8 @@ function StockInventoriesController(
   }, {
     field           : 'S_MIN',
     displayName     : 'MIN',
+    headerCellFilter : 'translate',
+    headerTooltip   : 'STOCK.MINIMUM',
     enableFiltering : false,
     enableSorting   : false,
     cellClass       : 'text-right',
@@ -109,6 +108,8 @@ function StockInventoriesController(
   }, {
     field           : 'S_MAX',
     displayName     : 'MAX',
+    headerCellFilter : 'translate',
+    headerTooltip   : 'STOCK.MAXIMUM',
     enableFiltering : false,
     enableSorting   : false,
     cellClass       : 'text-right',
@@ -116,14 +117,30 @@ function StockInventoriesController(
   }, {
     field            : 'S_Q',
     displayName      : 'STOCK.ORDERS',
+    headerTooltip    : 'STOCK.REFILL_QUANTITY',
     headerCellFilter : 'translate',
     enableFiltering  : false,
     enableSorting    : true,
     type             : 'number',
     cellClass        : 'text-right',
     cellTemplate     : 'modules/stock/inventories/templates/appro.cell.html',
-  },
-  {
+  }, {
+    field            : 'lifetime',
+    displayName      : 'STOCK.DAYS_UNTIL_STOCK_OUT',
+    headerTooltip    : 'STOCK.DAYS_UNTIL_STOCK_OUT',
+    headerCellFilter : 'translate',
+    type             : 'number',
+    visible          : false,
+  }, {
+    field            : 'wac',
+    displayName      : 'STOCK.WAC',
+    headerTooltip    : 'STOCK.WAC',
+    headerCellFilter : 'translate',
+    cellFilter       : 'currency:grid.appScope.enterprise.currency_id',
+    cellClass        : 'text-right',
+    type             : 'number',
+    visible          : false,
+  }, {
     field            : 'action',
     displayName      : '',
     enableFiltering  : false,
@@ -301,7 +318,7 @@ function StockInventoriesController(
   vm.downloadExcel = () => {
     const filterOpts = stockInventoryFilters.formatHTTP();
     const defaultOpts = {
-      renderer : 'xlsxReport',
+      renderer : 'xlsx',
       lang : Languages.key,
       renameKeys : true,
       displayNames : gridColumns.getDisplayNames(),

--- a/client/src/modules/stock/lots/registry.service.js
+++ b/client/src/modules/stock/lots/registry.service.js
@@ -176,8 +176,8 @@ function LotsRegistryService(uiGridConstants, Session) {
       visible : false,
     }, {
       field : 'avg_consumption',
-      displayName : 'FORM.LABELS.AVG_CONSUMPTION',
-      headerTooltip : 'FORM.LABELS.AVG_CONSUMPTION',
+      displayName : 'STOCK.CMM',
+      headerTooltip : 'STOCK.MONTHLY_CONSUMPTION.AVERAGE_MONTHLY_CONSUMPTION',
       headerCellFilter : 'translate',
       type : 'number',
       visible : false,
@@ -197,8 +197,8 @@ function LotsRegistryService(uiGridConstants, Session) {
       visible : false,
     }, {
       field : 'documentReference',
-      displayName : 'STOCK.DOCUMENT',
-      headerTooltip : 'STOCK.DOCUMENT',
+      displayName : 'TABLE.COLUMNS.REFERENCE',
+      headerTooltip : 'TABLE.COLUMNS.REFERENCE',
       headerCellFilter : 'translate',
       cellFilter : 'date',
       visible : false,

--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -94,6 +94,18 @@ function StockMovementsController(
       displayName : 'STOCK.FLUX',
       headerCellFilter : 'translate',
     }, {
+      field : 'description',
+      displayName : 'TABLE.COLUMNS.DESCRIPTION',
+      headerTooltip : 'TABLE.COLUMNS.DESCRIPTION',
+      headerCellFilter : 'translate',
+      visible : false,
+    }, {
+      field : 'target',
+      displayName : 'FORM.LABELS.TARGET',
+      headerTooltip : 'FORM.LABELS.TARGET',
+      headerCellFilter : 'translate',
+      visible : false,
+    }, {
       field : 'cost',
       type : 'number',
       displayName : 'STOCK.COST',
@@ -104,6 +116,15 @@ function StockMovementsController(
       footerCellFilter : 'currency:grid.appScope.enterprise.currency_id',
       aggregationHideLabel : true,
       aggregationType : aggregateCostColumn,
+    }, {
+      field            : 'wac',
+      displayName      : 'STOCK.WAC',
+      headerTooltip    : 'STOCK.WAC',
+      headerCellFilter : 'translate',
+      cellFilter       : 'currency:grid.appScope.enterprise.currency_id',
+      cellClass        : 'text-right',
+      type             : 'number',
+      visible          : false,
     }, {
       field : 'date',
       type : 'date',
@@ -116,6 +137,12 @@ function StockMovementsController(
       displayName : 'FORM.LABELS.SERVER_DATE',
       headerCellFilter : 'translate',
       cellTemplate : 'modules/stock/movements/templates/created_at.cell.html',
+      visible : false,
+    }, {
+      field : 'document_requisition',
+      displayName : 'REQUISITION.STOCK_REQUISITION',
+      headerTooltip : 'REQUISITION.STOCK_REQUISITION',
+      headerCellFilter : 'translate',
       visible : false,
     }, {
       field : 'userName',

--- a/server/controllers/stock/reports/common.js
+++ b/server/controllers/stock/reports/common.js
@@ -175,6 +175,17 @@ const stockFluxReceipt = {
   15 : { key : 'INVENTORY_ADJUSTMENT', path : 'adjustment' },
 };
 
+// Stock status label keys
+// WARNING: Must match stockStatusLabelKeys in client StockService
+const stockStatusLabelKeys = {
+  stock_out         : 'STOCK.STATUS.STOCK_OUT',
+  in_stock          : 'STOCK.STATUS.IN_STOCK',
+  security_reached  : 'STOCK.STATUS.SECURITY',
+  minimum_reached   : 'STOCK.STATUS.MINIMUM',
+  over_maximum      : 'STOCK.STATUS.OVER_MAX',
+  unused_stock      : 'STOCK.STATUS.UNUSED_STOCK',
+};
+
 // Exports
 module.exports = {
   _,
@@ -193,6 +204,7 @@ module.exports = {
   getDepotMovement,
   getVoucherReferenceForStockMovement,
   pdfOptions,
+  stockStatusLabelKeys,
   STOCK_EXIT_PATIENT_TEMPLATE,
   POS_STOCK_EXIT_PATIENT_TEMPLATE,
   STOCK_EXIT_SERVICE_TEMPLATE,

--- a/server/controllers/stock/reports/stock/inline_movements_report.js
+++ b/server/controllers/stock/reports/stock/inline_movements_report.js
@@ -2,6 +2,8 @@ const {
   _, ReportManager, Stock, formatFilters, STOCK_INLINE_MOVEMENTS_REPORT_TEMPLATE,
 } = require('../common');
 
+const i18n = require('../../../../lib/helpers/translate');
+
 /**
  * @method stockInlineMovementsReport
  *
@@ -12,10 +14,10 @@ const {
  * GET /reports/stock/inline-movements
  */
 async function stockInlineMovementsReport(req, res, next) {
+  const { lang } = req.query;
   const optionReport = _.extend(req.query, {
     filename : 'TREE.STOCK_INLINE_MOVEMENTS',
     csvKey : 'rows',
-    renameKeys : false,
   });
 
   // set up the report with report manager
@@ -29,6 +31,21 @@ async function stockInlineMovementsReport(req, res, next) {
     }
 
     const rows = await Stock.getMovements(null, params);
+
+    const purgeKeys = ['depot_uuid', 'document_uuid', 'entity_uuid', 'flux_id', 'invoice_uuid',
+      'is_exit', 'stock_requisition_uuid',
+    ];
+
+    rows.forEach(row => {
+      // Purge unneeded fields from the row
+      purgeKeys.forEach(key => {
+        delete row[key];
+      });
+
+      // Translate the Flux type
+      row.fluxName = i18n(lang)(row.flux_label);
+      delete row.flux_label;
+    });
 
     const data = {
       rows,

--- a/server/controllers/stock/reports/stock/lots_report.js
+++ b/server/controllers/stock/reports/stock/lots_report.js
@@ -1,5 +1,5 @@
 const {
-  _, ReportManager, Stock, formatFilters, STOCK_LOTS_REPORT_TEMPLATE,
+  _, ReportManager, Stock, formatFilters, STOCK_LOTS_REPORT_TEMPLATE, stockStatusLabelKeys,
 } = require('../common');
 
 const i18n = require('../../../../lib/helpers/translate');
@@ -18,7 +18,6 @@ function stockLotsReport(req, res, next) {
   let options = {};
   let display = {};
   let filters;
-
   const data = {};
   let hasFilter = false;
   let report;
@@ -66,22 +65,10 @@ function stockLotsReport(req, res, next) {
 
   const dateKeys = ['min_stock_date', 'max_stock_date'];
 
-  // stock status label keys
-  // WARNING: Must match stockStatusLabelKeys in client StockService
-  // TODO: Move to shared constants file for client and server sides
-  const stockStatusLabelKeys = {
-    stock_out         : 'STOCK.STATUS.STOCK_OUT',
-    in_stock          : 'STOCK.STATUS.IN_STOCK',
-    security_reached  : 'STOCK.STATUS.SECURITY',
-    minimum_reached   : 'STOCK.STATUS.MINIMUM',
-    over_maximum      : 'STOCK.STATUS.OVER_MAX',
-    unused_stock      : 'STOCK.STATUS.UNUSED_STOCK',
-  };
-
   return Stock.getLotsDepot(null, options)
     .then((rows) => {
-      // Purge unneeded fields from the row
       rows.forEach(row => {
+        // Purge unneeded fields from the row
         purgeKeys.forEach(key => {
           delete row[key];
         });


### PR DESCRIPTION
Fixed Excel export/download for
- Articles in Stock (changed 'xlsxReport' to 'xlsx' until [Issue 6313](https://github.com/IMA-WorldHealth/bhima/issues/6313) is fixed)
- Stock Movements
- Stock Lots (minor changes)

Added more hidden columns to these reports.

NOTE: This PR does not fix Excel exports for the Inventory registry (since it does not currently have an Excel export).  If this is still desired, please create a new issue for it.

Followup from PR https://github.com/IMA-WorldHealth/bhima/pull/6304.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6313

**TESTING**
- Any dataset
- Try Lots Registry, Articles in Stock, and Stock movements.  For each:
  - Try Menu > Columns and show all hidden columns
     - Verify that the columns make sense
  - Try Menu > Download as Excel
     - Open the downloaded file
       - Verify all column headers are translated (Capitalized)
       - Check data in all columns