### PR TITLE
Clean up ngIfs in lot selection for stock entry

### DIFF
--- a/client/src/modules/stock/entry/modals/templates/selectLot.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/selectLot.tmpl.html
@@ -1,7 +1,6 @@
 <a id="lot-uuid-{{ match.model.uuid }}" href>
   <span ng-bind-html="match.model.label | uibTypeaheadHighlight:query"></span>
-  <span ng-if="match.model.tracking_expiration" style="margin-left: 1em">[</span>
-  <span ng-if="match.model.tracking_expiration" translate>INVENTORY.EXPIRES</span>
-  <span ng-if="match.model.tracking_expiration" ng-bind-html="match.model.expiration_date | date"></span>
-  <span ng-if="match.model.tracking_expiration" >]</span>
+  <span ng-if="match.model.tracking_expiration" style="margin-left: 1em">
+    [<span translate>INVENTORY.EXPIRES</span> <span ng-bind-html="match.model.expiration_date | date"></span>]
+  </span>
 </a>


### PR DESCRIPTION
Per the request in PR https://github.com/IMA-WorldHealth/bhima/pull/6323 (See https://github.com/IMA-WorldHealth/bhima/pull/6323#discussion_r790472623), this reduces the number of ngIfs in the lot selection dropdown code for Stock Entry.

**TESTING**
- Use any data set
- Pick any article that is in stock
- Check the inventory group for that article of stock and determine if it is tracking expiration.  If it is, temporarily change it to not tracking (Inventory > Inventory Configuration > (select item) and click [Edit]).
- Do stock entry and stock exit forms and verify that when you select a lot it does not include the expiration date on the drop-down to select the lot.
- Change the tracking expiration status to track expiration dates.
- Repeat the entry/exit forms and verify that the lot selection drop-downs now have expiration dates
- DON"T FORGET:  Change the tracking expiration setting for the inventory group back to its original value.
