### PR TITLE
Display generated lot barcode

### DIFF
--- a/client/src/i18n/fr/barcode.json
+++ b/client/src/i18n/fr/barcode.json
@@ -2,6 +2,7 @@
   "BARCODE" : {
     "BARCODE": "Code-barre",
     "SCAN": "Scanner",
+    "SCAN_BARCODE" : "Scanner le code-barre",
     "SCAN_DOCUMENT" : "Scanner le code-barres du document",
     "AWAITING_INPUT" : "En Attente d'Entrée",
     "AWAITING_HTTP" : "Code-barres lu! Recherche l'enregistrement....",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -316,6 +316,7 @@
     "INVENTORY_ADJUSTMENT" : "Ajustement de stock"
   },
   "LOTS" : {
+    "BARCODE_FOR_LOT" : "Code-barre pour le lot",
     "REGISTRY" : "Registre des lots",
     "MERGED_LOTS_AUTOMATICALLY": "{{NumLots}} lots fusionnés automatiquement pour {{numInventories}} articles d'inventaire",
     "ENABLE_CORRECTING_LOT_EXPIRATION_DATES": "Permettre la correction des dates d'expiration des lots",

--- a/client/src/js/services/receipts/ReceiptModal.js
+++ b/client/src/js/services/receipts/ReceiptModal.js
@@ -334,6 +334,7 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
   service.stockAssignReceipt = stockAssignReceipt;
   service.stockRequisitionReceipt = stockRequisitionReceipt;
   service.getReceiptFnByFluxId = getReceiptFnByFluxId;
+  service.lotBarcodeReceipt = lotBarcodeReceipt;
 
   /**
    * @method stockRequisitionReceipt
@@ -370,6 +371,17 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
   function stockAssignReceipt(uuid, notifyCreated) {
     const opts = { title : 'ASSIGN.STOCK_ASSIGN', notifyCreated, renderer : Receipts.renderer };
     const promise = Receipts.stockAssignReceipt(uuid, { renderer : opts.renderer });
+    return ReceiptFactory(promise, opts);
+  }
+
+  /**
+   * @method lotBarcodeReceipt
+   * @param {string} uuid
+   * @param {boolean} notifyCreated
+   */
+  function lotBarcodeReceipt(uuid, notifyCreated) {
+    const opts = { title : 'LOTS.BARCODE_FOR_LOT', notifyCreated, renderer : Receipts.renderer };
+    const promise = Receipts.lotBarcodeReceipt(uuid, { renderer : opts.renderer });
     return ReceiptFactory(promise, opts);
   }
 

--- a/client/src/js/services/receipts/ReceiptService.js
+++ b/client/src/js/services/receipts/ReceiptService.js
@@ -184,6 +184,14 @@ function ReceiptService($http, util, Language, AppCache, Session) {
   service.stockRequisitionReceipt = stockRequisitionReceipt;
   service.stockAdjustmentReport = stockAdjustmentReport;
   service.stockAggregateConsumptionReceipt = stockAggregateConsumptionReceipt;
+  service.lotBarcodeReceipt = lotBarcodeReceipt;
+
+  // lot barcode
+  function lotBarcodeReceipt(uuid, options) {
+    options.posReceipt = service.posReceipt;
+    const route = `/receipts/stock/lots/${uuid}/barcode`;
+    return fetch(route, options);
+  }
 
   // stock requisition receipt
   function stockRequisitionReceipt(uuid, options) {

--- a/client/src/modules/stock/StockFilterer.service.js
+++ b/client/src/modules/stock/StockFilterer.service.js
@@ -16,6 +16,7 @@ function StockFiltererService(Filters, AppCache, $httpParamSerializer, Languages
     { key : 'invoice_uuid', label : 'FORM.LABELS.INVOICE' },
     { key : 'group_uuid', label : 'STOCK.INVENTORY_GROUP' },
     { key : 'label', label : 'STOCK.LOT' },
+    { key : 'barcode', label : 'BARCODE.BARCODE' },
     { key : 'is_exit', label : 'STOCK.OUTPUT', valueFilter : 'boolean' },
     { key : 'reference', label : 'FORM.LABELS.REFERENCE' },
     { key : 'flux_id', label : 'STOCK.FLUX' },

--- a/client/src/modules/stock/lots/registry.html
+++ b/client/src/modules/stock/lots/registry.html
@@ -52,6 +52,11 @@
             <li role="separator" class="divider"></li>
             <li role="menuitem" bh-require-enterprise-setting="barcodes">
               <a href ng-click="StockLotsCtrl.openBarcodeScanner()" data-action="scan-barcode">
+                <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN</span>
+              </a>
+            </li>
+            <li role="menuitem" bh-require-enterprise-setting="barcodes">
+              <a href ng-click="StockLotsCtrl.openLotBarcodeScanner()" data-action="scan-barcode">
                 <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN_BARCODE</span>
               </a>
             </li>

--- a/client/src/modules/stock/lots/registry.js
+++ b/client/src/modules/stock/lots/registry.js
@@ -4,7 +4,7 @@ angular.module('bhima.controllers')
 StockLotsController.$inject = [
   'StockService', 'NotifyService', 'uiGridConstants', 'StockModalService', 'LanguageService',
   'GridGroupingService', 'GridStateService', 'GridColumnService', '$state', '$httpParamSerializer',
-  'BarcodeService', 'LotService', 'LotsRegistryService', 'moment', 'bhConstants',
+  'BarcodeService', 'LotsRegistryService', 'moment', 'bhConstants', 'ReceiptModal',
 ];
 
 /**
@@ -14,7 +14,7 @@ StockLotsController.$inject = [
 function StockLotsController(
   Stock, Notify, uiGridConstants, Modal, Languages,
   Grouping, GridState, Columns, $state, $httpParamSerializer,
-  Barcode, LotService, LotsRegistry, moment, bhConstants,
+  Barcode, LotsRegistry, moment, bhConstants, Receipts,
 ) {
   const vm = this;
   const cacheKey = 'lot-grid';
@@ -27,6 +27,12 @@ function StockLotsController(
 
   // barcode scanner
   vm.openBarcodeScanner = openBarcodeScanner;
+
+  // barcode scanner
+  vm.openLotBarcodeScanner = openLotBarcodeScanner;
+
+  // show lot barcode
+  vm.openLotBarcodeModal = openLotBarcodeModal;
 
   // options for the UI grid
   vm.gridOptions = {
@@ -293,6 +299,26 @@ function StockLotsController(
         load(stockLotFilters.formatHTTP(true));
         vm.latestViewFilters = stockLotFilters.formatView();
       });
+  }
+
+  function openLotBarcodeScanner() {
+    Barcode.modal({ shouldSearch : false })
+      .then(record => {
+        stockLotFilters.replaceFilters([
+          { key : 'barcode', value : record.uuid, displayValue : record.uuid },
+        ]);
+
+        load(stockLotFilters.formatHTTP(true));
+        vm.latestViewFilters = stockLotFilters.formatView();
+      });
+  }
+
+  /**
+   * @description display the barcode of the lot in a modal
+   * @param {string} uuid the lot uuid
+   */
+  function openLotBarcodeModal(uuid) {
+    return Receipts.lotBarcodeReceipt(uuid);
   }
 
   startup();

--- a/client/src/modules/stock/lots/registry.service.js
+++ b/client/src/modules/stock/lots/registry.service.js
@@ -52,6 +52,12 @@ function LotsRegistryService(uiGridConstants, Session) {
       headerTooltip : 'STOCK.LOT',
       headerCellFilter : 'translate',
     }, {
+      field : 'barcode',
+      displayName : 'BARCODE.BARCODE',
+      headerTooltip : 'BARCODE.BARCODE',
+      headerCellFilter : 'translate',
+      visible : false,
+    }, {
       field : 'lot_description',
       displayName : 'FORM.LABELS.DESCRIPTION',
       headerTooltip : 'FORM.LABELS.DESCRIPTION',

--- a/client/src/modules/stock/lots/templates/action.cell.html
+++ b/client/src/modules/stock/lots/templates/action.cell.html
@@ -7,6 +7,16 @@
   <ul data-action="{{ rowRenderIndex}}"  class="dropdown-menu-right" bh-dropdown-menu-auto-dropup uib-dropdown-menu>
     <li class="bh-dropdown-header">{{row.entity.label}} - {{row.entity.text}}</li>
 
+    <li role="separator" class="divider"></li>
+    
+    <li>
+      <a data-method="lot-schedule" ng-click="grid.appScope.openLotBarcodeModal(row.entity.uuid)" href>
+        <i class="fa fa-barcode"></i> <span translate>BARCODE.BARCODE</span>
+      </a>
+    </li>
+
+    <li role="separator" class="divider"></li>
+
     <li bh-has-permission="grid.appScope.bhConstants.actions.EDIT_LOT">
       <a data-method="edit" ng-click="grid.appScope.openLotModal(row.entity.uuid)" href>
         <i class="fa fa-edit"></i> <span translate>FORM.LABELS.EDIT</span>

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -875,6 +875,7 @@ exports.configure = function configure(app) {
   app.get('/receipts/stock/assign/:uuid', stockReports.stockAssignReceipt);
   app.get('/receipts/stock/requisition/:uuid', stockReports.stockRequisitionReceipt);
   app.get('/receipts/stock/adjustment/:document_uuid', stockReports.stockAdjustmentReceipt);
+  app.get('/receipts/stock/lots/:uuid/barcode', stockReports.lotBarcodeReceipt);
 
   // stock consumption API
   app.get('/stock/consumptions/average/:periodId', stock.getStockConsumptionAverage);

--- a/server/controllers/stock/reports/common.js
+++ b/server/controllers/stock/reports/common.js
@@ -14,6 +14,7 @@ const STOCK_ASSIGN_TEMPLATE = `${BASE_PATH}/stock/assignment/stock_assign.receip
 const STOCK_ASSIGN_REGISTRY_TEMPLATE = `${BASE_PATH}/stock/assignment/stock_assign.registry.handlebars`;
 const STOCK_CONSUMPTION_GRAPTH_TEMPLATE = `${BASE_PATH}/stock_consumption_graph.handlebars`;
 const STOCK_MOVEMENT_REPORT_TEMPLATE = `${BASE_PATH}/stock_movement_report.handlebars`;
+const LOT_BARCODE_TEMPLATE = `${BASE_PATH}/stock/lot_barcode/lot_barcode.handlebars`;
 
 const STOCK_ENTRY_DEPOT_TEMPLATE = `${BASE_PATH}/stock_entry_depot.receipt.handlebars`;
 const STOCK_ENTRY_PURCHASE_TEMPLATE = `${BASE_PATH}/stock_entry_purchase.receipt.handlebars`;
@@ -224,6 +225,7 @@ module.exports = {
   STOCK_ENTRY_REPORT_TEMPLATE,
   STOCK_LOST_STOCK_REPORT_TEMPLATE,
   STOCK_LOTS_REPORT_TEMPLATE,
+  LOT_BARCODE_TEMPLATE,
   STOCK_MOVEMENTS_REPORT_TEMPLATE,
   STOCK_INLINE_MOVEMENTS_REPORT_TEMPLATE,
   STOCK_SHEET_REPORT_TEMPLATE,

--- a/server/controllers/stock/reports/index.js
+++ b/server/controllers/stock/reports/index.js
@@ -41,6 +41,7 @@ const stockAssignReceipt = require('./stock/assignment/stock_assign.receipt');
 const stockAssignReport = require('./stock/assignment/stock_assign.registry');
 const stockRequisitionReceipt = require('../requisition/requisition.receipt');
 const stockChangesReport = require('./stock/stock_changes/stock_changes');
+const lotBarcodeReceipt = require('./stock/lot_barcode/lot_barcode');
 
 /**
   * @function determineReceiptType
@@ -162,6 +163,7 @@ exports.purchaseOrderAnalysis = require('./purchase_order_analysis');
 
 exports.purchasePrices = require('./purchase_prices');
 
+exports.lotBarcodeReceipt = lotBarcodeReceipt;
 exports.lostStockReport = lostStockReport;
 exports.stockChangesReport = stockChangesReport;
 exports.stockAdjustmentReceipt = stockAdjustmentReceipt;

--- a/server/controllers/stock/reports/stock/lot_barcode/lot_barcode.handlebars
+++ b/server/controllers/stock/reports/stock/lot_barcode/lot_barcode.handlebars
@@ -3,7 +3,8 @@
 <!-- body  -->
 <div class="text-center">
   {{#if metadata.enterprise.settings.enable_barcodes}}
-    <small>{{ details.inventory_text }} - {{ details.label }}</small><br>
+    <small>{{ details.inventory_text }}</small><br>
+    <small>{{translate 'FORM.LABELS.CODE'}}: {{ details.code }}, {{translate 'FORM.LABELS.LOT'}}: {{ details.label }}</small><br>
     <span>{{> barcode value=barcode}}</span><br>
     <small><strong>{{ barcode }}</strong></small>
 

--- a/server/controllers/stock/reports/stock/lot_barcode/lot_barcode.handlebars
+++ b/server/controllers/stock/reports/stock/lot_barcode/lot_barcode.handlebars
@@ -3,10 +3,10 @@
 <!-- body  -->
 <div class="text-center">
   {{#if metadata.enterprise.settings.enable_barcodes}}
-    <small>{{ details.inventory_text }}</small><br>
-    <small>{{translate 'FORM.LABELS.CODE'}}: {{ details.code }}, {{translate 'FORM.LABELS.LOT'}}: {{ details.label }}</small><br>
+    <span>{{ details.inventory_text }}</span><br>
+    <span>{{translate 'FORM.LABELS.CODE'}}: {{ details.code }}, {{translate 'FORM.LABELS.LOT'}}: {{ details.label }}</span><br>
     <span>{{> barcode value=barcode}}</span><br>
-    <small><strong>{{ barcode }}</strong></small>
+    <span><strong>{{ barcode }}</strong></span>
 
     <script>JsBarcode('.barcode').init();</script>
   {{/if}}

--- a/server/controllers/stock/reports/stock/lot_barcode/lot_barcode.handlebars
+++ b/server/controllers/stock/reports/stock/lot_barcode/lot_barcode.handlebars
@@ -1,0 +1,12 @@
+{{> head title="LOTS.BARCODE_FOR_LOT" }}
+
+<!-- body  -->
+<div class="text-center">
+  {{#if metadata.enterprise.settings.enable_barcodes}}
+    <small>{{ details.inventory_text }} - {{ details.label }}</small><br>
+    <span>{{> barcode value=barcode}}</span><br>
+    <small><strong>{{ barcode }}</strong></small>
+
+    <script>JsBarcode('.barcode').init();</script>
+  {{/if}}
+</div>

--- a/server/controllers/stock/reports/stock/lot_barcode/lot_barcode.js
+++ b/server/controllers/stock/reports/stock/lot_barcode/lot_barcode.js
@@ -1,0 +1,51 @@
+const {
+  _, ReportManager, db, identifiers, barcode, LOT_BARCODE_TEMPLATE,
+} = require('../../common');
+
+/**
+ * @method lotBarcodeReceipt
+ *
+ * @description
+ * This method displays the lot barcode
+ *
+ * GET /receipts/stock/lots/:uuid/barcode
+ */
+function lotBarcodeReceipt(req, res, next) {
+  let report;
+  const data = {};
+  const uuid = db.bid(req.params.uuid);
+  const options = {
+    filename : 'LOTS.BARCODE_FOR_LOT',
+    pageSize : 'A6',
+    orientation : 'landscape',
+  };
+  const optionReport = _.extend(req.query, options);
+
+  try {
+    report = new ReportManager(LOT_BARCODE_TEMPLATE, req.session, optionReport);
+  } catch (e) {
+    return next(e);
+  }
+
+  const sql = `
+    SELECT BUID(l.uuid) AS uuid, l.label, i.code, i.text AS inventory_text
+    FROM lot l
+    JOIN inventory i ON i.uuid = l.inventory_uuid
+    WHERE l.uuid = ?;
+  `;
+
+  return db.one(sql, [db.bid(uuid)])
+    .then(details => {
+      const { key } = identifiers.LOT;
+      data.details = details;
+      data.barcode = barcode.generate(key, details.uuid);
+      return report.render(data);
+    })
+    .then((result) => {
+      res.set(result.headers).send(result.report);
+    })
+    .catch(next)
+    .done();
+}
+
+module.exports = lotBarcodeReceipt;

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -9,3 +9,6 @@ UPDATE report SET `report_key` = 'analysis_auxiliary_cashbox', `title_key` = 'RE
 UPDATE unit SET
   `name` = 'Analysis of Cashbox', `key` = 'REPORT.ANALYSIS_AUX_CASHBOX.TITLE', `description` = 'Analysis of auxiliary cashbox', `path` = '/reports/analysis_auxiliary_cashbox'
   WHERE path = '/reports/analysis_auxiliary_cashboxes';
+
+-- regenerate barcodes for lots
+UPDATE lot SET barcode = CONCAT('LT', LEFT(HEX(lot.uuid), 8));

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -9,6 +9,3 @@ UPDATE report SET `report_key` = 'analysis_auxiliary_cashbox', `title_key` = 'RE
 UPDATE unit SET
   `name` = 'Analysis of Cashbox', `key` = 'REPORT.ANALYSIS_AUX_CASHBOX.TITLE', `description` = 'Analysis of auxiliary cashbox', `path` = '/reports/analysis_auxiliary_cashbox'
   WHERE path = '/reports/analysis_auxiliary_cashboxes';
-
--- regenerate barcodes for lots
-UPDATE lot SET barcode = CONCAT('LT', LEFT(HEX(lot.uuid), 8));


### PR DESCRIPTION
This PR : 
- Adds the feature to show to the user the lot barcode as document

![image](https://user-images.githubusercontent.com/5445251/150984916-eeee0926-0433-45ad-9569-ba8b50184944.png)

- Adds in the lot registry the barcode column

![chrome_jCExftzSas](https://user-images.githubusercontent.com/5445251/150986201-b539df53-05cd-44e9-a43d-047fba79e17d.png)

- Adds an option to search in the lot registry with the generated barcode

![image](https://user-images.githubusercontent.com/5445251/150985078-aeb0f9e6-f68f-4c18-b6f1-52864d2aceb9.png)

- Fix warning about expiration for assets
