### PR TITLE
Updated configurable analysis report

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -95,6 +95,7 @@
       "TITLE": "Compare invoiced items to received stock"
     },
     "CONFIGURABLE_ANALYSIS_REPORT" : {
+      "CONFIGURE_ANALYSIS_TOOLS": "Click here to configure the analysis tools",
       "HIDE_ACCOUNT_DETAILS": "Hide account details",
       "HIDE_DETAILS_TYPES": "Hide details of types",
       "TITLE": "Configurable analysis report"

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -87,6 +87,7 @@
       "TITLE": "Comparaison des articles facturés sur les reçus"
     },
     "CONFIGURABLE_ANALYSIS_REPORT" : {
+      "CONFIGURE_ANALYSIS_TOOLS": "Cliquez ici pour configurer les outils d'analyse",
       "HIDE_ACCOUNT_DETAILS": "Cacher les détailles des comptes",
       "HIDE_DETAILS_TYPES": "Cacher les détailles des types",
       "TITLE": "Rapport d'analyse configurable"

--- a/client/src/modules/reports/generate/configurable_analysis_report/configurable_analysis_report.html
+++ b/client/src/modules/reports/generate/configurable_analysis_report/configurable_analysis_report.html
@@ -8,7 +8,7 @@
 <div ng-show="!ReportConfigCtrl.previewGenerated">
   <div class="row">
     <div class="col-md-12">
-      <h3 class="text-capitalize" translate>REPORT.CONFIGURABLE_ANALYSIS_REPORT.TITLE</h3>
+      <h2 class="text-capitalize" translate>REPORT.CONFIGURABLE_ANALYSIS_REPORT.TITLE</h2>
     </div>
   </div>
 
@@ -21,54 +21,63 @@
 
         <div class="panel-body">
           <form name="ConfigForm" bh-submit="ReportConfigCtrl.preview(ConfigForm)" novalidate>
-            <bh-fiscal-period-select
-              on-select-fiscal-callback="ReportConfigCtrl.onSelectFiscal(fiscal)"
-              on-select-period-from-callback="ReportConfigCtrl.onSelectPeriodFrom(period)"
-              on-select-period-to-callback="ReportConfigCtrl.onSelectPeriodTo(period)">
-            </bh-fiscal-period-select>
 
-            <hr>
-            <bh-multiple-cashbox-select
-              cashbox-ids="ReportConfigCtrl.reportDetails.cashboxes"
-              on-change="ReportConfigCtrl.onSelectCashboxes(cashboxes)"
-              required="true">
-            </bh-multiple-cashbox-select>
-
-            <hr>
-            <div class="checkbox">
-              <label>
-                <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.hide_account_details" ng-true-value="0" ng-false-value="1">
-                <span translate>REPORT.CONFIGURABLE_ANALYSIS_REPORT.HIDE_ACCOUNT_DETAILS</span>
-              </label>
-            </div>
-            <div class="checkbox">
-              <label>
-                <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.hide_details_types" ng-true-value="0" ng-false-value="1">
-                <span translate>REPORT.CONFIGURABLE_ANALYSIS_REPORT.HIDE_DETAILS_TYPES</span>
-              </label>
-            </div>
-
-            <hr>
-            <bh-yes-no-radios
-              value="ReportConfigCtrl.reportDetails.includeUnpostedValues"
-              on-change-callback="ReportConfigCtrl.onChangeUnpostedValues(value)"
-              name="includeUnpostedValues"
-              label="REPORT.OPTIONS.INCLUDE_UNPOSTED_RECORDS"
-              help-text="REPORT.OPTIONS.INCLUDE_UNPOSTED_RECORDS_HELP">
-            </bh-yes-no-radios>
-
-            <div ng-if="!ReportConfigCtrl.configurationsAreMissing">
-              <bh-loading-button loading-state="ConfigForm.$loading">
-                <span translate>REPORT.UTIL.PREVIEW</span>
-              </bh-loading-button>
-            </div>
-
-            <div ng-if="ReportConfigCtrl.configurationsAreMissing">
-              <span class="label label-warning text-capitalize">
+            <div ng-if="ReportConfigCtrl.configurationsAreMissing" style="margin-bottom: 1em;">
+              <p class="alert alert-danger text-capitalize" style="padding: 6px 0;">
                 <i class="fa fa-exclamation-triangle"></i>
-                <span style="font-size: 14px" translate> FORM.INFO.THE_NECESSARY_CONFIG_MISSING </span>
-              </span>
+                <span style="font-size: 1.25em;" translate> FORM.INFO.THE_NECESSARY_CONFIG_MISSING </span>
+              </p>
+              <p class="text-center">
+                <a href ui-sref="configuration_analysis_tools"><strong translate>REPORT.CONFIGURABLE_ANALYSIS_REPORT.CONFIGURE_ANALYSIS_TOOLS</strong></a>
+              </p>
             </div>
+
+            <fieldset
+              ng-show="!ReportConfigCtrl.configurationsAreMissing">
+
+              <bh-fiscal-period-select
+                on-select-fiscal-callback="ReportConfigCtrl.onSelectFiscal(fiscal)"
+                on-select-period-from-callback="ReportConfigCtrl.onSelectPeriodFrom(period)"
+                on-select-period-to-callback="ReportConfigCtrl.onSelectPeriodTo(period)">
+              </bh-fiscal-period-select>
+
+              <hr>
+              <bh-multiple-cashbox-select
+                cashbox-ids="ReportConfigCtrl.reportDetails.cashboxes"
+                on-change="ReportConfigCtrl.onSelectCashboxes(cashboxes)"
+                required="true">
+              </bh-multiple-cashbox-select>
+
+              <hr>
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.hide_account_details" ng-true-value="0" ng-false-value="1">
+                  <span translate>REPORT.CONFIGURABLE_ANALYSIS_REPORT.HIDE_ACCOUNT_DETAILS</span>
+                </label>
+              </div>
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.hide_details_types" ng-true-value="0" ng-false-value="1">
+                  <span translate>REPORT.CONFIGURABLE_ANALYSIS_REPORT.HIDE_DETAILS_TYPES</span>
+                </label>
+              </div>
+
+              <hr>
+              <bh-yes-no-radios
+                value="ReportConfigCtrl.reportDetails.includeUnpostedValues"
+                on-change-callback="ReportConfigCtrl.onChangeUnpostedValues(value)"
+                name="includeUnpostedValues"
+                label="REPORT.OPTIONS.INCLUDE_UNPOSTED_RECORDS"
+                help-text="REPORT.OPTIONS.INCLUDE_UNPOSTED_RECORDS_HELP">
+              </bh-yes-no-radios>
+
+              <div ng-if="!ReportConfigCtrl.configurationsAreMissing">
+                <bh-loading-button loading-state="ConfigForm.$loading">
+                  <span translate>REPORT.UTIL.PREVIEW</span>
+                </bh-loading-button>
+              </div>
+
+            </fieldset>
           </form>
         </div>
       </div>

--- a/server/controllers/finance/reports/configurable_analysis_report/index.js
+++ b/server/controllers/finance/reports/configurable_analysis_report/index.js
@@ -134,6 +134,7 @@ function report(req, res, next) {
       data.type = type;
       data.config = config;
       data.dataConfig = dataConfig;
+      data.provisionary = params.includeUnpostedValues;
 
       const checkConfiguration = (data.type.length && data.config.length && data.dataConfig.length);
 


### PR DESCRIPTION
Updated the configurable analysis report to disable the form if the configuration has not been initialized.

Also updated the report to show "Provisionary" in the title block if the options for the report use "Include Unposted Values" is YES.   

Note: I was not sure how to run a test without the configuration initialized, but I tested the functionality by overriding the flag in the controller.  It should work correctly.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6627

**TESTING**
- Use any data set
- Go to:  Finances > Report > Configurable Analsysis Report
  - If the configuration has not been initialized, the warning will be shown clearly at the top and the form elements will be disabled and grayed out.
- Try setting the option "Include Unposted Values" to "Yes" and verify that "(Provisionary)" appears in the title block.