### PR TITLE
Fixed issue with the Stock Expiration Report selection page

### DIFF
--- a/client/src/modules/reports/generate/stock_expiration_report/stock_expiration_report.config.js
+++ b/client/src/modules/reports/generate/stock_expiration_report/stock_expiration_report.config.js
@@ -60,6 +60,11 @@ function StockExpirationReportConfigCtrl($sce, Notify, SavedReports, AppCache, r
       return 0;
     }
 
+    // Clear previously selected depot UUID if not doing specific depot
+    if (!vm.chooseOneDepot) {
+      delete vm.reportDetails.depot_uuid;
+    }
+
     // update cached configuration
     cache.reportDetails = formatData(vm.reportDetails);
 


### PR DESCRIPTION
FIx minor issue with Stock Expiration Report selection page.

Closes https://github.com/IMA-WorldHealth/bhima/issues/7250

*TESTING*
- Use bhima_test
- Go to `Stock > Reports > Stock Expiration Report`
- Select a currency
- Select the `One Specific Currency` option
- Select 'Depot Secondaire'
- Do the preview.   There should be no expired stock.
- Refresh the form
- Select the `One Specific Depot` option
- Select 'Depot Secondaire' again
- Unselect the `One Specific Depot` option (the depot selector should disappear)
- Now preview the form.   You should see only the Depot Principal expired stock (since there is no expired stock in the other depots).

This now works correctly.  If you did this before, you would have seen the report for the Depot Secondaire -- in other words it remembered your depot selection if though you unselected the `One Sepecific Depot`.