### PR TITLE
Update puppeteer and coral

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.33.0",
       "license": "GPL-2.0",
       "dependencies": {
-        "@ima-worldhealth/coral": "^2.15.0",
+        "@ima-worldhealth/coral": "^3.0.0",
         "@ima-worldhealth/tree": "^2.6.0",
         "@types/angular": "^1.8.9",
         "@uirouter/angularjs": "^1.1.1",
@@ -63,7 +63,7 @@
         "ngstorage": "^0.3.11",
         "nodemailer": "^6.9.15",
         "p-retry": "^4.6.2",
-        "puppeteer": "^22.15.0",
+        "puppeteer": "^23.4.0",
         "q": "^1.5.1",
         "stream-to-promise": "^3.0.0",
         "tempy": "^1.0.1",
@@ -386,13 +386,14 @@
       "dev": true
     },
     "node_modules/@ima-worldhealth/coral": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@ima-worldhealth/coral/-/coral-2.15.0.tgz",
-      "integrity": "sha512-At85wsMBN84CLzSyMsre15eh30Es/Mw/KJfteSRGHdHTsGfkVxOqzt+aI9AmWenNrWIuBfq2R1nUZFn/jjAPbw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ima-worldhealth/coral/-/coral-3.0.0.tgz",
+      "integrity": "sha512-rYxxGUQLDaDrMK64ChHzcCEUYgD+ZCdINb2MoKvSkAHy+FcEpYemToSSF+tgaOm8wXnGvX2QYGGqy7DAKefHIw==",
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
         "inline-source": "^8.0.2",
-        "puppeteer": "^22.12.1",
+        "puppeteer": "^23.4.0",
         "puppeteer-cluster": "^0.24.0"
       }
     },
@@ -1464,12 +1465,12 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
-      "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.0.tgz",
+      "integrity": "sha512-x8J1csfIygOwf6D6qUAZ0ASk3z63zPb7wkNeHRerCMh82qWKUrOgkuP005AJC8lDL6/evtXETGEJVcwykKT4/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.3.6",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.4.0",
@@ -3283,9 +3284,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
-      "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.5.tgz",
+      "integrity": "sha512-RuLrmzYrxSb0s9SgpB+QN5jJucPduZQ/9SIe76MDxYJuecPW5mxMdacJ1f4EtgiV+R0p3sCkznTMvH0MPGFqjA==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "3.0.1",
@@ -4875,9 +4876,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1312386",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
-      "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
+      "version": "0.0.1342118",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1342118.tgz",
+      "integrity": "sha512-75fMas7PkYNDTmDyb6PRJCH7ILmHLp+BhrZGeMsa4bCh40DTxgCz2NRy5UDzII4C5KuD0oBMZ9vXKhEl6UD/3w==",
       "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
@@ -12647,19 +12648,21 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.15.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.15.0.tgz",
-      "integrity": "sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.4.0.tgz",
+      "integrity": "sha512-FxgFFJI7NAsX8uebiEDSjS86vufz9TaqERQHShQT0lCbSRI3jUPEcz/0HdwLiYvfYNsc1zGjqY3NsGZya4PvUA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.3.0",
+        "@puppeteer/browsers": "2.4.0",
+        "chromium-bidi": "0.6.5",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1312386",
-        "puppeteer-core": "22.15.0"
+        "devtools-protocol": "0.0.1342118",
+        "puppeteer-core": "23.4.0",
+        "typed-query-selector": "^2.12.0"
       },
       "bin": {
-        "puppeteer": "lib/esm/puppeteer/node/cli.js"
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
       },
       "engines": {
         "node": ">=18"
@@ -12677,15 +12680,16 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.15.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
-      "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.4.0.tgz",
+      "integrity": "sha512-fqkIP5FOcb38jfBj/OcBz1wFaI9nk40uQKSORvnXws6wCbep2dg8yxZ3ddJxBIfQsxoiEOvnrykFinUScrB/ew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.3.0",
-        "chromium-bidi": "0.6.3",
-        "debug": "^4.3.6",
-        "devtools-protocol": "0.0.1312386",
+        "@puppeteer/browsers": "2.4.0",
+        "chromium-bidi": "0.6.5",
+        "debug": "^4.3.7",
+        "devtools-protocol": "0.0.1342118",
+        "typed-query-selector": "^2.12.0",
         "ws": "^8.18.0"
       },
       "engines": {
@@ -15317,6 +15321,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "license": "MIT"
     },
     "node_modules/typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "jeremielodi"
   ],
   "dependencies": {
-    "@ima-worldhealth/coral": "^2.15.0",
+    "@ima-worldhealth/coral": "^3.0.0",
     "@ima-worldhealth/tree": "^2.6.0",
     "@types/angular": "^1.8.9",
     "@uirouter/angularjs": "^1.1.1",
@@ -146,7 +146,7 @@
     "ngstorage": "^0.3.11",
     "nodemailer": "^6.9.15",
     "p-retry": "^4.6.2",
-    "puppeteer": "^22.15.0",
+    "puppeteer": "^23.4.0",
     "q": "^1.5.1",
     "stream-to-promise": "^3.0.0",
     "tempy": "^1.0.1",

--- a/server/lib/renderers/pdf.js
+++ b/server/lib/renderers/pdf.js
@@ -89,5 +89,6 @@ async function renderPDF(context, template, options = {}) {
 
   debug('PDF created with coral.');
 
-  return pdf;
+  // Convert from Uint8Array to a buffer
+  return Buffer.from(pdf);
 }


### PR DESCRIPTION
This PR updates puppeteer and coral.

The puppeteer API has changed; its PDF functions return a Uint8Array instead of a Buffer.
This PR also changes the BHIMA pdf render function (renderPDF() in server/lib/renderers/pdf.js) to return a Buffer so that all BHIMA functionality remains unchanged.

**TESTING:**
- Make sure normal tests work
- Verify that generating PDF documents works (eg, reports, etc)
