### PR TITLE
Modified the rumer integration test to work in different time zones

### DIFF
--- a/test/integration/stock/rumer.js
+++ b/test/integration/stock/rumer.js
@@ -14,8 +14,8 @@ describe('test/integration/stock Stock Depot RUMER data REST API', () => {
       .get(`/stock/rumer`)
       .query({
         depot_uuid : depotUuid,
-        start_date : startDate,
-        end_date : endDate,
+        start_date : `${startDate}T00:00:00`, // Forces treating it as local time, not UTC
+        end_date : `${endDate}T00:00:00`, // Forces treating it as local time, not UTC
       })
       .then((res) => {
         const data = res.body;


### PR DESCRIPTION
When I run the integration tests in Pacific time (UTC - 8 hours), the RUMER integration test fails.  I tracked this down to the way that the Javascript `Date()` function treats inputs.  If the input is only a date, it interprets it as UTC, but if it includes a time, it treats it as local time.  (See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format).  I was able to work around the problem with the test by adding a time component to the date strings in the test.  

This is apparently the same issue pointed out by @sfount  in Issue https://github.com/IMA-WorldHealth/bhima/issues/1793.  Also by @mbayopanda in Issue https://github.com/IMA-WorldHealth/bhima/issues/3157.

See also Issue https://github.com/IMA-WorldHealth/bhima/issues/7385.

If this passes the github CI/semaphore tests, I think this modification will not present problems for running tests in DR Congo.

@jniles, please run the integration tests in your time zone.

Note: This PR only impacts tests, so should not prevent moving ahead on a release.




