### PR TITLE
Add the enable external access flag to users

### DIFF
--- a/client/src/i18n/en/users.json
+++ b/client/src/i18n/en/users.json
@@ -6,6 +6,8 @@
     "CREATE" : "Create",
     "CREATED" : "Created",
     "DESCRIPTION" : "User management unit and rights",
+    "ENABLE_EXTERNAL_ACCESS" : "Enable External Access",
+    "ENABLE_EXTERNAL_ACCESS_DESCRIPTION" : "Unlocks the user account on external sites that mirror the hospital database.  The user will be able to log in with their username and password on mirrored sites.",
     "PASSWORD_MISMATCH" : "Passwords entered are not the same",
     "PASSWORDPOLICY" : "To conform with our Strong Password policy, the password must be more than 7 characters. It must include a special character (e.g. @), one or more numerical digits, and both uppercase and lowercase letters.",
     "PERMISSIONS" : "Permissions",

--- a/client/src/i18n/fr/users.json
+++ b/client/src/i18n/fr/users.json
@@ -6,6 +6,8 @@
     "CREATE" : "Créer",
     "CREATED" : "Crée avec succés",
     "DESCRIPTION" : "Module de gestion des utilisateur et leurs droits",
+    "ENABLE_EXTERNAL_ACCESS" : "Activer l'accès externe",
+    "ENABLE_EXTERNAL_ACCESS_DESCRIPTION" : "Déverrouille le compte utilisateur sur les sites externes qui reflètent la base de données de l'hôpital. L'utilisateur pourra se connecter avec son nom d'utilisateur et son mot de passe sur des sites Web en miroir.",
     "PASSWORD_MISMATCH" : "Les mots de passe fournis ne sont pas identiques",
     "PASSWORDPOLICY" : "Pour se conformer à notre politique de mot de passe fort, le mot de passe doit avoir plus de 7 caractères contentant au moins un caractère spécial (ex.: @, #) , un ou plusiers chiffres ansi que les lettres majuscules et miniscules",
     "PERMISSIONS" : "Permissions",

--- a/client/src/js/components/bhUser.js
+++ b/client/src/js/components/bhUser.js
@@ -33,10 +33,6 @@ function bhUser(Users, $translate) {
   function _loadUser(userId) {
     Users.read(userId)
       .then((user) => {
-        // sanitise user according to server API alias of `lastLogin`
-        // @TODO(sfount) this should be standardised across the application
-        //               as the database record, last_login should be used
-        user.last_login = user.lastLogin;
         $ctrl.user = user;
       });
   }

--- a/client/src/modules/users/user.modal.html
+++ b/client/src/modules/users/user.modal.html
@@ -13,10 +13,7 @@
       </li>
     </ol>
   </div>
-
-  <div class="modal-body" style="overflow-y: scroll; max-height:600px; ">
-
-    <div class="form-group" ng-class="{ 'has-error' : UserForm.$submitted && UserForm.display_name.$invalid }">
+<div class="modal-body" style="overflow-y: scroll; max-height:600px; "> <div class="form-group" ng-class="{ 'has-error' : UserForm.$submitted && UserForm.display_name.$invalid }">
       <label class="control-label" translate>FORM.LABELS.DISPLAY_NAME</label>
       <input
         name="display_name"
@@ -139,6 +136,19 @@
             ng-model="UserModalCtrl.user.is_admin">
           <span translate>USERS.SUPER</span>
         </label>
+      </div>
+    </div>
+
+    <div class="form-group" ng-if="!UserModalCtrl.isCreateState">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" name="enable_external_access" ng-true-value="1" ng-false-value="0"
+            ng-model="UserModalCtrl.user.enable_external_access">
+          <span translate>USERS.ENABLE_EXTERNAL_ACCESS</span>
+        </label>
+      </div>
+      <div class="help-block">
+        <p translate>USERS.ENABLE_EXTERNAL_ACCESS_DESCRIPTION</p>
       </div>
     </div>
   </div>

--- a/client/src/modules/users/users.js
+++ b/client/src/modules/users/users.js
@@ -67,7 +67,7 @@ function UsersController($state, $uibModal, Users, Notify, Modal, uiGridConstant
         cellClass : muteDisabledCells,
       },
       {
-        field : 'lastLogin',
+        field : 'last_login',
         type : 'date',
         displayName : 'USERS.LAST_LOGIN',
         cellFilter : 'date:"dd/MM/yyyy HH:mm:ss"',

--- a/client/src/modules/users/users.service.js
+++ b/client/src/modules/users/users.service.js
@@ -85,7 +85,7 @@ function UserService(Api, Filters, bhConstants, AppCache, Periods) {
   function update(id, user) {
 
     // delete properties that should not be updated
-    delete user.lastLogin;
+    delete user.last_login;
     delete user.id;
     delete user.active;
     delete user.roles;

--- a/server/controllers/admin/users/index.js
+++ b/server/controllers/admin/users/index.js
@@ -11,7 +11,6 @@
  * @requires BadRequest
  */
 
-const _ = require('lodash');
 const db = require('../../../lib/db');
 const FilterParser = require('../../../lib/filter');
 const NotFound = require('../../../lib/errors/NotFound');
@@ -52,7 +51,7 @@ async function lookupUser(id) {
 
   let sql = `
     SELECT user.id, user.username, user.email, user.display_name,
-      user.active, user.last_login AS lastLogin, user.deactivated, user.is_admin,
+      user.active, user.last_login AS lastLogin, user.deactivated, user.is_admin, user.enable_external_access,
       GROUP_CONCAT(DISTINCT role.label ORDER BY role.label DESC SEPARATOR ', ') AS roles,
       GROUP_CONCAT(DISTINCT depot.text ORDER BY depot.text DESC SEPARATOR ', ') AS depots,
       GROUP_CONCAT(DISTINCT cb.label ORDER BY cb.label DESC SEPARATOR ', ') AS cashboxes
@@ -101,6 +100,7 @@ async function list(req, res, next) {
   try {
     const sql = `
       SELECT user.id, user.display_name, user.username, user.deactivated, user.last_login as lastLogin,
+        user.enable_external_access,
         GROUP_CONCAT(DISTINCT role.label ORDER BY role.label DESC SEPARATOR ', ') AS roles,
         GROUP_CONCAT(DISTINCT depot.text ORDER BY depot.text DESC SEPARATOR ', ') AS depots,
         GROUP_CONCAT(DISTINCT cb.label ORDER BY cb.label DESC SEPARATOR ', ') AS cashboxes
@@ -254,7 +254,7 @@ function update(req, res, next) {
 
   // begin updating the user if data was sent back (the user might has
   // simply sent permissions changes).
-  if (!_.isEmpty(data)) {
+  if (Object.keys(data).length !== 0) {
     transaction
       .addQuery('UPDATE user SET ? WHERE id = ?;', [data, req.params.id]);
   }

--- a/server/controllers/admin/users/index.js
+++ b/server/controllers/admin/users/index.js
@@ -51,7 +51,7 @@ async function lookupUser(id) {
 
   let sql = `
     SELECT user.id, user.username, user.email, user.display_name,
-      user.active, user.last_login AS lastLogin, user.deactivated, user.is_admin, user.enable_external_access,
+      user.active, user.last_login, user.deactivated, user.is_admin, user.enable_external_access,
       GROUP_CONCAT(DISTINCT role.label ORDER BY role.label DESC SEPARATOR ', ') AS roles,
       GROUP_CONCAT(DISTINCT depot.text ORDER BY depot.text DESC SEPARATOR ', ') AS depots,
       GROUP_CONCAT(DISTINCT cb.label ORDER BY cb.label DESC SEPARATOR ', ') AS cashboxes
@@ -99,7 +99,7 @@ async function list(req, res, next) {
 
   try {
     const sql = `
-      SELECT user.id, user.display_name, user.username, user.deactivated, user.last_login as lastLogin,
+      SELECT user.id, user.display_name, user.username, user.deactivated, user.last_login,
         user.enable_external_access,
         GROUP_CONCAT(DISTINCT role.label ORDER BY role.label DESC SEPARATOR ', ') AS roles,
         GROUP_CONCAT(DISTINCT depot.text ORDER BY depot.text DESC SEPARATOR ', ') AS depots,

--- a/server/controllers/inventory/depots/extra.js
+++ b/server/controllers/inventory/depots/extra.js
@@ -35,7 +35,7 @@ async function getInventoryWac(req, res, next) {
   try {
     const binaryInventoryUuid = db.bid(req.params.inventoryUuid);
     const querySelect = `
-      SELECT 
+      SELECT
         BUID(sv.inventory_uuid) inventory_uuid,
         i.text, sv.date, sv.quantity, sv.wac
       FROM stock_value sv
@@ -98,7 +98,7 @@ async function getInventory(req, res, next) {
 async function getUsers(req, res, next) {
   const sql = `
     SELECT user.id, user.username, user.email, user.display_name,
-      user.active, user.last_login AS lastLogin, user.deactivated,
+      user.active, user.last_login, user.deactivated,
       GROUP_CONCAT(DISTINCT role.label ORDER BY role.label DESC SEPARATOR ', ') AS roles,
       GROUP_CONCAT(DISTINCT cb.label ORDER BY cb.label DESC SEPARATOR ', ') AS cashboxes
     FROM user

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -36,3 +36,11 @@ CALL add_column_if_missing('enterprise_setting', 'percentage_fixed_bonus', 'TINY
  */
 ALTER TABLE `employee` DROP COLUMN  `is_medical`;
 CALL add_column_if_missing('title_employee', 'is_medical', 'TINYINT(1) DEFAULT 0');
+
+/**
+ * author: jniles
+ * description: enable_external_access allows backup scripts to determine which
+ * user accounts to leave unlocked.
+ * date: 2023-10-17
+*/
+CALL add_column_if_missing('user', 'enable_external_access', 'TINYINT(1) NOT NULL DEFAULT 0');

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1808,6 +1808,7 @@ CREATE TABLE `user` (
   `created_at`    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at`    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `is_admin`      TINYINT(1) NOT NULL DEFAULT 0,
+  `enable_external_access`      TINYINT(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `user_1` (`username`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;

--- a/server/models/schema.sql
+++ b/server/models/schema.sql
@@ -1808,7 +1808,7 @@ CREATE TABLE `user` (
   `created_at`    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at`    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `is_admin`      TINYINT(1) NOT NULL DEFAULT 0,
-  `enable_external_access`      TINYINT(1) NOT NULL DEFAULT 0,
+  `enable_external_access`   TINYINT(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `user_1` (`username`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;

--- a/test/integration/users.js
+++ b/test/integration/users.js
@@ -33,6 +33,7 @@ describe('(/users) Users and Permissions', () => {
     'bd4b1452-4742-e4fa-a128-246814140877',
   ];
 
+  // this is a depot uuid
   const depotManagementSupervision = 'F9CAEB16168443C5A6C447DBAC1DF296';
   const usersManagement = [2];
   const usersSupervision = [3, 4];
@@ -164,7 +165,7 @@ describe('(/users) Users and Permissions', () => {
       .catch(helpers.handler);
   });
 
-  it('DELETE /users/:id will not possible to delete the user who have Permissions', () => {
+  it('DELETE /users/:id will not delete a user who has permissions set', () => {
     return agent.delete(`/users/${newUser.id}`)
       .then(res => {
         helpers.api.errored(res, 400);
@@ -173,9 +174,9 @@ describe('(/users) Users and Permissions', () => {
   });
 
   // Add depot permissions for user
-  it('POST /users/:id/depots will create user depots', () => {
+  it('POST /users/:id/depots will assign some depots to a user', () => {
     return agent.post(`/users/${newUser.id}/depots`)
-      .send({ depots }) // just the root node
+      .send({ depots })
       .then(res => {
         expect(res).to.have.status(201);
         return agent.get(`/users/${newUser.id}/depots`);
@@ -189,9 +190,9 @@ describe('(/users) Users and Permissions', () => {
   });
 
   // Add depot supervision for user
-  it('POST /users/:id/depotsSupervision will create user depots for Supervision', () => {
+  it('POST /users/:id/depotsSupervision will create user depots for supervision', () => {
     return agent.post(`/users/${newUser.id}/depotsSupervision`)
-      .send({ depots : depotsSupervision }) // just the root node
+      .send({ depots : depotsSupervision })
       .then(res => {
         expect(res).to.have.status(201);
         return agent.get(`/users/${newUser.id}/depotsSupervision`);
@@ -205,7 +206,7 @@ describe('(/users) Users and Permissions', () => {
   });
 
   // Assign users management permissions for depot
-  it('POST /users/:uuid/depotUsersManagment : Assign users management permissions for depot', () => {
+  it('POST /users/:uuid/depotUsersManagment : assign users management permissions for depot', () => {
     return agent.post(`/users/${depotManagementSupervision}/depotUsersManagment`)
       .send({ users : usersManagement })
       .then(res => {
@@ -220,7 +221,7 @@ describe('(/users) Users and Permissions', () => {
   });
 
   // Assign users supervision permissions for depot
-  it('POST /users/:uuid/depotUsersSupervision : Assign users supervision permissions for depot', () => {
+  it('POST /users/:uuid/depotUsersSupervision: assign users supervision permissions for depot', () => {
     return agent.post(`/users/${depotManagementSupervision}/depotUsersSupervision`)
       .send({ users : usersSupervision })
       .then(res => {
@@ -253,7 +254,7 @@ describe('(/users) Users and Permissions', () => {
   // Add cashbox permissions for user
   it('POST /users/:id/cashboxes will create user cashboxes', () => {
     return agent.post(`/users/${newUser.id}/cashboxes`)
-      .send({ cashboxes }) // just the root node
+      .send({ cashboxes })
       .then(res => {
         expect(res).to.have.status(201);
         return agent.get(`/users/${newUser.id}/cashboxes`);
@@ -267,7 +268,7 @@ describe('(/users) Users and Permissions', () => {
   });
 
   // Reset cashbox permissions for user
-  it('POST /users/:id/cashboxes will reset user cashboxes', () => {
+  it('POST /users/:id/cashboxes with empty array will reset user cashboxes', () => {
     return agent.post(`/users/${newUser.id}/cashboxes`)
       .send({ cashboxes : [] })
       .then(res => {
@@ -282,7 +283,7 @@ describe('(/users) Users and Permissions', () => {
       .catch(helpers.handler);
   });
 
-  it('POST /users/:id/cashboxes will reject invalid data formats', () => {
+  it('POST /users/:id/cashboxes will reject invalid data', () => {
     return agent.post(`/users/${newUser.id}/cashboxes`)
       .send({ })
       .then((result) => {


### PR DESCRIPTION
Implements the `enable_external_access` flag on the `user` table.  It is modifiable on the user edit modal.  There is not functionality linked in BHIMA for this flag, rather, it is designed to allow our backup scripts to determine which user accounts to lock and which to leave open.  See #7287 for a full explanation.

To test:
 1. Log in to the test database.
 2. Use the "action" dropdown menu to edit a user.
 3. Click the checkbox on the bottom of the user modal and confirm it updates when saving and editing.

Screenshots:
<img width="625" alt="Screenshot 2023-10-17 at 8 57 15 PM" src="https://github.com/IMA-WorldHealth/bhima/assets/896472/67a4b107-db9f-4573-9bd5-08ae175bf448">

@mbayopanda, this French translation could probably be cleaned up a lot 🤷 😆 

Closes #7287.