### PR TITLE
Fix bug in editing asset serial number during stock entry

### DIFF
--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -156,7 +156,7 @@ function StockEntryController(
     vm.movement.date = date;
 
     // Check all stock lines and their lots to make sure that all
-    // the lot expiration statuses are still
+    // the lot expiration statuses are still valid
     vm.stockForm.store.data.forEach(stockLine => {
 
       // Check the expiration status of all previously selected lots
@@ -556,7 +556,7 @@ function StockEntryController(
    */
   function setLots(stockLine) {
     if (!stockLine.inventory_uuid) {
-      // Prevent the lots modal pop-up if now inventory code has been selected
+      // Prevent the lots modal pop-up if new inventory code has been selected
       return;
     }
     // Additional information for an inventory Group

--- a/client/src/modules/stock/entry/modals/StockEntryModalForm.service.js
+++ b/client/src/modules/stock/entry/modals/StockEntryModalForm.service.js
@@ -24,6 +24,7 @@ function StockEntryModalForm(uuid) {
     this.unit_cost = row.unit_cost || null;
     this.quantity = row.quantity || 1;
     this.lot = row.lot || null;
+    this.serial_number = row.serial_number || null;
     this.isInvalid = true;
     this.isValid = false;
     this.identifier = uuid();

--- a/client/src/modules/stock/entry/modals/lots.modal.js
+++ b/client/src/modules/stock/entry/modals/lots.modal.js
@@ -252,7 +252,7 @@ function StockDefineLotsModalController(
    * @param {string} rowLot the row.entity.lot string/object
    */
   function onLotBlur(rowLot) {
-    // NOTE: rowLot will be an object if an existed lot was
+    // NOTE: rowLot will be an object if an existing lot was
     //       selected from the typeahead. Otherwise
     //       it will be the lot name string that was typed in.
     //       Complain if the lot exists and is expired.


### PR DESCRIPTION
Fixes bug when trying to update a serial number of an asset during stock entry.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6694

**TESTING**
- Use bhima_test
- Go to Stock > Stock Entry
   - Select Integration
   - Add a motorcycle (use inventory code MOT...)
   - Click on the "Lots" popup
     - Add a new label (eg, "MOT3") 
     - Add a value for the serial number
     - Click on [Submit]
   - Click on the "Lots" popup again.  The previously entered serial number should be there

