### PR TITLE
Fix integration stock tests 

### DIFF
--- a/test/data/core.sql
+++ b/test/data/core.sql
@@ -109,6 +109,9 @@ CALL CreateFiscalYear(1, @fiscalYear2021, @superUser, 'Fiscal Year 2022', 12, DA
 SET @fiscalYear2023 = 0;
 CALL CreateFiscalYear(1, @fiscalYear2022, @superUser, 'Fiscal Year 2023', 12, DATE('2023-01-01'), DATE('2023-12-31'), 'Notes for 2023', @fiscalYear2023);
 
+SET @fiscalYear2024 = 0;
+CALL CreateFiscalYear(1, @fiscalYear2023, @superUser, 'Fiscal Year 2024', 12, DATE('2024-01-01'), DATE('2024-12-31'), 'Notes for 2024', @fiscalYear2024);
+
 --
 -- Project permission
 --


### PR DESCRIPTION
This PR adds FY2024 to the test/data/core.sql file to fix a problem with integration stock tests.

Basically, the tests relied on finding a period `@two_months_ago` which failed when the data changed to March 1 (since there was no FY2024 defined and therefore no periods for FY2024.   This PR simply defines FY2024 in the `core.sql` file and the tests now pass again.
