### PR TITLE
feat(debtors): add option to filter client reports by solvency

### DIFF
--- a/client/src/i18n/en/debtor_group.json
+++ b/client/src/i18n/en/debtor_group.json
@@ -23,13 +23,17 @@
     "NEW_DEBTOR_GROUP": "New Debtor Group",
     "NO_GROUPS" : "No debtor groups found",
     "POLICIES": {
+      "CONVENTIONED": "Conventioned",
+      "INSOLVENT": "Insolvent",
+      "NOT_ASSIMILATED_CLIENT": "Not assimilated to client",
+      "SOLVENT": "Solvent",
       "TITLE": "Group Policies",
       "SUBSIDIES": {
-        "TITLE": "Subsidies",
+        "EMPTY": "This debtor group is not subscribed to any subsidies",
         "INFO": "With this configuration unchecked no member of this debtor group will qualify for any subsidies",
         "LABEL": "This group qualifies for subsidies",
-        "UPDATE": "Update Subsidies",
-        "EMPTY": "This debtor group is not subscribed to any subsidies"
+        "TITLE": "Subsidies",
+        "UPDATE": "Update Subsidies"
       },
       "DISCOUNTS": {
         "TITLE": "Discounts",
@@ -42,7 +46,8 @@
         "LABEL": "This group is exempt from paying invoicing fees",
         "UPDATE": "Update Invoicing Fees",
         "EMPTY": "This debtor group is not subscribed to any invoicing fees"
-      }
+      },
+      "NON_CLIENT_DEBTOR_GROUPS": "Non-Client Debtor Groups"
     },
     "TITLE": "Debtor Group Management",
     "SUBSCRIBED": "Debtors subscribed",
@@ -50,6 +55,7 @@
     "LOADING": "Fetching Debtor Group",
     "CONVENTION": {
       "TITLE": "Convention",
+      "DEBTOR_GROUP_INSOLVENT": "This debtor group is insolvent",
       "DESCRIPTION": "The invoices of debtors in this group will be covered by this debtor group's account. Patients belonging to this group will be blocked from paying their bills at the cash window.",
       "CANNOT_PAY": "This patient does not pay invoices. Its invoices are covered by"
     },

--- a/client/src/i18n/en/report.json
+++ b/client/src/i18n/en/report.json
@@ -82,12 +82,22 @@
     "CHART_OF_ACCOUNTS": "Chart of Accounts",
     "CLIENTS": {
       "TITLE" : "Annual Clients Report",
+      "CLIENTS_REPORT": "Clients Report",
       "DESCRIPTION": "This report displays all the debtor groups, their account balances at the beginning of the fiscal year, the debits and credits to their accounts, and their ending balances.",
+      "GLOBAL_DEBTOR_GROUP_REPORT": "Global Report of Debtor Groups",
       "HIDE_LOCKED_CLIENTS" : "Hide Locked Clients",
       "HIDE_LOCKED_CLIENTS_HELP_TEXT" : "Selecting yes will filter out all locked clients from the report.  By default, the value is no.",
       "INCLUDE_CASH_CLIENTS" : "Include Cash Clients",
       "INCLUDE_CASH_CLIENTS_HELP_TEXT" : "Selecting this option will add in cash debtor groups.  By default only non-cash clients (conventions) are queried.",
-      "NO_LOCKED_CLIENTS_FOUND" : "No locked clients found."
+      "INSOLVENT_CLIENTS_REPORT" : "Insolvent Clients Report",
+      "NO_LOCKED_CLIENTS_FOUND" : "No locked clients found.",
+      "BLOCKED_CLIENTS_REPORT": "Blocked Clients Report",
+      "REPORT_DEBT_GROUP_NON_CLIENT": "Report of debtor groups categorized as non-Clients (Cash Clients)",
+      "REPORT_OF_CONVENTIONED_CLIENTS": "Report of conventioned clients",
+      "REPORT_OF_NON_CONVENTIONED_CLIENTS": "Report of non-contracted customers",
+      "REPORT_SOLVENT_CLIENTS" : "Solvent Clients Report",
+      "OVERALL_CUSTOMER_REPORT": "Overall Customer Report",
+      "SHOW_ALL_DEBTOR_GROUPS": "Show all debtor groups"
     },
     "CLOSING_BALANCE": "Closing Balance",
     "COMPARE_INVOICED_RECEIVED": {

--- a/client/src/i18n/fr/debtor_group.json
+++ b/client/src/i18n/fr/debtor_group.json
@@ -24,13 +24,17 @@
     "NEW_DEBTOR_GROUP": "Nouveau Groupe de Débiteur",
     "NO_GROUPS" : "Aucun Groupe Débiteur trouvés",
     "POLICIES": {
+      "CONVENTIONED": "Conventioné",
+      "INSOLVENT": "Insolvable",
+      "NOT_ASSIMILATED_CLIENT": "Non assimilé aux clients",
+      "SOLVENT": "Solvable",      
       "TITLE": "Les stratégies de groupe",
       "SUBSIDIES": {
-        "TITLE": "Subventions",
+        "EMPTY": "Ce groupe de Débiteurs n'est pas souscrit à des subventions",
         "INFO": "Avec cette configuration, aucun membre de ce Groupe Débiteur ne sera subventionné",
         "LABEL": "Ce groupe est qualifié pour les subventions",
-        "UPDATE": "Mettre à jour les subventions",
-        "EMPTY": "Ce groupe de Débiteurs n'est pas souscrit à des subventions"
+        "TITLE": "Subventions",
+        "UPDATE": "Mettre à jour les subventions"
       },
       "DISCOUNTS": {
         "TITLE": "Réductions",
@@ -43,13 +47,15 @@
         "LABEL": "Ce Groupe est exempté du paiement des services de facturation",
         "EMPTY": "Ce Groupe Débiteur n'est pas abonné à des services de facturation",
         "UPDATE": "Mettre à jour les services de facturation"
-      }
+      },
+      "NON_CLIENT_DEBTOR_GROUPS": "Groupes Débiteurs Non-Clients"
     },
     "TITLE": "Gestion des Groupes des Débiteurs",
     "SUBSCRIBED": "Débiteurs abonnés",
     "SUBSCRIPTIONS": "Abonnements",
     "CONVENTION": {
       "TITLE": "Convention",
+      "DEBTOR_GROUP_INSOLVENT": "Ce groupe débiteur est insolvable",
       "DESCRIPTION": "Les factures des débiteurs de ce groupe seront couvertes par le compte de ce débiteur. Les patients appartenant à ce groupe seront empêchés de payer leurs factures à la caisse",
       "CANNOT_PAY": "Ce patient ne paie pas de factures. Ses factures sont couvertes par"
     },

--- a/client/src/i18n/fr/report.json
+++ b/client/src/i18n/fr/report.json
@@ -289,11 +289,20 @@
     "CLIENTS" : {
       "TITLE" : "Rapport Annuel des Clients",
       "DESCRIPTION" : "Ce rapport affiche tous les groupes de débiteurs, leurs soldes de compte au début de l'exercice, les soldes actuels et leurs soldes de clôture.",
+      "GLOBAL_DEBTOR_GROUP_REPORT": "Rapport global des groupes débiteurs",
       "HIDE_LOCKED_CLIENTS" : "Masquer les clients verrouillés",
       "HIDE_LOCKED_CLIENTS_HELP_TEXT" : "Si vous sélectionnez oui, tous les clients verrouillés seront filtrés dans le rapport. Par défaut, la valeur est non.",
       "INCLUDE_CASH_CLIENTS" : "Inclure les payant cash",
       "INCLUDE_CASH_CLIENTS_HELP_TEXT" : "La sélection de cette option ajoutera des groupes de débiteurs en espèces. Par défaut, seules les conventions sont interrogées.",
-      "NO_LOCKED_CLIENTS_FOUND" : "Aucun client bloqué n'a été trouvé."
+      "INSOLVENT_CLIENTS_REPORT" : "Rapport des clients insolvables",
+      "NO_LOCKED_CLIENTS_FOUND" : "Aucun client bloqué n'a été trouvé.",
+      "BLOCKED_CLIENTS_REPORT": "Rapport des clients bloqués",
+      "REPORT_DEBT_GROUP_NON_CLIENT": "Rapport des groupes débiteurs categorisés comme non Clients",
+      "REPORT_OF_CONVENTIONED_CLIENTS": "Rapport des clients conventionnés",
+      "REPORT_OF_NON_CONVENTIONED_CLIENTS": "Rapport des clients non conventionnés (Payant cash)",
+      "REPORT_SOLVENT_CLIENTS" : "Rapport des clients solvables",
+      "OVERALL_CUSTOMER_REPORT": "Rapport global des clients",
+      "SHOW_ALL_DEBTOR_GROUPS": "Afficher tous les groupes débiteurs"
     },
     "UNPAID_INVOICE_PAYMENTS_REPORT": {
       "TITLE": "Rapport de Factures Non-Payées",

--- a/client/src/modules/debtors/groups.create.js
+++ b/client/src/modules/debtors/groups.create.js
@@ -18,7 +18,7 @@ DebtorGroupCreateController.$inject = [
 
 function DebtorGroupCreateController(
   $state, ScrollTo, Session, DebtorGroups,
-  Accounts, Prices, Uuid, Notify, Color
+  Accounts, Prices, Uuid, Notify, Color,
 ) {
   const vm = this;
 

--- a/client/src/modules/debtors/groups.list.html
+++ b/client/src/modules/debtors/groups.list.html
@@ -43,6 +43,20 @@
                   <i class="fa fa-circle" style="color: {{ debtorGroup.color }}"></i> <b>{{debtorGroup.name}}</b>
                   <span ng-if="debtorGroup.locked" class="fa fa-lock text-danger"></span>
                 </h4>
+                <h4>
+                  <span ng-if="debtorGroup.is_insolvent" class="fa fa-exclamation-triangle text-danger"></span>
+                  <span ng-if="debtorGroup.is_insolvent" class="text-warning" translate>
+                    DEBTOR_GROUP.POLICIES.INSOLVENT
+                  </span>
+                  <span ng-if="debtorGroup.is_convention" class="fa fa-university text-primary"></span>
+                  <span ng-if="debtorGroup.is_convention" class="text-primary" translate>
+                    DEBTOR_GROUP.POLICIES.CONVENTIONED
+                  </span>
+                  <span ng-if="debtorGroup.is_non_client_debtor_groups" class="fa fa-home text-success"></span>
+                  <span ng-if="debtorGroup.is_non_client_debtor_groups" class="text-success" translate>
+                    DEBTOR_GROUP.POLICIES.NOT_ASSIMILATED_CLIENT
+                  </span>
+                </h4>
                 <h5 style="margin-top : 0px;"></span><span translate> FORM.LABELS.ACCOUNT_NUMBER </span> : <b>{{debtorGroup.account_number}}</b></h5>
               </div>
               <div class="col-md-6 text-float-util">

--- a/client/src/modules/debtors/groups.update.html
+++ b/client/src/modules/debtors/groups.update.html
@@ -162,6 +162,17 @@
                 <span translate>DEBTOR_GROUP.CONVENTION.TITLE</span>
               </label>
             </div>
+            <div class="checkbox">
+              <label>
+                <input
+                  type="checkbox"
+                  name="is_insolvent"
+                  ng-model="GroupUpdateCtrl.group.is_insolvent"
+                  ng-true-value="1"
+                  ng-false-value="0">
+                <span translate>DEBTOR_GROUP.CONVENTION.DEBTOR_GROUP_INSOLVENT</span>
+              </label>
+            </div>
           </div>
         </div>
 
@@ -187,6 +198,17 @@
                     <span translate>DEBTOR_GROUP.POLICIES.SUBSIDIES.LABEL</span>
                   </label>
                 </div>
+                <div class="checkbox">
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="is_non_client_debtor_groups"
+                      ng-model="GroupUpdateCtrl.group.is_non_client_debtor_groups"
+                      ng-true-value="1"
+                      ng-false-value="0">
+                    <span translate>DEBTOR_GROUP.POLICIES.NON_CLIENT_DEBTOR_GROUPS</span>
+                  </label>
+                </div>
               </div>
             </div>
             <div class="row">
@@ -201,7 +223,7 @@
                     <input ng-model="GroupUpdateCtrl.group.apply_discounts" name="apply_discounts" type="checkbox">
                     <span translate>DEBTOR_GROUP.POLICIES.DISCOUNTS.LABEL</span>
                   </label>
-                </div>
+                </div>           
               </div>
             </div>
             <div class="row">

--- a/client/src/modules/debtors/groups.update.js
+++ b/client/src/modules/debtors/groups.update.js
@@ -12,7 +12,7 @@ DebtorGroupsUpdateController.$inject = [
 
 function DebtorGroupsUpdateController(
   $state, DebtorGroups, Prices,
-  ScrollTo, util, Notify, Modal, Color
+  ScrollTo, util, Notify, Modal, Color,
 ) {
   const vm = this;
   vm.group = {};
@@ -51,7 +51,6 @@ function DebtorGroupsUpdateController(
       vm.$loading = false;
     });
 
-
   function formatData(group) {
     delete group.subsidies;
     delete group.invoicingFees;
@@ -73,6 +72,8 @@ function DebtorGroupsUpdateController(
       $state.go('debtorGroups.list', null, { reload : true });
       return;
     }
+
+    vm.group.color = vm.group.is_insolvent ? '#FFA500' : '#000000';
 
     let submitDebtorGroup = angular.copy(vm.group);
     submitDebtorGroup = formatData(submitDebtorGroup);

--- a/client/src/modules/reports/generate/annual_clients_report/annual_clients_report.html
+++ b/client/src/modules/reports/generate/annual_clients_report/annual_clients_report.html
@@ -46,6 +46,64 @@
             on-change-callback="ReportConfigCtrl.onIncludeCashClientsToggle(value)">
           </bh-yes-no-radios>
 
+          <bh-yes-no-radios
+            label="REPORT.CLIENTS.SHOW_ALL_DEBTOR_GROUPS"
+            value="ReportConfigCtrl.reportDetails.showAllDebtorGroup"
+            name="showAllDebtorGroup"
+            on-change-callback="ReportConfigCtrl.onShowAllDebtorGroupToggle(value)">
+          </bh-yes-no-radios>
+
+          <div ng-if="!ReportConfigCtrl.reportDetails.showAllDebtorGroup" style="padding-left: 5%;">
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.solvent" ng-true-value="1" ng-false-value="0">
+                <span translate>REPORT.CLIENTS.REPORT_SOLVENT_CLIENTS</span>
+              </label>
+            </div>
+
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.insolvent" ng-true-value="1" ng-false-value="0">
+                <span translate>REPORT.CLIENTS.INSOLVENT_CLIENTS_REPORT</span>
+              </label>
+            </div>
+
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.conventioned" ng-true-value="1" ng-false-value="0">
+                <span translate>REPORT.CLIENTS.REPORT_OF_CONVENTIONED_CLIENTS</span>
+              </label>
+            </div>
+
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.non_conventioned" ng-true-value="1" ng-false-value="0">
+                <span translate>REPORT.CLIENTS.REPORT_OF_NON_CONVENTIONED_CLIENTS</span>
+              </label>
+            </div>
+
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.group_client" ng-true-value="1" ng-false-value="0">
+                <span translate>REPORT.CLIENTS.OVERALL_CUSTOMER_REPORT</span>
+              </label>
+            </div>
+
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.group_non_client" ng-true-value="1" ng-false-value="0">
+                <span translate>REPORT.CLIENTS.REPORT_DEBT_GROUP_NON_CLIENT</span>
+              </label>
+            </div>
+
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.is_locked" ng-true-value="1" ng-false-value="0">
+                <span translate>REPORT.CLIENTS.BLOCKED_CLIENTS_REPORT</span>
+              </label>
+            </div>
+          </div>
+
           <bh-currency-select
             currency-id="ReportConfigCtrl.reportDetails.currencyId"
             on-change="ReportConfigCtrl.onSelectCurrency(currency)">

--- a/client/src/modules/reports/generate/annual_clients_report/annual_clients_report.js
+++ b/client/src/modules/reports/generate/annual_clients_report/annual_clients_report.js
@@ -23,6 +23,7 @@ function AnnualClientsReportController($state, $sce, Notify, AppCache, SavedRepo
     currencyId : Session.enterprise.currency_id,
     hideLockedClients : 0,
     includeCashClients : 0,
+    showAllDebtorGroup : 1,
   };
 
   checkCachedConfiguration();
@@ -46,6 +47,10 @@ function AnnualClientsReportController($state, $sce, Notify, AppCache, SavedRepo
 
   vm.onIncludeCashClientsToggle = includeCashClients => {
     Object.assign(vm.reportDetails, { includeCashClients });
+  };
+
+  vm.onShowAllDebtorGroupToggle = showAllDebtorGroup => {
+    vm.reportDetails.showAllDebtorGroup = showAllDebtorGroup;
   };
 
   vm.requestSaveAs = function requestSaveAs() {

--- a/server/controllers/finance/reports/debtors/annual_clients_report.handlebars
+++ b/server/controllers/finance/reports/debtors/annual_clients_report.handlebars
@@ -24,7 +24,6 @@
   <main class="container">
     {{#> header }}
       <h4 class="text-right text-capitalize">
-        <strong>{{fiscalYear.label}}</strong><br/>
         {{date fiscalYear.start_date "MMMM YYYY"}} - {{date fiscalYear.end_date "MMMM YYYY"}}
       </h4>
     {{/header}}
@@ -32,6 +31,58 @@
     {{> exchangeRate rate=exchangeRate currencyId=currencyId}}
 
     <section>
+      {{#if overallCustomer}}
+        <h3 class="text-center text-uppercase">
+          <strong>{{translate 'REPORT.CLIENTS.OVERALL_CUSTOMER_REPORT' }}</strong>
+        </h3>
+      {{/if}}
+
+      {{#if solventClient}}
+        <h3 class="text-center text-uppercase">
+          <strong>{{translate 'REPORT.CLIENTS.REPORT_SOLVENT_CLIENTS' }}</strong>
+        </h3>
+      {{/if}}
+
+      {{#if inSolventClient}}
+        <h3 class="text-center text-uppercase">
+          <strong>{{translate 'REPORT.CLIENTS.INSOLVENT_CLIENTS_REPORT' }}</strong>
+        </h3>
+      {{/if}}
+
+      {{#if debtorConventioned}}
+        <h3 class="text-center text-uppercase">
+          <strong>{{translate 'REPORT.CLIENTS.REPORT_OF_CONVENTIONED_CLIENTS' }}</strong>
+        </h3>
+      {{/if}}
+
+      {{#if debtorNonConventioned}}
+        <h3 class="text-center text-uppercase">
+          <strong>{{translate 'REPORT.CLIENTS.REPORT_OF_NON_CONVENTIONED_CLIENTS' }}</strong>
+        </h3>
+      {{/if}}
+
+      {{#if isLocked}}
+        <h3 class="text-center text-uppercase">
+          <strong>{{translate 'REPORT.CLIENTS.BLOCKED_CLIENTS_REPORT' }}</strong>
+        </h3>
+      {{/if}}
+
+      {{#if groupNonClient}}
+        <h3 class="text-center text-uppercase">
+          <strong>{{translate 'REPORT.CLIENTS.REPORT_DEBT_GROUP_NON_CLIENT' }}</strong>
+        </h3>
+      {{/if}}
+
+      {{#if globalClient}}
+        <h3 class="text-center text-uppercase">
+          <strong>{{translate 'REPORT.CLIENTS.GLOBAL_DEBTOR_GROUP_REPORT' }}</strong>
+        </h3>
+      {{/if}}
+
+      <h3 class="text-center text-uppercase">
+        <strong>{{fiscalYear.label}}</strong>
+      </h3>
+
       <table class="table table-condensed table-report table-bordered">
         <thead>
           <tr class="text-capitalize text-center" style="background-color: #ddd;">

--- a/server/models/01-schema.sql
+++ b/server/models/01-schema.sql
@@ -385,6 +385,8 @@ CREATE TABLE `debtor_group` (
   `apply_invoicing_fees` BOOLEAN NOT NULL DEFAULT TRUE,
   `apply_subsidies` BOOLEAN NOT NULL DEFAULT TRUE,
   `color` VARCHAR(8) NULL,
+  `is_insolvent` TINYINT(1) NOT NULL DEFAULT 0,
+  `is_non_client_debtor_groups` TINYINT(1) NOT NULL DEFAULT 0,
   `created_at`      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at`      TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`uuid`),

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -1,1 +1,8 @@
 -- next release v1.34.0
+/*
+ * @author: lomamech
+ * @date: 2024-08-24
+ * @description: Categorize Debtor Group: Distinguishing Insolvent and Solvent Entities
+ */
+ALTER TABLE `debtor_group` ADD COLUMN `is_insolvent` TINYINT(1) NOT NULL DEFAULT 0 AFTER `color`;
+ALTER TABLE `debtor_group` ADD COLUMN `is_non_client_debtor_groups` TINYINT(1) NOT NULL DEFAULT 0 AFTER `is_insolvent`;

--- a/test/data.sql
+++ b/test/data.sql
@@ -422,9 +422,9 @@ INSERT INTO cashbox_permission (user_id, cashbox_id) VALUES
 SOURCE test/data/inventories.sql;
 
 INSERT INTO `debtor_group` VALUES
-  (1, HUID('4de0fe47-177f-4d30-b95f-cff8166400b4'), 'Church Employees', 174, HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, NULL, NULL, 0, 10, 0, NULL, 1, 1, 1, '#ff0000', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (1, HUID('66f03607-bfbc-4b23-aa92-9321ca0ff586'), 'NGO IMA World Health', 175, HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, NULL, NULL, 0, 300, 1, NULL, 1, 1, 1, '#00ff00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (1, HUID('a11e6b7f-fbbb-432e-ac2a-5312a66dccf4'), 'Cash Paying Clients', 176, HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, NULL, NULL, 0, 20, 1, NULL, 1, 1, 1, '#0000ff',CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+  (1, HUID('4de0fe47-177f-4d30-b95f-cff8166400b4'), 'Church Employees', 174, HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, NULL, NULL, 0, 10, 0, NULL, 1, 1, 1, '#ff0000', 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (1, HUID('66f03607-bfbc-4b23-aa92-9321ca0ff586'), 'NGO IMA World Health', 175, HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, NULL, NULL, 0, 300, 1, NULL, 1, 1, 1, '#00ff00', 0, 0,CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (1, HUID('a11e6b7f-fbbb-432e-ac2a-5312a66dccf4'), 'Cash Paying Clients', 176, HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, NULL, NULL, 0, 20, 1, NULL, 1, 1, 1, '#0000ff', 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 INSERT INTO `patient_group` VALUES
   (HUID('0b8fcc00-8640-479d-872a-31d36361fcfd'), 1, NULL, 'Test Patient Group 1', 'Test Patient Group 1 Note', '2016-03-10 08:44:23'),

--- a/test/data/core.sql
+++ b/test/data/core.sql
@@ -131,9 +131,9 @@ INSERT INTO `exchange_rate` VALUES
 --
 
 INSERT INTO `debtor_group` VALUES
-  (1, HUID('4de0fe47-177f-4d30-b95f-cff8166400b4'), 'Church Employees', 174, HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, NULL, NULL, 0, 10, 0, NULL, 1, 1, 1, '#ff0000', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (1, HUID('66f03607-bfbc-4b23-aa92-9321ca0ff586'), 'NGO IMA World Health', 175, HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, NULL, NULL, 0, 300, 1, NULL, 1, 1, 1, '#00ff00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (1, HUID('a11e6b7f-fbbb-432e-ac2a-5312a66dccf4'), 'Cash Paying Clients', 176, HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, NULL, NULL, 0, 20, 1, NULL, 1, 1, 1, '#0000ff',CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+  (1, HUID('4de0fe47-177f-4d30-b95f-cff8166400b4'), 'Church Employees', 174, HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, NULL, NULL, 0, 10, 0, NULL, 1, 1, 1, '#ff0000', 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (1, HUID('66f03607-bfbc-4b23-aa92-9321ca0ff586'), 'NGO IMA World Health', 175, HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, NULL, NULL, 0, 300, 1, NULL, 1, 1, 1, '#00ff00', 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (1, HUID('a11e6b7f-fbbb-432e-ac2a-5312a66dccf4'), 'Cash Paying Clients', 176, HUID('1f162a10-9f67-4788-9eff-c1fea42fcc9b'), NULL, NULL, NULL, 0, 20, 1, NULL, 1, 1, 1, '#0000ff', 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 --
 -- patient group

--- a/test/integration/debtorGroups.js
+++ b/test/integration/debtorGroups.js
@@ -33,12 +33,14 @@ describe('test/integration/debtorGroups The debtor groups API', () => {
     note : 'Updated debtor group de test',
     locked : 1,
     max_credit : 1000,
+    is_insolvent : 0,
+    is_non_client_debtor_groups : 0,
     is_convention : 1,
     price_list_uuid : helpers.data.PRICE_LIST,
     apply_discounts : 1,
     apply_invoicing_fees : 1,
     apply_subsidies : 1,
-    color : '#00ffff',
+    color : '#FF0000',
   };
 
   const lockedGroup = {


### PR DESCRIPTION
- Added the ability to filter client reports by solvency category, distinguishing between solvent and insolvent clients.
- Updated the debtors management module to include the option to define clients as insolvent.

closes #7674