### PR TITLE
Added ODKSettingsService back

### DIFF
--- a/client/src/modules/odk-settings/odk-settings.service.js
+++ b/client/src/modules/odk-settings/odk-settings.service.js
@@ -1,0 +1,57 @@
+angular.module('bhima.services')
+  .service('ODKSettingsService', ODKSettingsService);
+
+ODKSettingsService.$inject = ['PrototypeApiService'];
+
+function ODKSettingsService(Api) {
+
+  const baseUrl = '/admin/odk-settings/';
+  const service = new Api(baseUrl);
+
+  // //
+  // service.syncEnterprise = () => {
+  //   return service.$http.post(baseUrl.concat('sync-enterprise'))
+  //     .then(service.util.unwrapHttpResponse);
+  // };
+
+  // //
+  // service.syncAppUsers = () => {
+  //   return service.$http.post(baseUrl.concat('sync-app-users'))
+  //     .then(service.util.unwrapHttpResponse);
+  // };
+
+  // //
+  // service.syncForms = () => {
+  //   return service.$http.post(baseUrl.concat('sync-forms')).then(service.util.unwrapHttpResponse);
+  // };
+
+  // service.syncSubmissions = () => {
+  //   return service.$http.post(baseUrl.concat('sync-submissions')).then(service.util.unwrapHttpResponse);
+  // };
+  // //
+  // service.syncStockMovements = () => {
+  //   return service.$http.post(baseUrl.concat('sync-stock-movements'))
+  //     .then(service.util.unwrapHttpResponse);
+  // };
+
+  // service.getProjectSettings = () => {
+  //   return service.$http.get(baseUrl.concat('project-settings'))
+  //     .then(service.util.unwrapHttpResponse);
+  // };
+
+  // service.getAppUsers = () => {
+  //   return service.$http.get(baseUrl.concat('app-users'))
+  //     .then(service.util.unwrapHttpResponse);
+  // };
+
+  service.getAppUserQRCode = (userId) => {
+    return service.$http.get(baseUrl.concat(`app-users/${userId}/qrcode`))
+      .then(service.util.unwrapHttpResponse);
+  };
+
+  // service.getUserSettings = () => {
+  //   // todo
+  // };
+
+  return service;
+}


### PR DESCRIPTION
Fixes a problem with the recent deletion of the ODK Central server code. 
It turns out that the Admin / Users and Permissions Management page still had a dependency on the ODKSettingsServer for doing user QR codes.   This PR restores only the ODKSettingsService files to get the Users page working again.

Note that was caught due to the playwright end-to-end tests.

A new issue to get refactor this and get rid of the other ODK left-overs will be created soon.
