### PR TITLE
Fix total calculation in the stock sheet report for exit

### DIFF
--- a/server/controllers/stock/core.js
+++ b/server/controllers/stock/core.js
@@ -1285,7 +1285,7 @@ async function getInventoryMovements(params) {
       // exit
       movement.exit.quantity = line.quantity;
       movement.exit.unit_cost = stockUnitCost;
-      movement.exit.value = line.quantity * line.unit_cost;
+      movement.exit.value = line.quantity * stockUnitCost;
     } else {
       const newQuantity = line.quantity + stockQuantity;
       // fix negative value disorder


### PR DESCRIPTION
This PR fixes the `Total` column calculation in the stock sheet report for the exit section.

