### PR TITLE
Use correct translation tokens for reports

### DIFF
--- a/server/controllers/stock/reports/stock/adjustment_receipt.js
+++ b/server/controllers/stock/reports/stock/adjustment_receipt.js
@@ -10,7 +10,7 @@ const {
  * This method builds the stock adjustment receipt file to be sent to the client.
  */
 async function stockAdjustmentReceipt(documentUuid, session, options) {
-  const optionReport = _.extend(options, { filename : 'STOCK.REPORTS.ADJUSTMENT' });
+  const optionReport = _.extend(options, { filename : 'STOCK.RECEIPT.ADJUSTMENT' });
   const autoStockAccountingEnabled = session.stock_settings.enable_auto_stock_accounting;
 
   const FLUX_TYPE = [

--- a/server/controllers/stock/reports/stock/exit_service_receipt.js
+++ b/server/controllers/stock/reports/stock/exit_service_receipt.js
@@ -13,7 +13,7 @@ const {
  */
 async function stockExitServiceReceipt(documentUuid, session, options) {
   const data = {};
-  const optionReport = _.extend(options, { filename : 'STOCK.REPORTS.EXIT_SERVICE' });
+  const optionReport = _.extend(options, { filename : 'STOCK.RECEIPT.EXIT_SERVICE' });
   const autoStockAccountingEnabled = session.stock_settings.enable_auto_stock_accounting;
 
   let template = STOCK_EXIT_SERVICE_TEMPLATE;


### PR DESCRIPTION
The recent update of many reports apparently used the incorrect/obsolete translation items for the report names.