### PR TITLE
Updated headercrumbs for User and Role management create/edit dialogs

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -887,6 +887,7 @@
             "DECEMBER": "December",
             "PERMISSION_ASSIGNED_SUCCESS":"Permissions successfully assigned",
             "EDIT_ROLE":"Assign role(s)",
+            "ROLE": "Role",
             "ROLES_FOR":"Role(s) for",
             "ROLES" : "Roles",
             "STATUS_TYPE":{

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -887,6 +887,7 @@
             "DECEMBER": "Décembre",
             "PERMISSION_ASSIGNED_SUCCESS":"Permission assigné avec succès",
             "EDIT_ROLE":"Assigner le(s) rôle(s)",
+            "ROLE": "Rôle",
             "ROLES_FOR":"Rôle(s) pour",
             "ROLES" : "Rôles",
             "STATUS_TYPE":{

--- a/client/src/modules/roles/createUpdate.html
+++ b/client/src/modules/roles/createUpdate.html
@@ -1,9 +1,10 @@
 <form name="roleForm" bh-submit="RolesAddCtrl.submit(roleForm)" novalidate>
   <div class="modal-header">
     <ol class="headercrumb">
+      <li class="static" translate>TREE.ADMIN</li>
+      <li class="static" translate>TREE.ROLE_MANAGEMENT</li>
       <li>
-        <span translate>TREE.ROLE_MANAGEMENT</span>
-
+        <span translate>FORM.LABELS.ROLE</span>
         <label class="label label-warning text-uppercase" translate>
           {{RolesAddCtrl.action}}
         </label>

--- a/client/src/modules/users/user.modal.html
+++ b/client/src/modules/users/user.modal.html
@@ -1,8 +1,8 @@
 <form name="UserForm" bh-submit="UserModalCtrl.submit(UserForm)" novalidate>
   <div class="modal-header">
     <ol class="headercrumb">
+      <li class="static" translate>TREE.ADMIN</li>
       <li class="static" translate>USERS.TITLE</li>
-
       <li ng-if="UserModalCtrl.isCreateState" class="title">
         <span translate>USERS.ADDING_USER</span>
         <label class="badge badge-warning" translate>FORM.LABELS.CREATE</label>


### PR DESCRIPTION
Updated the Role Management and User Management create/edit dialogs to improve their headercrumbs.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6317

**TESTING**
- Any database is fine
- Try creating and editing Roles and Users
   - Administration > Role Management
   - Administration > User Management
- Verify that the headercrumb at the top of the create/edit dialog is okay in all 4 cases.