### PR TITLE
Update connect-redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "bootstrap": "^3.3.0",
     "chart.js": "^3.9.1",
     "chartjs-plugin-datalabels": "^2.1.0",
-    "connect-redis": "^6.1.3",
+    "connect-redis": "^7.1.0",
     "cron": "^2.3.1",
     "cropper": "^4.0.0",
     "cross-env": "^7.0.3",

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -9,7 +9,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const session = require('express-session');
 // NOTE: connect-redis now automatically imports the session data from
-//       express-session. See migration notes in
+//       express-session. See the migration notes in
 //       https://github.com/tj/connect-redis/releases/tag/v7.0.0
 const RedisStore = require('connect-redis').default;
 const Redis = require('ioredis');

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -8,7 +8,10 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const session = require('express-session');
-const RedisStore = require('connect-redis')(session);
+// NOTE: connect-redis now automatically imports the session data from
+//       express-session. See migration notes in
+//       https://github.com/tj/connect-redis/releases/tag/v7.0.0
+const RedisStore = require('connect-redis').default;
 const Redis = require('ioredis');
 const morgan = require('morgan');
 const helmet = require('helmet');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1993,10 +1993,10 @@ confusing-browser-globals@^1.0.10:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
   integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
 
-connect-redis@^6.1.3:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-6.1.3.tgz#0a83c953f9ece45ae37d304a8e8d1c3c6a60b4b9"
-  integrity sha512-aaNluLlAn/3JPxRwdzw7lhvEoU6Enb+d83xnokUNhC9dktqBoawKWL+WuxinxvBLTz6q9vReTnUDnUslaz74aw==
+connect-redis@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-7.1.0.tgz#6618334697f2ed91536848cdc03734def2138acf"
+  integrity sha512-UaqO1EirWjON2ENsyau7N5lbkrdYBpS6mYlXSeff/OYXsd6EGZ+SXSmNPoljL2PSua8fgjAEaldSA73PMZQ9Eg==
 
 connect@^3.7.0:
   version "3.7.0"


### PR DESCRIPTION
This updates connect-redis to the latest version and deals with breaking changes introduced in connect-redis v7.0.0.  
(See https://github.com/tj/connect-redis/releases/tag/v7.0.0 for details).

This should make failing bump [PR 7065](https://github.com/IMA-WorldHealth/bhima/pull/7065) obsolete
