### PR TITLE
feat(payroll): add service to multiple payroll

### DIFF
--- a/client/src/modules/multiple_payroll/multiple_payroll.js
+++ b/client/src/modules/multiple_payroll/multiple_payroll.js
@@ -48,6 +48,10 @@ function MultiplePayrollController(
     displayName : 'FORM.LABELS.EMPLOYEE_NAME',
     headerCellFilter : 'translate',
   }, {
+    field : 'service_name',
+    displayName : 'FORM.LABELS.SERVICE',
+    headerCellFilter : 'translate',
+  }, {
     field : 'code',
     displayName : 'FORM.LABELS.CODE',
     headerCellFilter : 'translate',

--- a/client/src/modules/multiple_payroll_indice/multiple_payroll_indice.js
+++ b/client/src/modules/multiple_payroll_indice/multiple_payroll_indice.js
@@ -47,8 +47,11 @@ function MultiplePayrollIndiceController(
     width : 100,
     aggregationType  : uiGridConstants.aggregationTypes.count,
     aggregationHideLabel : true,
-  },
-  {
+  }, {
+    field : 'service_name',
+    displayName : 'FORM.LABELS.SERVICE',
+    headerCellFilter : 'translate',
+  }, {
     field : 'action',
     width : 100,
     displayName : '',
@@ -108,7 +111,7 @@ function MultiplePayrollIndiceController(
 
   function renameGridHeaders(rubrics) {
     const actions = angular.copy(columnDefs[columnDefs.length - 1]);
-    const newColumns = columnDefs.slice(0, 1);
+    const newColumns = columnDefs.slice(0, 2);
 
     const header = {
       type : 'number',
@@ -136,19 +139,19 @@ function MultiplePayrollIndiceController(
   }
 
   function setGridData(employees) {
-    const data = [];
-    employees.forEach(employee => {
+    return employees.map(employee => {
       const row = {
         employee_uuid : employee.uuid,
         display_name : employee.display_name,
+        service_name : employee.service_name,
       };
 
       employee.rubrics.forEach(r => {
         row[r.rubric_id] = r.rubric_value;
       });
-      data.push(row);
+
+      return row;
     });
-    return data;
   }
   // remove a filter with from the filter object, save the filters and reload
   function onRemoveFilter(key) {


### PR DESCRIPTION
Adds the service column to the multiple payroll to allow managers to see which services have paid their staff on time.  It also adds it to the multiple payroll index page.

_Multiple Payroll_
![image](https://github.com/IMA-WorldHealth/bhima/assets/896472/411bb5e3-d458-4f82-b904-e7ca89192a67)

_Multiple Payroll Index_
![image](https://github.com/IMA-WorldHealth/bhima/assets/896472/c569eade-6cd2-4e09-bece-5a0c492db94c)


Closes #7124.