### PR TITLE
Install only chromium browser for semaphore end-to-end test

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -57,7 +57,7 @@ blocks:
             - checkout
             - 'echo "Testing node:$NODEJS_VERSION on mysql:$MYSQL_VERSION"'
             - yarn --ignore-engines
-            - npx playwright install
+            - npx playwright install chromium
             - 'yarn build:db'
             - yarn build
             - mkdir results


### PR DESCRIPTION
In the past, semaphore uses the command `npx playwright install` to install the Playwright dependencies.  However this install all three browsers.  But the semaphore end-to-end tests are only run against Chromium.  This update only installs chromium, not the other two browsers.  I might speed up the CI testing a bit.
