### PR TITLE
Fixed employee end-to-end tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:client-unit": "cross-env SUITE=\"client-unit\" ./sh/test.sh",
     "test:server-unit": "cross-env SUITE=\"server-unit\" ./sh/test.sh",
     "test:show-results": "./sh/test-show-results.sh",
-    "test:clean-reports": "./sh/test-clean-reports.sh",
+    "test:clean": "./sh/test-clean-reports.sh",
     "build": "cross-env ./node_modules/.bin/gulp build",
     "build:db": "cross-env ./sh/build-database.sh",
     "build:clean": "cross-env ./sh/build-init-database.sh",

--- a/test/end-to-end/employees/registration.page.js
+++ b/test/end-to-end/employees/registration.page.js
@@ -66,11 +66,6 @@ class RegistrationPage {
     return TU.uiSelect('EmployeeCtrl.employee.fonction_id', fonction);
   }
 
-  // set Medical Staff
-  setIsMedical() {
-    return TU.locator(by.model('EmployeeCtrl.employee.is_medical')).click();
-  }
-
   // set email
   setEmail(email) {
     return TU.input('EmployeeCtrl.employee.email', email);

--- a/test/end-to-end/employees/registration.spec.js
+++ b/test/end-to-end/employees/registration.spec.js
@@ -73,7 +73,6 @@ test.describe('Employees', () => {
     await registrationPage.setNumberChild(employee.nb_enfant);
     await registrationPage.setService('Administration');
     await registrationPage.setFunction('Infirmier');
-    await registrationPage.setIsMedical();
     await registrationPage.setEmail(employee.email);
     await registrationPage.setAddress(employee.adresse);
     await registrationPage.setCurrencyInput('individual_salary', 0);
@@ -102,7 +101,6 @@ test.describe('Employees', () => {
     await registrationPage.setNumberChild(patient.nb_enfant);
     await registrationPage.setService('Administration');
     await registrationPage.setFunction('Infirmier');
-    await registrationPage.setIsMedical();
     await registrationPage.setEmail(patient.email);
     await registrationPage.setAddress(patient.adresse);
     await registrationPage.setCurrencyInput('individual_salary', 0);

--- a/test/end-to-end/employees/update.spec.js
+++ b/test/end-to-end/employees/update.spec.js
@@ -28,7 +28,6 @@ test.describe('Update Employees', () => {
 
     await registrationPage.setService('Administration');
     await registrationPage.setFunction('Infirmier');
-    await registrationPage.setIsMedical();
     await registrationPage.setGrade('A1');
 
     await registrationPage.setCurrencyInput('TPR', 10);


### PR DESCRIPTION
Fix a regression in the employee end-to-end tests.
Creating employees no longer involves the "is medical" flag since that is now defined by the job title, so attempts to change the "is medical" status while creating/editing in the end-to-end tests were removed.
