### PR TITLE
fix(stock): added creation success key

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -249,7 +249,8 @@
       "EXIT_DEPOT"     : "Stock exit to depot",
       "EXIT_SERVICE"   : "Stock exit to service",
       "EXIT_SERVICES"   : "Stock exit to services",
-      "EXIT_LOSS"      : "Stock exit to loss"
+      "EXIT_LOSS"      : "Stock exit to loss",
+      "SUCCESS" : "Stock movement created successfully"
     },
     "RECEIVER"        : "Receiver",
     "RECEPTION_TRANSFER" : "Transfer",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -281,7 +281,7 @@
     "STOCK_VALUE_WITH_WAC" : "Valeur finale du stock avec le cout unitaire de l'entreprise",
     "STOCK_MOVEMENT"  : "Voir le mouvement de Stock",
     "STOCK_MOVEMENTS" : "Les Mouvements de Stock",
-    "SUCCESS"         : "Mouvement realisé avec succès",
+    "SUCCESS"         : "Mouvement de stock realisé avec succès",
     "SUCCESSFULLY_DELETED" : "Supprimé avec succès",
     "TO"              : "Destination",
     "UNIT_COST"       : "Coût unitaire",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -249,7 +249,8 @@
       "EXIT_DEPOT"     : "Transfer vers un dépot",
       "EXIT_SERVICE"   : "Distribution à un service",
       "EXIT_SERVICES"   : "Distributions aux services",
-      "EXIT_LOSS"      : "Perte de stock"
+      "EXIT_LOSS"      : "Perte de stock",
+      "SUCCESS" : "Mouvement créé avec succès"
     },
     "RECEIVER"        : "Recepteur",
     "RECEPTION_TRANSFER" : "Transfert",

--- a/client/src/js/services/receipts/ReceiptModal.js
+++ b/client/src/js/services/receipts/ReceiptModal.js
@@ -358,7 +358,12 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
    * @param {boolean} notifyCreated
    */
   function stockExitPatientReceipt(documentUuid, notifyCreated) {
-    const opts = { title : 'STOCK.RECEIPT.EXIT_PATIENT', notifyCreated, renderer : Receipts.renderer };
+    const opts = {
+      title : 'STOCK.RECEIPT.EXIT_PATIENT',
+      notifyCreated,
+      renderer : Receipts.renderer,
+      createdKey : 'STOCK.RECEIPT.SUCCESS',
+    };
     const promise = Receipts.stockExitPatientReceipt(documentUuid, { renderer : opts.renderer });
     return ReceiptFactory(promise, opts);
   }
@@ -391,7 +396,12 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
    * @param {boolean} notifyCreated
    */
   function stockExitLossReceipt(documentUuid, notifyCreated) {
-    const opts = { title : 'STOCK.RECEIPT.EXIT_LOSS', notifyCreated, renderer : Receipts.renderer };
+    const opts = {
+      title : 'STOCK.RECEIPT.EXIT_LOSS',
+      notifyCreated,
+      renderer : Receipts.renderer,
+      createdKey : 'STOCK.RECEIPT.SUCCESS',
+    };
     const promise = Receipts.stockExitLossReceipt(documentUuid, { renderer : opts.renderer });
     return ReceiptFactory(promise, opts);
   }
@@ -402,7 +412,12 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
    * @param {boolean} notifyCreated
    */
   function stockAggregateConsumptionReceipt(documentUuid, notifyCreated) {
-    const opts = { title : 'STOCK.RECEIPT.AGGREGATE_CONSUMPTION', notifyCreated, renderer : Receipts.renderer };
+    const opts = {
+      createdKey : 'STOCK.RECEIPT.SUCCESS',
+      title : 'STOCK.RECEIPT.AGGREGATE_CONSUMPTION',
+      notifyCreated,
+      renderer : Receipts.renderer,
+    };
     const promise = Receipts.stockAggregateConsumptionReceipt(documentUuid, { renderer : opts.renderer });
     return ReceiptFactory(promise, opts);
   }
@@ -414,6 +429,7 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
    */
   function stockExitServiceReceipt(documentUuid, notifyCreated) {
     const opts = {
+      createdKey : 'STOCK.RECEIPT.SUCCESS',
       title : 'STOCK.RECEIPT.EXIT_SERVICE',
       notifyCreated,
       renderer : Receipts.renderer,
@@ -429,6 +445,7 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
    */
   function stockExitDepotReceipt(documentUuid, notifyCreated) {
     const opts = {
+      createdKey : 'STOCK.RECEIPT.SUCCESS',
       title : 'STOCK.RECEIPT.EXIT_DEPOT',
       notifyCreated,
       renderer : Receipts.renderer,
@@ -445,6 +462,7 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
    */
   function stockEntryDepotReceipt(documentUuid, notifyCreated) {
     const opts = {
+      createdKey : 'STOCK.RECEIPT.SUCCESS',
       title : 'STOCK.RECEIPT.ENTRY_DEPOT',
       notifyCreated,
       renderer : Receipts.renderer,
@@ -461,6 +479,7 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
    */
   function stockEntryPurchaseReceipt(documentUuid, notifyCreated) {
     const opts = {
+      createdKey : 'STOCK.RECEIPT.SUCCESS',
       title : 'STOCK.RECEIPT.ENTRY_PURCHASE',
       notifyCreated,
       renderer : Receipts.renderer,
@@ -479,6 +498,7 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
     const opts = {
       title : 'STOCK.RECEIPT.ENTRY_INTEGRATION',
       notifyCreated,
+      createdKey : 'STOCK.RECEIPT.SUCCESS',
       renderer : Receipts.renderer,
     };
 
@@ -494,6 +514,7 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
   function stockEntryDonationReceipt(documentUuid, notifyCreated) {
     const opts = {
       title : 'STOCK.RECEIPT.ENTRY_DONATION',
+      createdKey : 'STOCK.RECEIPT.SUCCESS',
       notifyCreated,
       renderer : Receipts.renderer,
     };
@@ -508,7 +529,12 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
    * @param {boolean} notifyCreated
    */
   function stockAdjustmentReceipt(documentUuid, notifyCreated) {
-    const opts = { title : 'STOCK.RECEIPT.ADJUSTMENT', notifyCreated, renderer : Receipts.renderer };
+    const opts = {
+      title : 'STOCK.RECEIPT.ADJUSTMENT',
+      createdKey : 'STOCK.RECEIPT.SUCCESS',
+      notifyCreated,
+      renderer : Receipts.renderer,
+    };
     const promise = Receipts.stockAdjustmentReceipt(documentUuid, { renderer : opts.renderer });
     return ReceiptFactory(promise, opts);
   }
@@ -519,7 +545,12 @@ function ReceiptModal(Modal, Receipts, Invoice, Cash, Voucher) {
    * @param {boolean} notifyCreated
    */
   function stockAdjustmentReport(depotUuid, date, notifyCreated) {
-    const opts = { title : 'STOCK.RECEIPT.ADJUSTMENT', notifyCreated, renderer : Receipts.renderer };
+    const opts = {
+      createdKey : 'STOCK.RECEIPT.SUCCESS',
+      title : 'STOCK.RECEIPT.ADJUSTMENT',
+      notifyCreated,
+      renderer : Receipts.renderer,
+    };
     const promise = Receipts.stockAdjustmentReport(depotUuid, date, { renderer : opts.renderer });
     return ReceiptFactory(promise, opts);
   }

--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -613,7 +613,7 @@ function StockEntryController(
       })
       .then(() => {
         vm.reset();
-        ReceiptModal.stockEntryPurchaseReceipt(vm.document.uuid, bhConstants.flux.FROM_PURCHASE);
+        ReceiptModal.stockEntryPurchaseReceipt(vm.document.uuid, true);
       })
       .catch(Notify.handleError);
   }
@@ -640,7 +640,7 @@ function StockEntryController(
     return Stock.integration.create(entry)
       .then(document => {
         vm.reset();
-        ReceiptModal.stockEntryIntegrationReceipt(document.uuid, bhConstants.flux.FROM_INTEGRATION);
+        ReceiptModal.stockEntryIntegrationReceipt(document.uuid, true);
       })
       .catch(Notify.handleError);
   }
@@ -667,7 +667,7 @@ function StockEntryController(
     return Stock.stocks.create(movement)
       .then((document) => {
         vm.reset();
-        ReceiptModal.stockEntryDonationReceipt(document.uuid, bhConstants.flux.FROM_DONATION);
+        ReceiptModal.stockEntryDonationReceipt(document.uuid, true);
       })
       .catch(Notify.handleError);
   }


### PR DESCRIPTION
Adds the creation success key to all stock movements.

Closes #6512.

![image](https://user-images.githubusercontent.com/896472/164009012-82ee8845-8037-4ff5-92c9-7a5fa14cf060.png)
