### PR TITLE
fix(invoices): improve receipt currency rendering

### DIFF
--- a/client/src/i18n/fr/periods.json
+++ b/client/src/i18n/fr/periods.json
@@ -13,7 +13,7 @@
     "START" : "Début",
     "END" : "Fin",
     "PERIOD_LIMIT" : "Limite de Période",
-    "PERIOD_LIMIT_OPTIONAL" : "Limite de Période (optinnelle)",
+    "PERIOD_LIMIT_OPTIONAL" : "Limite de Période (facultatif)",
     "CUSTOM_FROM" : "de",
     "CUSTOM_TO" : "à",
     "SELECT_PERIOD" : "Choisir une Période",

--- a/server/controllers/finance/reports/invoices/receipt.handlebars
+++ b/server/controllers/finance/reports/invoices/receipt.handlebars
@@ -103,7 +103,7 @@
           {{/each}}
           <tr style="font-weight: bold;">
             <td class="text-right text-capitalize" style="border:0px">{{translate 'FORM.LABELS.TOTAL'}} ({{translate 'FORM.LABELS.INVOICING_FEES'}}) = </td>
-            <td class="text-right" style="border:0px">+{{currency (sum billing 'value') ../metadata.enterprise.currency_id}}</td>
+            <td class="text-right" style="border:0px">+{{currency (sum billing 'value') metadata.enterprise.currency_id}}</td>
           </tr>
         </table>
       {{/if}}
@@ -114,7 +114,7 @@
         <table style="width: 100%;" class="table-report">
           <tr style="border:0px">
             <td class="text-right" style="border:0px">
-              <b>-{{currency (sum subsidy 'value') metadata.enterprise.currency_id}}</b>
+              <b>{{debcred (multiply (sum subsidy 'value') -1)  metadata.enterprise.currency_id}}</b>
             </td>
           </tr>
         </table>

--- a/test/integration/reports/finance/invoices.receipt.js
+++ b/test/integration/reports/finance/invoices.receipt.js
@@ -5,13 +5,13 @@ const RenderingTests = require('../rendering');
 
 const target = '/reports/finance/invoices/';
 
-describe(`(${target}) Invoice Receipt`, function () {
+describe(`(${target}) Invoice Receipt`, () => {
 
   const validInvoice = '957e4e79-a6bb-4b4d-a8f7-c42152b2c2f6';
 
   const keys = [
     'billing', 'cost', 'date', 'debtor_name', 'debtor_uuid', 'description', 'display_name',
-    'items', 'metadata', 'patient_uuid', 'recipient', 'reference', 'subsidy', 'user_id', 'uuid', 'currency_id'
+    'items', 'metadata', 'patient_uuid', 'recipient', 'reference', 'subsidy', 'user_id', 'uuid', 'currency_id',
   ];
 
   // set up the rendering test suite and execute it
@@ -19,13 +19,13 @@ describe(`(${target}) Invoice Receipt`, function () {
   suite();
 
   // known data for requests and assertions
-  const invoiceItemLength  = 1;
-  const invalidInvoice    = 'unknown';
+  const invoiceItemLength = 1;
+  const invalidInvoice = 'unknown';
 
-  it(`GET ${target}:uuid should return JSON data for a valid invoice uuid`, function () {
+  it(`GET ${target}:uuid should return JSON data for a valid invoice uuid`, () => {
     return agent.get(target.concat(validInvoice))
       .query({ renderer : 'json' })
-      .then(function (result) {
+      .then((result) => {
         expect(result).to.have.status(200);
         expect(result).to.be.json;
         expect(result.body.items).to.have.length(invoiceItemLength);
@@ -33,9 +33,9 @@ describe(`(${target}) Invoice Receipt`, function () {
       .catch(helpers.handler);
   });
 
-  it(`GET ${target}:uuid should return not found for invalid uuid`, function () {
+  it(`GET ${target}:uuid should return not found for invalid uuid`, () => {
     return agent.get(target.concat(invalidInvoice))
-      .then(function (result) {
+      .then((result) => {
         helpers.api.errored(result, 404);
       })
       .catch(helpers.handler);


### PR DESCRIPTION
This commit fixes two bugs in receipt rendering:

1. The subsidies now follow the deb/cred convention we have previously established (Closes #6923).
2. The currency is properly rendered for totals of billing services (found while fixing this issue).

In addition, I also found a typo in the French translation of the period limit text and fixed that here.

Closes #6923.

Screenshots of changes:
<img width="915" alt="Screenshot 2023-10-09 at 3 20 12 PM" src="https://github.com/IMA-WorldHealth/bhima/assets/896472/6f99747d-918e-474e-a2ee-50b2fa256d57">
<img width="915" alt="Screenshot 2023-10-09 at 3 25 54 PM" src="https://github.com/IMA-WorldHealth/bhima/assets/896472/e517c424-d7d3-476c-b500-5b6701f739a0">
