### PR TITLE
Fix stock exit via shipment action menu

### DIFF
--- a/client/src/modules/stock/StockExitForm.service.js
+++ b/client/src/modules/stock/StockExitForm.service.js
@@ -298,6 +298,7 @@ function StockExitFormService(
 
     const lotsInShipment = lots.map(lot => lot.lot_uuid);
     const lotsInPool = this._pool.list().map(lot => lot.lot_uuid);
+    console.log("Lots in pool for StockExitForm: ", lotsInPool.length);
     let lotsUnavailable = false;
     lotsInShipment.forEach(uuid => {
       if (!lotsInPool.includes(uuid)) {
@@ -336,6 +337,8 @@ function StockExitFormService(
         }
       });
 
+    console.log("Available lots in StockExitForm: ", lotsInPool.length);
+
     // If the pool does not contain one of the lots that is the shipment,
     // that is because there is no stock remaining for that lot.  So for these
     // lots we need to reconstruct the lot and add it to the unavailable list
@@ -369,16 +372,16 @@ function StockExitFormService(
       // this is how much is available to us to use
       const availableQuantity = lot._quantity_available;
 
-      // if the available quantity is greater than or equal to the required
-      // quantity, allocate the entire available quantity to this lot item
-      // and reduce the requested quantity by that amount.
       if (availableQuantity >= requestedQuantity) {
+        // if the available quantity is greater than or equal to the required
+        // quantity, allocate the entire available quantity to this lot item
+        // and reduce the requested quantity by that amount.
+        console.log("Adding lot ");
         addLot(match, requestedQuantity);
         requestedQuantity = 0;
-
-      // otherwise, we need to reduce by the quantity available in the lot,
-      // and move to the next lot to start consuming it.
       } else {
+        // otherwise, we need to reduce by the quantity available in the lot,
+        // and move to the next lot to start consuming it.
         addLot(match, availableQuantity);
         requestedQuantity -= availableQuantity;
       }
@@ -425,6 +428,7 @@ function StockExitFormService(
 
     this._toggleInfoMessage(available.length > 0, 'success', SUCCESS_FILLED_N_ITEMS, { count : available.length });
 
+    console.log("Lots added to stock exit form data: ", this.store.data.length);
   };
 
   StockExitForm.prototype.setLotsFromInventoryList = function setLotsFromInventoryList(inventories, uuidKey = 'uuid') {
@@ -600,6 +604,7 @@ function StockExitFormService(
     }
 
     if (destDepot.shipment) {
+      console.log(`Loading shipment ${destDepot.shipment.lots.length} lots into stock exit form`);
       this.details.shipment_uuid = destDepot.shipment.uuid;
       this.setLotsFromShipmentList(destDepot.shipment.lots, 'lot_uuid');
     }

--- a/client/src/modules/stock/exit/exit.html
+++ b/client/src/modules/stock/exit/exit.html
@@ -162,7 +162,7 @@
         ui-grid-auto-resize
         ui-grid-resize-columns>
         <bh-grid-loading-indicator
-          loading-state="StockCtrl.stockForm.isLoading()"
+          loading-state="StockCtrl.loading || StockCtrl.stockForm.isLoading()"
           empty-state="StockCtrl.emptyStock"
           error-state="StockCtrl.hasError"
           empty-state-message="STOCK.EMPTY">

--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -215,7 +215,7 @@ function StockExitController(
 
       Shipments.readAll(params.shipment)
         .then(shipment => {
-          console.log("shipment: ", shipment);
+          console.log(`shipment loaded (${shipment.lots.length} lots): `);
           vm.shipment = shipment;
           return Depot.read(vm.shipment.origin_depot_uuid);
         })

--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -105,7 +105,7 @@ function StockExitController(
       width : 25,
       cellTemplate : 'modules/stock/exit/templates/actions.tmpl.html',
     }],
-    data : vm.stockForm.store.data,
+    // ??? data : vm.stockForm.store.data,
 
     // fastWatch to false is required for updating the grid correctly for
     // inventories loaded from an invoice for patient exit
@@ -137,7 +137,6 @@ function StockExitController(
     vm.validate();
   };
 
-  //
   vm.setLotFromDropdown = function setLotFromDropdown(row, lot) {
     vm.stockForm._pool.use(lot.lot_uuid);
     row.configure(lot);
@@ -205,14 +204,11 @@ function StockExitController(
   };
 
   function startup() {
-    // setting params for grid loading state
     vm.hasError = false;
-
     vm.stockForm.setup();
 
     // Handle startups from a shipment
     if (params.shipment) {
-      vm.loading = true;
 
       Shipments.readAll(params.shipment)
         .then(shipment => {
@@ -228,12 +224,13 @@ function StockExitController(
           const depotExitType = ExitTypes.exitTypes.find(item => item.label === 'depot');
           onSelectExitType(depotExitType, destDepot);
           vm.destLabel = depotExitType.formatLabel(destDepot);
+          vm.gridOptions.data = vm.stockForm.store.data;
           vm.validate();
         })
-        .catch(Notify.handleError)
-        .finally(() => {
-          vm.loading = false;
-        });
+        .catch(Notify.handleError);
+    }
+    else {
+      vm.gridOptions.data = vm.stockForm.store.data;
     }
 
     vm.validate();

--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -215,6 +215,7 @@ function StockExitController(
 
       Shipments.readAll(params.shipment)
         .then(shipment => {
+          console.log("shipment: ", shipment);
           vm.shipment = shipment;
           return Depot.read(vm.shipment.origin_depot_uuid);
         })
@@ -228,6 +229,7 @@ function StockExitController(
           onSelectExitType(depotExitType, destDepot);
           vm.destLabel = depotExitType.formatLabel(destDepot);
           vm.gridOptions.data = vm.stockForm.store.data;
+          console.log("Grid shipment data: ", vm.gridOptions.data);
           vm.loading = false;
           vm.validate();
         })

--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -209,6 +209,7 @@ function StockExitController(
 
     // Handle startups from a shipment
     if (params.shipment) {
+      vm.loading = true;
 
       Shipments.readAll(params.shipment)
         .then(shipment => {
@@ -225,6 +226,7 @@ function StockExitController(
           onSelectExitType(depotExitType, destDepot);
           vm.destLabel = depotExitType.formatLabel(destDepot);
           vm.gridOptions.data = vm.stockForm.store.data;
+          vm.loading = false;
           vm.validate();
         })
         .catch(Notify.handleError);

--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -38,6 +38,8 @@ function StockExitController(
   vm.onSelectExitType = onSelectExitType;
   vm.destLabel = '';
 
+  vm.loading = false;
+
   vm.submit = submit;
 
   const gridFooterTemplate = `

--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -228,6 +228,7 @@ function StockExitController(
           const depotExitType = ExitTypes.exitTypes.find(item => item.label === 'depot');
           onSelectExitType(depotExitType, destDepot);
           vm.destLabel = depotExitType.formatLabel(destDepot);
+          vm.validate();
         })
         .catch(Notify.handleError)
         .finally(() => {

--- a/client/src/modules/stock/exit/exit.js
+++ b/client/src/modules/stock/exit/exit.js
@@ -228,8 +228,7 @@ function StockExitController(
           vm.validate();
         })
         .catch(Notify.handleError);
-    }
-    else {
+    } else {
       vm.gridOptions.data = vm.stockForm.store.data;
     }
 

--- a/server/controllers/asset_management/shipment/shipment.js
+++ b/server/controllers/asset_management/shipment/shipment.js
@@ -40,7 +40,6 @@ exports.single = async (req, res, next) => {
 exports.details = async (req, res, next) => {
   try {
     const result = await lookup(req.params.uuid);
-    console.log("Shipment: ", result);
     res.status(200).json(result);
   } catch (error) {
     next(error);

--- a/server/controllers/asset_management/shipment/shipment.js
+++ b/server/controllers/asset_management/shipment/shipment.js
@@ -40,6 +40,7 @@ exports.single = async (req, res, next) => {
 exports.details = async (req, res, next) => {
   try {
     const result = await lookup(req.params.uuid);
+    console.log("Shipment: ", result);
     res.status(200).json(result);
   } catch (error) {
     next(error);


### PR DESCRIPTION
I asked @jniles to take a look at this problem.  He suggested the fix in this PR.  Thanks @jniles !

Note that this test could be tried on a production server by inserting this new line at client/src/modules/stock/exit/exit.js at line 231:

   `vm.validate();`

If this does not work, We will need to try doing some debugging on the server and client sides to see why all items are not getting from the server to the client.

Closes https://github.com/IMA-WorldHealth/bhima/issues/6809

**TESTING**
- Ideally do this with a server on a separate computer from the client
- Create a shipment with many items and mark it ready for shipping
- In the Shipments Registry, use the action menu for the new shipment and do the "Exit stock for this shipment" command
- Verify that all the items in the shipment appear in the stock exit
