### PR TITLE
Prevent expired stock from being added to shipments

### DIFF
--- a/client/src/modules/shipment/create-shipment.js
+++ b/client/src/modules/shipment/create-shipment.js
@@ -20,7 +20,9 @@ function CreateShipmentController(
 
   vm.existingShipmentUuid = existingShipmentUuid;
   vm.isCreateState = $state.params.isCreateState;
+
   vm.stockForm = new StockForm('ShipmentForm');
+  vm.stockForm.setAllowExpired(false);
 
   const gridFooterTemplate = `
     <div style="margin-left: 10px;">

--- a/client/src/modules/stock/StockExitForm.service.js
+++ b/client/src/modules/stock/StockExitForm.service.js
@@ -48,6 +48,7 @@ function StockExitFormService(
     this.cache = AppCache(cacheKey);
     this.details = { is_exit : 1 };
     this.store = new Store({ identifier : 'uuid', data : [] });
+    this.allowExpired = true;
 
     // this variable is private and will contain the stock for the current depot.
     this._pool = new Pool('lot_uuid', []);
@@ -57,6 +58,14 @@ function StockExitFormService(
 
     this._messages = new Map();
   }
+
+  /**
+   * Set flag to allow or disable expired stock
+   * @param {boolean} flag
+   */
+  StockExitForm.prototype.setAllowExpired = function setAllowExpired(flag) {
+    this.allowExpired = flag;
+  };
 
   StockExitForm.prototype._toggleInfoMessage = function _toggleInfoMessage(
     shouldShowMsg, msgType, msgText, msgKeys = {},
@@ -140,7 +149,10 @@ function StockExitFormService(
     return Depots.getStockQuantityForDate(depotUuid, parameters)
       .then(stock => {
 
-        const available = stock
+        const rawStock = this.allowExpired ? stock
+          : stock.filter(lot => !lot.is_asset && !lot.is_expired);
+
+        const available = rawStock
           .map(item => {
             const lot = new Lot(item);
 


### PR DESCRIPTION
Prevent expired stock to be shipped anywhere from a Depot.  Expired stock must be exited as expired and then is no longer tracked by BHIMA.  Normally it would be disposed.   If for some extraordinary reason, it needs to be shipped somewhere that shipment should occur outside of BHIMA and not using the BHIMA shipment functions.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6471

**TESTING**
- Use bhima_test
- Shipment > Create new shipment
  - Select Principal Depot
  - Set destination depot to Secondary Depot
  - Click [Add] to add a new line for an inventory/lot item
  - Type 'quin' into the inventory code area until it gives you one option for quinine. Select it.
  - Verify that it is not possible to select lot QUININE-A (which is expired)
- Since StockExitFormService is used by both Shipments and Stock Exit, verify Stock Exit still works properly
  - Stock > Stock Exit
    - Click on [LOSS]
    - Click [Add] to add a new line for inventory/lot
    - Type 'quin' into the inventory code and select the quinine inventory item
    - Verify that you can now select QUININE-A even thought it is expired

