### PR TITLE
Enable stock entry of assets

### DIFF
--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -103,6 +103,14 @@ function StockEntryController(
       },
 
       {
+        field : 'is_asset',
+        width : 100,
+        displayName : 'FORM.LABELS.ASSET',
+        headerCellFilter : 'translate',
+        cellTemplate : '/modules/inventory/list/templates/asset.cell.tmpl.html',
+      },
+
+      {
         field : 'actions',
         width : 25,
         cellTemplate : 'modules/stock/entry/templates/actions.tmpl.html',
@@ -276,7 +284,7 @@ function StockEntryController(
   function loadInventories() {
     setupStock();
 
-    Inventory.read(null, { consumable : 1, skipTags : true })
+    Inventory.read(null, { consumable_or_asset : 1, skipTags : true })
       .then((inventories) => {
         vm.inventories = inventories;
         inventoryStore = new Store({ identifier : 'uuid', data : inventories });

--- a/server/controllers/inventory/index.js
+++ b/server/controllers/inventory/index.js
@@ -118,7 +118,7 @@ async function computeWac(inventoryUuid) {
   const binaryInventoryUuid = db.bid(inventoryUuid);
   const queryRecompute = 'CALL RecomputeInventoryStockValue(?, ?);';
   const querySelect = `
-    SELECT 
+    SELECT
       BUID(sv.inventory_uuid) inventory_uuid,
       i.text, sv.date, sv.quantity, sv.wac
     FROM stock_value sv

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -275,20 +275,26 @@ async function getItemsMetadata(params) {
   filters.equals('unit_id');
   filters.equals('type_id');
   filters.equals('code');
-  filters.equals('price');
   filters.equals('consumable');
+  filters.equals('is_asset');
+  filters.equals('price');
   filters.equals('locked');
   filters.equals('label');
   filters.equals('sellable');
   filters.equals('note');
   filters.equals('importance');
-  filters.equals('is_asset');
   filters.equals('manufacturer_brand');
   filters.equals('manufacturer_model');
   filters.equals('reference_number');
   filters.custom('tags', 't.uuid IN (?)', [params.tags]);
   filters.custom('find_null_importance', 'inventory.importance IS NULL');
   filters.custom('inventory_uuids', 'inventory.uuid IN (?)', params.inventory_uuids);
+
+  // Handle requests for either consumables or assets
+  if ('consumable_or_asset' in params && params.consumable_or_asset === '1') {
+    filters.custom('consumable_or_asset', '(inventory.consumable = 1 OR inventory.is_asset = 1)');
+  }
+
   filters.setOrder('ORDER BY inventory.code ASC');
 
   // The query above produces multiple rows for inventory items with more than one tag


### PR DESCRIPTION
This PR changes Stock Entry to enable entry of Assets.

Generally, assets are not marked as consumable (since they will not be consumed by patients, etc).   However, the Stock Entry page currently only allow entry of consumable stock items.   This PR changes that so that either consumables or assets may be entered. 

Note: If you checkout master and try the procedure below, you will not be able to select the new asset inventory item by its code since it is not a consumable item.

**TESTING**
- Use any data set
- In Inventory > Inventory Configuration, create an new inventory group (eg, Vehicle) 
- In Inventory > Inventory Registry, click on [Add Inventory Item] to create a new inventory item for a specific model of motor cycle (in the 'Vehicle' inventory group previously created).
   - Mark it as an asset
   - Do NOT mark it as consumable (we may need to complain if both are selected?)
- Go to Stock > Stock Entry
- Try added a new motorcycle (eg via Integration).  In the new line add the "code" created above and you should be able to select the new asset inventory item.
- See the new items in the stock Lots registry  (note that "asset" and related fields are hidden by default but can be displayed using the column configuration.

Note that this PR does not adjust the stock entry UI/modal, etc, to be friendlier to entering Assets (with changed labels, etc).   We should do that in a separate issue.
