### PR TITLE
fix(docs): remove link to ODK central plugin

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -10,8 +10,6 @@ This manual is split into chapters:
 4. [Inventory and Stock Management](./stock-management)
 5. Reporting and Statistics
 6. [Developer Reference](./for-developers)
-7. Plugins
-		1. [ODK Central Plugin](./plugins/odk-central)
 8. [Glossary](./glossary.md)
 
 # About


### PR DESCRIPTION
Removes the link to the deleted ODK central plugin.