### PR TITLE
Fix lost asset serial numbers in stock entry for shipments

### DIFF
--- a/client/src/modules/stock/entry/entry.js
+++ b/client/src/modules/stock/entry/entry.js
@@ -515,6 +515,7 @@ function StockEntryController(
           isValid : true,
           lot : items[index].label,
           quantity : item.quantity,
+          serial_number : items[index].serial_number,
           expiration_date : new Date(items[index].expiration_date),
           uuid : items[index].uuid,
         });
@@ -776,6 +777,7 @@ function StockEntryController(
 
         const inventory = inventoryStore.get(line.inventory_uuid);
         const entryDate = vm.movement.date || Date();
+
         line.code = inventory.code;
         line.label = inventory.label;
         line.unit_cost = inventory.price;

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -561,10 +561,10 @@ async function getLotsMovements(depotUuid, params) {
 
   const sql = `
     SELECT
-      BUID(l.uuid) AS uuid, l.label, m.quantity, m.reference, m.description,
+      BUID(l.uuid) AS uuid, l.label, l.serial_number, l.unit_cost, l.expiration_date,
+      m.quantity, m.reference, m.description,
       d.text AS depot_text, d.min_months_security_stock,
-      IF(is_exit = 1, "OUT", "IN") AS io, l.unit_cost,
-      l.expiration_date, BUID(l.inventory_uuid) AS inventory_uuid,
+      IF(is_exit = 1, "OUT", "IN") AS io, BUID(l.inventory_uuid) AS inventory_uuid,
       (SELECT MIN(sm.date) FROM stock_movement sm WHERE sm.lot_uuid = l.uuid) AS entry_date,
       i.code, i.text,
       BUID(m.depot_uuid) AS depot_uuid, m.is_exit, m.date, BUID(m.document_uuid) AS document_uuid,


### PR DESCRIPTION
Fixes a bug in transferring assets using the Shipments interface where the serial_number was being lost during the stock entry phase.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6720

**TESTING**
- Use bhima_test
- Go to the shipments registry:  Shipments > Shipment Registry
   - Note the lot name and serial number for the motorcycle to use in the next step
   - Create a shipment to transfer the selected motorcycle (code = MOT...) from the Primary Depot to the secondary Depot.
   - Use the action menu for the new shipment to mark is as ready to ship
   - Use the action menu for the new shipment to do the stock exit
   - Use the action menu for the new shipment to do the stock entry
      - BEFORE clicking [Submit] to complete the stock entry, click on the link to the **Lots** for the lot (asset)
      - Verify that the original serial number is still present
      - Close the lots update modal
      - Click on the main [Submit] to complete the stock entry
- In the shipments registry
   - Verify that the serial number of the selected asset is unchanged
