### PR TITLE
feat(employees): add a locked search filter

### DIFF
--- a/client/src/js/components/bhYesNoRadios.js
+++ b/client/src/js/components/bhYesNoRadios.js
@@ -1,11 +1,12 @@
 angular.module('bhima.components')
   .component('bhYesNoRadios', {
     bindings : {
-      value : '<',
+      value : '<?',
       label : '@',
       name : '@',
       helpText : '@?',
       onChangeCallback : '&',
+      required : '<?',
     },
     transclude  : true,
     templateUrl : 'modules/templates/bhYesNoRadios.tmpl.html',
@@ -22,7 +23,16 @@ function YesNoRadioController() {
   const $ctrl = this;
 
   $ctrl.$onInit = () => {
-    $ctrl.value = Number.parseInt($ctrl.value, 10);
+    // only attempt to parse the input if the input is defined
+    if (angular.isDefined($ctrl.value)) {
+      $ctrl.value = Number.parseInt($ctrl.value, 10);
+    }
+
+    // ensure default behavior of required if nothing
+    // is passed in is preserved.
+    if (!angular.isDefined($ctrl.required)) {
+      $ctrl.required = true;
+    }
   };
 
   $ctrl.onChange = (value) => {

--- a/client/src/modules/cash/cash-form.service.js
+++ b/client/src/modules/cash/cash-form.service.js
@@ -81,7 +81,6 @@ function CashFormService(AppCache, Session, Patients, Exchange) {
     }
   };
 
-
   /**
    * @method isCaution
    *

--- a/client/src/modules/employees/employee.service.js
+++ b/client/src/modules/employees/employee.service.js
@@ -32,6 +32,7 @@ function EmployeeService(Filters, $uibModal, Api, AppCache, Languages, $httpPara
   employeeFilters.registerCustomFilters([
     { key : 'display_name', label : 'FORM.LABELS.NAME' },
     { key : 'sex', label : 'FORM.LABELS.GENDER' },
+    { key : 'locked', label : 'FORM.LABELS.LOCKED', valueFilter : 'boolean' },
     { key : 'code', label : 'FORM.LABELS.CODE' },
     {
       key : 'dateBirthFrom', label : 'FORM.LABELS.DOB', comparitor : '>', valueFilter : 'date',

--- a/client/src/modules/employees/registry/search.modal.html
+++ b/client/src/modules/employees/registry/search.modal.html
@@ -119,6 +119,15 @@
             </div>
           </div>
 
+          <bh-yes-no-radios
+            label = "FORM.LABELS.LOCKED"
+            value = "ModalCtrl.searchQueries.locked"
+            name = "locked"
+            required = "0"
+            on-change-callback="ModalCtrl.onLockedChange(value)">
+            <bh-clear on-clear="ModalCtrl.clear('locked')"></bh-clear>
+          </bh-yes-no-radios>
+
           <bh-date-interval
             label="FORM.LABELS.DOB"
             date-id="dob-date"

--- a/client/src/modules/employees/registry/search.modal.js
+++ b/client/src/modules/employees/registry/search.modal.js
@@ -29,7 +29,7 @@ function EmployeeRegistryModalController(ModalInstance, SearchModal, Store, util
   // these properties will be used to filter employee data form the client
   const searchQueryOptions = [
     'display_name', 'sex', 'code', 'dateBirthFrom', 'dateBirthTo',
-    'dateEmbaucheFrom', 'dateEmbaucheTo', 'grade_uuid', 'fonction_id',
+    'dateEmbaucheFrom', 'dateEmbaucheTo', 'grade_uuid', 'fonction_id', 'locked',
     'service_uuid', 'cost_center_id', 'is_medical', 'reference', 'title_employee_id',
   ];
 
@@ -62,6 +62,10 @@ function EmployeeRegistryModalController(ModalInstance, SearchModal, Store, util
   vm.onSelectGrade = function onSelectGrade(grade) {
     displayValues.grade_uuid = grade.text;
     vm.searchQueries.grade_uuid = grade.uuid;
+  };
+
+  vm.onLockedChange = value => {
+    vm.searchQueries.locked = value;
   };
 
   // custom filter fonction_id - assign the value to the searchQueries object
@@ -101,7 +105,6 @@ function EmployeeRegistryModalController(ModalInstance, SearchModal, Store, util
   // returns the parameters to the parent controller
   function submit(form) {
     if (form.$invalid) { return 0; }
-
     const loggedChanges = SearchModal.getChanges(vm.searchQueries, changes, displayValues, lastDisplayValues);
     return ModalInstance.close(loggedChanges);
   }

--- a/client/src/modules/templates/bhYesNoRadios.tmpl.html
+++ b/client/src/modules/templates/bhYesNoRadios.tmpl.html
@@ -1,5 +1,6 @@
 <div class="form-group" ng-form="bhYesNoForm"
   data-bh-yes-no-radios
+  novalidate
   ng-class="{ 'has-error' : bhYesNoForm.$submitted && bhYesNoForm.$invalid }">
 
   <label class="control-label" translate>{{$ctrl.label}}</label>
@@ -15,7 +16,7 @@
         ng-value="1"
         ng-model="$ctrl.value"
         ng-change="$ctrl.onChange($ctrl.value)"
-        required>
+        ng-required="$ctrl.required">
       <span translate>FORM.LABELS.YES</span>
     </label>
 
@@ -27,7 +28,7 @@
         ng-value="0"
         ng-model="$ctrl.value"
         ng-change="$ctrl.onChange($ctrl.value)"
-        required>
+        ng-required="$ctrl.required">
       <span translate>FORM.LABELS.NO</span>
     </label>
 

--- a/server/controllers/payroll/employees/index.js
+++ b/server/controllers/payroll/employees/index.js
@@ -470,20 +470,23 @@ function find(options) {
 
   const filters = new FilterParser(options, { tableAlias : 'employee' });
 
-  filters.fullText('display_name', 'display_name', 'patient');
-  filters.dateFrom('dateEmbaucheFrom', 'date_embauche');
-  filters.dateTo('dateEmbaucheTo', 'date_embauche');
   filters.dateFrom('dateBirthFrom', 'dob', 'patient');
+  filters.dateFrom('dateEmbaucheFrom', 'date_embauche');
   filters.dateTo('dateBirthTo', 'dob', 'patient');
-  filters.equals('sex', 'sex', 'patient');
+  filters.dateTo('dateEmbaucheTo', 'date_embauche');
   filters.equals('code', 'code', 'employee');
-  filters.equals('service_uuid', 'service_uuid', 'employee');
   filters.equals('fonction_id', 'fonction_id', 'employee');
-  filters.equals('title_employee_id', 'title_employee_id', 'employee');
   filters.equals('grade_uuid', 'grade_uuid', 'employee');
   filters.equals('is_medical', 'is_medical', 'title_employee');
+  filters.equals('locked', 'locked', 'employee');
   filters.equals('reference', 'text', 'entity_map');
+  filters.equals('service_uuid', 'service_uuid', 'employee');
+  filters.equals('sex', 'sex', 'patient');
+  filters.equals('title_employee_id', 'title_employee_id', 'employee');
+  filters.fullText('display_name', 'display_name', 'patient');
 
+
+  // NOTE(@jniles) - why does this query exist in the fashion it does?
   if (options.cost_center_id) {
     if (options.cost_center_id > -1) {
       filters.equals('cost_center_id', 'id', 'cc');
@@ -558,7 +561,7 @@ function patientToEmployee(req, res, next) {
   delete employee.debtor_uuid;
   delete employee.hospital_no;
 
-  // Delete not necessary Data for Employee
+  // delete data that shouldn't be attached to employees
   delete employee.display_name;
   delete employee.dob;
   delete employee.sex;


### PR DESCRIPTION
This commit adds a locked filter to the employee search modal.  The locked filter allows a user to select only employees that have been locked or unlocked.

I used the `bhYesNoRadios` to do this, but it required an update to the parsing logic to allow for undefined values.  I also added the ability to remove the "required" attribute from the radio buttons so that validation wouldn't trigger every submit.

Closes #7798.