### PR TITLE
Enable marking a partial requisition as completed

### DIFF
--- a/client/src/i18n/en/form.json
+++ b/client/src/i18n/en/form.json
@@ -107,10 +107,11 @@
             "CONFIRM_ACTION": "Do you confirm this action?",
             "CONFIRMATION_NEEDED": "Confirmation Needed",
             "CONFIRM_ACTIVATION": "Do you really want to allow this user's system access",
+            "CONFIRM_MARKING_REQUISITION_COMPLETE": "Do you really want to mark this requisition as complete?  It is only partially fulfilled!",
             "CONFIRM_CREDIT_NOTE": "Warning! The invoice you selected has already paid.  You must first reverse the payment(s) before you can reverse this invoice.",
             "CONFIRM_DEACTIVATION": "Do you really want to revoke this user's system access",
             "CONFIRM_DELETE": "You are about to delete a record.  This action is permanent and cannot be undone.  Click \"Confirm\" to accept or \"Cancel\" to halt this action.",
-            "CANNOT_UNDONE_ACTION": "This action CANNOT BE REVERSED. The action will be permanent. You must be sure that you want to do this action.",
+            "CANNOT_UNDO_ACTION": "This action CANNOT BE REVERSED. The action will be permanent. You must be sure that you want to do this action.",
             "NO_CORRESPONDANCY": "No correspondency found for ",
             "PLEASE_TYPE_TEXT": "Please type {{value}} to confirm",
             "PLEASE_READ": "Unexpected bad things will happen if you don't read this!",
@@ -231,7 +232,8 @@
             "REQUISITION": {
               "CANCEL": "Cancel the inventory requisition request",
               "DONE": "The requisition can no longer be completed and will be considered done",
-              "IN_PROGRESS": "Rehabilitated the requisition request"
+              "IN_PROGRESS": "Rehabilitate the requisition request",
+              "MARK_COMPLETED": "Mark this requisition as completed"
             },
             "RESULT_FOUND": "Result found",
             "ROWS": "Rows",

--- a/client/src/i18n/fr/form.json
+++ b/client/src/i18n/fr/form.json
@@ -107,10 +107,11 @@
             "CONFIRM_ACTION": "Confirmez vous cette action ?",
             "CONFIRMATION_NEEDED": "Confirmation Requise",
             "CONFIRM_ACTIVATION": "Voulez vous vraiment activer les droits d'accès de cet utilisateur",
+            "CONFIRM_MARKING_REQUISITION_COMPLETE": "Voulez-vous vraiment marquer cette réquisition comme complète ?  Elle n'est que partiellement remplie !",
             "CONFIRM_CREDIT_NOTE": "Attention! La facture dont vous voulez annuler a déjà été payée. Vous devez annuler tous les paiements avant d'annuler la facture.",
             "CONFIRM_DEACTIVATION": "Voulez vous vraiment blocker les droits d'accès de cet utilisateur",
             "CONFIRM_DELETE": "Vous êtes sur le point de supprimer un enregistrement. Cette action sera permanent et ne pourra etre annulé. Cliquer sur \"Confirmer\" pour accepter ou \"Annuler\" pour annuler cette action",
-            "CANNOT_UNDONE_ACTION": "Cette action NE POURRA PAS ETRE ANNULER, les consequences de cette action seront definitives. Vous devez être sûre que vous voulez vraiment effectuer cette action",
+            "CANNOT_UNDO_ACTION": "Cette action NE POURRA PAS ETRE ANNULER, les consequences de cette action seront definitives. Vous devez être sûre que vous voulez vraiment effectuer cette action",
             "NO_CORRESPONDANCY": "Aucune correspondance trouvée pour",
             "PLEASE_TYPE_TEXT": "Veuillez saisir {{value}} pour confirmer ",
             "PLEASE_READ": "Vous risquez de perdre des donnees importantes si vous ne lisez pas ce message!",
@@ -231,7 +232,8 @@
             "REQUISITION": {
               "CANCEL": "Annuler la demande de réquisition des stocks",
               "DONE": "La requisition ne pourra plus être completée et sera consideré comme traitée",
-              "IN_PROGRESS": "Rehabilité la demande de requisition"
+              "IN_PROGRESS": "Réhabiliter la demande de requisition",
+              "MARK_COMPLETED": "Marquez cette requisition comme remplie"
             },
             "RESULT_FOUND": "Résultat trouvé",
             "ROWS": "enregistrements",

--- a/client/src/modules/stock/requisition/modals/status.js
+++ b/client/src/modules/stock/requisition/modals/status.js
@@ -2,11 +2,13 @@ angular.module('bhima.controllers')
   .controller('RequisitionStatusModalController', RequisitionStatusModalController);
 
 RequisitionStatusModalController.$inject = [
-  '$uibModalInstance', 'NotifyService', 'StockService', 'data',
+  '$uibModalInstance', 'NotifyService', 'ModalService', 'StockService', 'bhConstants', 'data',
 ];
 
-function RequisitionStatusModalController(Instance, Notify, Stock, Data) {
+function RequisitionStatusModalController(Instance, Notify, Modal, Stock, bhConstants, Data) {
   const vm = this;
+
+  const COMPLETED = bhConstants.stockRequisition.completed_status;
 
   // global variables
   vm.requisition = Data;
@@ -19,11 +21,27 @@ function RequisitionStatusModalController(Instance, Notify, Stock, Data) {
   function submit() {
     const data = { status_id : vm.status };
 
-    Stock.stockRequisition.update(vm.requisition.uuid, data)
-      .then(() => {
-        Instance.close();
-      })
-      .catch(Notify.handleError);
+    // If we are marking the requisition as complete, verify first
+    if (Number(vm.status) === COMPLETED) {
+      Modal.confirm('FORM.DIALOGS.CONFIRM_MARKING_REQUISITION_COMPLETE')
+        .then((ans) => {
+          if (!ans) { return 0; }
+          return Stock.stockRequisition.update(vm.requisition.uuid, data);
+        })
+        .then(() => {
+          Instance.close(); // This closes the confirm dialog
+        })
+        .finally(() => {
+          vm.close();
+        })
+        .catch(Notify.handleError);
+    } else {
+      Stock.stockRequisition.update(vm.requisition.uuid, data)
+        .then(() => {
+          Instance.close();
+        })
+        .catch(Notify.handleError);
+    }
   }
 
 }

--- a/client/src/modules/stock/requisition/modals/status.tmpl.html
+++ b/client/src/modules/stock/requisition/modals/status.tmpl.html
@@ -5,7 +5,7 @@
   </ol>
 </div>
 
-<form 
+<form
   name="ModalForm"
   ng-submit="$ctrl.submit($ctrl.status)"
   data-modal="requisition-status"
@@ -14,18 +14,28 @@
 <div class="modal-body">
   <div class="form-group" ng-if="$ctrl.requisition.status_key === 'partially'">
     <label class="text-action">
-      <input type="radio" id="done" name="status" ng-model="$ctrl.status" value="2"> 
+      <input type="radio" id="done" name="status" ng-model="$ctrl.status" value="2">
       <span class="label label-primary" translate>FORM.LABELS.STATUS_TYPE.DONE</span>
       <p translate>FORM.INFO.REQUISITION.DONE</p>
     </label>
   </div>
 
   <div class="form-group" ng-if="$ctrl.requisition.status_key === 'in_progress'">
-    <label class="text-action">
-      <input type="radio" id="cancelled" name="status" ng-model="$ctrl.status" value="5">
-      <span class="label label-danger" translate>FORM.LABELS.STATUS_TYPE.CANCELLED</span>
-      <p translate>FORM.INFO.REQUISITION.CANCEL</p>
-    </label>
+    <div>
+      <label class="text-action">
+        <input type="radio" id="completed" name="status" ng-model="$ctrl.status" value="6">
+        <span class="label label-danger" translate>FORM.LABELS.STATUS_TYPE.COMPLETED</span>
+        <p translate>FORM.INFO.REQUISITION.MARK_COMPLETED</p>
+      </label>
+    </div>
+
+    <div>
+      <label class="text-action">
+        <input type="radio" id="cancelled" name="status" ng-model="$ctrl.status" value="5">
+        <span class="label label-danger" translate>FORM.LABELS.STATUS_TYPE.CANCELLED</span>
+        <p translate>FORM.INFO.REQUISITION.CANCEL</p>
+      </label>
+    </div>
   </div>
 
   <div class="form-group" ng-if="$ctrl.requisition.status_key === 'cancelled'">

--- a/client/src/modules/templates/modals/confirmDialog.modal.html
+++ b/client/src/modules/templates/modals/confirmDialog.modal.html
@@ -10,7 +10,7 @@
   </div>
 
   <div class="modal-body">
-    <p translate>FORM.DIALOGS.CANNOT_UNDONE_ACTION</p>
+    <p translate>FORM.DIALOGS.CANNOT_UNDO_ACTION</p>
 
     <br>
     <div class="form-group"


### PR DESCRIPTION
This PR is a follow up of [PR 6673](https://github.com/IMA-WorldHealth/bhima/pull/6673) to allow requisitions that are partially completed to be marked as complete.  

Closes https://github.com/IMA-WorldHealth/bhima/issues/6674

**TESTING**
- Use bhima_test
- Go to the requisition registry:  Stock > Requisition
  - Use the action menu for a requisition that is in "In Progress" and edit its status.  Note the new option to mark the requisition as complete.   
  - When you select the "Mark as complete" option and click [Submit], a confirmation dialog will be displayed
  - You should be able to click [Cancel] on the confirmation dialog and go back to the requisition registry
  - If you repeat the process but click [Confirm] on the confirmation dialog, the status of the requisition should change to "Completed".


