### PR TITLE
Fix name capitalization of configuration analysis report title

### DIFF
--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -98,7 +98,7 @@
       "CONFIGURE_ANALYSIS_TOOLS": "Click here to configure the analysis tools",
       "HIDE_ACCOUNT_DETAILS": "Hide account details",
       "HIDE_DETAILS_TYPES": "Hide details of types",
-      "TITLE": "Configurable analysis report"
+      "TITLE": "Configurable Analysis Report"
     },
     "CONFIGURATION": "Report Configuration",
     "DELETE": "Delete Report",


### PR DESCRIPTION
Fixes the capitalization of the title of the generated configuration analysis report.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6175

Other items in this Issue were already addressed recently.

**TESTING**
- Check English title in the generated report for:
   - Finances > Reports > Configurable Analysis Report
