### PR TITLE
fix: remove '...' from action column headers

### DIFF
--- a/client/src/modules/functions/functions.js
+++ b/client/src/modules/functions/functions.js
@@ -36,7 +36,7 @@ function FunctionManagementController(Functions, Modals, Notify, uiGridConstants
     }, {
       field : 'action',
       width : 80,
-      displayName : '...',
+      displayName : '',
       cellTemplate : '/modules/functions/templates/action.tmpl.html',
       enableSorting : false,
       enableFiltering : false,
@@ -79,7 +79,6 @@ function FunctionManagementController(Functions, Modals, Notify, uiGridConstants
           .catch(Notify.handleError);
       });
   }
-
 
   loadFunctions();
 }

--- a/client/src/modules/prices/modal/createItems.js
+++ b/client/src/modules/prices/modal/createItems.js
@@ -91,7 +91,7 @@ function PriceListItemsModalController(
   }, {
     field : 'actions',
     width : 25,
-    displayName : '...',
+    displayName : '',
     cellTemplate : `/modules/prices/templates/delete_price_item.tmpl.html`,
   }];
 

--- a/client/src/modules/purchases/detailed/registry.js
+++ b/client/src/modules/purchases/detailed/registry.js
@@ -159,7 +159,7 @@ function PurchaseDetailedController(
     enableSorting : false,
   }, {
     field : 'action',
-    displayName : '...',
+    displayName : '',
     enableFiltering : false,
     enableColumnMenu : false,
     enableSorting : false,

--- a/client/src/modules/titles/titles.js
+++ b/client/src/modules/titles/titles.js
@@ -42,7 +42,7 @@ function TitleManagementController(Titles, Modals, Notify, uiGridConstants) {
     }, {
       field : 'action',
       width : 80,
-      displayName : '...',
+      displayName : '',
       cellTemplate : '/modules/titles/templates/action.tmpl.html',
       enableSorting : false,
       enableFiltering : false,

--- a/client/src/modules/vouchers/voucher-registry.ctrl.js
+++ b/client/src/modules/vouchers/voucher-registry.ctrl.js
@@ -108,7 +108,7 @@ function VoucherController(
     headerCellFilter : 'translate',
   }, {
     field : 'action',
-    displayName : '...',
+    displayName : '',
     enableFiltering : false,
     enableColumnMenu : false,
     enableSorting : false,


### PR DESCRIPTION
This commit removes the '...' from action column headers in ui-grids on registries.  This prevents them from appearing in column selection modals and users cannot hide them.

Closes #7477.