### PR TITLE
Improved shipment document

### DIFF
--- a/server/controllers/asset_management/shipment/reports/shipment-overview.handlebars
+++ b/server/controllers/asset_management/shipment/reports/shipment-overview.handlebars
@@ -147,7 +147,8 @@
             <th>{{translate 'STOCK.INVENTORY'}}</th>
             <th>{{translate 'STOCK.LOT'}}</th>
             <th>{{translate 'STOCK.QUANTITY'}}</th>
-            <th>{{translate 'SHIPMENT.LOT_CONDITION'}}</th>
+            <th>{{translate 'STOCK.UNIT_COST'}}</th>
+            <th>{{translate 'STOCK.COST'}}</th>
             <th>{{translate 'SHIPMENT.DATE_PACKED'}}</th>
           </tr>
         </thead>
@@ -158,7 +159,8 @@
               <td>{{inventory_label}}</td>
               <td>{{lot_label}}</td>
               <td>{{quantity_sent}}</td>
-              <td>{{translate condition}}</td>
+              <td>{{currency unit_price ../metadata.enterprise.currency_id}}</td>
+              <td>{{currency cost ../metadata.enterprise.currency_id}}</td>
               <td>{{date date_packed}}</td>
             </tr>
           {{else}}
@@ -167,7 +169,8 @@
         </tbody>
         <tfoot>
           <tr style="font-weight: bold;">
-            <td colspan="6">{{records.length}} {{translate 'STOCK.ITEMS'}}</td>
+            <td colspan="5">{{records.length}} {{translate 'STOCK.ITEMS'}}</td>
+            <td>{{currency totalCost metadata.enterprise.currency_id}}</td>
           </tr>
         </tfoot>
       </table>

--- a/server/controllers/asset_management/shipment/reports/shipment-overview.js
+++ b/server/controllers/asset_management/shipment/reports/shipment-overview.js
@@ -14,6 +14,11 @@ async function getShipmentOverview(req, res, next) {
     });
     const single = await shipment.lookupSingle(uuid);
     const records = await shipment.getPackingList(uuid);
+    records.forEach(row => {
+      row.cost = row.quantity_sent * row.unit_price;
+    });
+    const totalCost = records.reduce((agg, row) => agg + row.cost, 0);
+
     const log = await shipment.getShipmentInfo(uuid);
     const step = shipment.getStep(single.status_name);
 
@@ -21,6 +26,7 @@ async function getShipmentOverview(req, res, next) {
       step,
       single,
       records,
+      totalCost,
       log,
       date : new Date(),
     };

--- a/server/controllers/asset_management/shipment/shipment.js
+++ b/server/controllers/asset_management/shipment/shipment.js
@@ -635,14 +635,15 @@ async function getPackingList(identifier) {
       sh.anticipated_delivery_date,
       sh.receiver, u.display_name AS created_by,
       shi.quantity_sent, shi.quantity_delivered, shi.date_packed,
-      l.label AS lot_label, i.code AS inventory_code,
-      i.text AS inventory_label, i.is_asset,
+      l.label AS lot_label, sv.wac AS unit_price,
+      i.code AS inventory_code, i.text AS inventory_label, i.is_asset,
       dm.text AS reference
     FROM shipment sh
     JOIN shipment_status ss ON ss.id = sh.status_id
     JOIN shipment_item shi ON shi.shipment_uuid = sh.uuid
     JOIN lot l ON l.uuid = shi.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid
+    JOIN stock_value sv ON sv.inventory_uuid = i.uuid
     JOIN user u ON u.id = sh.created_by
     JOIN document_map dm ON dm.uuid = sh.uuid
     WHERE sh.uuid = ?


### PR DESCRIPTION
Added information about unit price and cost totals for shipment documents.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6527

**TESTING**
- Go to:  Shipments > New Shipment
- Create a new shipment
- This should leave you in the Shipments Registry
- Use the "document" action item for the shipment
- Observe the unit price, item cost, and total at the bottom of the grid.
