### PR TITLE
Fix duplicate display in assets registry

### DIFF
--- a/client/src/modules/assets/assets-registry.js
+++ b/client/src/modules/assets/assets-registry.js
@@ -151,7 +151,7 @@ function AssetsRegistryController(
         // FIXME(@jniles): we should do this ordering on the server via an ORDER BY
         lots.sort(AssetsRegistry.orderByDepot);
 
-        vm.gridOptions.data = lots;
+        vm.gridOptions.data = lots.filter(lot => lot.quantity > 0);
 
         vm.grouping.unfoldAllGroups();
         vm.gridApi.core.notifyDataChange(uiGridConstants.dataChange.COLUMN);


### PR DESCRIPTION
As described in [Issue 6681](https://github.com/IMA-WorldHealth/bhima/issues/6681), the assets registry appears to show duplicate assets when an asset is transferred from one depot to another.    This is due to a bug in the assets registry display.  The actual transfers are working correctly.

When you look at stock "Articles in Stock" if any lots exist in any depot they are shown in all depots where the currently exist or existed in the past (due to the way that stock movements are used for these queries).  However if there are no lots left in a depot that the lots are transferred from, the lot will still be listed, but the quantity will be 0.  That is what is happening with the Assets registry.   By default the column for the quantity for the assets is not shown since assets are supposed to be unique and therefore the quantity = 1 at all times.  However before this fix, the transferred asset is shown in both depots (but the quantity is 0 in the source depot).  Enabling the quantity display makes this obvious.

The fix it to not display any assets with quantity = 0.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6681

**TESTING** 
- Use bhima_test
- Go to the assets registry:  Assets Management > Assets Registry and review the already-defined assets (motorcycles)
- Transfer an asset (eg MOT1) from the primary depot to the secondary depot (you can use the Shipments interface or via direct exit and entry).  At this point, only do the stock exit.
- After the stock exit visit the Assets Registry and notice that the asset being transferred is not shown.  If you visit the Articles in Stock, you will see that it is in transit
- Complete the transfer
-  Go back to assets registry and notice the correct display
