### PR TITLE
List all lots from the API

### DIFF
--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -627,7 +627,7 @@ async function getMovements(depotUuid, params) {
     m.flux_id, BUID(m.entity_uuid) AS entity_uuid, SUM(m.unit_cost * m.quantity) AS cost,
     f.label AS flux_label, BUID(m.invoice_uuid) AS invoice_uuid, dm.text AS documentReference,
     BUID(m.stock_requisition_uuid) AS stock_requisition_uuid, sr_m.text AS document_requisition,
-    u.display_name AS userName, IFNULL(em.text, IFNULL(serv.name, IFNULL(dm2.text, dp.text))) AS target, sv.wac
+    u.display_name AS userName, IFNULL(dp.text, IFNULL(serv.name, IFNULL(em.text, dm2.text))) AS target, sv.wac
   FROM stock_movement m
     JOIN lot l ON l.uuid = m.lot_uuid
     JOIN inventory i ON i.uuid = l.inventory_uuid

--- a/server/controllers/stock/index.js
+++ b/server/controllers/stock/index.js
@@ -464,6 +464,7 @@ async function movementsFromMobile(params) {
     const [bhima] = movements;
     return validLots.length ? {
       document_uuid : bhima.document_uuid,
+      description : mobile.description,
       flux_id : mobile.fluxId,
       is_exit : mobile.isExit,
       depot_uuid : mobile.depotUuid,
@@ -500,6 +501,7 @@ async function movementsFromMobile(params) {
     flux_id : mobile.fluxId,
     is_exit : mobile.isExit,
     depot_uuid : mobile.depotUuid,
+    entity_uuid : mobile.depotUuid,
     date : mobile.date,
     description : mobile.description,
     lots : mobileLots.map(item => {
@@ -1070,7 +1072,7 @@ async function listLotsDepot(req, res, next) {
   params.min_delay = req.session.stock_settings.min_delay;
   params.default_purchase_interval = req.session.stock_settings.default_purchase_interval;
 
-  if (req.session.stock_settings.enable_strict_depot_permission) {
+  if (req.session.stock_settings.enable_strict_depot_permission && !params.fullList) {
     params.check_user_id = req.session.user.id;
   }
 


### PR DESCRIPTION
This PR adds options for getting all available lots without the restriction of `stock_setting`, this option is for allowing to the mobile app to load all lots directly during the mobile app configuration.

Its also fixes some missing information from the mobile app.