### PR TITLE
docs: fix mysql docker instructions

### DIFF
--- a/docs/en/for-developers/installing-bhima.md
+++ b/docs/en/for-developers/installing-bhima.md
@@ -146,9 +146,9 @@ To start a MySQL server using docker you can use:
 # in this example, we use "mysql" as the tag name
 
 docker run --name mysql -p 3306:3306 \
-  -d mysql/mysql-server:8.0 \
   -e MYSQL_ROOT_PASSWORD=MyPassword \
   -e MYSQL_ROOT_HOST=% \
+  -d mysql/mysql-server:8.0 \
   --sql-mode='STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION' \
   --default-authentication-plugin=mysql_native_password
 

--- a/docs/fr/for-developers/installing-bhima.md
+++ b/docs/fr/for-developers/installing-bhima.md
@@ -129,9 +129,10 @@ Tu peux aussi utiliser docker avec mysql.  Le command pour le lancer est:
 
 #demarrer docker sur port 3306
 
-docker run --name mysql8 -p 3306:3306 \
+docker run --name mysql -p 3306:3306 \
   -e MYSQL_ROOT_PASSWORD=MyPassword \
-  -d mysql:8 \
+  -e MYSQL_ROOT_HOST=% \
+  -d mysql/mysql-server:8.0 \
   --sql-mode='STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION' \
   --default-authentication-plugin=mysql_native_password
 


### PR DESCRIPTION
This commit fixes the docker installation instructions to ensure
that the commands are ordered properly.

-----
[View rendered docs/en/for-developers/installing-bhima.md](https://github.com/jniles/bhima/blob/docs-fix-docker-install-instructions/docs/en/for-developers/installing-bhima.md)
[View rendered docs/fr/for-developers/installing-bhima.md](https://github.com/jniles/bhima/blob/docs-fix-docker-install-instructions/docs/fr/for-developers/installing-bhima.md)