### PR TITLE
fix(shipments): filter out used assets

### DIFF
--- a/client/src/js/components/bhDepotSelect/bhDepotSelect.js
+++ b/client/src/js/components/bhDepotSelect/bhDepotSelect.js
@@ -55,7 +55,7 @@ function DepotSelectController(Depots, Notify) {
 
     const options = {
       text : (text || '').toLowerCase(),
-      exception : $ctrl.exception,
+      exception : $ctrl.exception, // TODO(@jniles) - ensure that this is a UUID, not an object
     };
 
     if ($ctrl.filterByUserPermission) {

--- a/client/src/modules/shipment/create-shipment.html
+++ b/client/src/modules/shipment/create-shipment.html
@@ -130,7 +130,7 @@
           </div>
         </div>
 
-        <div ng-if="!CreateShipCtrl.existingShipmentUuid && CreateShipCtrl.alreadyAffected.length" class="col-md-4">
+        <div ng-if="!CreateShipCtrl.existingShipmentUuid && CreateShipCtrl.alreadyAllocated.length" class="col-md-4">
           <div class="form-group">
             <div class="alert alert-warning" style="margin: 0;">
               <span translate>SHIPMENT.EXISTING_ASSETS_IN_OTHER_SHIPMENT</span>
@@ -141,7 +141,7 @@
                   <th translate>SHIPMENT.TITLE</th>
                   <th translate>ASSET.TITLE</th>
                 </tr>
-                <tr ng-repeat="item in CreateShipCtrl.alreadyAffected track by item.uuid">
+                <tr ng-repeat="item in CreateShipCtrl.alreadyAllocated track by item.uuid">
                   <td><a ng-click="CreateShipCtrl.getOverview(item.shipment_uuid)" href>{{ item.reference }}</a></td>
                   <td>{{ item.inventory_code + ' - ' + item.inventory_text + ' (' + item.lot_label + ')'}}</td>
                 </tr>
@@ -219,4 +219,5 @@
       </div>
     </form>
   </div>
+  <br />
 </div>

--- a/client/src/modules/shipment/shipment.service.js
+++ b/client/src/modules/shipment/shipment.service.js
@@ -22,8 +22,8 @@ function ShipmentService(Api, $httpParamSerializer, Languages) {
       .then(service.util.unwrapHttpResponse);
   };
 
-  service.getAffectedAssets = (parameters) => {
-    return service.$http.get(`/shipments/affected-assets`, { params : parameters })
+  service.getAllocatedAssets = (parameters) => {
+    return service.$http.get(`/shipments/allocated-assets`, { params : parameters })
       .then(service.util.unwrapHttpResponse);
   };
 

--- a/client/src/modules/stock/StockExitForm.service.js
+++ b/client/src/modules/stock/StockExitForm.service.js
@@ -147,7 +147,6 @@ function StockExitFormService(
    *
    * @description
    * Loads the quantity in stock for the depot at a given date.
-   *
    */
   StockExitForm.prototype.fetchQuantityInStock = function fetchQuantityInStock(depotUuid, date) {
     if (!depotUuid || !date) { return {}; }
@@ -227,7 +226,7 @@ function StockExitFormService(
 
     // get all lots that are no longer used
     this._pool.unavailable.data
-      .filter(lot => !usedLotUuids.has(lot.lot_uuid))
+      .filter(lot => !usedLotUuids.has(lot.lot_uuid) && lot._quantity_available > 0)
       .forEach(lot => { this._pool.release(lot.lot_uuid); });
 
   };

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -1142,7 +1142,7 @@ exports.configure = function configure(app) {
 
   // shipment registry
   app.get('/shipments', shipment.list);
-  app.get('/shipments/affected-assets', shipment.affectedAssets);
+  app.get('/shipments/allocated-assets', shipment.allocatedAssets);
   app.get('/shipments/:uuid', shipment.single);
   app.get('/shipments/:uuid/full', shipment.details);
   app.get('/shipments/:uuid/overview', shipment.overview);

--- a/server/controllers/asset_management/shipment/index.js
+++ b/server/controllers/asset_management/shipment/index.js
@@ -20,5 +20,5 @@ module.exports = {
   writeStockExitShipment : shipment.writeStockExitShipment,
   writeStockEntryShipment : shipment.writeStockEntryShipment,
   updateShipmentStatusAfterEntry : shipment.updateShipmentStatusAfterEntry,
-  affectedAssets : shipment.findAffectedAssets,
+  allocatedAssets : shipment.findAllocatedAssets,
 };

--- a/server/controllers/asset_management/shipment/shipment.js
+++ b/server/controllers/asset_management/shipment/shipment.js
@@ -405,10 +405,10 @@ exports.listInTransitInventories = async (req, res, next) => {
   }
 };
 
-exports.findAffectedAssets = async (req, res, next) => {
+exports.findAllocatedAssets = async (req, res, next) => {
   try {
     const params = req.query;
-    const result = await findAffectedAssets(params);
+    const result = await findAllocatedAssets(params);
     res.status(200).json(result);
   } catch (error) {
     next(error);
@@ -520,7 +520,7 @@ function find(params) {
   return db.exec(query, queryParameters);
 }
 
-function findAffectedAssets(params) {
+function findAllocatedAssets(params) {
   const filters = getShipmentFilters(params);
   const sql = `
     SELECT

--- a/test/integration-stock/shipment.js
+++ b/test/integration-stock/shipment.js
@@ -103,8 +103,8 @@ describe('(/shipments) the shipments API', () => {
       .catch(helpers.handler);
   });
 
-  it('GET /shipments/affected-assets get list of affected assets', () => {
-    return agent.get(`/shipments/affected-assets`)
+  it('GET /shipments/allocated-assets get list of previously allocated assets', () => {
+    return agent.get(`/shipments/allocated-assets`)
       .then(res => {
         expect(res).to.have.status(200);
         expect(res.body).to.an('array');


### PR DESCRIPTION
This PR updates the shipments to ensure that used lots are not shows in the list, or reduced by the quantity used.  Further, I've taken the liberty to rename the "affected" to "assigned" on both the client and the server as well as fix some of the asynchronous logic.

Finally, the logic is updated to make sure we don't refresh the lots when we change the date.

Closes #6523.