### PR TITLE
Fix several problems in create shipment form

### DIFF
--- a/client/src/modules/shipment/create-shipment.html
+++ b/client/src/modules/shipment/create-shipment.html
@@ -46,6 +46,7 @@
             depot-uuid="CreateShipCtrl.shipment.destination_depot_uuid"
             label="SHIPMENT.DESTINATION_DEPOT"
             on-select-callback="CreateShipCtrl.onSelectDestinationDepot(depot)"
+            exception="CreateShipCtrl.depot"
             required="true">
           </bh-depot-select>
 
@@ -53,6 +54,7 @@
           <bh-date-editor
             label="SHIPMENT.ANTICIPATED_DELIVERY_DATE"
             date-value="CreateShipCtrl.shipment.anticipated_delivery_date"
+            min-date="CreateShipCtrl.today"
             allow-future-date="true"
             on-change="CreateShipCtrl.setDate(date)"
             required="true">

--- a/client/src/modules/shipment/create-shipment.js
+++ b/client/src/modules/shipment/create-shipment.js
@@ -65,7 +65,7 @@ function CreateShipmentController(
         width : 150,
         displayName : 'TABLE.COLUMNS.QUANTITY',
         headerCellFilter : 'translate',
-        cellTemplate : 'modules/stock/exit/templates/quantity.tmpl.html',
+        cellTemplate : 'modules/shipment/templates/quantity.tmpl.html',
         aggregationType : uiGridConstants.aggregationTypes.sum,
       }, {
         field : 'unit_type',
@@ -104,7 +104,7 @@ function CreateShipmentController(
 
   vm.maxLength = util.maxLength;
   vm.enterprise = Session.enterprise;
-  vm.maxDate = new Date();
+  vm.today = new Date();
   vm.onChangeDepot = onChangeDepot;
   vm.getOverview = getOverview;
   vm.setReady = setReady;
@@ -127,6 +127,10 @@ function CreateShipmentController(
   };
 
   vm.configureItem = function configureItem(row, lot) {
+    if (lot.isAsset()) {
+      // Override default quantity for assets
+      lot.quantity = 1;
+    }
     vm.stockForm.configureItem(row, lot);
     vm.validateItems();
   };
@@ -181,6 +185,9 @@ function CreateShipmentController(
     // set the shipment origin
     vm.shipment.origin_depot_uuid = vm.depot.uuid;
 
+    // Delete the old destination depot
+    delete vm.shipment.destination_depot_uuid;
+
     // trick an exit type which is required
     vm.stockForm.setExitType('loss');
     vm.stockForm.setLossDistribution();
@@ -217,7 +224,6 @@ function CreateShipmentController(
   function startup() {
     vm.loading = true;
     vm.hasError = false;
-
     vm.stockForm.setup();
     vm.validateItems();
 

--- a/client/src/modules/shipment/templates/quantity.tmpl.html
+++ b/client/src/modules/shipment/templates/quantity.tmpl.html
@@ -1,0 +1,12 @@
+<div class="ui-grid-cell-contents">
+  <input
+    name="quantity"
+    type="number"
+    min="0"
+    ng-max="{{ row.entity._quantity_available}}"
+    ng-disabled="!row.entity.lot_uuid"
+    class="form-control"
+    style="padding-left : 5px !important;text-align: right;"
+    ng-model="row.entity.quantity"
+    ng-change="grid.appScope.validateItems()" required>
+</div>

--- a/client/src/modules/stock/LotItem.service.js
+++ b/client/src/modules/stock/LotItem.service.js
@@ -245,7 +245,7 @@ function LotItemService(uuid, $translate) {
    * Returns true if the lot is an asset.
    */
   Lot.prototype.isAsset = function isAsset() {
-    return this.__is_asset === true;
+    return !!this.__is_asset;
   };
 
   /**

--- a/client/src/modules/stock/StockExitForm.service.js
+++ b/client/src/modules/stock/StockExitForm.service.js
@@ -160,7 +160,7 @@ function StockExitFormService(
       .then(stock => {
 
         const rawStock = this.allowExpired ? stock
-          : stock.filter(lot => !lot.is_asset && !lot.is_expired);
+          : stock.filter(lot => lot.is_asset || !lot.is_expired);
 
         const available = rawStock
           .map(item => {

--- a/server/controllers/asset_management/shipment/shipment.js
+++ b/server/controllers/asset_management/shipment/shipment.js
@@ -376,7 +376,7 @@ exports.listInTransitInventories = async (req, res, next) => {
       DATEDIFF(l.expiration_date, CURRENT_DATE()) AS lifetime,
       BUID(l.inventory_uuid) AS inventory_uuid,
       BUID(sh.origin_depot_uuid) AS depot_uuid,
-      i.purchase_interval, i.delay,
+      i.purchase_interval, i.delay, i.is_asset,
       iu.text AS unit_type,
       ig.name AS group_name, ig.tracking_expiration, ig.tracking_consumption,
       CONCAT('LT', LEFT(HEX(l.uuid), 8)) AS barcode
@@ -525,7 +525,8 @@ function findAffectedAssets(params) {
       BUID(shi.uuid) AS uuid, BUID(sh.uuid) AS shipment_uuid,
       BUID(shi.lot_uuid) AS lot_uuid, shi.quantity_sent,
       l.label AS lot_label, i.code AS inventory_code,
-      i.text AS inventory_text, dm.text AS reference
+      i.text AS inventory_text, i.is_asset,
+      dm.text AS reference
     FROM shipment sh
     JOIN shipment_item shi ON shi.shipment_uuid = sh.uuid
     JOIN lot l ON l.uuid = shi.lot_uuid
@@ -629,7 +630,8 @@ async function getPackingList(identifier) {
       sh.anticipated_delivery_date,
       sh.receiver, u.display_name AS created_by,
       shi.quantity_sent, shi.quantity_delivered, shi.date_packed,
-      l.label AS lot_label, i.code AS inventory_code, i.text AS inventory_label,
+      l.label AS lot_label, i.code AS inventory_code,
+      i.text AS inventory_label, i.is_asset,
       dm.text AS reference
     FROM shipment sh
     JOIN shipment_status ss ON ss.id = sh.status_id

--- a/server/controllers/inventory/depots/index.js
+++ b/server/controllers/inventory/depots/index.js
@@ -120,9 +120,10 @@ function getLotsInStockForDate(depotUuid, date) {
       SELECT
         BUID(inventory.uuid) AS inventory_uuid,
         BUID(lot.uuid) AS lot_uuid,
-        balances.quantity, 
+        balances.quantity,
         inventory.code,
         inventory.text,
+        inventory.is_asset,
         BUID(inventory.group_uuid) AS group_uuid,
         lot.expiration_date,
         (lot.expiration_date < DATE(?)) AS is_expired,
@@ -131,7 +132,7 @@ function getLotsInStockForDate(depotUuid, date) {
         inventory_group.tracking_consumption,
         inventory_unit.text AS unit
       FROM (
-        SELECT 
+        SELECT
           sm.lot_uuid,
           SUM(IF(sm.is_exit, -1 * sm.quantity, sm.quantity)) AS quantity
         FROM stock_movement AS sm


### PR DESCRIPTION
Fixes several minor usability problems in the form to create shipments.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6522  -- Filter out source depot from destination depot drop-down
Closes https://github.com/IMA-WorldHealth/bhima/issues/6525  -- Shipment expected delivery date cannot be in the past
Closes https://github.com/IMA-WorldHealth/bhima/issues/6526  -- Assets in shipments sould default to quantity = 1

Also fixed a bug that was preventing updating quantity from automatically validating the row in form.

**TESTTING**
- Use bhima_test
- Try creating a shipment
   -  Assets should default to quantity = 1 (non-assets to 0)
   - Try changing the quantity (for non-asset) and see the row validation work immediately
   - Verify that a expected delivery date in the past cannot be selected
   - Verify that the source depot does not appear in the drop-down list for selecting the destination depot
   - Choose the source depot, set the destination depot, and then change the source depot. Verify that the destination depot is cleared (since it may not be valid any longer).
