### PR TITLE
Fix issues in Stock Inventories Report

### DIFF
--- a/server/controllers/finance/reports/vouchers/receipt.handlebars
+++ b/server/controllers/finance/reports/vouchers/receipt.handlebars
@@ -10,7 +10,6 @@
       </div>
     {{/if}}
   {{/header}}
-  QQQ1
 
   <header>
     <!-- headings  -->

--- a/server/controllers/stock/reports/stock/inventories_report.js
+++ b/server/controllers/stock/reports/stock/inventories_report.js
@@ -1,5 +1,5 @@
 const {
-  _, ReportManager, formatFilters, Stock, STOCK_INVENTORIES_REPORT_TEMPLATE, stockStatusLabelKeys,
+  _, db, ReportManager, formatFilters, Stock, STOCK_INVENTORIES_REPORT_TEMPLATE, stockStatusLabelKeys,
 } = require('../common');
 
 const i18n = require('../../../../lib/helpers/translate');
@@ -30,6 +30,20 @@ async function stockInventoriesReport(req, res, next) {
     delete options.label;
 
     const filters = formatFilters(options);
+
+    // Update the name for the depot filter if specified
+    const depotFilter = filters.find(filt => filt.field === 'depot_uuid');
+    if (depotFilter) {
+      const depot = await db.one('SELECT text FROM depot WHERE uuid = ?', db.bid(depotFilter.value));
+      depotFilter.value = depot.text;
+    }
+
+    // Update the name for the inventory filter if specified
+    const inventoryFilter = filters.find(filt => filt.field === 'inventory_uuid');
+    if (inventoryFilter) {
+      const inventory = await db.one('SELECT text FROM inventory WHERE uuid = ?', db.bid(inventoryFilter.value));
+      inventoryFilter.value = inventory.text;
+    }
 
     if (req.session.stock_settings.enable_strict_depot_permission) {
       options.check_user_id = req.session.user.id;

--- a/server/controllers/stock/reports/stock_inventories.report.handlebars
+++ b/server/controllers/stock/reports/stock_inventories.report.handlebars
@@ -28,12 +28,12 @@
       {{#each depots as | items name |}}
 
         <!-- this is the depot group header -->
-        <tr style="border:none">
-          <th style="border:none; border-bottom: solid black 2px;" class="text-uppercase" colspan="7">
+        <tr style="border:none;">
+          <th style="border:none; border-bottom: solid black 2px; padding-top: 1.5em;" class="text-uppercase" colspan="7">
             {{ name }}
           </th>
 
-          <th colspan="4" style="border:none; border-bottom: solid black 2px;" class="text-right">
+          <th colspan="4" style="border:none; border-bottom: solid black 2px; padding-top: 1.5em;" class="text-right">
             ({{ items.length }} {{ translate "TABLE.AGGREGATES.RECORDS" }})
           </th>
         </tr>
@@ -60,8 +60,6 @@
             <td class="text-right">{{S_MAX}}</td>
             <td class="text-right">{{S_Q}}</td>
           </tr>
-        {{else }}
-          {{> emptyTable columns=11}}
         {{/each}}
 
         <!-- blank row  -->
@@ -72,6 +70,8 @@
           </tr>
         {{/unless}}
 
+      {{else}}
+         {{> emptyTable columns=11}}
       {{/each}}
     </tbody>
   </table>


### PR DESCRIPTION
This fixes a couple of issues with the Stock Inventories report:
- Fixes the filter displays for depot and inventory filters
- Small fix to the grid display to show "No records" if none are found.   The problem here was that the emptyTables partial was being invoked in the loop for each depot.   But due to to the way the data structured, if a depot has no articles in stock, it will not appear in the table.  So moved it out of the depot loop.
- Minor formatting improvements
- Also removed an unrelated diagnostic comment left over from a previous PR.

NOTE: The fix for the depot and inventory filter was a change to the `formatFilters()` function in `server/controllers/finance/reports/shared.js`.  This should address the same filter display in other reports that used the function.   BTW I was not sure if I needed to do anything extra for the depot/inventory db queries introduced in the `formatFilters()` function (eg, escaping, catch errors, etc) so I welcome suggestions for improving this code.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6611

**TESTING**
- Go to:  Stock > Reports > Stock Inventories
  - Try the report with and without selecting a depot and/or inventory and check the outputs of the report
  - Select an inventory that has no articles and verify that the table display in the report includes "There are no records to display." message

