### PR TITLE
Do not show expiration date for lots that do not expire

### DIFF
--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -706,6 +706,9 @@ function StockEntryController(
         line.expiration_date = entryDate;
         line.unit = inventory.unit;
         line.tracking_expiration = inventory.tracking_expiration;
+        line.candidateLots.forEach(lot => {
+          lot.tracking_expiration = line.tracking_expiration;
+        });
         setInitialized(line);
 
         return Inventory.inventoryWac(line.inventory_uuid);

--- a/client/src/modules/stock/entry/modals/templates/selectLot.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/selectLot.tmpl.html
@@ -1,7 +1,7 @@
 <a id="lot-uuid-{{ match.model.uuid }}" href>
   <span ng-bind-html="match.model.label | uibTypeaheadHighlight:query"></span>
-  <span style="margin-left: 1em">[</span>
-  <span translate>INVENTORY.EXPIRES</span><span> </span>
-  <span ng-bind-html="match.model.expiration_date | date"></span>
-  <span>]</span>
+  <span ng-if="match.model.tracking_expiration" style="margin-left: 1em">[</span>
+  <span ng-if="match.model.tracking_expiration" translate>INVENTORY.EXPIRES</span>
+  <span ng-if="match.model.tracking_expiration" ng-bind-html="match.model.expiration_date | date"></span>
+  <span ng-if="match.model.tracking_expiration" >]</span>
 </a>

--- a/client/src/modules/stock/exit/templates/lot.tmpl.html
+++ b/client/src/modules/stock/exit/templates/lot.tmpl.html
@@ -8,7 +8,8 @@
       <span>{{$select.selected.label}}</span>
     </ui-select-match>
     <ui-select-choices repeat="lot as lot in row.entity.lots | filter: $select.search">
-      <span title="{{lot.expiration_date | date:grid.appScope.DATE_FMT}}">{{ lot.label }} ({{ "LOTS_SCHEDULE.LOT_EXPIRES" | translate }} {{lot.expiration_date | date:grid.appScope.DATE_FMT}})</span>
+      <span ng-if="lot.tracking_expiration" title="{{lot.expiration_date | date:grid.appScope.DATE_FMT}}">{{ lot.label }} ({{ "LOTS_SCHEDULE.LOT_EXPIRES" | translate }} {{lot.expiration_date | date:grid.appScope.DATE_FMT}})</span>
+      <span ng-if="!lot.tracking_expiration">{{ lot.label }}</span>
     </ui-select-choices>
   </ui-select>
 </div>


### PR DESCRIPTION
Fixed the Stock Entry and Stock Exit forms to prevent displaying expiration dates for lots that do not expire.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6321

**TESTING**
- Use any data set
- Pick any article that is in stock
- Check the inventory group for that article of stock and determine if it is tracking expiration.  If it is, temporarily change it to not tracking (Inventory > Inventory Configuration > (select item) and click [Edit]).
- Do stock entry and stock exit forms and verify that when you select a lot it does not include the expiration date on the drop-down to select the lot.
- Change the tracking expiration status to track expiration dates.
- Repeat the entry/exit forms and verify that the lot selection drop-downs now have expiration dates
- Change the tracking expiration setting for the inventory group back to its original value.