### PR TITLE
fix(admissions): block transfer of discharged patients

### DIFF
--- a/client/src/modules/patients/visits/registry.js
+++ b/client/src/modules/patients/visits/registry.js
@@ -9,7 +9,6 @@ AdmissionRegistryController.$inject = [
 /**
  * Admission Registry Controller
  *
- * *
  * This module is responsible for the management of Admission Registry.
  */
 function AdmissionRegistryController(
@@ -19,7 +18,7 @@ function AdmissionRegistryController(
   const vm = this;
   const cacheKey = 'AdmissionRegistry';
 
-  // the grid registry filterer
+  // the grid registry filter
   const { grid } = Visits;
 
   vm.loading = false;
@@ -37,6 +36,7 @@ function AdmissionRegistryController(
       <a ui-sref="patientRecord({ patientUuid : row.entity.patient_uuid })">{{row.entity.reference}}</a>
     </div>
   `;
+
   const patientDetailsTemplate = `
     <div class="ui-grid-cell-contents">
       <a ui-sref="patientRecord({ patientUuid : row.entity.patient_uuid })">{{row.entity.display_name}}</a>
@@ -154,6 +154,7 @@ function AdmissionRegistryController(
     // hook the returned admissions up to the grid.
     return Visits.admissions.read(null, filters)
       .then((admissions) => {
+
         // put data in the grid
         vm.uiGridOptions.data = admissions;
         // grid : update view filters

--- a/client/src/modules/patients/visits/templates/action.cell.html
+++ b/client/src/modules/patients/visits/templates/action.cell.html
@@ -12,7 +12,7 @@
       </a>
     </li>
     <li>
-      <a ng-if="row.entity.bed_label" data-method="transfer" ng-click="grid.appScope.openTransferModal(row.entity)" href>
+      <a ng-if="row.entity.bed_label && row.entity.is_open" data-method="transfer" ng-click="grid.appScope.openTransferModal(row.entity)" href>
         <span class="fa fa-exchange"></span> <span translate>PATIENT_RECORDS.TRANSFER.TITLE</span>
       </a>
     </li>


### PR DESCRIPTION
This commit fixes a bug in the admissions registry where you could transfer a patient that has already been discharged.  This shouldn't happen in practice as the patient has left the hospital.

Closes #7809.

To test this:
 1. Create a Ward, Room, and Bed via Ward Management > Settings.
 2. Admit a patient to that room (as hospitalization).
 3. Note that you have the option to "transfer" the patient in the menu in the Admissions registry.
 4. Discharge the patient.
 5. Note that you cannot transfer the patient anymore.