### PR TITLE
Convert lots registry custom search flag from Assets-only to Exclude-assets

### DIFF
--- a/client/src/i18n/en/asset.json
+++ b/client/src/i18n/en/asset.json
@@ -10,6 +10,7 @@
     "ASSIGN_TO" : "Assign to",
     "DETAILS" : "Asset Details",
     "DOCUMENT" : "Assignment Document",
+    "EXCLUDE_ASSETS" : "Exclude assets",
     "LAST_SCAN_DATE" : "Last Scan Date",
     "NEW_ASSET_SCAN" : "New Asset Scan",
     "NEW_REQUIRED_INVENTORY_SCAN" : "New Required Inventory Scan",

--- a/client/src/i18n/fr/asset.json
+++ b/client/src/i18n/fr/asset.json
@@ -10,6 +10,7 @@
     "ASSIGN_TO" : "Assigner à",
     "DETAILS" : "Détail de l'actif",
     "DOCUMENT" : "Document",
+    "EXCLUDE_ASSETS" : "Exclure les actifs",
     "LAST_SCAN_DATE" : "Date du dernier scan",
     "NEW_ASSET_SCAN" : "Nouveau scan d'un actif",
     "NEW_REQUIRED_INVENTORY_SCAN" : "Nouvelle scan d'inventaire obligatoire",

--- a/client/src/modules/stock/lots/modals/search.modal.html
+++ b/client/src/modules/stock/lots/modals/search.modal.html
@@ -51,18 +51,6 @@
             </div>
           </div>
 
-          <!-- is_asset -->
-          <div class="form-group">
-            <div class="checkbox">
-              <label>
-                <input type="checkbox"
-                  ng-model="$ctrl.searchQueries.is_asset"
-                  ng-true-value="1" ng-false-value="0">
-                <span translate>FORM.LABELS.ASSETS_ONLY</span>
-              </label>
-            </div>
-          </div>
-
           <!-- reference_number  -->
           <div class="form-group">
             <label class="control-label" translate>FORM.LABELS.REFERENCE_NUMBER</label>
@@ -102,6 +90,19 @@
             on-change-callback="$ctrl.onToggleExpiryRisk(value)">
             <bh-clear on-clear="$ctrl.clear('is_expiry_risk')"></bh-clear>
           </bh-yes-no-radios>
+
+          <!-- is_asset -->
+          <div class="form-group">
+            <div class="checkbox">
+              <label>
+                <input type="checkbox"
+                  ng-model="$ctrl.excludeAssets"
+                  ng-change="$ctrl.onExcludeAssets()"
+                  ng-true-value="1" ng-false-value="0">
+                <span translate>ASSET.EXCLUDE_ASSETS</span>
+              </label>
+            </div>
+          </div>
 
           <!-- tags -->
           <bh-tag-select

--- a/client/src/modules/stock/lots/modals/search.modal.js
+++ b/client/src/modules/stock/lots/modals/search.modal.js
@@ -30,6 +30,12 @@ function SearchLotsModalController(data, util, Store, Instance, Periods, Stock, 
   // assign already defined custom filters to searchQueries object
   vm.searchQueries = util.maskObjectFromKeys(data, searchQueryOptions);
 
+  // Set the excludeAssets flag based on the existing custom search filter
+  vm.excludeAssets = 0;
+  if ('is_asset' in vm.searchQueries && !vm.searchQueries.is_asset) {
+    vm.excludeAssets = 1;
+  }
+
   // default filter period - directly write to changes list
   vm.onSelectPeriod = function onSelectPeriod(period) {
     const periodFilters = Periods.processFilterChanges(period);
@@ -49,6 +55,14 @@ function SearchLotsModalController(data, util, Store, Instance, Periods, Stock, 
   vm.onSelectInventory = function onSelectInventory(inventory) {
     vm.searchQueries.inventory_uuid = inventory.uuid;
     displayValues.inventory_uuid = inventory.label;
+  };
+
+  vm.onExcludeAssets = function onExcludeAssets() {
+    if (vm.excludeAssets) {
+      vm.searchQueries.is_asset = 0;
+    } else {
+      vm.clear('is_asset');
+    }
   };
 
   // include/exclude empty lots


### PR DESCRIPTION
Changes the logic of the "Assets only" custom search query flag to "Exclude Assets".   To look at only assets, the user should use the Assets Managements > Assets Registry page.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6532

**TESTING**
- use bhima_test
- Try Stock > Stock Lots and try the "Exclude assets" flag near the bottom of the search query modal.  When set, notice that the two assets (MOT1 and MOT2) are no longer listed.
