### PR TITLE
chore: remove receipt parens

### DIFF
--- a/server/controllers/finance/reports/vouchers/receipt.handlebars
+++ b/server/controllers/finance/reports/vouchers/receipt.handlebars
@@ -70,7 +70,7 @@
       <tr>
         <th colspan="2" class="text-left">
           {{translate 'FORM.LABELS.TOTAL'}}
-          {{#if showNumberOfLines}}({{numberOfLines}} {{translate 'FORM.LABELS.RECORDS'}}){{/if}}
+          {{#if showNumberOfLines}}{{numberOfLines}} {{translate 'FORM.LABELS.RECORDS'}}{{/if}}
         </th>
         <th class="text-right">{{currency (sum items 'debit') details.currency_id}}</th>
         <th class="text-right">{{currency (sum items 'credit') details.currency_id}}</th>


### PR DESCRIPTION
Removes the multiple parentheses in the voucher receipt.

Closes #6924.

<img width="882" alt="Screenshot 2023-05-16 at 10 26 19 AM" src="https://github.com/IMA-WorldHealth/bhima/assets/896472/d6ddf823-6bc6-4c76-99b8-3f3649990701">
