### PR TITLE
Add pagination in the stock_movement end-point

### DIFF
--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -340,7 +340,6 @@ async function getAssets(params) {
       params.scan_status === 'scanned' ? 'last_scan.uuid IS NOT NULL' : 'last_scan.uuid IS NULL');
   }
   filters.setGroup(groupByClause);
-
   filters.setHaving(havingClause);
   filters.setOrder('ORDER BY i.code, l.label');
   const query = filters.applyQuery(sql);
@@ -434,7 +433,6 @@ async function getLotsDepot(depotUuid, params, finalClause) {
   `;
 
   const groupByClause = finalClause || ` GROUP BY l.uuid, m.depot_uuid ${emptyLotToken} ORDER BY i.code, l.label `;
-
   const filters = getLotFilters(params);
   filters.setGroup(groupByClause);
 
@@ -484,7 +482,7 @@ async function getLotsDepot(depotUuid, params, finalClause) {
 
   if (params.paging) {
     return {
-      pager : paginatedResults,
+      pager : paginatedResults.pager,
       rows : inventoriesWithLotsProcessed,
     };
   }
@@ -979,24 +977,26 @@ async function getInventoryQuantityAndConsumption(params) {
 
   const clause = ` GROUP BY l.inventory_uuid, m.depot_uuid ${emptyLotToken} ORDER BY ig.name, i.text `;
 
-  let filteredRows = await getLots(sql, params, clause);
-  if (filteredRows.length === 0) { return []; }
+  const filteredRows = await getLots(sql, params, clause);
+  let _filteredRows = params.paging ? filteredRows.rows : filteredRows;
+
+  if (_filteredRows.length === 0) { return []; }
 
   const settingsql = `
     SELECT month_average_consumption, average_consumption_algo, min_delay, default_purchase_interval
     FROM stock_setting WHERE enterprise_id = ?
   `;
 
-  const opts = await db.one(settingsql, filteredRows[0].enterprise_id);
+  const opts = await db.one(settingsql, _filteredRows[0].enterprise_id);
 
   // add the minimum delay to the rows
-  filteredRows.forEach(row => {
+  _filteredRows.forEach(row => {
     row.min_delay = opts.min_delay;
   });
 
   // add the CMM
-  filteredRows = await getBulkInventoryCMM(
-    filteredRows,
+  _filteredRows = await getBulkInventoryCMM(
+    _filteredRows,
     opts.month_average_consumption,
     opts.average_consumption_algo,
     opts.default_purchase_interval,
@@ -1004,14 +1004,14 @@ async function getInventoryQuantityAndConsumption(params) {
   );
 
   if (_status) {
-    filteredRows = filteredRows.filter(row => row.status === _status);
+    _filteredRows = _filteredRows.filter(row => row.status === _status);
   }
 
   if (requirePurchaseOrder) {
-    filteredRows = filteredRows.filter(row => row.S_Q > 0);
+    _filteredRows = _filteredRows.filter(row => row.S_Q > 0);
   }
 
-  return filteredRows;
+  return params.paging ? { ...filteredRows, rows : _filteredRows } : _filteredRows;
 }
 
 /**

--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -241,6 +241,13 @@ function getLots(sqlQuery, parameters, finalClause = '', orderBy = '') {
     filters.setOrder(orderBy);
   }
 
+  if (parameters.paging) {
+    const FROM_INDEX = String(sql).lastIndexOf('FROM');
+    const select = String(sql).substring(0, FROM_INDEX - 1);
+    const tables = String(sql).substring(FROM_INDEX, sql.length - 1);
+    return db.paginateQuery(select, parameters, tables, filters);
+  }
+
   const query = filters.applyQuery(sql);
   const queryParameters = filters.parameters();
 

--- a/server/lib/db/index.js
+++ b/server/lib/db/index.js
@@ -319,16 +319,23 @@ class DatabaseConnector {
       const total = (await this.exec(filters.getAllResultQuery(sql.concat(' ', tables)), queryParameters)).length;
       const page = params.page ? parseInt(params.page, 10) : 1;
       const limit = params.limit ? parseInt(params.limit, 10) : 100;
+      const pageCount = Math.ceil(total / limit);
       pager = {
         total,
         page,
         page_size : limit,
         page_min : (page - 1) * limit,
         page_max : (page) * limit,
-        page_count : Math.ceil(total / limit),
+        page_count : pageCount,
       };
       const paginatedQuery = filters.applyPaginationQuery(sql.concat(' ', tables), pager.page_size, pager.page_min);
       rows = await this.exec(paginatedQuery, queryParameters);
+      if (rows.length === 0) {
+        // update page_min and page_max after the query
+        // in case of empty result
+        pager.page_min = null;
+        pager.page_max = null;
+      }
     }
 
     return { rows, pager };

--- a/server/lib/filter.js
+++ b/server/lib/filter.js
@@ -312,12 +312,29 @@ class FilterParser {
 
     return `
       SELECT
-        COUNT(*) AS total, ${page} AS page,
-        ${limit} AS page_size, (${(page - 1) * limit}) AS page_min, (${(page) * limit}) AS page_max,
+        COUNT(*) AS total,
+        ${page} AS page,
+        ${limit} AS page_size, 
+        (${(page - 1) * limit}) AS page_min, 
+        (${(page) * limit}) AS page_max,
         CEIL(COUNT(*) / ${limit}) AS page_count
       ${table} 
       WHERE ${conditionStatements} 
     `;
+  }
+
+  // FIXME: This strategie is temp solution to fix the pager.total compare to the rows.size
+  // The reason is we have to use COUNT(DISTINCT specific_column) FOR ALL OUR CASES in the above
+  // query
+  getAllResultQuery(sql) {
+    if (this._autoParseStatements) {
+      this._parseDefaultFilters();
+    }
+
+    const conditionStatements = this._parseStatements();
+    const group = this._group;
+
+    return `${sql} WHERE ${conditionStatements} ${group}`;
   }
 
   applyPaginationQuery(sql, limit, page) {

--- a/server/lib/filter.js
+++ b/server/lib/filter.js
@@ -299,6 +299,38 @@ class FilterParser {
 
     return limitString;
   }
+
+  /**
+   * pagination handler
+   */
+  paginationLimitQuery(table, limit = 100, page = 1) {
+    if (this._autoParseStatements) {
+      this._parseDefaultFilters();
+    }
+
+    const conditionStatements = this._parseStatements();
+
+    return `
+      SELECT
+        COUNT(*) AS total, ${page} AS page,
+        ${limit} AS page_size, (${(page - 1) * limit}) AS page_min, (${(page) * limit}) AS page_max,
+        CEIL(COUNT(*) / ${limit}) AS page_count
+      ${table} 
+      WHERE ${conditionStatements} 
+    `;
+  }
+
+  applyPaginationQuery(sql, limit, page) {
+    if (this._autoParseStatements) {
+      this._parseDefaultFilters();
+    }
+
+    const conditionStatements = this._parseStatements();
+    const order = this._order;
+    const group = this._group;
+
+    return `${sql} WHERE ${conditionStatements} ${group} ${order} LIMIT ${limit} OFFSET ${page}`;
+  }
 }
 
 module.exports = FilterParser;


### PR DESCRIPTION
This PR adds paging in the `stock_movment` end-point.

To perform queries with paging, you have to add: `?paging=true` in the HTTP request, which returns an object with two elements: 
```js
{
  rows: [], // records
  pager: {
    "total": 18, // total of records found in the database
    "page": 4, // the current page, pages are indexed from 1
    "page_size": 5, // the number of records returned by pages
    "page_min": 15, // the minimum counted record of the page
    "page_max": 20, // the maximum counted record of the page
    "page_count": 4 // the total of pages
  } // pagination information
}
```

To test the feature:

- Log into BHIMA (with browser or REST Tools)
- Go to this route: `stock/lots/movements/?paging=true` to have pager information
- Go to this route: `stock/lots/movements/?paging=true&page=2` to have page 2 of records
- Go to this route: `stock/lots/movements/?paging=true&page=2&limit=10` to have page 2 when the number of records on each page must be 10

This feature is enabled for these end-points: 
- `/stock/lots/depots/` : for getting the list of lots with their quantities (see Lots in stock registry)
- `/stock/lots/depotsDetailed/` : for getting the detailed list of lots (see Lots in stock registry)
- `/stock/lots/movements/` : for getting the list of stock movements made (see Stock movements registry)
- `/stock/inventories/depots/` : for getting the list of inventories without consideration of lots (see Article in stock registry)
