### PR TITLE
Feature problem with creating requisition request

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -72,6 +72,7 @@
     "TRACK_CONSUMPTION":"Track consumption",
     "TRACK_EXPIRATION":"Track expiration",
     "ERRORS" : {
+      "DEPOT_NOT_ALLOWED_DISTRIBUTE": "ERROR! <b>'{{ depot }}'</b> depot is not allowed to distribute to any depot",
       "EXCESSIVE_QUANTITY": "Excessive Quantity",
       "INVALID_GLOBAL_QUANTITY" : "Invalid Global Lot's Quantity",
       "INVALID_LOT_EXPIRATION" : "Invalid Lot Expiration Date",

--- a/client/src/i18n/fr/stock.json
+++ b/client/src/i18n/fr/stock.json
@@ -72,6 +72,7 @@
     "TRACK_CONSUMPTION":"Suivre la consommation",
     "TRACK_EXPIRATION":"Suivre l'expiration",
     "ERRORS" : {
+      "DEPOT_NOT_ALLOWED_DISTRIBUTE": "ERREUR ! <strong>'{{ depot }}'</strong> n'est pas autorisé à distribuer vers aucun dépôt",
       "EXCESSIVE_QUANTITY": "Quantité excessive",
       "INVALID_GLOBAL_QUANTITY" : "Quantité globale des lots invalide",
       "INVALID_LOT_EXPIRATION" : "Date d'expiration invalide",

--- a/client/src/js/components/bhDepotSelect/bhDepotSelect.js
+++ b/client/src/js/components/bhDepotSelect/bhDepotSelect.js
@@ -6,9 +6,11 @@ angular.module('bhima.components')
     bindings    : {
       depotUuid        : '<',
       filterByUserPermission  : '@?',
+      filterAuthorizedDepotForDistribution : '@?',
       onSelectCallback : '&',
       label            : '@?',
       required         : '<?',
+      disabled         : '<?',
       exception        : '<?', // uuid string or an array of uuids
     },
   });
@@ -60,6 +62,10 @@ function DepotSelectController(Depots, Notify) {
 
     if ($ctrl.filterByUserPermission) {
       options.only_user = true;
+    }
+
+    if ($ctrl.filterAuthorizedDepotForDistribution) {
+      options.only_distributor = true;
     }
 
     return Depots.searchByName(options);

--- a/client/src/js/components/bhDepotSelect/bhDepotSelect.tmpl.html
+++ b/client/src/js/components/bhDepotSelect/bhDepotSelect.tmpl.html
@@ -22,6 +22,7 @@
       typeahead-min-length="0"
       autocomplete="off"
       translate-attr="{ 'placeholder': 'FORM.SELECT.DEPOT' }"
+      ng-disabled="$ctrl.disabled"
       ng-required="$ctrl.required">
 
     <span ng-show="$ctrl.$loading" class="glyphicon glyphicon-hourglass form-control-feedback"></span>

--- a/client/src/js/components/bhServiceOrDepot/bhServiceOrDepot.html
+++ b/client/src/js/components/bhServiceOrDepot/bhServiceOrDepot.html
@@ -42,6 +42,7 @@
   <div ng-if="$ctrl.requestorType.type_key === 'depot'">
     <bh-depot-select
       depot-uuid="$ctrl.uuid"
+      filter-by-user-permission="true"
       label="REQUISITION.DEPOT_REQUESTOR"
       on-select-callback="$ctrl.onSelectRequestor(depot)"
       required="true">

--- a/client/src/modules/depots/modals/depot.modal.html
+++ b/client/src/modules/depots/modals/depot.modal.html
@@ -185,6 +185,7 @@
               <input type="checkbox" id="{{depot.uuid}}" ng-model="depot._checked" ng-change="DepotModalCtrl.setNodeValue(depot.children, depot)" />
               <span translate>{{depot.text}}</span>
             </label>
+            <span class="fa fa-arrow-left" role="button" ng-click="DepotModalCtrl.setRootValue(depot)"></span>
           </div>
         </div>
       </div>

--- a/client/src/modules/depots/modals/depot.modal.js
+++ b/client/src/modules/depots/modals/depot.modal.js
@@ -148,6 +148,11 @@ function DepotModalController($state, Depots, Notify, Session, params, FormatTre
   }
   vm.setNodeValue = setNodeValue;
 
+  function setRootValue(depot) {
+    depot._checked = !depot._checked;
+  }
+  vm.setRootValue = setRootValue;
+
   function setAllNodeValue(depots, allStatus) {
     depots.forEach(depot => {
       depot._checked = allStatus;

--- a/client/src/modules/stock/requisition/modals/action.modal.html
+++ b/client/src/modules/stock/requisition/modals/action.modal.html
@@ -32,10 +32,11 @@
     <div id="depot-supplier" class="form-group">
       <bh-depot-select
         depot-uuid="$ctrl.model.depot_uuid"
-        filter-by-user-permission="true"
         label="REQUISITION.DEPOT_SUPPLIER"
+        filter-authorized-depot-for-distribution="true"
         required="true"
         exception="$ctrl.model.requestor_uuid"
+        disabled="!$ctrl.model.requestor_uuid"
         on-select-callback="$ctrl.onSelectDepot(depot)">
       </bh-depot-select>
     </div>

--- a/client/src/modules/stock/requisition/modals/action.modal.js
+++ b/client/src/modules/stock/requisition/modals/action.modal.js
@@ -90,6 +90,9 @@ function ActionRequisitionModalController(
     vm.model.requestor_uuid = requestor.uuid;
     // enable auto suggestions only if a depot is selected
     vm.enableAutoSuggest = (requestor.requestor_type_id === DEPOT_REQUESTOR_TYPE && requestor.uuid);
+
+    // Cancel the supplier depot selection if the user changes the requesting depot
+    vm.model.depot_uuid = [];
   };
 
   if (data.uuid) {

--- a/server/controllers/inventory/depots/index.js
+++ b/server/controllers/inventory/depots/index.js
@@ -435,6 +435,12 @@ function searchByName(req, res, next) {
     options.user_id = req.session.user.id;
   }
 
+  // When the enable_strict_depot_distribution option is activated, you can only make
+  // a requisition request if the supplier depot is configured to distribute to the beneficiary depot
+  if (req.query.only_distributor && req.session.stock_settings.enable_strict_depot_distribution) {
+    options.only_distributor_for = req.query.exception;
+  }
+
   options.exception = req.query.exception;
   options.limit = req.query.limit || 10;
   options.enterprise_id = req.session.enterprise.id;
@@ -443,7 +449,7 @@ function searchByName(req, res, next) {
     return next(new BadRequest('text attribute must be specified for a name search'));
   }
 
-  db.convert(options, ['exception']);
+  db.convert(options, ['exception', 'only_distributor_for']);
 
   const filters = new FilterParser(options, { tableAlias : 'd' });
 
@@ -468,6 +474,11 @@ function searchByName(req, res, next) {
   filters.custom(
     'user_id',
     'd.uuid IN (SELECT depot_permission.depot_uuid FROM depot_permission WHERE depot_permission.user_id = ?)',
+  );
+
+  filters.custom(
+    'only_distributor_for',
+    'd.uuid IN (SELECT dp.depot_uuid FROM depot_distribution_permission AS dp WHERE dp.distribution_depot_uuid = ?)',
   );
 
   filters.fullText('text', 'text', 'd');


### PR DESCRIPTION
- Restoring the Activate the restriction of distribution depots option
- For the management of requisitions, you can only make a requisition for a deposit for which you have the right to manage
- when the restrict distribution option is activated, the requisition request can only be made to a structure that is authorized to distribute to the requesting depot
- Cancel the supplier depot selection if the user changes the requesting
  depot
- Restrict the display of the requisition register to depots managed by the user either as a requestor or as a supplier
- Added the ability to select a parent repository without selecting child repositories
- Clean the supplier depot when the selection change

closes https://github.com/IMA-WorldHealth/bhima/issues/6875