### PR TITLE
Add barcode scans for stock assignment

### DIFF
--- a/client/src/i18n/en/asset.json
+++ b/client/src/i18n/en/asset.json
@@ -45,6 +45,7 @@
     "TITLE" : "Assets",
     "VIEW_IN_INVENTORY" : "View Asset in Inventory",
     "VIEW_IN_STOCK" : "View Asset in Stock",
+    "WARN_ALREADY_ASSIGNED" : "This asset/lot is already assigned. Remove the assignment before reassigning it !",
     "CONDITION" : {
       "NEW" : "New",
       "GOOD" : "Good",

--- a/client/src/i18n/fr/asset.json
+++ b/client/src/i18n/fr/asset.json
@@ -45,6 +45,7 @@
     "TITLE" : "Actifs",
     "VIEW_IN_INVENTORY" : "Visualiser l'actif dans l'inventaire",
     "VIEW_IN_STOCK" : "Visualiser l'actif dans stock",
+    "WARN_ALREADY_ASSIGNED" : "Cet actif/lot est déjà assignée.  Supprimez cette assignation avant de la réassigner !",
     "CONDITION" : {
       "NEW" : "Nouveau",
       "GOOD" : "Bon",

--- a/client/src/modules/assets/modals/assign.modal.html
+++ b/client/src/modules/assets/modals/assign.modal.html
@@ -5,10 +5,18 @@
   novalidate>
 
   <div class="modal-header">
-    <ol class="headercrumb">
-      <li class="static" translate>ASSIGN.STOCK_ASSIGN</li>
-      <li class="title" translate>FORM.LABELS.CREATE</li>
-    </ol>
+    <div style="display: inline-block">
+      <ol class="headercrumb">
+        <li class="static" translate>ASSIGN.STOCK_ASSIGN</li>
+        <li class="title" translate>FORM.LABELS.CREATE</li>
+      </ol>
+    </div>
+    <div style="display: inline-block; float: right; margin-right: 10px;">
+      <a href class="btn btn-success"
+        ng-click="$ctrl.assignByBarcode()">
+        <span class="fa fa-plus"></span> <span class="hidden-xs" translate>BARCODE</span>
+      </a>
+    </div>
   </div>
 
   <div class="modal-body" ng-if="$ctrl.loading">

--- a/client/src/modules/assets/modals/assign.modal.js
+++ b/client/src/modules/assets/modals/assign.modal.js
@@ -3,14 +3,15 @@ angular.module('bhima.controllers')
 
 // dependencies injections
 AssetAssignmentModalController.$inject = [
-  'appcache', '$state', 'data',
-  'DepotService', 'NotifyService', '$uibModalInstance',
-  'StockService', 'util', 'ReceiptModal',
+  'appcache', '$state', 'data', '$uibModalInstance', 'ModalService',
+  'BarcodeService', 'NotifyService', 'ReceiptModal', 'StockService', 'util',
 ];
 
-function AssetAssignmentModalController(AppCache, $state, data, Depots, Notify, Modal, Stock, Util, Receipts) {
+function AssetAssignmentModalController(
+  AppCache, $state, data, Modal, ModalService,
+  Barcode, Notify, Receipts, Stock, Util) {
   const vm = this;
-  const cache = AppCache('stock-assign-grid');
+  const cache = AppCache('stock-assign-modal');
 
   // global variables
   vm.model = {
@@ -75,6 +76,34 @@ function AssetAssignmentModalController(AppCache, $state, data, Depots, Notify, 
       vm.maxQuantityLot = vm.availableLots[0].quantity;
     }
   }
+
+  vm.assignByBarcode = function assignByBarcode() {
+    Barcode.modal({ shouldSearch : false, title : 'ASSET.SCAN_ASSET_BARCODE' })
+      .then(record => {
+        Stock.lots.read(null, { barcode : record.uuid })
+          .then(lots => {
+            if (lots.length > 0) {
+              const lot = lots[0];
+              vm.model.depot_uuid = lot.depot_uuid;
+              loadAvailableInventories(lot.depot_uuid)
+                .then(() => {
+                  const lotFound = vm.availableInventories.find(elt => elt.uuid === lot.uuid);
+                  if (lotFound) {
+                    vm.selectedInventory = lotFound;
+                    vm.inventory_uuid = lot.inventory_uuid;
+                    onSelectInventory(vm.selectedInventory);
+                    vm.model.lot_uuid = lot.uuid;
+                    onSelectLot(lot);
+                  } else {
+                    // If the lot has already been assigned, warn the user that
+                    // it must be unassigned first.
+                    ModalService.alert('ASSET.WARN_ALREADY_ASSIGNED');
+                  }
+                });
+            }
+          });
+      });
+  };
 
   vm.onSelectEntity = onSelectEntity;
   function onSelectEntity(entity) {

--- a/client/src/modules/templates/modals/alert.modal.html
+++ b/client/src/modules/templates/modals/alert.modal.html
@@ -12,7 +12,7 @@
     <!-- translateable prompt -->
     <p class="text-left">
       <span class="glyphicon glyphicon-alert text-warning"></span>
-      <span translate>{{ AlertModalCtrl.prompt }}</span>
+      <span translate style="margin-left: 0.5em"> {{ AlertModalCtrl.prompt }} </span>
     </p>
   </div>
 


### PR DESCRIPTION
Add barcode option for selecting the asset/lot to be assigned.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6534

**TESTING**
- Use bhima_test (reload it)
- Go to:  Asset Registry
- Use the action menu to get the barcode for MOT2, scan/print/note the barcode for later use
- Click on the [New Assignment] button to the left of the [Menu] button
- On the modal that comes up, click on [Barcode] button.  This prompts for a barcode to scan
- Scan the previously saved barcode
   - It should fill in the form except for the person/entity to assign it to
   - Click [Submit] to save the assignment
- In the asset registry, note that MOT2 has the new assignment
- Repeat the procedure above for MOT2. This time it will not allow you to make the assignment (since the asset is already assigned).  Read the warning message that comes up.