### PR TITLE
Enter stocks for shipments using shipment registry action menu

### DIFF
--- a/client/src/js/components/bhStockEntryExitType.js
+++ b/client/src/js/components/bhStockEntryExitType.js
@@ -4,6 +4,7 @@ angular.module('bhima.components')
     controller : StockEntryExitTypeController,
     bindings : {
       onEntryExitTypeSelectCallback : '&',
+      selectedEntryExitType : '=',
       isEntry : '@',
       reference : '<?',
       displayName : '<?',
@@ -70,7 +71,7 @@ function StockEntryExitTypeController(StockEntryExitTypes) {
   };
 
   $ctrl.isTypeSelected = (type) => {
-    return angular.equals(type, $ctrl.selectedEntryExitType);
+    return angular.equals(type.label, $ctrl.selectedEntryExitType?.label);
   };
 
   $ctrl.selectEntryExitType = (type) => {
@@ -80,7 +81,7 @@ function StockEntryExitTypeController(StockEntryExitTypes) {
 
   // reload entry/exit types
   function reloadEntryExitTypes() {
-    delete $ctrl.selectedEntryExitType;
+    $ctrl.selectedEntryExitType = {};
 
     if (!$ctrl.depot) { return; }
 

--- a/client/src/js/services/StockService.js
+++ b/client/src/js/services/StockService.js
@@ -165,6 +165,28 @@ function StockService(Api, StockFilterer, HttpCache, util, Periods) {
   }
 
   /**
+   * Filter partial transfers to compute adjusted quantities
+   * @param {list} allTransfers
+   * @return {list} list of stock exits with adjusted quantities
+   *
+   * NOTE: This function may return an empty list.  It is up to the
+   *       caller to handle error messages when that happens.
+   */
+  function filterPartialTransfers(allTransfers) {
+    // we need to adjust the quantities appropriately.
+    const exitTransfers = allTransfers.filter(item => item.is_exit);
+    exitTransfers.forEach(item => {
+      const previousTransfers = allTransfers.filter(trn => !trn.is_exit && trn.uuid === item.uuid);
+      if (previousTransfers.length > 0) {
+        previousTransfers.forEach(pt => {
+          item.quantity -= pt.quantity;
+        });
+      }
+    });
+    return exitTransfers.filter(item => item.quantity > 0);
+  }
+
+  /**
    * @function processLotsFromStore
    *
    * @description
@@ -231,6 +253,7 @@ function StockService(Api, StockFilterer, HttpCache, util, Periods) {
     integration,
     transfers,
     filter : stockFilter,
+    filterPartialTransfers,
     uniformSelectedEntity,
     processLotsFromStore,
     statusLabelMap,

--- a/client/src/modules/shipment/shipment.js
+++ b/client/src/modules/shipment/shipment.js
@@ -218,6 +218,9 @@ function ShipmentRegistryController(
           item.isAtDepot = item.status_id === Constants.shipmentStatus.AT_DEPOT;
           item.isReady = item.status_id === Constants.shipmentStatus.READY_FOR_SHIPMENT;
           item.inTransit = item.status_id === Constants.shipmentStatus.IN_TRANSIT;
+          item.isPartial = item.status_id === Constants.shipmentStatus.PARTIAL;
+          item.isComplete = item.status_id === Constants.shipmentStatus.COMPLETE;
+          // @TODO: Handle EMPTY, DELIVERED, LOST
           return item;
         });
       })
@@ -252,13 +255,12 @@ function ShipmentRegistryController(
     $state.go('shipments.create');
   }
 
-  function gotoStockEntry(/* uuid */) {
-    // Temporarily disabled
-    // $state.go('stockEntry', { shipment : uuid });
+  function gotoStockEntry(shipmentUuid) {
+    $state.go('stockEntry', { shipment : shipmentUuid });
   }
 
-  function gotoStockExit(uuid) {
-    $state.go('stockExit', { shipment : uuid });
+  function gotoStockExit(shipmentUuid) {
+    $state.go('stockExit', { shipment : shipmentUuid });
   }
 
   // initialize module

--- a/client/src/modules/shipment/templates/action.tmpl.html
+++ b/client/src/modules/shipment/templates/action.tmpl.html
@@ -45,7 +45,7 @@
         </span>
       </a>
     </li>
-    <li ng-if="row.entity.inTransit">
+    <li ng-if="row.entity.inTransit || row.entity.isPartial">
       <a ng-click="grid.appScope.gotoStockEntry(row.entity.uuid)" href>
         <span class="">
           <i class="fa fa-truck"></i> <span translate>SHIPMENT.ENTER_STOCK_FOR_SHIPMENT</span>

--- a/client/src/modules/stock/entry/entry.html
+++ b/client/src/modules/stock/entry/entry.html
@@ -43,6 +43,7 @@
       <div class="row">
         <bh-stock-entry-exit-type
           on-entry-exit-type-select-callback="StockCtrl.selectEntryType(type)"
+          selected-entry-exit-type="StockCtrl.selectedEntryType"
           reference="StockCtrl.reference"
           display-name="StockCtrl.displayName"
           is-entry="true"

--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -3,10 +3,10 @@ angular.module('bhima.controllers')
 
 // dependencies injections
 StockEntryController.$inject = [
-  'InventoryService', 'NotifyService', 'SessionService', 'util',
+  '$state', 'InventoryService', 'NotifyService', 'SessionService', 'util',
   'bhConstants', 'ReceiptModal', 'PurchaseOrderService',
-  'StockFormService', 'StockService', 'StockModalService',
-  'LotService', 'ExchangeRateService',
+  'StockFormService', 'StockService', 'StockModalService', 'StockEntryExitTypeService',
+  'DepotService', 'ShipmentService', 'LotService', 'ExchangeRateService',
   'uiGridConstants', 'Store', 'uuid', '$translate',
 ];
 
@@ -17,10 +17,10 @@ StockEntryController.$inject = [
  * This controller is responsible to handle stock entry module.
  */
 function StockEntryController(
-  Inventory, Notify, Session, util,
+  $state, Inventory, Notify, Session, util,
   bhConstants, ReceiptModal, Purchase,
-  StockForm, Stock, StockModal,
-  Lots, Exchange,
+  StockForm, Stock, StockModal, EntryTypes,
+  Depot, Shipments, Lots, Exchange,
   uiGridConstants, Store, Uuid, $translate,
 ) {
   // variables
@@ -29,6 +29,9 @@ function StockEntryController(
   // constants
   const vm = this;
   const mapEntry = initEntryMap();
+  const { params } = $state;
+
+  vm.selectedEntryType = {};
 
   // view models variables and methods
   vm.stockForm = new StockForm('StockEntry');
@@ -265,16 +268,66 @@ function StockEntryController(
       entity : {},
     };
 
-    // Load the exchange rates
-    Exchange.read()
-      .then(() => {
-        // loading all purchasable inventories
-        loadInventories();
-      })
-      .catch(Notify.handleError)
-      .finally(() => {
-        toggleLoadingIndicator();
-      });
+    if (params.shipment) {
+      vm.loading = true;
+      Exchange.read()
+        .then(() => {
+          // First load details about the shipments
+          return Shipments.read(params.shipment);
+        })
+        .then(shipment => {
+          vm.shipment = shipment;
+          // Get the destination depot specified by the shipment
+          return Depot.read(shipment.destination_depot_uuid);
+        })
+        .then(destDepot => {
+          destDepot.shipment = vm.shipment;
+          vm.depot = destDepot;
+          // load/reload all purchasable inventories for this depot
+          return loadInventories();
+        })
+        .then(() => {
+          // Get the lots for this shipment
+          return Stock.movements.read(null, { document_uuid : vm.shipment.document_uuid });
+        })
+        .then((allTransfers) => {
+          // Note: Always assume partial entries are possible
+          const transfers = Stock.filterPartialTransfers(allTransfers);
+          if (transfers.length === 0) {
+            // Complain if we try to use a shipment that has already been completed
+            Notify.warn($translate.instant('STOCK.TRANSFER_COMPLETED'), 6000);
+          } else {
+            handleSelectedEntity(transfers, 'transfer_reception');
+            setSelectedEntity(vm.movement.entity.instance);
+
+            const transferType = EntryTypes.entryTypes.find(item => item.label === 'transfer_reception');
+            vm.selectedEntryType = transferType;
+            vm.movement.entry_type = transferType.label;
+
+            vm.resetEntryExitTypes = false;
+            vm.entityAllowAddItems = false;
+
+            vm.hasValidInput = hasValidInput();
+          }
+
+          return Exchange.read();
+        })
+        .catch(Notify.handleError)
+        .finally(() => {
+          toggleLoadingIndicator();
+        });
+    } else {
+      // Load the exchange rates
+      Exchange.read()
+        .then(() => {
+          // loading all purchasable inventories
+          loadInventories();
+        })
+        .catch(Notify.handleError)
+        .finally(() => {
+          toggleLoadingIndicator();
+        });
+    }
   }
 
   /**
@@ -284,10 +337,11 @@ function StockEntryController(
   function loadInventories() {
     setupStock();
 
-    Inventory.read(null, { consumable_or_asset : 1, skipTags : true })
+    return Inventory.read(null, { consumable_or_asset : 1, skipTags : true })
       .then((inventories) => {
         vm.inventories = inventories;
         inventoryStore = new Store({ identifier : 'uuid', data : inventories });
+        return true;
       })
       .catch(Notify.handleError);
   }

--- a/server/controllers/asset_management/shipment/shipment.js
+++ b/server/controllers/asset_management/shipment/shipment.js
@@ -501,6 +501,7 @@ function find(params) {
       BUID(d2.uuid) AS destination_depot_uuid,
       d2.text AS destination_depot,
       sh.name, sh.description, sh.note,
+      BUID(sh.document_uuid) AS document_uuid,
       sh.created_at AS date, sh.date_sent, sh.date_delivered,
       sh.date_ready_for_shipment, sh.anticipated_delivery_date,
       sh.receiver, u.display_name AS created_by
@@ -554,6 +555,7 @@ async function lookup(identifier) {
       d2.text AS destination_depot,
       BUID(d2.uuid) AS destination_depot_uuid,
       sh.name, sh.description, sh.note,
+      BUID(sh.document_uuid) AS document_uuid,
       sh.created_at AS date, sh.date_sent, sh.date_delivered,
       sh.anticipated_delivery_date, sh.date_ready_for_shipment,
       sh.receiver, u.display_name AS created_by,
@@ -594,6 +596,7 @@ async function lookupSingle(identifier) {
       d2.text AS destination_depot,
       BUID(d2.uuid) AS destination_depot_uuid,
       sh.name, sh.description, sh.note,
+      BUID(sh.document_uuid) AS document_uuid,
       sh.created_at AS date, sh.date_sent, sh.date_delivered,
       sh.anticipated_delivery_date, sh.date_ready_for_shipment,
       sh.receiver, u.display_name AS created_by
@@ -626,6 +629,7 @@ async function getPackingList(identifier) {
       ss.id AS status_id,
       ss.name AS status_name,
       sh.name, sh.description, sh.note,
+      BUID(sh.document_uuid) AS document_uuid,
       sh.created_at AS date, sh.date_sent, sh.date_delivered,
       sh.anticipated_delivery_date,
       sh.receiver, u.display_name AS created_by,

--- a/server/controllers/stock/reports/stock_entry_depot.receipt.handlebars
+++ b/server/controllers/stock/reports/stock_entry_depot.receipt.handlebars
@@ -14,7 +14,13 @@
 
     <!-- summary  -->
     <div class="row receipt-summary">
-      <h4 style="margin: 0 0 5px 0; text-align: center">{{translate 'SHIPMENT.TITLE'}}: {{entry.details.shipment_reference}}</h4>
+      {{#if entry.details.shipment_reference}}
+      <div class="row">
+        <div class="col-xs-12">
+          <h4 style="margin-bottom: 5px;"><strong>{{translate 'SHIPMENT.TITLE'}}: {{entry.details.shipment_reference}}</strong></h4>
+        </div>
+      </div>
+      {{/if}}
       <div class="col-xs-6">
         <h4>{{translate 'STOCK.FROM'}}</h4>
         <span class="text-capitalize">{{translate 'STOCK.DEPOT'}}</span>: <strong>{{entry.details.otherDepotName}}</strong> <br>


### PR DESCRIPTION
Implements going to Stock Exits automatically from the Shipment Registry action menu

Closes https://github.com/IMA-WorldHealth/bhima/issues/6529

**TESTING**
- Use bhima_test
- Testing complete shipments
   - Create a new shipment, mark it ready for shipping (via action menu in the Shipment Registry)
   - In the Shipment Registry, use the action menu item to go to stock exit.   
     - Press [Submit] to complete the stock exit.
   - Go back to the Shipment Registry
   - Notice that the status is now "In Transit"
   - Use the action menu again to start the Stock Entry for the shipment (via the action menu)
   - You should be able to press [Submit] to complete the stock entry
   - Return to the Shipment Registry and note the status is now "Complete"
- Testing partial shipments
  - Repeat the process in the last test
    - Create a shipment with an item that includes quantity > 1
    - Do a Stock Exit for the shipment
    - Do the Stock Entry for the shipment BUT update the quantity (click on the "Lot" field) to by subtract one from the original quantity (simulate a missing item in the shipment)
    - Click [Submit]
    - Return to the Shipment Registry
       - Note that the shipment status has changed to "Partial"
       - Do Stock Entry for that shipment again
    - Note that the quantity has been updated correctly
    - Click [Submit] to complete the stock entry
    - Return to the Shipment Registry and notice that the shipment is now marked as "Complete"
