### PR TITLE
fix(stock): improve Stock Sheet report

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -277,7 +277,7 @@
       "STOCK_OUT_NOT_USABLE" : "Stock Out (Not usable)",
       "UNUSED_STOCK"  : "Unused stock"
     },
-    "STOCK_VALUE_WITH_WAC" : "End value of the stock with the unit cost of the company",
+    "STOCK_VALUE_WITH_WAC" : "End value of stock with the final unit cost",
     "STOCK_MOVEMENT"  : "View Stock Movement",
     "STOCK_MOVEMENTS" : "View Stock Movements",
     "SUCCESS"         : "Successfully created a movement",

--- a/server/controllers/inventory/index.js
+++ b/server/controllers/inventory/index.js
@@ -116,13 +116,15 @@ async function getInventoryWac(req, res, next) {
 
 async function computeWac(inventoryUuid) {
   const binaryInventoryUuid = db.bid(inventoryUuid);
+
   const queryRecompute = 'CALL RecomputeInventoryStockValue(?, ?);';
+
   const querySelect = `
     SELECT
       BUID(sv.inventory_uuid) inventory_uuid,
       i.text, sv.date, sv.quantity, sv.wac
     FROM stock_value sv
-    JOIN inventory i ON i.uuid = sv.inventory_uuid
+      JOIN inventory i ON i.uuid = sv.inventory_uuid
     WHERE sv.inventory_uuid = ?;
   `;
 
@@ -133,7 +135,6 @@ async function computeWac(inventoryUuid) {
 
 // get inventory log as excel
 // GET /inventory/download/log/:uuid?rendere=xlsx?lang=fr
-
 async function logDownLoad(req, res, next) {
   try {
     const { lang } = req.query;

--- a/server/controllers/stock/reports/stock_sheet.report.handlebars
+++ b/server/controllers/stock/reports/stock_sheet.report.handlebars
@@ -62,7 +62,7 @@
               {{#unless ../depot.text}}
               <td style="border-right: 1px solid #000;">{{depot_text}}</td>
               {{/unless}}
-              <td style="border-left: 1px solid #000;">{{translate flux}}</td>
+              <td style="border-left: 1px solid #000;">{{translate flux}} {{#if reason}}- {{reason}}{{/if}}</td>
               <td style="border-left: 1px solid #000;">{{label}}</td>
 
               {{!-- entry --}}

--- a/server/lib/template/partials/exchangeRate.handlebars
+++ b/server/lib/template/partials/exchangeRate.handlebars
@@ -4,7 +4,7 @@
   {{#gt rate 1}}
     {{translate 'FORM.LABELS.EXCHANGE_RATE'}}: {{currency rate currencyId 4}}
     {{translate 'FORM.INFO.PER'}} {{currency 1 metadata.enterprise.currency_id 0}}
-  {{else}} XYZ
+  {{else}}
     {{translate 'FORM.LABELS.EXCHANGE_RATE'}}: {{currency (divide 1 rate) metadata.enterprise.currency_id 4}}
     {{translate 'FORM.INFO.PER'}} {{currency 1 currencyId 0}}
   {{/gt}}


### PR DESCRIPTION
This commit fixes the rendering of the unit cost calculation on the
stock sheet report.  It also adds in the purchase order, patient
reference, or other references on the line as needed.

Closes #6652.
Closes #5415.

![image](https://user-images.githubusercontent.com/896472/171259685-4539880a-999c-4819-bc95-99d4fe4af209.png)
