### PR TITLE
Fix integration tests for round-off errors

### DIFF
--- a/server/controllers/stock/functions/rumer.function.js
+++ b/server/controllers/stock/functions/rumer.function.js
@@ -23,6 +23,7 @@ const DEFAULT_PARAMS = {
  */
 async function getData(reqQuery) {
   const params = reqQuery;
+
   params.depotUuid = params.depotUuid || params.depot_uuid;
   params.exclude_out_stock = parseInt(params.exclude_out_stock, 10);
   params.include_daily_balances = parseInt(params.include_daily_balances, 10);
@@ -31,7 +32,6 @@ async function getData(reqQuery) {
   const data = {};
   const headerReport = [];
   const configurationData = [];
-
   params.start_date = moment(new Date(params.start_date)).format('YYYY-MM-DD');
   params.end_date = moment(new Date(params.end_date)).format('YYYY-MM-DD');
 

--- a/test/integration/stock/rumer.js
+++ b/test/integration/stock/rumer.js
@@ -14,8 +14,8 @@ describe('test/integration/stock Stock Depot RUMER data REST API', () => {
       .get(`/stock/rumer`)
       .query({
         depot_uuid : depotUuid,
-        start_date : startDate,
-        end_date : endDate,
+        start_date : `${startDate}T00:00:01`, //  Hack to avoid roundoff changing the date
+        end_date : `${endDate}T00:00:01`, // Hack to avoid roundoff changing the date
       })
       .then((res) => {
         const data = res.body;


### PR DESCRIPTION
In some cases on my dev environment, the test 'GET /stock/rumer (test/integration/stock/rumer.js)' was changing the startDate from '2022-01-01' to '2021-12-31'.  I believe this due to the following sequence of commands in the test (and related files):

- `get('/stock/rumer')` with params.startDate = 2022-01-01
- The startDate is massaged in server/controllers/stock/functions/rumer.function.js : getData
  - `params.start_date = moment(new Date(params.start_date)).format('YYYY-MM-DD');`
  - This last line changes start_date as shown above.

Not sure why this happening.   Is it related to the time zone or time of day?

However, the hack in the test file forces the moment to reconstruct the start_date string correctly.