### PR TITLE
fix(stock): improve Stock Value Report

### DIFF
--- a/client/src/modules/reports/generate/stock_value/stock_value.config.js
+++ b/client/src/modules/reports/generate/stock_value/stock_value.config.js
@@ -4,12 +4,12 @@ angular.module('bhima.controllers')
 StockValueConfigController.$inject = [
   '$sce', 'NotifyService', 'BaseReportService',
   'AppCache', 'reportData', '$state',
-  'LanguageService', 'moment',
+  'LanguageService', 'moment', 'SessionService',
 ];
 
 function StockValueConfigController(
   $sce, Notify, SavedReports,
-  AppCache, reportData, $state, Languages, moment,
+  AppCache, reportData, $state, Languages, moment, Session,
 ) {
 
   const vm = this;
@@ -19,6 +19,7 @@ function StockValueConfigController(
   vm.reportDetails = {
     dateTo : new Date(),
     excludeZeroValue : 0,
+    currency_id : Session.enterprise.currency_id,
   };
 
   // Default values
@@ -52,10 +53,6 @@ function StockValueConfigController(
     vm.reportDetails.currency_id = currency.id;
   };
 
-  vm.onExcludeZeroValue = () => {
-    vm.reportDetails.exclude_zero_value = vm.excludeZeroValue;
-  };
-
   vm.preview = function preview(form) {
     if (form.$invalid) { return 0; }
 
@@ -66,6 +63,8 @@ function StockValueConfigController(
       lang : Languages.key,
       dateTo,
     };
+
+    cache.reportDetails = angular.copy(vm.reportDetails);
 
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(options))
       .then((result) => {
@@ -92,6 +91,7 @@ function StockValueConfigController(
   function checkCachedConfiguration() {
     if (cache.reportDetails) {
       vm.reportDetails = angular.copy(cache.reportDetails);
+      vm.dateTo = new Date(); // always default to today
     }
   }
 }

--- a/client/src/modules/reports/generate/stock_value/stock_value.config.js
+++ b/client/src/modules/reports/generate/stock_value/stock_value.config.js
@@ -7,27 +7,32 @@ StockValueConfigController.$inject = [
   'LanguageService', 'moment',
 ];
 
-function StockValueConfigController($sce, Notify, SavedReports,
-  AppCache, reportData, $state, Languages, moment) {
+function StockValueConfigController(
+  $sce, Notify, SavedReports,
+  AppCache, reportData, $state, Languages, moment,
+) {
+
   const vm = this;
   const cache = new AppCache('configure_stock_value_report');
   const reportUrl = 'reports/stock/value';
 
+  vm.reportDetails = {
+    dateTo : new Date(),
+    excludeZeroValue : 0,
+  };
+
   // Default values
   vm.previewGenerated = false;
-  vm.orderByCreatedAt = 0;
-  vm.dateTo = new Date();
-  vm.excludeZeroValue = 0;
 
   vm.onDateChange = (date) => {
-    vm.dateTo = date;
+    vm.reportDetails.dateTo = date;
   };
 
   // check cached configuration
   checkCachedConfiguration();
 
   vm.onSelectDepot = function onSelectDepot(depot) {
-    vm.depot = depot;
+    vm.reportDetails.depot_uuid = depot.uuid;
   };
 
   vm.onSelectCronReport = report => {
@@ -35,7 +40,7 @@ function StockValueConfigController($sce, Notify, SavedReports,
   };
 
   vm.clear = function clear(key) {
-    delete vm[key];
+    delete vm.reportDetails[key];
   };
 
   vm.clearPreview = function clearPreview() {
@@ -45,38 +50,24 @@ function StockValueConfigController($sce, Notify, SavedReports,
 
   vm.onSelectCurrency = (currency) => {
     vm.reportDetails.currency_id = currency.id;
-    vm.currency_id = currency.id;
   };
 
   vm.onExcludeZeroValue = () => {
     vm.reportDetails.exclude_zero_value = vm.excludeZeroValue;
   };
 
-  function formatData() {
-    const params = {
-      depot_uuid : vm.depot.uuid,
-      dateTo : vm.dateTo,
-      currency_id : vm.currency_id,
-      exclude_zero_value : vm.excludeZeroValue,
-    };
-    cache.reportDetails = angular.copy(params);
-    params.dateTo = moment(params.dateTo).format('YYYY-MM-DD');
-
-    const options = {
-      params,
-      lang : Languages.key,
-    };
-
-    vm.reportDetails = options;
-    return vm.reportDetails;
-  }
-
   vm.preview = function preview(form) {
     if (form.$invalid) { return 0; }
 
-    vm.reportDetails = formatData();
+    const dateTo = moment(vm.reportDetails.dateTo).format('YYYY-MM-DD');
 
-    return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
+    const options = {
+      ...vm.reportDetails,
+      lang : Languages.key,
+      dateTo,
+    };
+
+    return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(options))
       .then((result) => {
         vm.previewGenerated = true;
         vm.previewResult = $sce.trustAsHtml(result);
@@ -85,7 +76,6 @@ function StockValueConfigController($sce, Notify, SavedReports,
   };
 
   vm.requestSaveAs = function requestSaveAs() {
-    vm.reportDetails = formatData();
     const options = {
       url : reportUrl,
       report : reportData,
@@ -100,6 +90,8 @@ function StockValueConfigController($sce, Notify, SavedReports,
   };
 
   function checkCachedConfiguration() {
-    vm.reportDetails = angular.copy(cache.reportDetails || {});
+    if (cache.reportDetails) {
+      vm.reportDetails = angular.copy(cache.reportDetails);
+    }
   }
 }

--- a/client/src/modules/reports/generate/stock_value/stock_value.html
+++ b/client/src/modules/reports/generate/stock_value/stock_value.html
@@ -42,9 +42,7 @@
 
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-true-value="1" ng-false-value="0"
-                ng-model="ReportConfigCtrl.reportDetails.excludeZeroValue"
-                ng-change="ReportConfigCtrl.onExcludeZeroValue()">
+              <input type="checkbox" ng-true-value="1" ng-false-value="0" ng-model="ReportConfigCtrl.reportDetails.excludeZeroValue">
               <span translate>REPORT.STOCK_VALUE.EXCLUDE_INVENTORIES_ZERO_VALUE</span>
             </label>
           </div>

--- a/client/src/modules/reports/generate/stock_value/stock_value.html
+++ b/client/src/modules/reports/generate/stock_value/stock_value.html
@@ -26,7 +26,7 @@
 
           <!-- select depot -->
           <bh-depot-select
-            depot-uuid="ReportConfigCtrl.depot.uuid"
+            depot-uuid="ReportConfigCtrl.reportDetails.depot_uuid"
             on-select-callback="ReportConfigCtrl.onSelectDepot(depot)"
             required="true">
             <bh-clear on-clear="ReportConfigCtrl.clear('depot')"></bh-clear>
@@ -36,14 +36,14 @@
           <bh-date-editor
             label="FORM.LABELS.UNTIL_DATE"
             limit-min-fiscal
-            date-value="ReportConfigCtrl.dateTo"
+            date-value="ReportConfigCtrl.reportDetails.dateTo"
             on-change="ReportConfigCtrl.onDateChange(date)">
           </bh-date-editor>
 
           <div class="checkbox">
             <label>
               <input type="checkbox" ng-true-value="1" ng-false-value="0"
-                ng-model="ReportConfigCtrl.excludeZeroValue"
+                ng-model="ReportConfigCtrl.reportDetails.excludeZeroValue"
                 ng-change="ReportConfigCtrl.onExcludeZeroValue()">
               <span translate>REPORT.STOCK_VALUE.EXCLUDE_INVENTORIES_ZERO_VALUE</span>
             </label>
@@ -51,7 +51,7 @@
 
           <!-- the currency to be used in the footer -->
           <bh-currency-select
-           currency-id="ReportConfigCtrl.currency_id"
+           currency-id="ReportConfigCtrl.reportDetails.currency_id"
            on-change="ReportConfigCtrl.onSelectCurrency(currency)">
           </bh-currency-select>
 

--- a/server/controllers/stock/reports/stock/value.js
+++ b/server/controllers/stock/reports/stock/value.js
@@ -32,7 +32,7 @@ async function reporting(_options, session) {
   const options = (typeof (_options.params) === 'string') ? JSON.parse(_options.params) : _options;
 
   data.dateTo = options.dateTo;
-  data.isEnterpriseCurrency = options.currency_id === session.enterprise.currency_id;
+  data.isEnterpriseCurrency = Number(options.currency_id) === session.enterprise.currency_id;
 
   const depot = await db.one('SELECT * FROM depot WHERE uuid = ?', [db.bid(options.depot_uuid)]);
   const exchangeRate = await Exchange.getExchangeRate(enterpriseId, options.currency_id, new Date());

--- a/server/controllers/stock/reports/stock_value.report.handlebars
+++ b/server/controllers/stock/reports/stock_value.report.handlebars
@@ -21,7 +21,7 @@
           {{date dateTo}}
         </h4>
 
-        {{#unless isEntepriseCurrency}}
+        {{#unless isEnterpriseCurrency}}
           {{> exchangeRate rate=exchangeRate currencyId=currency_id}}
         {{/unless}}
 

--- a/server/controllers/stock/reports/stock_value.report.handlebars
+++ b/server/controllers/stock/reports/stock_value.report.handlebars
@@ -1,4 +1,4 @@
-{{> head title="TREE.STOCK_INVENTORY" }}
+{{> head title="TREE.STOCK_VALUE" }}
 
 <body>
 
@@ -21,7 +21,9 @@
           {{date dateTo}}
         </h4>
 
-        {{> exchangeRate rate=exchangeRate currencyId=currencyId}}
+        {{#unless isEntepriseCurrency}}
+          {{> exchangeRate rate=exchangeRate currencyId=currency_id}}
+        {{/unless}}
 
         <!-- list of data  -->
         <table class="table table-condensed table-report">
@@ -39,22 +41,22 @@
           <tbody>
             {{#each stockValues}}
             <tr {{#if hasWarning}}class="text-danger bg-danger"{{/if}} >
-                <td>{{inventory_code}}</td>
-                <td style="width:50%">{{inventory_name}}</td>
-                <td class="text-right">{{stockQtyPurchased}}</td>
-                <td class="text-right">{{currency stockUnitCost ../currency_id 4}}</td>
-                <td class="text-right">{{currency stockValue ../currency_id 2}}</td>
-                <td class="text-right">{{currency inventoryPrice ../currency_id 4}}</td>
-                <td class="text-right">{{currency saleValue ../currency_id 2}}</td>
+                <td>{{code}}</td>
+                <td style="width:50%">{{text}}</td>
+                <td class="text-right">{{quantity}}</td>
+                <td class="text-right">{{currency exchanged_wac ../currency_id 4}}</td>
+                <td class="text-right">{{currency exchanged_value ../currency_id 2}}</td>
+                <td class="text-right">{{currency exchanged_price ../currency_id 4}}</td>
+                <td class="text-right">{{currency exchanged_sales_value ../currency_id 2}}</td>
               </tr>
           {{else}}
             {{> emptyTable columns=7}}
           {{/each}}
           <tr>
             <th colspan="4" class="text-right">{{ translate "FORM.LABELS.VALUE_IN_STOCK"}}</th>
-            <th class="text-right">{{currency stockTotalValue currency_id 2}}</th>
+            <th class="text-right">{{currency totals.stockTotalValue currency_id 2}}</th>
             <th class="text-right">{{ translate "FORM.LABELS.SALE_VALUE"}}</th>
-            <th class="text-right">{{ currency stockTotalSaleValue currency_id 2}}</th>
+            <th class="text-right">{{ currency totals.stockTotalSaleValue currency_id 2}}</th>
           </tr>
           </tbody>
         </table>


### PR DESCRIPTION
This PR fixes various components of the stock value report cited in issue #6150. 

Notably, the query now uses the `stock_movement_status` table to pull in the quantities in stock for a given depot and loads the
`stock_value` table to get the value of the items in stock.  This speeds the query up significantly.

Miscellaneous changes:

- The report now defaults to the enterprise currency.
- The majority of the values are now cached, except for the date that defaults to today.
- Performance improvements as cited above.
- I've removed the coloration entirely.  

Closes #6150.