### PR TITLE
Updates to prevent marking a male patient pregnant during admission

### DIFF
--- a/client/src/modules/patients/visits/modals/visits-modal.ctrl.js
+++ b/client/src/modules/patients/visits/modals/visits-modal.ctrl.js
@@ -26,6 +26,8 @@ function VisitsAdmissionController(ModalInstance, Patients, Visits, Notify,
     hospitalized : 0,
     inside_health_zone : 1,
     is_new_case : 1,
+    is_refered : 0,
+    is_pregnant : 0,
   };
 
   vm.onBedRoomSelect = bed => {

--- a/client/src/modules/patients/visits/modals/visits.modal.html
+++ b/client/src/modules/patients/visits/modals/visits.modal.html
@@ -98,14 +98,16 @@
         <!-- optionally include help-text -->
     </bh-yes-no-radios>
 
-    <bh-yes-no-radios
-      label ="PATIENT_RECORDS.VISITS.IS_PREGNANT"
-      id = "patient-is-pregnant"
-      value = "AdmitCtrl.visit.is_pregnant"
-      on-change-callback = "AdmitCtrl.onChangePregnant(value)"
-      required = "false">
-        <!-- optionally include help-text -->
-    </bh-yes-no-radios>
+    <div ng-if="AdmitCtrl.isFemale">
+      <bh-yes-no-radios
+        label ="PATIENT_RECORDS.VISITS.IS_PREGNANT"
+        id = "patient-is-pregnant"
+        value = "AdmitCtrl.visit.is_pregnant"
+        on-change-callback = "AdmitCtrl.onChangePregnant(value)"
+        required = "false">
+          <!-- optionally include help-text -->
+      </bh-yes-no-radios>
+    </div>
 
     <!-- in health zone -->
     <p class="control-label" style="margin-bottom:5px;">

--- a/client/src/modules/patients/visits/registry.js
+++ b/client/src/modules/patients/visits/registry.js
@@ -71,6 +71,10 @@ function AdmissionRegistryController(
     headerCellFilter : 'translate',
     cellTemplate : patientDetailsTemplate,
   }, {
+    field : 'sex',
+    displayName : 'FORM.LABELS.SEX',
+    headerCellFilter : 'translate',
+  }, {
     field : 'hospital_no',
     displayName : 'PATIENT_RECORDS.HOSPITAL_NO',
     headerCellFilter : 'translate',

--- a/server/controllers/medical/patients/visits.js
+++ b/server/controllers/medical/patients/visits.js
@@ -38,7 +38,7 @@ const COLUMNS = `
   ISNULL(patient_visit.end_date) AS is_open, icd10.label as start_diagnosis_label, icd10.code as start_diagnosis_code,
   patient_visit.hospitalized,
   z.bed_label, z.room_label, z.ward_name,
-  patient.display_name, patient.hospital_no, em.text AS reference,
+  patient.display_name, patient.hospital_no, patient.sex, em.text AS reference,
   s.name AS service_name,
   dt.label AS discharge_label,
   inside_health_zone, is_new_case, is_refered, is_pregnant, BUID(last_service_uuid) AS last_service_uuid,

--- a/test/integration/patientVisits.js
+++ b/test/integration/patientVisits.js
@@ -15,7 +15,8 @@ describe('test/integration/patientVisits Patient Visits (/patients/:uuid/visits)
     'user_id', 'username', 'start_diagnosis_code', 'start_diagnosis_label',
     'hospitalized', 'last_service_uuid', 'discharge_type_id', 'inside_health_zone',
     'is_pregnant', 'is_refered', 'is_new_case', 'ward_name', 'room_label', 'bed_label',
-    'hospital_no', 'service_name', 'discharge_label', 'duration', 'display_name', 'reference',
+    'hospital_no', 'service_name', 'sex', 'discharge_label', 'duration', 'display_name',
+    'reference',
   ];
 
   // this will cache the last visit uuid


### PR DESCRIPTION
Prevent marking a male patient as pregnant during admission.

This PR prevents the "Is pregnant" yes/no selection from being displayed for male patients during admission.
It also:
 - Sets defaults for the "is referal" and "is pregnant" yes/no flags (both to NO)
 - Adds a "Sex" column for the Visits registry

Closes https://github.com/Third-Culture-Software/bhima/issues/7847

Note that I considered the comment in the issue:

>    "I'm not 100% sure if we should block this case, since it could be that the patient's sex was registered incorrectly 
>    and should be updated instead... but I'm willing to hear proposals for best practice around this. Ultimately, I 
>    assume it should be a fairly rare event."

I tried a "Danger" message, but had to close the new visit dialog for that to work, which was confusing.  I also tried a secondary Modal popup with a warning message, but had other issues.

Hopefully this error is rare and the data entry person will realize the problem if a woman cannot be marked as pregnant.
Perhaps one way to address this is to insert a line below the patient identifier line with patient sex, age, etc, when a patient is selected.  That should make the problem a little clearer to the data entry person.  That could be done as part of this PR or as a separate issue.

**TESTING**
- Use bhima_test
- Try admitting patient 'Test Patient 1'.  This is a female, and the pregnancy field should be visible and usable.
- Try admitting patient 'Test Patient 2'.  This is a male, and the pregnancy field should not be visible.

