### PR TITLE
fix(wards): allow removing services from wards

### DIFF
--- a/client/src/modules/ward/configuration/ward/modals/createUpdate.html
+++ b/client/src/modules/ward/configuration/ward/modals/createUpdate.html
@@ -24,6 +24,7 @@
     <bh-service-select 
       service-uuid="ModalCtrl.ward.service_uuid"
       on-select-callback="ModalCtrl.onSelectService(service)">
+      <bh-clear on-clear="ModalCtrl.clear('service_uuid')"></bh-clear>
     </bh-service-select>
 
     <div class="form-group" ng-class="{'has-error': ModalForm.$submitted && ModalForm.description.$invalid }">
@@ -32,8 +33,7 @@
         ng-model="ModalCtrl.ward.description"
         name="description"
         class="form-control"
-        rows="3"
-      >
+        rows="3">
       </textarea>
     </div>
   </div>

--- a/client/src/modules/ward/configuration/ward/modals/createUpdate.js
+++ b/client/src/modules/ward/configuration/ward/modals/createUpdate.js
@@ -2,19 +2,21 @@ angular.module('bhima.controllers')
   .controller('CreateUpdateWardController', CreateUpdateWardController);
 
 CreateUpdateWardController.$inject = [
-  'uuid', 'SessionService', 'WardService',
-  'ModalService', 'NotifyService', '$uibModalInstance',
+  'uuid', 'WardService', 'NotifyService', '$uibModalInstance',
   'ServiceService',
 ];
 
-function CreateUpdateWardController(uuid, Session, Ward, ModalService, Notify, Instance, Service) {
+function CreateUpdateWardController(uuid, Ward, Notify, Instance, Service) {
   const vm = this;
-  vm.close = close;
 
   vm.ward = {};
   vm.submit = submit;
   vm.isCreating = !uuid;
   vm.onSelectService = onSelectService;
+  vm.close = () => Instance.close();
+
+  // allows users to clear the service
+  vm.clear = key => { delete vm.ward[key]; };
 
   init();
 
@@ -54,10 +56,4 @@ function CreateUpdateWardController(uuid, Session, Ward, ModalService, Notify, I
       })
       .catch(Notify.handleError);
   }
-
-  // just close the modal
-  function close() {
-    return Instance.close();
-  }
-
 }

--- a/server/controllers/medical/ward/ward.js
+++ b/server/controllers/medical/ward/ward.js
@@ -22,14 +22,19 @@ function create(req, res, next) {
 // modify a ward informations
 function update(req, res, next) {
   const data = req.body;
-  delete data.uuid;
-  const uuid = db.bid(req.params.uuid);
-  db.convert(data, ['service_uuid']);
-  const sql = `UPDATE ward SET ? WHERE uuid =?`;
 
-  db.exec(sql, [data, uuid]).then(() => {
-    res.sendStatus(200);
-  })
+  delete data.uuid;
+  db.convert(data, ['service_uuid']);
+
+  const uuid = db.bid(req.params.uuid);
+
+  // if no service is set back, make it null
+  if (!data.service_uuid) { data.service_uuid = null; }
+
+  const sql = 'UPDATE ward SET ? WHERE uuid = ?';
+
+  db.exec(sql, [data, uuid])
+    .then(() => { res.sendStatus(200); })
     .catch(next);
 }
 


### PR DESCRIPTION
This commit fixes the "service" section of the ward create/update controller to allow for removing the service.

You can test this by creating a ward with a service, then updating the ward to remove the service.  You can also add a service to the ward.

Closes #7802.