### PR TITLE
Improvements to Assets Scans Registry

### DIFF
--- a/client/src/i18n/en/asset.json
+++ b/client/src/i18n/en/asset.json
@@ -8,6 +8,7 @@
     "ASSIGNED" : "Assigned",
     "ASSIGNMENT_HISTORY" : "Asset Assignment History",
     "ASSIGN_TO" : "Assign to",
+    "ASSIGNED_TO" : "Assigned to",
     "DETAILS" : "Asset Details",
     "DOCUMENT" : "Assignment Document",
     "EXCLUDE_ASSETS" : "Exclude assets",

--- a/client/src/i18n/fr/asset.json
+++ b/client/src/i18n/fr/asset.json
@@ -8,6 +8,7 @@
     "ASSIGNED" : "Assigné",
     "ASSIGNMENT_HISTORY" : "Historique d'assignation d'actif",
     "ASSIGN_TO" : "Assigner à",
+    "ASSIGNED_TO" : "Assigné à",
     "DETAILS" : "Détail de l'actif",
     "DOCUMENT" : "Document",
     "EXCLUDE_ASSETS" : "Exclure les actifs",

--- a/client/src/modules/asset_scans/asset-scans-registry.html
+++ b/client/src/modules/asset_scans/asset-scans-registry.html
@@ -3,19 +3,11 @@
     <ol class="headercrumb">
       <li class="static" translate>TREE.ASSET_MANAGEMENT.TITLE</li>
       <li class="title" translate>TREE.ASSETS_SCANS_REGISTRY</li>
-      <li class="title" ng-if="ScansCtrl.defaultDepot">{{ScansCtrl.defaultDepot.text}}</li>
     </ol>
 
     <div class="toolbar">
       <div class="toolbar-item">
         <bh-dropdown-menu>
-          <bh-dropdown-menu-item>
-            <a href ng-click="ScansCtrl.openChangeDepotModal()">
-              <i class="fa fa-archive"></i> <span translate>DEPOT.CHANGE</span>
-            </a>
-          </bh-dropdown-menu-item>
-
-          <bh-dropdown-menu-item role="separator" class="divider"></bh-dropdown-menu-item>
 
           <bh-dropdown-menu-item>
             <a href data-method="configure" ng-click="ScansCtrl.openColumnConfigModal()">

--- a/client/src/modules/asset_scans/asset-scans-registry.js
+++ b/client/src/modules/asset_scans/asset-scans-registry.js
@@ -22,7 +22,6 @@ function AssetScansRegistryController(
 ) {
   const vm = this;
   const cacheKey = 'assets-scans-grid';
-  const stockLotFilters = Stock.filter.lot;
 
   vm.conditions = bhConstants.assetCondition;
 

--- a/client/src/modules/asset_scans/asset-scans-registry.js
+++ b/client/src/modules/asset_scans/asset-scans-registry.js
@@ -54,20 +54,6 @@ function AssetScansRegistryController(
 
   vm.toggleInlineFilter = toggleInlineFilter;
 
-  vm.defaultDepot = null;
-
-  /**
-   * Open the modal to change the depot
-   */
-  vm.openChangeDepotModal = () => {
-    Depots.openSelectionModal(vm.defaultDepot, false, true)
-      .then(depot => {
-        vm.defaultDepot = depot || null;
-        load(vm.filters.formatHTTP(true));
-        vm.latestViewFilters = vm.filters.formatView();
-      });
-  };
-
   /**
    * edit asset scan
    *
@@ -105,9 +91,6 @@ function AssetScansRegistryController(
 
   // load the assets scans into the grid
   function load(filters) {
-    if (vm.defaultDepot) {
-      filters.depot_uuid = vm.defaultDepot.uuid;
-    }
     vm.hasError = false;
     toggleLoadingIndicator();
     AssetsScans.list(filters)
@@ -197,7 +180,7 @@ function AssetScansRegistryController(
           .then(ans => {
             if (!ans) { return; }
             load(vm.filters.formatHTTP(true));
-            vm.latestViewFilters = stockLotFilters.formatView();
+            vm.latestViewFilters = vm.filters.formatView();
           });
       });
   };

--- a/client/src/modules/asset_scans/asset-scans-registry.service.js
+++ b/client/src/modules/asset_scans/asset-scans-registry.service.js
@@ -147,6 +147,7 @@ function AssetsScansRegistryService(Session, Filters, AppCache, bhConstants, Per
     { key : 'depot_uuid', label : 'STOCK.DEPOT' },
     { key : 'inventory_uuid', label : 'FORM.LABELS.INVENTORY' },
     { key : 'group_uuid', label : 'STOCK.INVENTORY_GROUP' },
+    { key : 'assigned_to_uuid', label : 'ASSET.ASSIGNED_TO' },
     { key : 'reference_number', label : 'FORM.LABELS.REFERENCE_NUMBER' },
     { key : 'show_only_last_scans', label : 'ASSET.SHOW_ONLY_LAST_SCAN' },
   ]);

--- a/client/src/modules/asset_scans/modals/search.modal.html
+++ b/client/src/modules/asset_scans/modals/search.modal.html
@@ -41,6 +41,15 @@
             <bh-clear on-clear="$ctrl.clear('group_uuid')"></bh-clear>
           </bh-inventory-group-select>
 
+          <!-- entity -->
+          <bh-entity-select
+            label = "ASSET.ASSIGNED_TO"
+            entity-uuid="$ctrl.searchQueries.assigned_to_uuid"
+            on-select-callback="$ctrl.onSelectAssignedTo(entity)"
+            required="false">
+            <bh-clear on-clear="$ctrl.clear('assigned_to_uuid')"></bh-clear>
+          </bh-entity-select>
+
           <div class="form-group"
             ng-class="{ 'has-error' : ModalForm.$submitted && ModalForm.reference_number.$invalid }">
             <label class="control-label" translate>FORM.LABELS.REFERENCE_NUMBER</label>

--- a/client/src/modules/asset_scans/modals/search.modal.js
+++ b/client/src/modules/asset_scans/modals/search.modal.js
@@ -15,8 +15,8 @@ function AssetScansSearchModalController(data, util, Store, Instance, Stock, Sea
   vm.defaultQueries = {};
 
   const searchQueryOptions = [
-    'depot_uuid', 'inventory_uuid', 'group_uuid', 'asset_label', 'reference_number',
-    'show_only_last_scans',
+    'depot_uuid', 'inventory_uuid', 'group_uuid', 'assigned_to_uuid',
+    'asset_label', 'reference_number', 'show_only_last_scans',
   ];
 
   // displayValues will be an id:displayValue pair
@@ -48,6 +48,11 @@ function AssetScansSearchModalController(data, util, Store, Instance, Stock, Sea
   vm.onSelectGroup = (group) => {
     vm.searchQueries.group_uuid = group.uuid;
     displayValues.group_uuid = group.name;
+  };
+
+  vm.onSelectAssignedTo = function onSelectAssignedTo(entity) {
+    vm.searchQueries.assigned_to_uuid = entity.uuid;
+    displayValues.assigned_to_uuid = entity.display_name;
   };
 
   // custom filter - flag to only show the latests scan

--- a/client/src/modules/assets/modals/search.modal.html
+++ b/client/src/modules/assets/modals/search.modal.html
@@ -41,6 +41,15 @@
             <bh-clear on-clear="$ctrl.clear('group_uuid')"></bh-clear>
           </bh-inventory-group-select>
 
+          <!-- entity -->
+          <bh-entity-select
+            label = "ASSET.ASSIGNED_TO"
+            entity-uuid="$ctrl.searchQueries.assigned_to_uuid"
+            on-select-callback="$ctrl.onSelectAssignedTo(entity)"
+            required="false">
+            <bh-clear on-clear="$ctrl.clear('assigned_to_uuid')"></bh-clear>
+          </bh-entity-select>
+
           <!-- lot number  -->
           <div class="form-group">
             <label class="control-label" translate>ASSET.ASSET_LABEL</label>

--- a/client/src/modules/assets/modals/search.modal.js
+++ b/client/src/modules/assets/modals/search.modal.js
@@ -59,6 +59,11 @@ function AssetsSearchModalController(data, util, Store, Instance, Stock, SearchM
     displayValues.entry_date_to = dateTo;
   };
 
+  vm.onSelectAssignedTo = function onSelectAssignedTo(entity) {
+    vm.searchQueries.assigned_to_uuid = entity.uuid;
+    displayValues.assigned_to_uuid = entity.display_name;
+  };
+
   // toggle is_assigned search flag
   vm.onToggleAssigned = function onToggleAssigned(val) {
     vm.searchQueries.is_assigned = val;

--- a/client/src/modules/stock/StockFilterer.service.js
+++ b/client/src/modules/stock/StockFilterer.service.js
@@ -35,6 +35,7 @@ function StockFiltererService(Filters, AppCache, $httpParamSerializer, Languages
     { key : 'is_expired', label : 'STOCK.EXPIRED', valueFilter : 'boolean' },
     { key : 'is_expiry_risk', label : 'STOCK.STATUS.IS_IN_RISK_OF_EXPIRATION', valueFilter : 'boolean' },
     { key : 'is_assigned', label : 'ASSET.SHOW_ONLY', valueFilter : 'translate' },
+    { key : 'assigned_to_uuid', label : 'ASSET.ASSIGNED_TO' },
     { key : 'tag_uuid', label : 'TAG.LABEL' },
     { key : 'voucherReference', label : 'FORM.LABELS.REFERENCE_VOUCHER' },
     { key : 'tags', label : 'TAG.LABEL' },

--- a/server/controllers/stock/asset_scan.js
+++ b/server/controllers/stock/asset_scan.js
@@ -27,6 +27,7 @@ function binarize(params) {
     'depot_uuid',
     'group_uuid',
     'inventory_uuid',
+    'assigned_to_uuid',
     'location_uuid',
   ]);
 }
@@ -55,6 +56,7 @@ function getAssetScanFilters(parameters) {
   filters.equals('depot_uuid');
   filters.equals('group_uuid', 'group_uuid', 'i');
   filters.equals('inventory_uuid', 'inventory_uuid', 'l');
+  filters.equals('assigned_to_uuid', 'entity_uuid', 'sa');
   filters.equals('scanned_by');
   filters.fullText('reference_number', 'reference_number', 'l');
   filters.equals('condition_id', 'id', 'ac');

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -79,6 +79,7 @@ function getLotFilters(parameters) {
     'lot_uuid',
     'inventory_uuid',
     'group_uuid',
+    'assigned_to_uuid',
     'document_uuid',
     'entity_uuid',
     'service_uuid',
@@ -105,6 +106,7 @@ function getLotFilters(parameters) {
   filters.equals('text', 'text', 'i');
   filters.equals('label', 'label', 'l');
   filters.equals('is_asset', 'is_asset', 'i');
+  filters.equals('assigned_to_uuid', 'entity_uuid', 'sa');
   filters.fullText('reference_number', 'reference_number', 'l');
   filters.equals('period_id', 'period_id', 'm');
   filters.equals('is_exit', 'is_exit', 'm');


### PR DESCRIPTION
This PR fixes/improves two things with the Asset Scans Registry:
- It removes the default depot to ensure that the registry shows asset scans from all depots by default.  To restrict the display to one depot, use the custom search filter.
- It adds ability to limit the display to assets assigned to a specific entity

This PR also implements a custom filter in the Assets Registry to filter by the current assignment.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6680.
Closes https://github.com/IMA-WorldHealth/bhima/issues/6684


**TESTING**
- Use bhima_test
- Go to the Assets Registry page (Assets Management > Assets Registry)
- Notice that there are 2 assets (motorcycles)
- Use the Shipments interface or direct Stock Exit and Entry to transfer one of the assets to the Secondary Depot.  Note that the inventory code starts with "MOT."
- Verify the transfer in the Assets Registry page
- Go to the Assets Scans Registry page
  - Notice that both asset scans are still shown in the Primary depot.  That is NOT an error.  The depot column here represents the depot that manages the asset at the time of the scan and both scans occurred before the asset was transferred.
  - Add another scan for the asset in the Secondary Depot.  Now the Assets Scans Registry will show that asset scan as being in the Secondary depot, as expected.
  - Try the custom search filters for Depot and "Assigned To" to verify their behavior.
- Go to the Assets Registry page and try the "Assigned To" search filter