### PR TITLE
Fix issue with entry of multiple assets via Lots entry modal

### DIFF
--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -565,8 +565,10 @@ function StockEntryController(
     stockLine.tracking_expiration = inventory.tracking_expiration;
     stockLine.unique_item = inventory.unique_item;
     stockLine.is_asset = inventory.is_asset;
-    if (inventory.is_asset) {
-      stockLine.quantity = 1;
+    if (stockLine.lots && stockLine.lots.length > 0) {
+      stockLine.quantity = stockLine.lots.reduce((n, row) => n + row.quantity, 0);
+    } else {
+      stockLine.quantity = inventory.is_asset ? 1 : 0;
     }
 
     StockModal.openDefineLots({

--- a/client/src/modules/stock/entry/modals/lots.modal.html
+++ b/client/src/modules/stock/entry/modals/lots.modal.html
@@ -32,7 +32,6 @@
 
       <input
         ng-if="$ctrl.isCostEditable"
-        ng-disabled="$ctrl.stockLine.is_asset"
         class="form-control"
         type="number"
         ng-change="$ctrl.onChangeQuantity()"

--- a/client/src/modules/stock/entry/modals/lots.modal.js
+++ b/client/src/modules/stock/entry/modals/lots.modal.js
@@ -23,7 +23,7 @@ function StockDefineLotsModalController(
   }
 
   // Hide columns in the grid when it doesn't apply to this inventory item.
-  const shouldShowSerialNumber = Data.stockLine.is_asset;
+  const isAsset = Data.stockLine.is_asset;
   const showShowExpirationDate = !(Data.stockLine.tracking_expiration === false || Data.stockLine.is_asset);
 
   Data.stockLine.prev_unit_cost = Data.stockLine.unit_cost; // Save for later checks
@@ -50,6 +50,7 @@ function StockDefineLotsModalController(
   vm.stockLine = angular.copy(Data.stockLine);
   vm.entryType = Data.entry_type;
   vm.entryDate = Data.entry_date;
+  vm.isAsset = Data.stockLine.is_asset;
 
   vm.currencyId = Data.currency_id !== undefined
     ? Data.currency_id : vm.enterprise.currency_id;
@@ -110,7 +111,7 @@ function StockDefineLotsModalController(
     displayName : 'TABLE.COLUMNS.SERIAL_NUMBER',
     headerCellFilter : 'translate',
     aggregationHideLabel : true,
-    visible : shouldShowSerialNumber,
+    visible : isAsset,
     width : 220,
     cellTemplate : 'modules/stock/entry/modals/templates/serial_number.input.tmpl.html',
   }, {
@@ -129,6 +130,7 @@ function StockDefineLotsModalController(
     aggregationHideLabel : true,
     footerCellClass : 'text-right',
     cellTemplate : 'modules/stock/entry/modals/templates/lot.quantity.tmpl.html',
+    visible : !isAsset,
   }, {
     field : 'expiration_date',
     type : 'date',

--- a/client/src/modules/stock/entry/modals/templates/lot.quantity.tmpl.html
+++ b/client/src/modules/stock/entry/modals/templates/lot.quantity.tmpl.html
@@ -1,4 +1,5 @@
 <div class="ui-grid-cell-contents">
+
   <input
     min="0"
     type="number"


### PR DESCRIPTION
When you enter lots (by integration) and you want to add multiple instances of an asset, this PR makes this work more easily from the Lots modal popup.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6709

**TESTING**
- use bhima_test
- Go to:  Stock > Stock Entry
  - Select [Integration]
  - Add a new line for an asset.  Use inventory code:  MOT.HCRF250RX  for a motorcycle
  - Click on the **Lots** link to bring up the Lots entry modal. 
  - You should now be able to change the global quantities
  - Since Assets must be unique with quantity===1, the quantity field is not even shown
  - Try added multiple lines (with different LOT ids)
  - Click [Submit] on the modal
  - Try clicking the **Lots** link again to verify that the info on the non-yet-saved lots is still there
  - Close the modal
  - Try adding a non-asset (eg, inventory code DINJ_TRIB1A2_0) and use the "*Lots** link and verify that the Lots modal works as normal for non-assets
  - Close the Lots entry modal
  - Click on the [Submit] button to enter the stock.   
  - Check the receipt document to verify correct enty
- Go to Asset Management > Assets Registry and verify that the new assets appear there.
