### PR TITLE
Close requistions when stock exits complete them

### DIFF
--- a/client/src/js/components/bhHasRequisitionVoucher/bhHasRequisitionVoucher.html
+++ b/client/src/js/components/bhHasRequisitionVoucher/bhHasRequisitionVoucher.html
@@ -16,6 +16,7 @@
       requestor-uuid="$ctrl.requestor"
       required="$ctrl.required"
       disabled="$ctrl.requisitionDisabled"
+      disallow-completed="true"
       on-select-callback="$ctrl.onSelectRequisition(requisition)">
     </bh-requisition-select>
 

--- a/client/src/js/components/bhRequisitionSelect.js
+++ b/client/src/js/components/bhRequisitionSelect.js
@@ -7,6 +7,7 @@ angular.module('bhima.components')
       requisitionUuid : '<',
       requestorUuid : '<?',
       onSelectCallback : '&',
+      disallowCompleted : '@?',
       required : '@?',
       label : '@?',
       disabled : '<?',
@@ -14,26 +15,31 @@ angular.module('bhima.components')
   });
 
 RequisitionSelectController.$inject = [
-  'StockService', 'NotifyService',
+  'StockService', 'NotifyService', 'bhConstants',
 ];
 
 /**
  * Requisition Select Controller
  *
  */
-function RequisitionSelectController(Stock, Notify) {
+function RequisitionSelectController(Stock, Notify, bhConstants) {
   const $ctrl = this;
 
   $ctrl.$onInit = function onInit() {
     $ctrl.label = $ctrl.label || 'FORM.LABELS.REQUISITION_REFERENCE';
     $ctrl.required = $ctrl.required || false;
+    $ctrl.disallowCompleted = $ctrl.disallowCompleted || false;
 
     const params = {};
     params.requestor_uuid = $ctrl.requestorUuid;
 
+    $ctrl.disallowCompleted = false;
+
     Stock.stockRequisition.read(null, params)
       .then((requisitions) => {
-        $ctrl.requisitions = requisitions;
+        const COMPLETED = bhConstants.stockRequisition.completed_status;
+        $ctrl.requisitions = $ctrl.disallowCompleted
+          ? requisitions.filter(req => req.status_id !== COMPLETED) : requisitions;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/stock/requisition/modals/action.modal.js
+++ b/client/src/modules/stock/requisition/modals/action.modal.js
@@ -188,7 +188,7 @@ function ActionRequisitionModalController(
       const identifier = inventory.inventory_uuid ? inventory.inventory_uuid : inventory.uuid;
       const quantity = inventory.inventory_uuid ? inventory.S_Q : inventory.quantity;
 
-      inventory.isAvailable = !!vm.availableSupplierInventories.includes(identifier);
+      inventory.isAvailable = vm.availableSupplierInventories && !!vm.availableSupplierInventories.includes(identifier);
 
       if (inventory.isAvailable) {
         inventory.hasEnoughQuantity = !!(vm.supplierInventoriesQuantities.get(identifier) >= quantity);

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -638,6 +638,8 @@ async function depotMovement(document, params, metadata) {
 
   parameters.entity_uuid = parameters.entity_uuid ? db.bid(parameters.entity_uuid) : null;
 
+  const requistionUuid = parameters.stock_requisition_uuid;
+
   parameters.stock_requisition_uuid = parameters.stock_requisition_uuid
     ? db.bid(parameters.stock_requisition_uuid) : null;
 
@@ -689,6 +691,11 @@ async function depotMovement(document, params, metadata) {
 
   // update the quantity in stock as needed
   await updateQuantityInStockAfterMovement(inventoryUuids, document.date, depotUuid);
+
+  // Update the requistion
+  if (parameters.stock_requisition_uuid) {
+    await requisition.updateStatus(requistionUuid);
+  }
 
   if (!isExit) {
     await shipment.updateShipmentStatusAfterEntry(document);

--- a/server/controllers/stock/requisition/requisition.js
+++ b/server/controllers/stock/requisition/requisition.js
@@ -7,6 +7,7 @@ const util = require('../../../lib/util');
 const FilterParser = require('../../../lib/filter');
 
 const REQUISITION_STATUS_PARTIAL = 3;
+const REQUISITION_STATUS_COMPLETE = 6;
 const REQUISITION_STATUS_EXCESSIVE = 7;
 
 const SELECT_QUERY = `
@@ -270,6 +271,9 @@ exports.update = async (req, res, next) => {
         dataMovementRequisition.stock_requisition_uuid, dataMovementRequisition.stock_requisition_uuid,
       ]);
 
+      // Assume it is complete
+      requisition.status_id = REQUISITION_STATUS_COMPLETE;
+
       if (movementStatus.numberInventoryPartial > 0) {
         // Partially
         requisition.status_id = REQUISITION_STATUS_PARTIAL;
@@ -316,5 +320,20 @@ exports.deleteRequisition = async (req, res, next) => {
   }
 };
 
+/**
+ * @function updateStatus
+ * @description updates the status of a requisition based
+ * @param {string} uuid - The uuid of the requisition
+ */
+async function updateStatus(uuid) {
+  // First get the requisition details
+  const balance = await getDetailsBalance(db.bid(uuid));
+  if (balance.items.length === 0) {
+    await db.exec('UPDATE stock_requisition SET status_id = ? WHERE uuid = ?', [
+      REQUISITION_STATUS_COMPLETE, db.bid(uuid)]);
+  }
+}
+
 exports.getDetails = getDetails;
 exports.getDetailsBalance = getDetailsBalance;
+exports.updateStatus = updateStatus;


### PR DESCRIPTION
Updated the Stock Exit handling so that if a stock exits completes a requisition, it will be marked as complete.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6424

**Notes**
- This will only mark a requisition as complete if all items in the requisition are handled by the stock exit.  If any items are not handled, this change will leave it marked as "Partial".
- Since it is possible for a requisition to be completed even if all items are not handled (eg, when items are lost in transit), we probably need a way to mark such requisitions as completed.   A separate issue should be created to address this issue.

**TESTING**
- Use bhima_test
- Go to:  Stock > Stock Exit
  - Make sure the source depot is: Depot Principal
  - Select from [Depot] and choose the destination depot: Depot Secondaire
  - Answer "Yes" to "Do you have a requisition slip?"
  - Select the requisition
  - Click [Submit]
  - In the main Stock Exit form, notice that some items in the order (Prednisolone) are not available
  - Click [Submit] to perform as much of the requisition as possible.
- Go to: Stock > Requisition
  - Notice that the requistion SREQ.TPA.2 is still marked Partial.
  - Edit the requistion
     - Change the quantity for the quinine to 5 (greater than 4)
     - Delete the Prednisolone
     - Click [Submit]
- Go back to: Stock > Exit
  - Repeat the process above (exiting the extra quinine to fulfill the requisition)
- Go back to:  Stock > Requisition
  - Notice the requisition is now marked Complete
 