### PR TITLE
Fix rendering of installation docs

### DIFF
--- a/docs/en/for-developers/installing-bhima.md
+++ b/docs/en/for-developers/installing-bhima.md
@@ -47,11 +47,11 @@ NODE_MAJOR=20
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 sudo apt-get update
 sudo apt-get install nodejs
-```
 
 # Verify that nodejs and npm are installed as expected
 npm --version
 node --version
+```
 
 ```bash
 # Installs yarn without re-installing NodeJS


### PR DESCRIPTION
Fixes an issue in the rendering of the installation documentation that causes the verify step to look strange.

Previously:

<img width="575" alt="image" src="https://github.com/IMA-WorldHealth/bhima/assets/896472/01d57a6b-cd64-4d3b-a95f-530dc0a9b104">
