### PR TITLE
Updated test reporting script to neaten output

### DIFF
--- a/sh/test-show-results.sh
+++ b/sh/test-show-results.sh
@@ -9,49 +9,68 @@ fi
 echo "TEST RESULTS SUMMARY"
 echo
 if test -f "./results/client-unit-report"; then
-  sed -i -e 's/\x1b\[1A//g' ./results/client-unit-report  # Remove ANSI sequence that disrupts the display
+  sed -i -e 's/\x1b\[1A//g' ./results/client-unit-report  # Remove ANSI move sequences that disrupts the display
   echo "Client Unit Tests"
   echo "   " `grep "TOTAL" ./results/client-unit-report`
+  failed=`grep -i "FAIL" ./results/client-unit-report`
+  if [ "$failed" ]; then echo "   $failed"; fi
   echo
 fi
 if test -f "./results/server-unit-report"; then
-  sed -i -e 's/\x1b\[1A//g' ./results/server-unit-report  # Remove ANSI sequence that disrupts the display
+  sed -i -e 's/\x1b\[1A//g' ./results/server-unit-report  # Remove ANSI move sequences that disrupts the display
   echo "Server Unit Tests"
   echo "   " `grep 'passing' ./results/server-unit-report`
-  echo "   " `grep 'failing' ./results/server-unit-report`
+  failed=`grep 'failing' ./results/server-unit-report`
+  if [ "$failed" ]; then echo "   $failed"; fi
   echo
 fi
 if test -f "./results/integration-report"; then
-  sed -i -e 's/\x1b\[1A//g' ./results/integration-report  # Remove ANSI sequence that disrupts the display
+  sed -i -e 's/\x1b\[1A//g' ./results/integration-report  # Remove ANSI move sequences that disrupts the display
   echo "Integration Tests"
   echo "   " `grep passing ./results/integration-report`
-  echo "   " `egrep -e '(failing|pending)' ./results/integration-report`
+  pending=`egrep -e 'pending' ./results/integration-report`
+  if [ "$pending" ]; then echo "   $pending"; fi
+  failed=`egrep -e 'failing' ./results/integration-report`
+  if [ "$failed" ]; then echo "   $failed"; fi
   echo
 fi
 if test -f "./results/integration-stock-report"; then
-  sed -i -e 's/\x1b\[1A//g' ./results/integration-stock-report  # Remove ANSI sequence that disrupts the display
+  sed -i -e 's/\x1b\[1A//g' ./results/integration-stock-report  # Remove ANSI move sequences that disrupts the display
   echo "Stock Integration Tests"
   echo "   " `grep passing ./results/integration-stock-report`
-  echo "   " `egrep -e '(failing|pending)' ./results/integration-stock-report`
+  pending=`egrep -e 'pending' ./results/integration-stock-report`
+  if [ "$pending" ]; then echo "   $pending"; fi
+  failed=`egrep -e 'failing' ./results/integration-stock-report`
+  if [ "$failed" ]; then echo "   $failed"; fi
   echo
 fi
 
 # Show the E2E account tests, if available
 if test -f "./results/end-to-end-report-account"; then
-  sed -i -e 's/\x1b\[1A//g' ./results/end-to-end-report-account  # Remove ANSI sequence that disrupts the display
+  sed -i -e 's/\x1b\[1A//g' ./results/end-to-end-report-account  # Remove ANSI move sequences that disrupts the display
   echo "End-to-end account tests (Playwright)"
   echo "   " `grep passed ./results/end-to-end-report-account`
-  echo "   " `egrep -e '([0-9]+ failing|[0-9]+ failed|[0-9]+ pending|[0-9]+ skipped|[0-9]+ flakey)' ./results/end-to-end-report-account`
+  pending=`egrep -e '([0-9]+ pending)' ./results/end-to-end-report-account`
+  if [ "$pending" ]; then echo "   $pending"; fi
+  skipped=`egrep -e '([0-9]+ skipped|[0-9]+ flakey)' ./results/end-to-end-report-account`
+  if [ "$skipped" ]; then echo "   $skipped"; fi
+  failed=`egrep -e '([0-9]+ failing|[0-9]+ failed)' ./results/end-to-end-report-account`
+  if [ "$failed" ]; then echo "   $failed"; fi
   echo
 fi
 
 # Show all the E2E tests, if available
 for i in {1..8}; do
   if test -f "./results/end-to-end-report-$i"; then
-    sed -i -e 's/\x1b\[1A//g' ./results/end-to-end-report-$i  # Remove ANSI sequence that disrupts the display
+    sed -i -e 's/\x1b\[1A//g' ./results/end-to-end-report-$i  # Remove ANSI move sequences that disrupts the display
     echo "End-to-end tests $i (Playwright)"
     echo "   " `grep passed ./results/end-to-end-report-$i`
-    echo "   " `egrep -e '([0-9]+ failing|[0-9]+ failed|[0-9]+ pending|[0-9]+ skipped|[0-9]+ flakey)' ./results/end-to-end-report-$i`
+    pending=`egrep -e '([0-9]+ pending)' ./results/end-to-end-report-$i`
+    if [ "$pending" ]; then echo "   $pending"; fi
+    skipped=`egrep -e '([0-9]+ skipped|[0-9]+ flakey)' ./results/end-to-end-report-$i`
+    if [ "$skipped" ]; then echo "   $skipped"; fi
+    failed=`egrep -e '([0-9]+ failing|[0-9]+ failed)' ./results/end-to-end-report-$i`
+    if [ "$failed" ]; then echo "   $failed"; fi
     echo
   fi
 done


### PR DESCRIPTION
Only impacts format of `npm run test:show-results`
