### PR TITLE
Disable changing origin depot when editing shipments

### DIFF
--- a/client/src/i18n/en/shipment.json
+++ b/client/src/i18n/en/shipment.json
@@ -19,6 +19,7 @@
     "DOES_SHIPMENT_EXIST": "Do you have a shipment ready?",
     "DOES_SHIPMENT_EXIST_HELP": "Please provide the reference of a shipment that is ready to ship.",
     "EDIT": "Edit",
+    "EDIT_SHIPMENT": "Edit Shipment",
     "ENTER_SHIPMENT_PROGRESS": "Please enter the shipment progress status.  Include the current shipment location if it has changed.",
     "ENTER_SHIPMENT_PROGRESS_HELP_TEXT": "Ex. RECEPTION - IMA GOMA WAREHOUSE, GOMA",
     "ENTER_STOCK_FOR_SHIPMENT" : "Enter stock for this shipment",

--- a/client/src/i18n/fr/shipment.json
+++ b/client/src/i18n/fr/shipment.json
@@ -19,6 +19,7 @@
     "DOES_SHIPMENT_EXIST": "Avez-vous une expédition prête ?",
     "DOES_SHIPMENT_EXIST_HELP": "Veuillez renseigner la référence de l'expédition prête",
     "EDIT": "Editer",
+    "EDIT_SHIPMENT": "Modifier expédition",
     "ENTER_SHIPMENT_PROGRESS": "Veuillez entrer l'etat de progression de l'expédition avec sa localisation actuelle",
     "ENTER_SHIPMENT_PROGRESS_HELP_TEXT": "Ex. RECEPTION - IMA GOMA WAREHOUSE, GOMA",
     "ENTER_STOCK_FOR_SHIPMENT" : "Entrer le stock pour cette expédition",

--- a/client/src/modules/shipment/create-shipment.html
+++ b/client/src/modules/shipment/create-shipment.html
@@ -4,14 +4,16 @@
       <li class="static" translate>SHIPMENT.SHIPMENTS</li>
       <li><a ui-sref="shipments" translate>SHIPMENT.SHIPMENT_REGISTRY</a></li>
       <li class="title">
-        <span translate>SHIPMENT.NEW_SHIPMENT </span>&nbsp;
+        <span ng-if="CreateShipCtrl.isCreateState" translate>SHIPMENT.NEW_SHIPMENT</span>
+        <span ng-if="!CreateShipCtrl.isCreateState" translate>SHIPMENT.EDIT_SHIPMENT</span>
+        &nbsp;
         <span ng-if="CreateShipCtrl.depot.uuid" class="label label-primary">{{ CreateShipCtrl.depot.text }}</span>
       </li>
     </ol>
 
     <div class="toolbar">
       <div ng-if="!CreateShipCtrl.$loading" class="toolbar-item">
-        <bh-dropdown-menu>
+        <bh-dropdown-menu ng-if="CreateShipCtrl.isCreateState">
           <bh-dropdown-menu-item>
             <a href>
               <bh-change-depot


### PR DESCRIPTION
When editing a shipment, this PR prevents the user from changing the origin depot.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6571

**TESTING**
- create a new shipment
  - notice the breadcrumbs say: New Shipment
- in the shipment registry, edit a shipment
  - notice that the breadcrumbs say:  Edit Shipment
  - notice that the menu is no longer available so that there is no way to change the origin depot!
- Double-check the "Edit Shipment" translation in French