### PR TITLE
Clean up after end-to-end tests

### DIFF
--- a/sh/test-e2e-all.sh
+++ b/sh/test-e2e-all.sh
@@ -39,6 +39,15 @@ for i in {1..8}; do
 done
 date
 
+# Delete left-over zombie server process
+procs=`netstat -tulpn |& grep 8080` || true
+proc=`echo $procs | sed -r 's/.* ([0-9]+)\/node$/\1/g'`
+if [[ ! -z "$proc" ]]
+then
+    echo "Deleting zombie node Bhima process $proc"
+    kill -9 $proc || true
+fi
+
 # Show summary of results
 ./sh/test-show-results.sh
 


### PR DESCRIPTION
Occasionally, when running all the end-to-end test, the playwright server process is not cleaned up after the tests complete.  
This PR adds a final Playwright server process cleanup.
