### PR TITLE
Updated currency filter and added client-unit tests

### DIFF
--- a/client/src/js/services/currencyFormat.js
+++ b/client/src/js/services/currencyFormat.js
@@ -1,44 +1,43 @@
 /**
- * @description
  * Provides asynchronous GET requests for currency configuration files, fetched
  * configurations are cached and served directly to subsequent requests.
  *
  * @returns {object} Wrapper object exposing request configuration method
  */
 angular.module('bhima.services')
-.factory('currencyFormat', currencyFormat);
+  .factory('currencyFormat', currencyFormat);
 
 currencyFormat.$inject = [
-  'CurrencyService', '$http', 'Store'
+  'CurrencyService', '$http', 'Store',
 ];
 
 function currencyFormat(Currencies, $http, Store) {
-  var currencyConfigurationPath = '/i18n/currency/';
-  var loadedSupportedCurrencies = false;
-  var supportedCurrencies = new Store({identifier : 'id'});
-  var currentFormats = new Store({identifier : 'format_key'});
-  var fetchingKeys = [];
-  var invalidCurrency = { supported : false };
+  const currencyConfigurationPath = '/i18n/currency/';
+  let loadedSupportedCurrencies = false;
+  const supportedCurrencies = new Store({ identifier : 'id' });
+  const currentFormats = new Store({ identifier : 'format_key' });
+  const fetchingKeys = [];
+  const invalidCurrency = { supported : false };
 
   // Request all defined BHIMA currencies
   Currencies.read()
-  .then(function (currencies) {
-    supportedCurrencies.setData(currencies);
-    loadedSupportedCurrencies = true;
+    .then(currencies => {
+      supportedCurrencies.setData(currencies);
+      loadedSupportedCurrencies = true;
 
-    // automatically load all currency formats at startup
-    currencies.forEach(function (currency) {
-      searchFormatConfiguration(currency.id);
+      // automatically load all currency formats at startup
+      currencies.forEach(currency => {
+        searchFormatConfiguration(currency.id);
+      });
     });
-  });
 
   // Requests individual currency configurations
   function fetchFormatConfiguration(key) {
-    var formatObject = null;
+    let formatObject = null;
     fetchingKeys[key] = true;
 
     $http.get(currencyConfigurationPath.concat(key.toLowerCase(), '.json'))
-      .then(function (response) {
+      .then(response => {
 
         // Add configuration to local cache
         formatObject = response.data;
@@ -46,7 +45,7 @@ function currencyFormat(Currencies, $http, Store) {
         formatObject.format_key = key;
         addFormat(formatObject);
       })
-      .catch(function (err) {
+      .catch(() => {
 
         // Deny future attempts to request this configuration
         formatObject = invalidCurrency;
@@ -60,21 +59,22 @@ function currencyFormat(Currencies, $http, Store) {
   }
 
   /**
-   * @param {number} currencyId ID of currency to be checked against BHIMA's database
+   * Seach format configuration
    *
+   * @param {number} currencyId - ID of currency to be checked against BHIMA's database
    * @returns {object} Returns format configuration if it has been found and fetched,
    * objects reporting unsupported status if configuration or currency cannot be found
    */
   function searchFormatConfiguration(currencyId) {
-    var supportedCurrency = supportedCurrencies.get(currencyId);
+    const supportedCurrency = supportedCurrencies.get(currencyId);
 
     if (angular.isUndefined(supportedCurrency)) {
       return invalidCurrency;
     }
 
     // currency has been identified - search for configuration
-    var formatKey = supportedCurrency.format_key;
-    var progress = fetchingKeys[formatKey];
+    const formatKey = supportedCurrency.format_key;
+    const progress = fetchingKeys[formatKey];
 
     // initial for request for currency with this key - initialise configuration request
     if (!angular.isDefined(progress)) {
@@ -85,6 +85,8 @@ function currencyFormat(Currencies, $http, Store) {
   }
 
   /**
+   * Report status
+   *
    * @returns {boolean} Exposes status of initial currency index cache request
    */
   function reportStatus() {
@@ -93,6 +95,6 @@ function currencyFormat(Currencies, $http, Store) {
 
   return {
     request : searchFormatConfiguration,
-    indexReady : reportStatus
+    indexReady : reportStatus,
   };
 }

--- a/client/src/modules/purchases/registry/registry.js
+++ b/client/src/modules/purchases/registry/registry.js
@@ -117,7 +117,7 @@ function PurchaseRegistryController(
     enableSorting : false,
   }, {
     field : 'action',
-    displayName : '...',
+    displayName : '',
     enableFiltering : false,
     enableColumnMenu : false,
     enableSorting : false,

--- a/client/src/modules/purchases/templates/packaged.tmpl.html
+++ b/client/src/modules/purchases/templates/packaged.tmpl.html
@@ -1,6 +1,6 @@
 <div class="ui-grid-cell-contents">
   <div class="text-right" ng-if="row.entity.package_size > 1">
-    {{ row.entity.number_packages }}  {{ 'INVENTORY.UNITS.BOX.TEXT' | translate }} : ({{ row.entity.package_size }}) 
-    // {{ 'FORM.LABELS.PACKAGE_UNIT_COST' | translate }} : {{ row.entity.box_unit_price | currency: row.entity.currency_id: '4' }}
+    {{ row.entity.number_packages }}  {{ 'INVENTORY.UNITS.BOX.TEXT' | translate }} : ({{ row.entity.package_size }})
+    // {{ 'FORM.LABELS.PACKAGE_UNIT_COST' | translate }} : {{ row.entity.box_unit_price | currency: row.entity.currency_id:4 }}
   </div>
 </div>

--- a/client/src/modules/purchases/templates/purchase_price.tmpl.html
+++ b/client/src/modules/purchases/templates/purchase_price.tmpl.html
@@ -1,6 +1,5 @@
 <div class="ui-grid-cell-contents">
   <div class="text-right">
-    {{ row.entity.inventory_purchase_price | currency: row.entity.currency_id: '4' }}
-    <!-- {{ row.entity.inventory_purchase_price }} -->
+    {{ row.entity.inventory_purchase_price | currency: row.entity.currency_id:4 }}
   </div>
 </div>

--- a/test/client-unit/components/bhDateEditor.spec.js
+++ b/test/client-unit/components/bhDateEditor.spec.js
@@ -56,7 +56,7 @@ function bhDateEditorTests() {
     $compile = _$compile_;
     $scope = _$rootScope_.$new();
 
-    Session.create(Mocks.user(), Mocks.enterprise(), Mocks.project());
+    Session.create(Mocks.user(), Mocks.enterprise(), Mocks.stock_settings(), Mocks.project());
 
     // spy on the onChange callback
     $scope.date = new Date();

--- a/test/client-unit/filters/currency.spec.js
+++ b/test/client-unit/filters/currency.spec.js
@@ -1,0 +1,169 @@
+/* global inject, expect */
+describe('Currency Filter', () => {
+
+  const FC = 1;
+  const USD = 2;
+
+  let $httpBackend;
+
+  let currency;
+
+  beforeEach(module(
+    'bhima.services',
+    'bhima.filters',
+    'angularMoment',
+    'ngStorage',
+    'ui.router',
+    'pascalprecht.translate',
+  ));
+
+  beforeEach(inject(($filter, _$httpBackend_) => {
+    $httpBackend = _$httpBackend_;
+
+    currency = $filter('currency');
+
+    const currencies = [{
+      id : 1,
+      symbol : 'FC',
+      format_key : 'fc',
+      name : 'Congolese Francs',
+      min_monentary_unit : 50,
+    }, {
+      id : 2,
+      symbol : 'USD',
+      format_key : 'usd',
+      name : 'US Dollars',
+      min_monentary_unit : 0.01,
+    }, {
+      id : 3,
+      symbol : '€',
+      format_key : 'EUR',
+      name : 'Euro',
+      min_monentary_unit : 0.01,
+    }];
+
+    const currencyInfo = {
+      fc : {
+        CURRENCY_SYM : 'FC',
+        DECIMAL_SEP : ',',
+        GROUP_SEP : '.',
+        PATTERNS : [
+          {
+            gSize : 3,
+            lgSize : 3,
+            maxFrac : 3,
+            minFrac : 0,
+            minInt : 1,
+            negPre : '-',
+            negSuf : '',
+            posPre : '',
+            posSuf : '',
+          },
+          {
+            gSize : 3,
+            lgSize : 3,
+            maxFrac : 2,
+            minFrac : 2,
+            minInt : 1,
+            negPre : '-',
+            negSuf : '\u00a0\u00a4',
+            posPre : '',
+            posSuf : '\u00a0\u00a4',
+          },
+        ],
+      },
+      usd : {
+        CURRENCY_SYM : '$',
+        DECIMAL_SEP : '.',
+        GROUP_SEP : ',',
+        PATTERNS : [
+          {
+            gSize : 3,
+            lgSize : 3,
+            maxFrac : 3,
+            minFrac : 0,
+            minInt : 1,
+            negPre : '-',
+            negSuf : '',
+            posPre : '',
+            posSuf : '',
+          },
+          {
+            gSize : 3,
+            lgSize : 3,
+            maxFrac : 2,
+            minFrac : 2,
+            minInt : 1,
+            negPre : '-\u00a4',
+            negSuf : '',
+            posPre : '\u00a4',
+            posSuf : '',
+          },
+        ],
+      },
+      euro : {},
+    };
+
+    $httpBackend.when('GET', '/currencies')
+      .respond(currencies);
+
+    $httpBackend.when('GET', '/i18n/currency/fc.json')
+      .respond(currencyInfo.fc);
+
+    $httpBackend.when('GET', '/i18n/currency/usd.json')
+      .respond(currencyInfo.usd);
+
+    $httpBackend.when('GET', '/i18n/currency/eur.json')
+      .respond(currencyInfo.euro);
+  }));
+
+  // make sure $http is clean after tests
+  afterEach(() => {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  it('formats plain positive numbers', () => {
+    $httpBackend.flush();
+    expect(currency(4.4, FC)).to.equal('4,40 FC');
+    expect(currency(4.4, USD)).to.equal('$4.40');
+  });
+
+  it('formats plain negative numbers', () => {
+    $httpBackend.flush();
+    expect(currency(-4.4, FC)).to.equal('-4,40 FC'); // <-- non-breaking space
+    expect(currency(-4.4, USD)).to.equal('-$4.40');
+  });
+
+  it('formats infinities', () => {
+    $httpBackend.flush();
+    expect(currency(Infinity, FC)).to.equal('∞ FC');
+    expect(currency(-1 * Infinity, FC)).to.equal('-∞ FC');
+  });
+
+  it('formats numbers with exponents', () => {
+    $httpBackend.flush();
+    expect(currency(4.4e3, FC)).to.equal('4.400,00 FC');
+    expect(currency(-4.4e3, FC)).to.equal('-4.400,00 FC');
+    expect(currency(4.4e3, USD)).to.equal('$4,400.00');
+    expect(currency(-4.4e3, USD)).to.equal('-$4,400.00');
+  });
+
+  it('formatting kills numbers with large negative exponents', () => {
+    $httpBackend.flush();
+    expect(currency(4.4e-8, FC)).to.equal('0.00 FC');
+    expect(currency(4.4e-8, USD)).to.equal('$0.00');
+  });
+
+  it('formats formats with number of digits after the decimal', () => {
+    $httpBackend.flush();
+    expect(currency(4.5463, USD, 0)).to.equal('$5');
+    expect(currency(4.4356, USD, 0)).to.equal('$4');
+    expect(currency(4.4356, USD, 1)).to.equal('$4.4');
+    expect(currency(4.4356, USD, 2)).to.equal('$4.44');
+    expect(currency(4.4356, USD, 3)).to.equal('$4.436');
+    expect(currency(4.4356, USD, 4)).to.equal('$4.4356');
+    expect(currency(4.4356, USD, 5)).to.equal('$4.43560');
+  });
+
+});

--- a/test/client-unit/services/ExchangeRateService.spec.js
+++ b/test/client-unit/services/ExchangeRateService.spec.js
@@ -23,7 +23,7 @@ describe('ExchangeRateService', () => {
     Mocks = _MockDataService_;
 
     const enterprise = Mocks.enterprise();
-    Session.create(Mocks.user(), Mocks.enterprise(), Mocks.project());
+    Session.create(Mocks.user(), Mocks.enterprise(), Mocks.stock_settings(), Mocks.project()); // ??? fix
 
     const rates = [{
       id : 1,

--- a/test/client-unit/services/PasswordMeterService.spec.js
+++ b/test/client-unit/services/PasswordMeterService.spec.js
@@ -22,8 +22,9 @@ describe('PasswordMeterService', () => {
 
     const user = _MockDataService_.user();
     const project = _MockDataService_.project();
+    const stockSettings = _MockDataService_.stock_settings();
     const enterprise = _MockDataService_.enterprise();
-    Session.create(user, enterprise, project);
+    Session.create(user, enterprise, stockSettings, project);
 
     // make sure password validation is on
     Session.enterprise.settings.enable_password_validation = true;

--- a/test/client-unit/services/PatientInvoiceForm.spec.js
+++ b/test/client-unit/services/PatientInvoiceForm.spec.js
@@ -34,7 +34,7 @@ describe('PatientInvoiceForm', () => {
     $timeout = _$timeout_;
 
     // set up the required properties for the session
-    Session.create(Mocks.user(), Mocks.enterprise(), Mocks.project());
+    Session.create(Mocks.user(), Mocks.enterprise(), Mocks.stock_settings(), Mocks.project());
 
     httpBackend = $httpBackend;
 

--- a/test/client-unit/services/PurchaseOrderFormService.spec.js
+++ b/test/client-unit/services/PurchaseOrderFormService.spec.js
@@ -38,7 +38,7 @@ describe('PurchaseOrderForm', () => {
     $timeout = _$timeout_;
 
     // set up the required properties for the session
-    Session.create(Mocks.user(), Mocks.enterprise(), Mocks.project());
+    Session.create(Mocks.user(), Mocks.enterprise(), Mocks.stock_settings(), Mocks.project());
 
     httpBackend = $httpBackend;
 


### PR DESCRIPTION
Fixed issues with the currency filter (it was ignoring the third option for numDecimals).
Added client-unit tests.  See test/client-unit/filters/currency.spec.js

Usage in html for 3 digits after the decimal:

    ```<span>23.2 | currrency : Session.enterprise.currency_id:3</span>```

Closes https://github.com/IMA-WorldHealth/bhima/issues/4656

**TESTING**
- Use bhima_test
- run tests:  npm run test:client-unit
- run bhima:  npm run dev
- Go to the Purchase registry, observe the prices have 2 digits after the decimal.
- Go to the Detailed purchase registry.
   - Use the default search to chose "All time"
   - Observe that the unit costs have 4 digits after the decimal
