### PR TITLE
fix(stock): ensure correct movement filter text 

### DIFF
--- a/client/src/modules/stock/movements/modals/search.modal.html
+++ b/client/src/modules/stock/movements/modals/search.modal.html
@@ -22,12 +22,12 @@
             <bh-clear on-clear="$ctrl.clear('is_exit')"></bh-clear>
             <div>
               <label class="radio-inline">
-                <input type="radio" name="movement_direction" id="entry" value="0" ng-model="$ctrl.searchQueries.is_exit">
+                <input type="radio" name="movement_direction" id="entry" ng-value="0" ng-model="$ctrl.searchQueries.is_exit">
                 <span translate>STOCK.INPUT</span>
               </label>
 
               <label class="radio-inline">
-                <input type="radio" name="movement_direction" id="exit" value="1" ng-model="$ctrl.searchQueries.is_exit">
+                <input type="radio" name="movement_direction" id="exit" ng-value="1" ng-model="$ctrl.searchQueries.is_exit">
                 <span translate>STOCK.OUTPUT</span>
               </label>
             </div>

--- a/client/src/modules/stock/movements/modals/search.modal.js
+++ b/client/src/modules/stock/movements/modals/search.modal.js
@@ -105,7 +105,12 @@ function SearchMovementsModalController(data, Instance, Periods, Store, util, St
   vm.cancel = function cancel() { Instance.close(); };
 
   vm.submit = () => {
+    if (vm.searchQueries.is_exit) {
+      vm.searchQueries.is_exit = Number(vm.searchQueries.is_exit);
+    }
+
     const loggedChanges = SearchModal.getChanges(vm.searchQueries, changes, displayValues, lastDisplayValues);
+
     return Instance.close(loggedChanges);
   };
 }

--- a/client/src/modules/stock/movements/registry.js
+++ b/client/src/modules/stock/movements/registry.js
@@ -263,7 +263,6 @@ function StockMovementsController(
     const fluxName = $translate.instant(getFluxName(row.flux_id));
     // compute the fluxName from its ID
     row.fluxName = fluxName.concat(row.target ? ` - ${row.target}` : '').trim();
-
   }
 
   function toggleLoading() {

--- a/client/src/modules/stock/movements/templates/io.cell.html
+++ b/client/src/modules/stock/movements/templates/io.cell.html
@@ -1,8 +1,5 @@
 <div class="ui-grid-cell-contents">
-    <span ng-show="row.entity.is_exit === 1" class="label label-danger" translate>
-        STOCK.OUTPUT
-    </span>
-    <span ng-show="row.entity.is_exit === 0" class="label label-success" translate>
-        STOCK.INPUT
+    <span class="label" ng-class="{ 'label-danger' : row.entity.is_exit === 1, 'label-success' :  row.entity.is_exit === 0 }">
+      {{row.entity.io}}
     </span>
 </div>


### PR DESCRIPTION
This commit ensures that the entry/exit movement filter shows the correct values when searching for the movement direction.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6445.