### PR TITLE
chore: update testing standards

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,9 +1,0 @@
-status = [
-  "ci/semaphoreci/%"
-]
-
-delete_merged_branches = true
-
-timeout_sec = 14400
-
-cut_body_after = "</details>"

--- a/client/src/i18n/fr/account_statement.json
+++ b/client/src/i18n/fr/account_statement.json
@@ -3,6 +3,6 @@
     "TITLE":"Relevé de compte",
     "COMMENT":"Commentaire",
     "SELECTED_ROWS":"Ligne(s) selectionnée(s)",
-    "SUCCESSFULLY_COMMENTED":"Ligne(s) commentées avec succès" 
+    "SUCCESSFULLY_COMMENTED":"Ligne(s) commentées avec succès"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,5 @@
 const { defineConfig, devices } = require('@playwright/test');
+require('dotenv').config();
 
 /**
  * Read environment variables from file.
@@ -59,7 +60,7 @@ module.exports = defineConfig({
     actionTimeout : 0,
 
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL : 'http://localhost:8080',
+    baseURL : `http://localhost:${process.env.PORT || 8080}`,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     // trace: 'on-first-retry',


### PR DESCRIPTION
This PR does two things:

  1. Removes the legacy bors configuration from the repo.  
  2. Calls dotenv before running playwright tests to ensure that server is running on $PORT configured in the users dotenv, rather than hardcoded 8080.  Defaults back to 8080 for compatibility reasons.

