### PR TITLE
Verify that end date >= start date for bhDateInterval component

### DIFF
--- a/client/src/i18n/en/errors.json
+++ b/client/src/i18n/en/errors.json
@@ -18,6 +18,7 @@
     "UNAUTHORIZED" : "You have submitted a bad username or password combination.  Please login in with valid credentials to continue.",
     "UNKNOWN" : "An error occurred.",
     "OVERPAID_INVOICE" : "You have overpaid the invoices.",
+    "ER_DATE_RANGE" : "The end date cannot be before the start date!",
     "ER_DUP_KEY" : "A key collided in a unique database field.  Please retry your action.  If the problem persists, contact the developers.",
     "ER_DUP_ENTRY" : "You have duplicated a value in a unique field!  Please make sure that the necessary values are unique.",
     "ER_DUP_PURCHASE_ORDER_ITEM" : "You have duplicate items for an inventory item (shown in red).  Please delete it and update the previous item with that inventory item.",

--- a/client/src/i18n/fr/errors.json
+++ b/client/src/i18n/fr/errors.json
@@ -18,6 +18,7 @@
     "UNAUTHORIZED" : "Vous avez soumis un mauvais nom ou mot de passe.  Entrez un nom ou un mot de passe valid pour continuer.",
     "UNKNOWN" : "Une erreur est survenue.",
     "OVERPAID_INVOICE" : "Vous avez payé trop aux factures.",
+    "ER_DATE_RANGE" : "La date de fin ne peut pas être antérieure à la date de début !",
     "ER_DUP_KEY" : "Il ya déjà un enregistrement avec cette clé. Veuillez réessayer votre action. Si le problème persiste, contactez les développeurs.",
     "ER_DUP_ENTRY" : "Vous avez dupliqué une valeur dans un champ unique! Assurez-vous que les valeurs nécessaires sont uniques.",
     "ER_DUP_PURCHASE_ORDER_ITEM" : "Vous avez des éléments en double pour un article d'inventaire (indiqué en rouge).  Veuillez le supprimer et mettre à jour l'élément précédent avec cet élément d'inventaire.",

--- a/client/src/js/components/bhDateInterval.js
+++ b/client/src/js/components/bhDateInterval.js
@@ -36,12 +36,12 @@ angular.module('bhima.components')
 
 // dependencies injection
 bhDateInterval.$inject = [
-  'bhConstants', 'FiscalService',
+  'bhConstants', 'FiscalService', 'NotifyService',
   'SessionService', 'PeriodService', '$translate',
 ];
 
 // controller definition
-function bhDateInterval(bhConstants, Fiscal, Session, PeriodService, $translate) {
+function bhDateInterval(bhConstants, Fiscal, Notify, Session, PeriodService, $translate) {
   const $ctrl = this;
 
   PeriodService.dateFormat = 'YYYY-MM-DD';
@@ -70,6 +70,7 @@ function bhDateInterval(bhConstants, Fiscal, Session, PeriodService, $translate)
     $ctrl.pickerToOptions = { showWeeks : false, minDate : $ctrl.dateFrom };
     $ctrl.startDatePlaceholder = $translate.instant($ctrl.startDatePlaceholder || 'FORM.LABELS.START_DATE');
     $ctrl.endDatePlaceholder = $translate.instant($ctrl.endDatePlaceholder || 'FORM.LABELS.END_DATE');
+    $ctrl.dateRangeError = false;
 
     // if controller has requested limit-min-fiscal, fetch required information
     if (angular.isDefined($ctrl.limitMinFiscal)) {
@@ -88,6 +89,17 @@ function bhDateInterval(bhConstants, Fiscal, Session, PeriodService, $translate)
 
   $ctrl.onChangeDate = () => {
     angular.extend($ctrl.pickerToOptions, { minDate : $ctrl.dateFrom });
+
+    // Make sure dateTo >= dateFrom
+    if ($ctrl.dateFrom && $ctrl.dateTo) {
+      if ($ctrl.dateTo < $ctrl.dateFrom) {
+        Notify.danger('ERRORS.ER_DATE_RANGE', 8000);
+        $ctrl.dateTo = null;
+        $ctrl.dateRangeError = true;
+        return;
+      }
+      $ctrl.dateRangeError = false;
+    }
 
     if ($ctrl.onChange) {
       $ctrl.onChange({ dateFrom : $ctrl.dateFrom, dateTo : $ctrl.dateTo });

--- a/client/src/modules/templates/bhDateInterval.tmpl.html
+++ b/client/src/modules/templates/bhDateInterval.tmpl.html
@@ -59,7 +59,7 @@
     </div>
 
     <div class="form-group col-md-5"
-	 ng-class="{ 'has-error' : DateIntervalForm.$submitted && DateIntervalForm.dateTo.$invalid }">
+	    ng-class="{ 'has-error' : $ctrl.dateRangeError || (DateIntervalForm.$submitted && DateIntervalForm.dateTo.$invalid) }">
       <div class="input-group">
         <input
           id="modal-date-to"


### PR DESCRIPTION
Verify that "end date" >= "start date" when selecting a date interval using the bhDateInterval component.
When using the calendar widget this is not needed.  However if one types in the date manually, it is possible to chose an end date that is before the start date.  This PR adds checks to prevent that.   Note that if this occurs, the end date is erased immediately an error message is displayed.   I could not think of how to modify the form controls to do this automatically (in other words force the form into an error state so you could not submit).

Closes https://github.com/IMA-WorldHealth/bhima/issues/6233

NOTE: It was not necessary to fix anything related to the bhFiscalPeriodSelect component since its drop-down behavior prevents this type of error and there is no way to type in a period number manually.

**TESTING**
- Try the date interval in Stock > Stock Exit
- Enter a start date (manually or via the calendar widget)
- Verify that you cannot enter a end date before the start date via the calendar widget
- TYPE in an end date before the start date and observe the error handling behavior