### PR TITLE
Test adding an end-to-end test to the semaphore CI configuration

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -64,6 +64,7 @@ blocks:
             - 'yarn test:client-unit'
             - 'yarn test:integration'
             - 'yarn test:integration:stock'
+            - 'yarn test:e2e-account'
           matrix:
             - env_var: MYSQL_VERSION
               values:


### PR DESCRIPTION
This PR adds some end-to-end tests into the semaphore CI configuration so at least some of the end-to-end tests run when github/semaphore tests new PRs.

I tried adding test:e2e-stock to the CI tests, but it failed.  I think the testing virtual machines do not have enough memory or power.

Adding test:e2e-account increases the test times for PRs from about 3 minutes to nearly 6 minutes.
