### PR TITLE
Add top-level menu item for Assets Management

### DIFF
--- a/client/src/i18n/en/tree.json
+++ b/client/src/i18n/en/tree.json
@@ -11,6 +11,9 @@
     "AGED_DEBTORS" : "Aged Debtors Report",
     "AGGREGATED_STOCK_CONSUMPTION" : "Compute Aggregate Stock Consumption",
     "ALLOCATION_AUX_FEES_CENTERS" : "Allocation of Auxiliary Cost Centers",
+    "ASSET_MANAGEMENT" : {
+      "TITLE" : "Asset Management"
+    },
     "AVERAGE_MED_COST_REPORT" : "Average Medication Costs Per Patient",
     "BALANCE" : "Balance",
     "BALANCE_REPORT" : "Balance of Accounts",

--- a/client/src/i18n/fr/tree.json
+++ b/client/src/i18n/fr/tree.json
@@ -11,6 +11,9 @@
     "AGED_DEBTORS":"Balance âgée des Conventionnés",
     "AGGREGATED_STOCK_CONSUMPTION" : "Consommation de stock agrégée",
     "ALLOCATION_AUX_FEES_CENTERS" : "Allocation des centres de cout auxiliaires",
+    "ASSET_MANAGEMENT" : {
+      "TITLE" : "Gestion des actifs"
+    },
     "AVERAGE_MED_COST_REPORT" : "Coût moyen des médicaments par patient",
     "BALANCE":"Balance",
     "BALANCE_REPORT":"Balance des comptes",

--- a/server/models/bhima.sql
+++ b/server/models/bhima.sql
@@ -179,7 +179,8 @@ INSERT INTO unit VALUES
   (303, 'Cost Centers Balance Report','TREE.COST_CENTER_INCOME_EXPENSE_REPORT','Report of cc balance', 286,'/reports/cost_center_income_and_expense'),
   (304, '[SETTINGS] Settings', 'TREE.PAYROLL_SETTINGS', 'Payroll Settings', 57, '/payroll/setting'),
   (305, 'Avg Medical Costs Per Patient', 'TREE.AVERAGE_MED_COST_REPORT', 'Report of avg med costs', 282, '/reports/avg_med_costs_per_patient'),
-  (306, 'ODK Settings', 'TREE.ODK_SETTINGS', 'ODK Settings', 1, '/admin/odk-settings');
+  (306, 'ODK Settings', 'TREE.ODK_SETTINGS', 'ODK Settings', 1, '/admin/odk-settings'),
+  (307, 'Asset Management', 'TREE.ASSET_MANAGEMENT.TITLE', 'Asset Management', 0, '/ASSET_MANAGEMENT_FOLDER');
 
 -- Reserved system account type
 INSERT INTO `account_category` VALUES

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -31,7 +31,7 @@ CREATE TABLE `odk_app_user` (
   CONSTRAINT `odk_app_user__user` FOREIGN KEY (`bhima_user_id`) REFERENCES `user` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
-INSERT INTO unit VALUES
+INSERT IGNORE INTO unit VALUES
   (306, 'ODK Settings', 'TREE.ODK_SETTINGS', 'ODK Settings', 1, '/admin/odk-settings');
 
 UPDATE report SET `report_key` = 'analysis_auxiliary_cashbox', `title_key` = 'REPORT.ANALYSIS_AUX_CASHBOX.TITLE'
@@ -39,3 +39,11 @@ UPDATE report SET `report_key` = 'analysis_auxiliary_cashbox', `title_key` = 'RE
 
 UPDATE unit SET `name` = 'Analysis of Cashbox', `key` = 'REPORT.ANALYSIS_AUX_CASHBOX.TITLE', `description` = 'Analysis of auxiliary cashbox', `path` = '/reports/analysis_auxiliary_cashbox'
   WHERE path = '/reports/analysis_auxiliary_cashboxes';
+
+/*
+ * @author: jmcameron
+ * @description: Add new menu item for Assets Management
+ * @date: 2022-01-28
+ */
+INSERT IGNORE INTO unit VALUES
+  (307, 'Asset Management', 'TREE.ASSET_MANAGEMENT.TITLE', 'Asset Management', 0, '/ASSET_MANAGEMENT_FOLDER');


### PR DESCRIPTION
This PR adds a top-level menu item for Assets Management.

This is a starting point so that other issues related to Asset Management can be worked on separately.

**TESTING**
- Use bhima-test (rebuild)
- When you bring up Bhima, you should see a new top-level Assets Management menu item.
- NOTE: If you click on it, you will get a 404 since there are no menu items inside it yet.


Closes https://github.com/IMA-WorldHealth/bhima/issues/6352
