### PR TITLE
Refactor server unit tests

### DIFF
--- a/sh/integration-stock-tests.sh
+++ b/sh/integration-stock-tests.sh
@@ -17,7 +17,7 @@ echo "[test] Spawning server process..."
 
 echo "[test] running tests using mocha"
 # run the tests
-SUITE_NAME="BHIMA Integration Stock Tests" MOCHA_OUTPUT="results/integration-stock-report.xml" ./node_modules/.bin/mocha test/integration-stock --timeout 20000 \
+SUITE_NAME="BHIMA Stock Integration Tests" MOCHA_OUTPUT="results/integration-stock-report.xml" ./node_modules/.bin/mocha test/integration-stock --timeout 20000 \
   --reporter mocha-multi-reporters --reporter-options configFile="mocha-reporter-options.js" 2>&1 | tee ./results/integration-stock-report
 
 echo "[/test]"

--- a/sh/server-unit-tests.sh
+++ b/sh/server-unit-tests.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# bash strict mode
+set -euo pipefail
+
+# Make sure results directory exists
+if [[ ! -d results ]]; then
+  echo "Creating 'results' directory"
+  mkdir results
+fi
+
+# Kill the BHIMA server when the test is finished
+if [[ -z "${CI:-}" ]]
+then
+  trap 'jobs -p | xargs -r kill' EXIT
+fi
+
+echo "Building Test Databases"
+./sh/build-database.sh || { echo 'failed to build DB' ; exit 1; }
+
+echo "[test]"
+
+echo "[test] building the server..."
+# build the server
+./node_modules/.bin/gulp build
+
+echo "[test] running server unit tests using mocha"
+# run the tests
+SUITE_NAME="BHIMA Server Unit Tests" MOCHA_OUTPUT="results/server-unit-report.xml" ./node_modules/.bin/mocha test/server-unit \
+  --reporter mocha-multi-reporters --reporter-options configFile="mocha-reporter-options.js" 2>&1 | tee ./results/server-unit-report
+
+echo "[/test]"

--- a/sh/test.sh
+++ b/sh/test.sh
@@ -42,8 +42,7 @@ fi
 # run server-unit test
 if [ $SUITE = "server-unit" ] || [ $SUITE = "ALL" ] ; then
   startfold "Running server Unit Tests ......" "server-unit"
-  SUITE_NAME="BHIMA Server Unit Tests" MOCHA_OUTPUT="results/server-unit-report.xml" ./node_modules/.bin/mocha test/server-unit \
-    --reporter mocha-multi-reporters --reporter-options configFile="mocha-reporter-options.js" 2>&1 | tee ./results/server-unit-report
+  ./sh/server-unit-tests.sh
   endfold "server-unit" ;
 fi
 


### PR DESCRIPTION
Move the test code for the server unit tests into a separate shell script, so that additional checks can be done.
Hopefully this will address a problem on the End-to-end test server.
Normal operation of the basic tests and the server unit tests should not be affected.
