### PR TITLE
generate short token

### DIFF
--- a/server/config/jwt.js
+++ b/server/config/jwt.js
@@ -4,18 +4,14 @@ const config = {
   secret : process.env.SESS_SECRET,
 };
 
-function verify(req, successCallBack, failedCallBack) {
-  const token = req.headers['x-access-token'];
-  if (!token) {
-    return failedCallBack({ auth : false, message : 'No token provided. x-access-token should be provided' });
-  }
-  return jwt.verify(token, config.secret, (err, decoded) => {
-    if (err) {
-      failedCallBack(err);
-    } else {
-      // if everything good, save to request for use in other routes
-      successCallBack(decoded);
-    }
+function verify(token) {
+  return new Promise((resolve, reject) => {
+    jwt.verify(token, config.secret, (err, decoded) => {
+      if (err) {
+        reject(err);
+      }
+      resolve(decoded);
+    });
   });
 }
 

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -35,7 +35,7 @@ function loginRoute(req, res, next) {
     .then(session => {
       // bind the session variables
       _.merge(req.session, session);
-      session.token = JWTConfig.create(session);
+      session.token = JWTConfig.create({ ...session.user });
       // send the session data back to the client
       res.status(200).json(session);
     })

--- a/test/integration/remoteAccess.js
+++ b/test/integration/remoteAccess.js
@@ -56,7 +56,7 @@ describe('/remote access APIs', () => {
       .set('x-access-token', 'my wrong token')
       .send(validUser)
       .then(res => {
-        expect(res).to.have.status(401);
+        expect(res).to.have.status(500);
       })
       .catch(helpers.handler);
   });


### PR DESCRIPTION
Reduce the size of the token, because after authentication with the mobile application, it refuses to recover the data following the size of the token which was too large.