### PR TITLE
chore(ci): update semaphore configuration

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,9 +2,8 @@ version: v1.0
 name: Integration Tests
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu2004
-
+    type: e2-standard-2
+    os_image: ubuntu2204
 blocks:
   - name: Update Dependencies
     dependencies: []
@@ -16,7 +15,8 @@ blocks:
             - sudo apt-get install mysql-client redis-tools -y -qq
             - sudo apt autoremove -y -qq && sudo apt autoclean -y -qq
   - name: Integration Testing Matrix
-    dependencies: ["Update Dependencies"]
+    dependencies:
+      - Update Dependencies
     task:
       prologue:
         commands:
@@ -48,35 +48,35 @@ blocks:
       jobs:
         - name: Run Test Matrix
           commands:
-            - 'sem-service start mysql $MYSQL_VERSION'
+            - sem-service start mysql $MYSQL_VERSION
             - mysql -h 127.0.0.1 -P 3306 -u root -e "CREATE USER $DB_USER@$DB_HOST IDENTIFIED WITH mysql_native_password BY '$DB_PASS';"
             - mysql -h 127.0.0.1 -P 3306 -u root -e "GRANT ALL PRIVILEGES ON *.* TO $DB_USER@$DB_HOST WITH GRANT OPTION;"
             - mysql -h 127.0.0.1 -P 3306 -u root -e "FLUSH PRIVILEGES;"
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "SET @@global.sql_mode='STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION';"
+            - 'mysql -h 127.0.0.1 -P 3306 -u root -e "SET @@global.sql_mode=''STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION'';"'
             - nvm install $NODEJS_VERSION
             - checkout
             - 'echo "Testing node:$NODEJS_VERSION on mysql:$MYSQL_VERSION"'
-            - yarn --ignore-engines
+            - npm ci
             - npx playwright install chromium
-            - 'yarn build:db'
-            - yarn build
+            - 'npm run build:db'
+            - npm run build
             - mkdir results
-            - 'yarn test:server-unit'
-            - 'yarn test:client-unit'
-            - 'yarn test:integration'
-            - 'yarn test:integration:stock'
-            - 'yarn test:e2e-account'
+            - 'npm run test:server-unit'
+            - 'npm run test:client-unit'
+            - 'npm run test:integration'
+            - 'npm run test:integration:stock'
+            - 'npm run test:e2e-account'
           matrix:
             - env_var: MYSQL_VERSION
               values:
-                - '8.0'
+                - '8'
             - env_var: NODEJS_VERSION
               values:
-                - '16'
-                - 'node'
-
+                - '22'
+                - node
   - name: Install Testing Matrix
-    dependencies: ["Update Dependencies"]
+    dependencies:
+      - Update Dependencies
     task:
       prologue:
         commands:
@@ -106,22 +106,22 @@ blocks:
       jobs:
         - name: Run Test Matrix
           commands:
-            - 'sem-service start mysql $MYSQL_VERSION'
+            - sem-service start mysql $MYSQL_VERSION
             - mysql -h 127.0.0.1 -P 3306 -u root -e "CREATE USER $DB_USER@$DB_HOST IDENTIFIED WITH mysql_native_password BY '$DB_PASS';"
             - mysql -h 127.0.0.1 -P 3306 -u root -e "GRANT ALL PRIVILEGES ON *.* TO $DB_USER@$DB_HOST WITH GRANT OPTION;"
             - mysql -h 127.0.0.1 -P 3306 -u root -e "FLUSH PRIVILEGES;"
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "SET @@global.sql_mode='STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION';"
+            - 'mysql -h 127.0.0.1 -P 3306 -u root -e "SET @@global.sql_mode=''STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION'';"'
             - nvm install $NODEJS_VERSION
             - checkout
             - 'echo "[Installation] Testing node:$NODEJS_VERSION on mysql:$MYSQL_VERSION"'
-            - yarn --ignore-engines
-            - yarn build
+            - npm ci
+            - npm run build
             - bash ./sh/install-tests.sh
           matrix:
             - env_var: MYSQL_VERSION
               values:
-                - '8.0'
+                - '8'
             - env_var: NODEJS_VERSION
               values:
-                - '16'
-                - 'node'
+                - '22'
+                - node


### PR DESCRIPTION
This commit:
  1. Bumps the semaphore agent to Ubuntu 22
  2. Replaces yarn with npm
  3. Bumps NodeJS versions to 22 and current.

Closes #7905.