### PR TITLE
Fix account balance report

### DIFF
--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -21,10 +21,11 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
 
   vm.onSelectFiscalYear = (fiscalYear) => {
     vm.reportDetails.fiscal_id = fiscalYear.id;
+    delete vm.reportDetails.period_id;
   };
 
   vm.onSelectPeriod = (period) => {
-    vm.reportDetails.period_id = period.id;
+    vm.reportDetails.period_id = period?.id;
   };
 
   vm.clearPreview = function clearPreview() {
@@ -45,6 +46,10 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
   };
 
   vm.onChangeClosingBalances = bool => {
+    // If true, the period is the whole FY, so delete the period
+    if (bool) {
+      delete vm.reportDetails.period_id;
+    }
     vm.reportDetails.includeClosingBalances = bool;
   };
 
@@ -98,6 +103,10 @@ function BalanceReportConfigController($sce, Notify, SavedReports, AppCache, rep
     }
     if (!angular.isDefined(vm.reportDetails.shouldHideTitleAccounts)) {
       vm.reportDetails.shouldHideTitleAccounts = 0;
+    }
+    if (angular.isDefined(vm.reportDetails.fiscal_id)
+        && angular.isDefined(vm.reportDetails.includeClosingBalances)) {
+      delete vm.reportDetails.period_id;
     }
   }
 }

--- a/client/src/modules/reports/generate/balance_report/balance_report.html
+++ b/client/src/modules/reports/generate/balance_report/balance_report.html
@@ -41,8 +41,9 @@
               fiscal-year-id="ReportConfigCtrl.reportDetails.fiscal_id"
               period-id="ReportConfigCtrl.reportDetails.period_id"
               on-select-callback="ReportConfigCtrl.onSelectPeriod(period)"
-              disable="!ReportConfigCtrl.reportDetails.includeClosingBalances"
-              required="true">
+              disable="ReportConfigCtrl.reportDetails.includeClosingBalances"
+              required="!ReportConfigCtrl.reportDetails.includeClosingBalances"
+              ng-show="!ReportConfigCtrl.reportDetails.includeClosingBalances">
             </bh-period-selection>
 
             <bh-yes-no-radios


### PR DESCRIPTION
Fix the logic for handling the period in the Account Balance report.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6616

**TESTING**
- Use bhima_test
- Go to:  Finance > Reports > Balance of Accounts
  - If "Include Closing Balances" is yes
     - The "Period" selection should be hidden (and not required)
     - Verify that you can generate a report
  - If "Include Closing Balances" is No
    - The "Period" should be shown (and required)
    - Verify that you can generate a report
    - If you change the Fiscal Year, the period should be erased

