### PR TITLE
fix(vouchers): remove patientName column

### DIFF
--- a/client/src/modules/vouchers/voucher-registry.ctrl.js
+++ b/client/src/modules/vouchers/voucher-registry.ctrl.js
@@ -87,10 +87,6 @@ function VoucherController(
     cellTemplate : 'modules/journal/templates/created_at.cell.html',
     visible : false,
   }, {
-    name : 'patientName',
-    displayName : 'TABLE.COLUMNS.PATIENT',
-    headerCellFilter : 'translate',
-  }, {
     field : 'description',
     displayName : 'TABLE.COLUMNS.DESCRIPTION',
     headerCellFilter : 'translate',


### PR DESCRIPTION
Removes the patientName column that was accidentally copied and pasted in by yours truly, two years ago.  This is the PR that introduced the bug: https://github.com/IMA-WorldHealth/bhima/pull/6246.

The code was accidentally lifted from the patient registry which does have a patientName column.

