### PR TITLE
feat(payroll): add service to the excel export

### DIFF
--- a/server/controllers/payroll/multiplePayrollIndice/index.js
+++ b/server/controllers/payroll/multiplePayrollIndice/index.js
@@ -14,7 +14,7 @@ exports.parameters = require('./paramter.config');
 exports.reports = require('./report');
 
 // retrieve indice's value for employee(s)
-async function read(req, res, next) {
+function read(req, res, next) {
   lookUp(req.query).then(rows => {
     res.status(200).json(rows);
   }).catch(next);
@@ -68,11 +68,10 @@ function create(req, res, next) {
 
 // retrieve indice's value for employee(s)
 async function lookUp(options) {
-
   const payConfigId = options.payroll_configuration_id;
   const employeeUuid = options.employee_uuid;
 
-  const employeSql = `
+  const employeeSql = `
     SELECT BUID(emp.uuid) as uuid,UPPER(pt.display_name) AS display_name, pt.sex, service.name as service_name
     FROM payroll_configuration pc
       JOIN config_employee ce ON ce.id = pc.config_employee_id
@@ -111,7 +110,7 @@ async function lookUp(options) {
     employeeParams.push(db.bid(employeeUuid));
   }
 
-  const employees = await db.exec(employeSql, employeeParams);
+  const employees = await db.exec(employeeSql, employeeParams);
   const employeesMap = {};
   employees.forEach(employee => {
     employeesMap[employee.uuid] = employee;

--- a/server/controllers/payroll/multiplePayrollIndice/report.js
+++ b/server/controllers/payroll/multiplePayrollIndice/report.js
@@ -15,9 +15,9 @@ const REPORT_TEMPLATE = './server/controllers/payroll/multiplePayrollIndice/repo
 exports.document = multipayIndiceExport;
 
 /**
- * GET reports/finance/journal
+ * GET reports/finance/multiplepayrollIndice
  *
- * @method postingJournalExport
+ * @method multipayIndiceExport
  */
 function multipayIndiceExport(req, res, next) {
 
@@ -39,7 +39,7 @@ function multipayIndiceExport(req, res, next) {
 
   return multipayIndice.lookUp(options).then(indices => {
     const { employees, rubrics } = indices;
-    const rows = setGridData(employees, rubrics);
+    const rows = getEmployeeRubricMatrix(employees, rubrics);
     return report.render({ rows });
   })
     .then((result) => {
@@ -48,20 +48,30 @@ function multipayIndiceExport(req, res, next) {
     .catch(next);
 }
 
-function setGridData(employees, rubrics) {
-  const data = [];
-  const headers = { display_name : '' };
-  rubrics.forEach(r => {
-    headers[r.abbr] = '';
-  });
+/**
+ * @function getEmployeeRubricMatrix
+ *
+ * @description
+ * This function takes a list of employees and their assigned rubrics and returns
+ * a matrix of the employees by rubrics for display in a grid.
+ */
+function getEmployeeRubricMatrix(employees, rubrics) {
+  const headers = { display_name : '', service : '' };
 
-  employees.forEach(employee => {
-    const row = _.clone(headers);
-    row.display_name = employee.display_name;
+  rubrics.forEach(r => { headers[r.abbr] = ''; });
+
+  // return a matrix of employees by rubrics
+  return employees.map(employee => {
+    const row = {
+      display_name : employee.display_name,
+      service : employee.service_name,
+    };
+
+    // map each rubric into columns
     employee.rubrics.forEach(r => {
       row[r.rubric_abbr] = r.rubric_value;
     });
-    data.push(row);
+
+    return row;
   });
-  return data;
 }


### PR DESCRIPTION
Adds the service to the Excel export of the Multiple Payroll Indice report.

In order to test, please navigate to the Multiple Payroll Indice grid:
  1. In the tree, `Payroll > Indexes > Multiple Payroll (Index-based)` (`#!/multiple_payroll_indice`).
  2. Configure the report for a payment period, if necessary.
  3. Go to the menu, and download the Excel report (`Menu > Download as Excel`).
  4. Notice the second column in the Excel report is `Service`.

Compare this to `master`, where no service column exists.

Closes #7383.