### PR TITLE
Fix bogus errors in Stock Exits from shipments

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -200,7 +200,8 @@
       "WARN_MAIN_FORM_ERRORS" : "Please enter required fields in main form!",
       "WARN_NOT_CONSUMABLE_INVOICE" : "The invoice does not have any consumable items in it.  No lots have been automatically filled.",
       "WARN_OUT_OF_STOCK_QUANTITY" : "There is no stock of {{hrText}} to fill the requisition.  These item(s) have been skipped.",
-      "WARN_PAST_DATE" : "You have chosen a date in the past. Only the lots available on the chosen date will be visible as well as the quantity on this date."
+      "WARN_PAST_DATE" : "You have chosen a date in the past. Only the lots available on the chosen date will be visible as well as the quantity on this date.",
+      "WARN_SOME_SHIPMENT_LOTS_EXAUSTED" : "Some lots specified in the shipment are exhausted and have been skipped below."
     },
     "DEPOT_DISTRIBUTION" : "Depot Distribution",
     "DIRECTION": " Movement direction",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -200,7 +200,8 @@
       "WARN_MAIN_FORM_ERRORS" : "Veuillez saisir les éléments requis dans le formulaire principal !",
       "WARN_NOT_CONSUMABLE_INVOICE" : "La facture ne contient aucun article consommable. Aucun lot n'a été pourvu automatiquement.",
       "WARN_OUT_OF_STOCK_QUANTITY" : "Il n'y a pas de stock de {{hrText}} pour remplir la demande. Ces éléments ont été ignorés. ",
-      "WARN_PAST_DATE" : "Vous avez choisi une date dans le passé. Seuls les lots disponibles à la date choisie seront visibles ainsi que la quantité à cette date."
+      "WARN_PAST_DATE" : "Vous avez choisi une date dans le passé. Seuls les lots disponibles à la date choisie seront visibles ainsi que la quantité à cette date.",
+      "WARN_SOME_SHIPMENT_LOTS_EXAUSTED" : "Certains lots spécifiés dans l'expédition sont épuisés et ont été ignorés ci-dessous."
     },
     "DEPOT_DISTRIBUTION" : "Distribution au dépôt",
     "DIRECTION": "Direction du  movement",

--- a/client/src/modules/shipment/create-shipment.js
+++ b/client/src/modules/shipment/create-shipment.js
@@ -360,7 +360,7 @@ function CreateShipmentController(
         return Depot.read(vm.shipment.origin_depot_uuid);
       })
       .then(depot => onChangeDepot(depot))
-      .then(() => vm.stockForm.setLotsFromLotList(vm.shipment.lots, 'lot_uuid'))
+      .then(() => vm.stockForm.setLotsFromShipmentList(vm.shipment.lots, 'lot_uuid'))
       .catch(Notify.handleError);
   }
 

--- a/client/src/modules/stock/exit/modals/findDepot.modal.html
+++ b/client/src/modules/stock/exit/modals/findDepot.modal.html
@@ -16,6 +16,7 @@
     <div class="form-group">
       <label class="control-label" translate>STOCK.DEPOT</label>
       <ui-select name="depot"
+        ng-model="$ctrl.selected"
         ng-disabled="$ctrl.shipment">
         <ui-select-match>
           <span>{{$select.selected.text}}</span>


### PR DESCRIPTION
Eliminates bogus messages about missing/exhausted stock for Stock Exits from shipments.
Adds warning message when a lot in a shipment is exausted when the Stock Exit is performed.
Fixed cut-and-paste error in the last PR.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6530
Closes https://github.com/IMA-WorldHealth/bhima/issues/6555  (actually a dupe of 6539)

**TESTING**
- bhima_test
- Refresh the bhima_test databases (yarn build:db)
- Create a shipment with all three available types of stock
  - Mark the shipment ready to ship
- Do a stock exit from the shipment and notice no warning messages
- Make a second shipment with all three available types of stock
  - Mark it ready to ship
- BEFORE doing stock exit, Do a Stock Exit to Loss to exhaust either the  Vitamins or the Quinine
- Go to Stock Exit - [Depot] and select the shipment.  Click [Submit]
- Notice the new warning that some shipment items have been omitted.  Notice that only two rows appear in the list of items.


