### PR TITLE
Disable latest node in tests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -68,7 +68,7 @@ blocks:
               values:
                 - '14'
                 - '16'
-                - 'node'
+#                - 'node'
 
   - name: Install Testing Matrix
     dependencies: ["Update Dependencies"]
@@ -120,4 +120,4 @@ blocks:
               values:
                 - '14'
                 - '16'
-                - 'node'
+#                - 'node'


### PR DESCRIPTION
Update semaphore tests to not test with 'node'  (latest node, 18.0.0)
