### PR TITLE
chore: fixup docker file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,16 +2,16 @@
 node_modules
 .git
 
-# ignore loggin utilities
-npm-debug.log
-yarn-error.log
+# ignore logging utilities
+*.log
 
 # ignore documentation
 *.md
+Dockerfile
 
 # ignore unnecessary folders
 docs
-temp
+#temp
 test
 sh
 bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # define base image
-FROM node:lts-slim
+FROM node:lts-slim as build
 
 # download all the missing dependencies for chromium, plus chromium itself
 RUN apt-get update && apt-get install -y \
@@ -11,12 +11,13 @@ RUN apt-get update && apt-get install -y \
   libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 \
   libxss1 libxtst6 lsb-release libxshmfence1 chromium -y
 
-# ENV NODE_ENV=production
-ENV YARN_VERSION 1.22.17
-#ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD 1
+# set up environmental variables
+ENV YARN_VERSION=1.22.17 \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 \
+    CHROME_BIN=/usr/bin/chromium \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
 RUN yarn policies set-version $YARN_VERSION
-#ENV CHROME_BIN /usr/bin/chromium
-#ENV PUPPETEER_EXECUTABLE_PATH /usr/bin/chromium
 
 # define working directory inside the container
 WORKDIR /usr/src/app
@@ -38,6 +39,8 @@ RUN chown -R node:node *
 
 # ensure this container runs as the user "node"
 USER node
+
+ENV NODE_ENV production
 
 # define the start up command of the container to run the server
 CMD ["node", "server/app.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3'
 
 services:
   bhima:
-    build: .
-    image: imaworldhealth/bhima
+    #build: .
+    image: imaworldhealth/bhima:latest
     restart: unless-stopped
     ports:
       - $PORT:$PORT
@@ -14,7 +14,7 @@ services:
       - mysql
       - redis
   mysql:
-    image: mysql:8
+    image: mysql:latest
     restart: always
     command:
       - --default-authentication-plugin=mysql_native_password
@@ -23,8 +23,9 @@ services:
       - --collation-server=utf8mb4_unicode_ci
     volumes:
       - mysqldata:/var/lib/mysql/
-      - "./temp/docker-build.sql:/docker-entrypoint-initdb.d/bhima.sql"
+      - "./temp:/docker-entrypoint-initdb.d"
     environment:
+      # - MYSQL_ROOT_PASSWORD=2fe88872-0598-11ee-b0cf-47268d06eac1
       - MYSQL_RANDOM_ROOT_PASSWORD=1
       - MYSQL_USER=$DB_USER
       - MYSQL_PASSWORD=$DB_PASS

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:clean": "cross-env ./sh/build-init-database.sh",
     "build:stock": "cross-env ./sh/build-stock-database.sh",
     "build:docker": "cross-env ./sh/docker-init.sh",
+    "build:podman": "podman build --tag imaworldhealth/bhima:latest -f ./Dockerfile",
     "migrate": "cross-env ./sh/setup-migration-script.sh",
     "watch": "cross-env ./node_modules/.bin/gulp watch",
     "check:lang": "cross-env node ./utilities/translation/tfcomp.js client/src/i18n/en client/src/i18n/fr",


### PR DESCRIPTION
This commit fixes up the docker and compose files for distributing BHIMA.  It gets BHIMA building using `podman` or `docker` on a system without mysql and node installed.  Note that this only supports the x86_64 architecture at the moment.

If you want to test this for yourself:
  1. Check out this branch 
  2. Create a `.env` with credentials if you don't have them already.
  3. Run `./sh/docker-init.sh`.
  4. Run either `docker compose up -d` or `podman-compose up -d`.  

The rest should be automatically downloaded and installed.

----

This isn't completely working yet, due to how BHIMA packages the database.  For this to work, the user needs to have the file generated by "./sh/docker-init.sh" in their `/temp` folder, which somewhat defeats the purpose.  It could be that we just include this as a pre-requisite step (as done in the above instructions).