### PR TITLE
Prevent importing budget data for locked accounts

### DIFF
--- a/client/src/i18n/en/budget.json
+++ b/client/src/i18n/en/budget.json
@@ -23,6 +23,7 @@
     "IMPORT_BUDGET_ERROR_ACCT_TYPE": "ERROR: Budget import failed!  Check for incorrect Type values (should be 'title', 'income', or 'expense').",
     "IMPORT_BUDGET_ERROR_ACCT_TYPE_INCORRECT": "ERROR: Budget import failed!  Account type does not match account in the database.",
     "IMPORT_BUDGET_ERROR_BAD_BUDGET_VALUE": "ERROR: Budget import failed!  Budget value is not a number.",
+    "IMPORT_BUDGET_ERROR_LOCKED_ACCOUNT": "ERROR: Budget import failed!  The budget import data includes a locked account. Please remove it and try again : ",
     "IMPORT_BUDGET_ERROR_NEGATIVE_BUDGET_VALUE": "ERROR: Budget import failed!  Budget value is negative.",
     "IMPORT_BUDGET_WARN_TITLE_BUDGET_IGNORED": "WARNING: Budget values for title accounts are ignored",
     "INCOME_TOTAL": "Income Total",

--- a/client/src/i18n/fr/budget.json
+++ b/client/src/i18n/fr/budget.json
@@ -23,6 +23,7 @@
     "IMPORT_BUDGET_ERROR_ACCT_TYPE": "ERREUR : L'importation du budget a échoué !  Vérifier si les valeurs de type sont incorrectes (elles devraient être 'title', 'income', ou 'expense').",
     "IMPORT_BUDGET_ERROR_ACCT_TYPE_INCORRECT": "ERREUR : L'importation du budget a échoué !  Le type de compte ne correspond pas au compte dans la base de données.",
     "IMPORT_BUDGET_ERROR_BAD_BUDGET_VALUE": "ERREUR : L'importation du budget a échoué !  La valeur du budget n'est pas un nombre.",
+    "IMPORT_BUDGET_ERROR_LOCKED_ACCOUNT": "ERREUR : L'importation du budget a échoué !  Les données d'importation du budget comprennent un compte bloqué. Veuillez le supprimer et réessayer :",
     "IMPORT_BUDGET_ERROR_NEGATIVE_BUDGET_VALUE": "ERREUR : L'importation du budget a échoué !  La valeur du budget est négative.",
     "IMPORT_BUDGET_WARN_TITLE_BUDGET_IGNORED": "ATTENTION : Les valeurs budgétaires des comptes titres sont ignorées.",
     "INCOME_TOTAL": "Revenu totales",


### PR DESCRIPTION
Although PR https://github.com/IMA-WorldHealth/bhima/pull/7435 prevents the budget module from displaying locked accounts, it did not prevent budget imports from doing that.

This PR prevents importing budget data that includes accounts that are locked.  It errors out and prints an error message.

Closes https://github.com/IMA-WorldHealth/bhima/issues/7439

*TESTING*
- Use bhima_test, rebuild the database (`npm run build:db`)
- Use the **Finance > Budget Management** > Menu > Export YTD Budget Data (CSV)
- Edit the exported CSV and add a budget to several accounts such as 7011* (Vente...)
- In BHIMA, use the **Finance > Budget Management** > Menu > Import Bdget CSV file.  This should work.
- In the **Finance > Account Management** page, lock an account, such as 70112010 Vente d'actifs
- Return to the **Finance > Budget Management** page.  The locked account should not be visible.
- Try importing the same CSV file as before.  It should fail with a message showing which account is locked.  At this point, all the exiting budget data for the FY should be erased.
- Edit the CSV file and remove the line for the locked account.
- Repeat trying to import the BUDGET data.  It should work this time
