### PR TITLE
Improvements for the payroll settings page

### DIFF
--- a/client/src/modules/payroll/settings/settings.html
+++ b/client/src/modules/payroll/settings/settings.html
@@ -9,7 +9,7 @@
 <div class="flex-content">
   <div class="container-fluid">
     <form name="PayrollSettingsForm" bh-submit="PayrollSettingsCtrl.submit(PayrollSettingsForm)"
-      ng-model-options="{ updateOn: 'blur' }" novalidate>
+      ng-model-options="{ updateOn: 'default' }" novalidate>
 
       <div class="panel panel-default">
         <div class="panel-heading">
@@ -45,7 +45,7 @@
             </div>
             <span class="help-block" translate>
               SETTINGS.BASE_INDEX_GROWTH_RATE_HELP_TEXT
-            </span>                
+            </span>
             <div class="help-block" ng-messages="PayrollSettingsForm.base_index_growth_rate.$error" ng-show="PayrollSettingsForm.$submitted">
               <div ng-messages-include="modules/templates/messages.tmpl.html"></div>
             </div>
@@ -65,7 +65,9 @@
             on-change-callback="PayrollSettingsCtrl.enableActivatePensionFundSetting(value)">
           </bh-yes-no-radios>
 
-          <div class="form-group" ng-class="{ 'has-error' : PayrollSettingsForm.$submitted && PayrollSettingsForm.pension_transaction_type_id.$invalid }">
+          <div class="form-group"
+            ng-if="PayrollSettingsCtrl.enterprise.settings.enable_activate_pension_fund"
+            ng-class="{ 'has-error' : PayrollSettingsForm.$submitted && PayrollSettingsForm.pension_transaction_type_id.$invalid }">
             <label class="control-label" translate>
               FORM.LABELS.TRANSACTION_TYPE_PENSION
             </label>
@@ -82,8 +84,7 @@
 
               <ui-select-choices
                 ui-select-focus-patch
-                repeat="item.id as item in PayrollSettingsCtrl.types | filter:{ 'plainText' : $select.search }"
-                group-by="PayrollSettingsCtrl.groupTransactionByType">
+                repeat="item.id as item in PayrollSettingsCtrl.types | filter:{ 'plainText' : $select.search }">
                 <div ng-bind-html="item.plainText | highlight: $select.search"></div>
               </ui-select-choices>
             </ui-select>
@@ -97,6 +98,7 @@
           </div>
 
           <hr>
+
           <div class="form-group" ng-class="{ 'has-error' : PayrollSettingsForm.$submitted && PayrollSettingsForm.base_index_growth_rate.$invalid }">
             <label class="control-label" translate>
               SETTINGS.PERCENTAGE_ATTRIBUTED_FIXED_BONUS

--- a/client/src/modules/payroll/settings/settings.js
+++ b/client/src/modules/payroll/settings/settings.js
@@ -55,8 +55,14 @@ function PayrollSettingsController(
       return 0;
     }
 
-    const changes = {};
+    if (vm.enterprise.settings.enable_activate_pension_fund
+      && vm.enterprise.settings.pension_transaction_type_id === 0) {
+      form.pension_transaction_type_id.$invalid = true;
+      Notify.danger('FORM.ERRORS.MISSING');
+      return 0;
+    }
 
+    const changes = {};
     changes.settings = angular.copy(vm.enterprise.settings);
     const promise = Enterprises.update(vm.enterprise.id, changes);
 
@@ -66,23 +72,18 @@ function PayrollSettingsController(
       .catch(Notify.handleError);
   }
 
-  /**
-     * @function proxy
-     *
-     * @description
-     * Proxies requests for different payroll settings.
-     *
-     * @returns {function}
-     */
-  function proxy(key) {
-    return (enabled) => {
-      vm.enterprise.settings[key] = enabled;
-      $touched = true;
-    };
-  }
+  vm.enableIndexPaymentSetting = (val) => {
+    vm.enterprise.settings.enable_index_payment_system = val;
+    $touched = true;
+  };
 
-  vm.enableIndexPaymentSetting = proxy('enable_index_payment_system');
-  vm.enableActivatePensionFundSetting = proxy('enable_activate_pension_fund');
+  vm.enableActivatePensionFundSetting = (val) => {
+    vm.enterprise.settings.enable_activate_pension_fund = val;
+    if (!vm.enterprise.settings.enable_activate_pension_fund) {
+      vm.enterprise.settings.pension_transaction_type_id = 0;
+    }
+    $touched = true;
+  };
 
   startup();
 }


### PR DESCRIPTION
This PR does 2 things:

(1) It hides the pension transaction type selector if the "Enable Pension Fund Handling" is enabled and hides it otherwise.

(2) If the "Enable Pension Fund Handling" is enabled, you must select a pension transaction type

Closes https://github.com/IMA-WorldHealth/bhima/issues/7671

**TESTING**

- Use bhima_test
- Open the payroll settings page:   Human Resources > Payroll Settings
- By default, the "Enable Pension Fund Handling" is disabled.  The selector for the pension transaction type should not be visible.
- Click on the "Yes" option of "Enable Pension Fund Handling".  The selector for the pension transaction type should appear.
- Try submitting without selecting a pension transaction type.  This should produce an error and the pension transaction type selector should be marked in red
- Select a pension transaction type and save the payroll settings.  This should work.
- Log out, kill the browser.  Stop the BHIMA server.
- Restart the BHIMA server.   Open the browser, log into BHIMA.  Go to the payroll settings page.
- The pension settings should be remembered.
- "No" option of "Enable Pension Fund Handling" and save the settings.   This should work.
- Click on the "Yes" option of "Enable Pension Fund Handling".  Note that the pension transaction type has been cleared.