### PR TITLE
Removed inventory barcode scan from Stock Lots

### DIFF
--- a/client/src/i18n/en/barcode.json
+++ b/client/src/i18n/en/barcode.json
@@ -3,6 +3,7 @@
     "BARCODE": "Barcode",
     "SCAN": "Scan",
     "SCAN_BARCODE" : "Scan Barcode",
+    "SCAN_LOT_BARCODE" : "Scan Lot Barcode",
     "SCAN_DOCUMENT" : "Scan Document Barcode",
     "AWAITING_INPUT" : "Waiting for Input",
     "AWAITING_HTTP" : "Barcode Read!  Looking up Record...",

--- a/client/src/i18n/fr/barcode.json
+++ b/client/src/i18n/fr/barcode.json
@@ -3,6 +3,7 @@
     "BARCODE": "Code-barre",
     "SCAN": "Scanner",
     "SCAN_BARCODE" : "Scanner le code-barre",
+    "SCAN_LOT_BARCODE" : "Scanner le code-barre du lot",
     "SCAN_DOCUMENT" : "Scanner le code-barres du document",
     "AWAITING_INPUT" : "En Attente d'Entrée",
     "AWAITING_HTTP" : "Code-barres lu! Recherche l'enregistrement....",

--- a/client/src/modules/stock/lots/registry.html
+++ b/client/src/modules/stock/lots/registry.html
@@ -51,13 +51,8 @@
             </li>
             <li role="separator" class="divider"></li>
             <li role="menuitem" bh-require-enterprise-setting="barcodes">
-              <a href ng-click="StockLotsCtrl.openBarcodeScanner()" data-action="scan-barcode">
-                <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN</span>
-              </a>
-            </li>
-            <li role="menuitem" bh-require-enterprise-setting="barcodes">
               <a href ng-click="StockLotsCtrl.openLotBarcodeScanner()" data-action="scan-barcode">
-                <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN_BARCODE</span>
+                <span class="fa fa-barcode"></span> <span translate>BARCODE.SCAN_LOT_BARCODE</span>
               </a>
             </li>
           </ul>

--- a/client/src/modules/stock/lots/registry.js
+++ b/client/src/modules/stock/lots/registry.js
@@ -25,10 +25,7 @@ function StockLotsController(
   // grouping box
   vm.groupingBox = LotsRegistry.groupingBox;
 
-  // barcode scanner
-  vm.openBarcodeScanner = openBarcodeScanner;
-
-  // barcode scanner
+  // lot barcode scanner
   vm.openLotBarcodeScanner = openLotBarcodeScanner;
 
   // show lot barcode
@@ -281,25 +278,6 @@ function StockLotsController(
     vm.gridOptions.enableFiltering = !vm.gridOptions.enableFiltering;
     vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);
   };
-
-  /**
-   * @function openBarcodeScanner
-   *
-   * @description
-   * Opens the barcode scanner component and receives the record from the
-   * modal.
-   */
-  function openBarcodeScanner() {
-    Barcode.modal({ shouldSearch : false })
-      .then(record => {
-        stockLotFilters.replaceFilters([
-          { key : 'inventory_uuid', value : record.uuid, displayValue : record.reference },
-        ]);
-
-        load(stockLotFilters.formatHTTP(true));
-        vm.latestViewFilters = stockLotFilters.formatView();
-      });
-  }
 
   function openLotBarcodeScanner() {
     Barcode.modal({ shouldSearch : false })


### PR DESCRIPTION
Removed the ambiguous "Scan" from Stock Lots main menu.  It was for scanning inventory barcodes.  But we decided to eliminate it because we currently have no way to produce inventory barcodes, the concept of inventory barcodes seems like of limited usefulness, and we other ways to limit the Stock Lots registry display to specific inventory items (via the Search menu). 

Also renamed the remaining "Scan Barcode" in the menu to "Scan Lot Barcode" to make its purpose clearer.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6513

**TESTING**
- Visit the `Stock > Stock Lots` page and examine the main menu.  Test the "Scan Lot Barcode" item.
