### PR TITLE
Fix purchase price analysis report

### DIFF
--- a/client/src/modules/reports/generate/purchase_prices/purchase_prices.html
+++ b/client/src/modules/reports/generate/purchase_prices/purchase_prices.html
@@ -24,7 +24,8 @@
             <bh-inventory-select
               inventory-uuid="ReportConfigCtrl.reportDetails.inventory_uuid"
               on-select-callback="ReportConfigCtrl.onSelectInventory(inventory)"
-              only-consumable="1">
+              only-consumable="1"
+              required="true">
             </bh-inventory-select>
 
             <bh-loading-button loading-state="ConfigForm.$loading">


### PR DESCRIPTION
Made Inventory required in Inventory selection for the report.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6626

**TESTING**
- Go to:  Purhcase Orders > Reports > Purchase Price Analysis
- Verify that the report cannot be generated without selecting an inventory item
