### PR TITLE
fix(journal): sanitize added account props

### DIFF
--- a/client/src/modules/journal/journal.service.js
+++ b/client/src/modules/journal/journal.service.js
@@ -85,6 +85,7 @@ function JournalService(Api, AppCache, Filters, Periods, Modal, bhConstants, Tra
       delete row.project_name;
       delete row.display_name;
       delete row.posted;
+      delete row.account_type_id;
     });
 
     return rows.data;


### PR DESCRIPTION
This commit ensures that newly added accounts will be properly sanitized, and all their extra properties removed before submission to the server.

Closes #7527.

Follow the steps to reproduce in the issue to reproduce this issue.