### PR TITLE
chore(employee): add timestamps to employee table

### DIFF
--- a/server/models/01-schema.sql
+++ b/server/models/01-schema.sql
@@ -529,6 +529,8 @@ CREATE TABLE `employee` (
   `patient_uuid`  BINARY(16) DEFAULT NULL,
   `reference`     SMALLINT(5) UNSIGNED DEFAULT NULL,
   `title_employee_id`   TINYINT(3) UNSIGNED DEFAULT NULL,
+  `created_at`                TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`                TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`uuid`),
   UNIQUE KEY `employee_1` (`code`),
   UNIQUE KEY `employee_2` (`patient_uuid`),

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -65,3 +65,16 @@ ALTER TABLE `period` MODIFY `locked` TINYINT(1) NOT NULL DEFAULT 0;
 ALTER TABLE `period_total` MODIFY `locked` TINYINT(1) NOT NULL DEFAULT 0;
 ALTER TABLE `project` MODIFY `locked` TINYINT(1) NOT NULL DEFAULT 0;
 ALTER TABLE `supplier` MODIFY `locked` TINYINT(1) NOT NULL DEFAULT 0;
+
+--  @jniles
+--  2024-10-23
+--  add timestamps to the employee table for better tracking.
+ALTER TABLE `employee` ADD COLUMN `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE `employee` ADD COLUMN `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+-- default the "created_at" to the "date_embauche" from previous records.
+UPDATE `employee` SET created_at = date_embauche;
+UPDATE `employee` SET updated_at = date_embauche;
+
+
+


### PR DESCRIPTION
This commit adds created_at and updated_at timestamps to the employee table.

Closes #7817.