### PR TITLE
Minor UI tweaks to Employee Registration

### DIFF
--- a/client/src/js/components/bhCurrencyInput.js
+++ b/client/src/js/components/bhCurrencyInput.js
@@ -9,6 +9,7 @@ angular.module('bhima.components')
       disabled : '<?',
       required : '<?',
       min   : '@?',
+      horizontal : '@?',
     },
   });
 
@@ -28,7 +29,6 @@ function CurrencyInputController(Currencies) {
     $ctrl.label = $ctrl.label || 'FORM.LABELS.AMOUNT';
     $ctrl.required = angular.isDefined($ctrl.required) ? $ctrl.required : true;
   };
-
 
   $ctrl.$onChanges = function onChanges(changes) {
     if (changes.currencyId) {

--- a/client/src/js/services/CurrencyService.js
+++ b/client/src/js/services/CurrencyService.js
@@ -2,7 +2,7 @@ angular.module('bhima.services')
   .service('CurrencyService', CurrencyService);
 
 CurrencyService.$inject = [
-  '$http', '$q', 'util'
+  '$http', '$q', 'util',
 ];
 
 /**
@@ -16,10 +16,10 @@ CurrencyService.$inject = [
  *
  */
 function CurrencyService($http, $q, util) {
-  var service = this;
-  var baseUrl = '/currencies';
-  var cache;
-  var map;
+  const service = this;
+  const baseUrl = '/currencies';
+  let cache;
+  let map;
 
   /** read (and cache) currencies from the database */
   service.read = read;
@@ -55,7 +55,7 @@ function CurrencyService($http, $q, util) {
 
     return $http.get(baseUrl)
       .then(util.unwrapHttpResponse)
-      .then(function (currencies) {
+      .then((currencies) => {
 
         // cache currencies to avoid future HTTP lookups.
         cache = currencies;
@@ -78,9 +78,9 @@ function CurrencyService($http, $q, util) {
     if (map && map[id]) { return $q.resolve(map[id]); }
 
     // fetch the currency from the server
-    return $http.get(baseUrl.concat('/' + id))
+    return $http.get(baseUrl.concat(`/${id}`))
       .then(util.unwrapHttpResponse)
-      .then(function (currency) {
+      .then((currency) => {
 
         // ensure that the map exists
         if (!map) { map = {}; }
@@ -94,9 +94,9 @@ function CurrencyService($http, $q, util) {
   }
 
   function buildMap(currencies) {
-    return currencies.reduce(function (map, row) {
-      if (!map[row.id]) { map[row.id] = row; }
-      return map;
+    return currencies.reduce((agg, row) => {
+      if (!agg[row.id]) { agg[row.id] = row; }
+      return agg;
     }, {});
   }
 
@@ -130,7 +130,7 @@ function CurrencyService($http, $q, util) {
    * @returns {String} A label associated with the currency or an empty string
    */
   function format(id) {
-    return namer(id) + ' (' + symbol(id) + ')';
+    return `${namer(id)} (${symbol(id)})`;
   }
 
   return service;

--- a/client/src/modules/employees/registration/employees.html
+++ b/client/src/modules/employees/registration/employees.html
@@ -292,7 +292,7 @@
                         name="dateEmbauche"
                         type="text"
                         class="form-control"
-                        ng-model="EmployeeCtrl.employee.date_embauche"
+                        ng-model="EmployeeCtrl.employee.hiring_date"
                         uib-datepicker-popup="{{EmployeeCtrl.datepickerOptions.format}}"
                         datepicker-options="EmployeeCtrl.datepickerOptions"
                         is-open="EmployeeCtrl.dateEmbauchePopupIsOpen"

--- a/client/src/modules/employees/registration/employees.html
+++ b/client/src/modules/employees/registration/employees.html
@@ -8,9 +8,9 @@
 
     <!-- ng-if to stop flickering on load -->
     <span
-        ng-if="EmployeeCtrl.isUpdating"
-        style="margin-left : 5px"
-        class="label label-warning text-uppercase">
+      ng-if="EmployeeCtrl.isUpdating"
+      style="margin-left : 5px"
+      class="label label-warning text-uppercase">
       <span translate>FORM.LABELS.EDIT</span>
     </span>
   </div>
@@ -464,20 +464,9 @@
                     id="individual_salary"
                     currency-id="EmployeeCtrl.enterprise.currency_id"
                     model="EmployeeCtrl.employee.individual_salary"
-                    min = 0>
+                    min = 0
+                    horizontal = "true">
                   </bh-currency-input>
-
-                  <div ng-repeat="rubric in EmployeeCtrl.rubrics">
-                    <bh-currency-input
-                      data-payment-currency-input
-                      label="{{rubric.label}}"
-                      id="{{rubric.abbr}}"
-                      currency-id="EmployeeCtrl.enterprise.currency_id"
-                      model="EmployeeCtrl.employee.payroll[rubric.id]"
-                      required ="false"
-                      min = 0>
-                    </bh-currency-input>
-                  </div>
 
                   <!-- Employee bank -->
                   <div
@@ -515,20 +504,23 @@
                     </div>
                   </div>
 
-                  <!-- Employee locked state
-                  <div class="form-group"
-                    ng-class="{'has-error' : OptionalForm.locked.$invalid && EmployeeRegistrationForm.$submitted}">
-                    <label class="control-label">
-                      <input
-                        type="checkbox"
-                        name="locked"
-                        ng-true-value="1"
-                        ng-false-value="0"
-                        ng-model="EmployeeCtrl.employee.locked">
-                        <span translate>FORM.LABELS.LOCKED</span>
-                    </label>
+                  <h4 class="text-capitalize" translate>FORM.LABELS.RUBRICS</h4>
+
+                  <!-- TODO(@jniles): are all employee rubrics really currency values? -->
+
+                  <!-- loop through rubrics and display them -->
+                  <div ng-repeat="rubric in EmployeeCtrl.rubrics">
+                    <bh-currency-input
+                      data-payment-currency-input
+                      label="{{rubric.label}}"
+                      id="{{rubric.abbr}}"
+                      currency-id="EmployeeCtrl.enterprise.currency_id"
+                      model="EmployeeCtrl.employee.payroll[rubric.id]"
+                      required ="false"
+                      min = 0
+                      horizontal = "true">
+                    </bh-currency-input>
                   </div>
-                  -->
                 </div>
               </div>
             </div>

--- a/client/src/modules/employees/registration/employees.html
+++ b/client/src/modules/employees/registration/employees.html
@@ -504,7 +504,7 @@
                     </div>
                   </div>
 
-                  <h4 class="text-capitalize" translate>FORM.LABELS.RUBRICS</h4>
+                  <h4 class="text-capitalize text-bold" translate>FORM.LABELS.RUBRICS</h4>
 
                   <!-- TODO(@jniles): are all employee rubrics really currency values? -->
 

--- a/client/src/modules/employees/registration/employees.js
+++ b/client/src/modules/employees/registration/employees.js
@@ -82,7 +82,7 @@ function EmployeeController(Employees, Services, Grades, Functions, Titles, Cred
 
     // Sanitise DOB for Date Input
     employee.dob = new Date(employee.dob);
-    employee.date_embauche = new Date(employee.date_embauche);
+    employee.hiring_date = new Date(employee.hiring_date);
 
     // Assign name
     employee.name = employee.display_name;

--- a/client/src/modules/employees/registration/employees.js
+++ b/client/src/modules/employees/registration/employees.js
@@ -5,11 +5,11 @@ angular.module('bhima.controllers')
 EmployeeController.$inject = [
   'EmployeeService', 'ServiceService', 'GradeService', 'FunctionService', 'TitleService',
   'CreditorGroupService', 'util', 'NotifyService', '$state',
-  'bhConstants', 'ReceiptModal', 'SessionService', 'RubricService', 'PatientService',
+  'bhConstants', 'ReceiptModal', 'SessionService', 'RubricService', 'PatientService', 'moment',
 ];
 
 function EmployeeController(Employees, Services, Grades, Functions, Titles, CreditorGroups, util, Notify,
-  $state, bhConstants, Receipts, Session, Rubrics, Patients) {
+  $state, bhConstants, Receipts, Session, Rubrics, Patients, moment) {
   const vm = this;
   const referenceUuid = $state.params.uuid;
   const { saveAsEmployee } = $state.params;
@@ -32,7 +32,7 @@ function EmployeeController(Employees, Services, Grades, Functions, Titles, Cred
         vm.employee = employee;
         vm.employee.payroll = {};
 
-        /**
+        /*
         /* Finds the amounts of all Rubrics (advantage) defined by employees,
         /* these rubrics are those whose value Is defined by employee? is true
         */
@@ -87,8 +87,8 @@ function EmployeeController(Employees, Services, Grades, Functions, Titles, Cred
     // Assign name
     employee.name = employee.display_name;
     employee.displayGender = employee.sex;
-    // eslint-disable-next-line no-undef
     employee.displayAge = moment().diff(employee.dob, 'years');
+
   }
 
   function onSelectGrade(element) {
@@ -97,7 +97,7 @@ function EmployeeController(Employees, Services, Grades, Functions, Titles, Cred
     }
   }
 
-  // Expose lenths from util
+  // Expose lengths from util
   vm.length20 = util.length20;
 
   // Expose validation rule for date
@@ -106,7 +106,6 @@ function EmployeeController(Employees, Services, Grades, Functions, Titles, Cred
     minDate : bhConstants.dates.minDOB,
   };
 
-  // const yearOptions = bhConstants.yearOptions;
   const { dayOptions } = bhConstants;
 
   setupRegistration();
@@ -138,6 +137,7 @@ function EmployeeController(Employees, Services, Grades, Functions, Titles, Cred
     const currentOptions = dayOptions;
 
     // set the database flag to track if a date is set to JAN 01 or if the date is unknown
+    // TODO(@jniles): I don't think this is necessary in the case of employees.  We require a DOB.
     vm.employee.dob_unknown_date = !vm.fullDateEnabled;
 
     angular.merge(vm.datepickerOptions, currentOptions);

--- a/client/src/modules/employees/registry/registry.js
+++ b/client/src/modules/employees/registry/registry.js
@@ -101,7 +101,7 @@ function EmployeeRegistryController(
       cellClass        : muteDisabledCells,
     },
     {
-      field            : 'date_embauche',
+      field            : 'hiring_date',
       displayName      : 'FORM.LABELS.DATE_EMBAUCHE',
       headerCellFilter : 'translate',
       type             : 'date',

--- a/client/src/modules/templates/bhCurrencyInput.tmpl.html
+++ b/client/src/modules/templates/bhCurrencyInput.tmpl.html
@@ -2,36 +2,39 @@
   <div class="form-group"
     ng-class="{ 'has-error' : bhCurrencyInputForm.$submitted && bhCurrencyInputForm.currencyInputValue.$invalid }"
     data-bh-currency-input>
-    <label class="control-label" translate>{{ ::$ctrl.label }}</label>
 
-    <div class="input-group">
-      <span class="input-group-addon text-uppercase">{{ $ctrl.currency.symbol || '...' }}</span>
-      <input
-        class="form-control"
-        type="number"
-        name="currencyInputValue"
-        ng-model="$ctrl.model"
-        ng-min="$ctrl.min || $ctrl.currency.min_monentary_unit"
-        ng-required="$ctrl.required">
+    <label class="control-label" ng-class="{'col-md-3' : $ctrl.horizontal}" translate>{{ ::$ctrl.label }}</label>
+    <div ng-class="{'col-md-9' : $ctrl.horizontal}">
+
+      <div class="input-group">
+        <span class="input-group-addon text-uppercase">{{ $ctrl.currency.symbol || '...' }}</span>
+        <input
+          class="form-control"
+          type="number"
+          name="currencyInputValue"
+          ng-model="$ctrl.model"
+          ng-min="$ctrl.min || $ctrl.currency.min_monentary_unit"
+          ng-required="$ctrl.required">
+      </div>
+
+      <!-- validation messages -->
+      <p class="help-block" ng-messages="bhCurrencyInputForm.currencyInputValue.$error" ng-show="bhCurrencyInputForm.$submitted">
+
+        <!-- displays: "This value is required" -->
+        <span ng-message="required">
+          <i class="fa fa-exclamation-circle"></i> <span translate>FORM.ERRORS.REQUIRED</span>
+        </span>
+
+        <!-- displays: "This value is too small for the selected currency" -->
+        <span ng-message="min">
+          <i class="fa fa-exclamation-circle"></i> <span translate>FORM.ERRORS.MIN_CURRENCY_UNIT</span>
+        </span>
+
+        <!-- displays: "You must enter a valid number." -->
+        <span ng-message="number">
+          <i class="fa fa-exclamation-circle"></i> <span translate>FORM.ERRORS.NUMBER</span>
+        </span>
+      </p>
     </div>
-
-    <!-- validation messages -->
-    <p class="help-block" ng-messages="bhCurrencyInputForm.currencyInputValue.$error" ng-show="bhCurrencyInputForm.$submitted">
-
-      <!-- displays: "This value is required" -->
-      <span ng-message="required">
-        <i class="fa fa-exclamation-circle"></i> <span translate>FORM.ERRORS.REQUIRED</span>
-      </span>
-
-      <!-- displays: "This value is too small for the selected currency" -->
-      <span ng-message="min">
-        <i class="fa fa-exclamation-circle"></i> <span translate>FORM.ERRORS.MIN_CURRENCY_UNIT</span>
-      </span>
-
-      <!-- displays: "You must enter a valid number." -->
-      <span ng-message="number">
-        <i class="fa fa-exclamation-circle"></i> <span translate>FORM.ERRORS.NUMBER</span>
-      </span>
-    </p>
   </div>
 </ng-form>

--- a/server/controllers/payroll/configuration/index.js
+++ b/server/controllers/payroll/configuration/index.js
@@ -193,7 +193,7 @@ async function updateEmployeesBasicIndice(idPeriod, dateTo) {
   // this query searches for the date of hire, their relative base index with their rank,
   // their responsibility index linked to their function,
   const sqlFindNewEmployees = `
-    SELECT emp.uuid, emp.date_embauche, sgi.value, sfi.value AS function_indice_value,
+    SELECT emp.uuid, emp.hiring_date, sgi.value, sfi.value AS function_indice_value,
     emp.grade_uuid, emp.fonction_id, pa.display_name
     FROM employee AS emp
     JOIN config_employee_item AS it ON it.employee_uuid = emp.uuid
@@ -211,7 +211,7 @@ async function updateEmployeesBasicIndice(idPeriod, dateTo) {
   // this query the date of the very first increment as well as the last value of the base index,
   // the responsibility index linked to the function and date of hire
   const sqlFindOldEmployees = `
-    SELECT emp.uuid, emp.date_embauche, lastIndice.date AS lastDateIncrease,
+    SELECT emp.uuid, emp.hiring_date, lastIndice.date AS lastDateIncrease,
     MAX(lastIndice.grade_indice) AS grade_indice, sfi.value AS function_indice_value, emp.grade_uuid,
     emp.fonction_id, pa.display_name
     FROM employee AS emp
@@ -251,8 +251,8 @@ async function updateEmployeesBasicIndice(idPeriod, dateTo) {
 
   // Processing of new employee data
   newEmployees.forEach(employee => {
-    employee.date_embauche = moment(employee.date_embauche).format('YYYY-MM-DD');
-    const yearOfSeniority = parseInt(moment(dateTo).diff(employee.date_embauche, 'years'), 10);
+    employee.hiring_date = moment(employee.hiring_date).format('YYYY-MM-DD');
+    const yearOfSeniority = parseInt(moment(dateTo).diff(employee.hiring_date, 'years'), 10);
 
     // Here we increment the base index based on the number of years
     for (let i = 0; i < yearOfSeniority; i++) {
@@ -272,14 +272,14 @@ async function updateEmployeesBasicIndice(idPeriod, dateTo) {
   });
 
   oldEmployees.forEach(employee => {
-    employee.date_embauche = moment(employee.date_embauche).format('YYYY-MM-DD');
+    employee.hiring_date = moment(employee.hiring_date).format('YYYY-MM-DD');
     employee.lastDateIncrease = moment(employee.lastDateIncrease).format('YYYY-MM-DD');
     // For employees who have already been configured, we will compare the number of years of seniority
     // and the difference in years between the date of the last increment of the base index,
     // if this difference is greater than zero, the we will have to increment
     // the base index in relation to this difference
-    const yearOfSeniority = parseInt(moment(dateTo).diff(employee.date_embauche, 'years'), 10);
-    const yearLastIncrementation = parseInt(moment(employee.lastDateIncrease).diff(employee.date_embauche, 'years'),
+    const yearOfSeniority = parseInt(moment(dateTo).diff(employee.hiring_date, 'years'), 10);
+    const yearLastIncrementation = parseInt(moment(employee.lastDateIncrease).diff(employee.hiring_date, 'years'),
       10);
 
     const diffSeniorityIncrementation = yearOfSeniority - yearLastIncrementation;

--- a/server/controllers/payroll/employees/index.js
+++ b/server/controllers/payroll/employees/index.js
@@ -114,7 +114,7 @@ function lookupEmployee(uid) {
   const sql = `
     SELECT
       BUID(employee.uuid) AS uuid, employee.code, patient.display_name, patient.sex,
-      patient.dob, employee.date_embauche, BUID(employee.service_uuid) as service_uuid,
+      patient.dob, employee.hiring_date, BUID(employee.service_uuid) as service_uuid,
       employee.nb_spouse, employee.nb_enfant, BUID(employee.grade_uuid) as grade_uuid,
       employee.locked, title_employee.is_medical, grade.text, grade.basic_salary,
       fonction.id AS fonction_id, fonction.fonction_txt, service.name AS service_txt, patient.hospital_no,
@@ -212,8 +212,8 @@ async function update(req, res, next) {
     employee.dob = new Date(employee.dob);
   }
 
-  if (employee.date_embauche) {
-    employee.date_embauche = new Date(employee.date_embauche);
+  if (employee.hiring_date) {
+    employee.hiring_date = new Date(employee.hiring_date);
   }
 
   const creditor = {
@@ -241,7 +241,7 @@ async function update(req, res, next) {
   };
 
   const clean = {
-    date_embauche : employee.date_embauche,
+    hiring_date : employee.hiring_date,
     service_uuid : employee.service_uuid,
     nb_enfant : employee.nb_enfant,
     grade_uuid : employee.grade_uuid,
@@ -332,8 +332,8 @@ function create(req, res, next) {
     employee.dob = new Date(employee.dob);
   }
 
-  if (employee.date_embauche) {
-    employee.date_embauche = new Date(employee.date_embauche);
+  if (employee.hiring_date) {
+    employee.hiring_date = new Date(employee.hiring_date);
   }
 
   const creditor = {
@@ -439,7 +439,7 @@ function find(options) {
   const sql = `
     SELECT
       BUID(employee.uuid) AS uuid, employee.code, patient.display_name, patient.sex,
-      patient.dob, employee.date_embauche, BUID(employee.service_uuid) as service_uuid, employee.nb_spouse,
+      patient.dob, employee.hiring_date, BUID(employee.service_uuid) as service_uuid, employee.nb_spouse,
       employee.nb_enfant, BUID(employee.grade_uuid) as grade_uuid, employee.locked, grade.text,
       grade.basic_salary, fonction.id AS fonction_id, fonction.fonction_txt, patient.hospital_no,
       patient.phone, patient.email, patient.address_1 AS adresse, BUID(employee.patient_uuid) AS patient_uuid,
@@ -468,9 +468,9 @@ function find(options) {
   const filters = new FilterParser(options, { tableAlias : 'employee' });
 
   filters.dateFrom('dateBirthFrom', 'dob', 'patient');
-  filters.dateFrom('dateEmbaucheFrom', 'date_embauche');
+  filters.dateFrom('dateEmbaucheFrom', 'hiring_date');
   filters.dateTo('dateBirthTo', 'dob', 'patient');
-  filters.dateTo('dateEmbaucheTo', 'date_embauche');
+  filters.dateTo('dateEmbaucheTo', 'hiring_date');
   filters.equals('code', 'code', 'employee');
   filters.equals('fonction_id', 'fonction_id', 'employee');
   filters.equals('grade_uuid', 'grade_uuid', 'employee');
@@ -546,8 +546,8 @@ function patientToEmployee(req, res, next) {
     text : `Debiteur [${employee.display_name}]`,
   };
 
-  if (employee.date_embauche) {
-    employee.date_embauche = new Date(employee.date_embauche);
+  if (employee.hiring_date) {
+    employee.hiring_date = new Date(employee.hiring_date);
   }
 
   delete employee.debtor_group_uuid;

--- a/server/controllers/payroll/multiplePayroll/find.js
+++ b/server/controllers/payroll/multiplePayroll/find.js
@@ -26,7 +26,7 @@ function find(options) {
   }
 
   const sql = `
-    SELECT BUID(payroll.employee_uuid) AS employee_uuid, payroll.reference, payroll.code, payroll.date_embauche,
+    SELECT BUID(payroll.employee_uuid) AS employee_uuid, payroll.reference, payroll.code, payroll.hiring_date,
       payroll.nb_enfant, payroll.individual_salary, payroll.account_id, payroll.creditor_uuid, payroll.display_name,
       payroll.sex, payroll.payment_uuid, payroll.payroll_configuration_id, payroll.currency_id,
       payroll.payment_date, payroll.base_taxable, payroll.basic_salary, payroll.gross_salary, payroll.grade_salary,
@@ -36,7 +36,7 @@ function find(options) {
       IF (payroll.net_salary < 0, 1, 0) AS negativeValue
     FROM(
       SELECT employee.uuid AS employee_uuid, employee.reference, em.text AS hrreference, employee.code,
-        employee.date_embauche, employee.nb_enfant,employee.individual_salary, creditor_group.account_id,
+        employee.hiring_date, employee.nb_enfant,employee.individual_salary, creditor_group.account_id,
         BUID(employee.creditor_uuid) AS creditor_uuid,
         UPPER(patient.display_name) AS display_name, patient.sex, BUID(payment.uuid) AS payment_uuid,
         payment.payroll_configuration_id,  payment.currency_id, payment.payment_date, payment.base_taxable,
@@ -61,7 +61,7 @@ function find(options) {
         WHERE payment.payroll_configuration_id = '${options.payroll_configuration_id}'
       UNION
         SELECT employee.uuid AS employee_uuid,  employee.reference, em.text AS hrreference, employee.code,
-          employee.date_embauche, employee.nb_enfant, employee.individual_salary, creditor_group.account_id,
+          employee.hiring_date, employee.nb_enfant, employee.individual_salary, creditor_group.account_id,
         BUID(employee.creditor_uuid) AS creditor_uuid, UPPER(patient.display_name) AS display_name,
         patient.sex, NULL AS 'payment_uuid', '${options.payroll_configuration_id}' AS payroll_configuration_id,
         '${options.currency_id}' AS currency_id, NULL AS payment_date, 0 AS base_taxable, 0 AS basic_salary,

--- a/server/controllers/payroll/multiplePayroll/payrollSettings.js
+++ b/server/controllers/payroll/multiplePayroll/payrollSettings.js
@@ -90,7 +90,7 @@ function setConfig(
     const nbChildren = employee.nb_enfant;
 
     // determine the seniority of the employee by computing the difference between their hiring date and present date.
-    const yearsOfSeniority = moment(periodData.dateTo).diff(moment(employee.date_embauche), 'years');
+    const yearsOfSeniority = moment(periodData.dateTo).diff(moment(employee.hiring_date), 'years');
 
     /**
     * Some institutions allocate a percentage of the daily salary for off-day and holiday payments.

--- a/server/controllers/payroll/multiplePayroll/setConfiguration.js
+++ b/server/controllers/payroll/multiplePayroll/setConfiguration.js
@@ -62,8 +62,8 @@ async function config(req, res, next) {
     const workingDayCost = dailySalary * data.working_day;
     const nbChildren = employee.nb_enfant;
 
-    // Calcul of Seniority date Between date_embauche and the end date of Period
-    const yearsOfSeniority = moment(periodDateTo).diff(moment(employee.date_embauche), 'years');
+    // Calcul of Seniority date Between hiring_date and the end date of Period
+    const yearsOfSeniority = moment(periodDateTo).diff(moment(employee.hiring_date), 'years');
 
     /**
      * Some institution allocates a percentage for the offday and holiday payment.

--- a/server/controllers/payroll/multiplePayrollIndice/parameters.config.js
+++ b/server/controllers/payroll/multiplePayrollIndice/parameters.config.js
@@ -143,7 +143,7 @@ async function create(req, res, next) {
 
     // FIXME(@jniles) - we should make sure this can never be negative
     // if it is negative, can it be zeroed out?
-    const diff = moment(payrollPeriodDate).diff(moment(emp.date_embauche));
+    const diff = moment(payrollPeriodDate).diff(moment(emp.hiring_date));
     const duration = moment.duration(diff, 'milliseconds');
     const yearOfSeniority = parseInt(duration.asYears(), 10);
 
@@ -468,7 +468,7 @@ function stagePaymentIndice(payrollConfigurationId) {
 
   const sqlGetEmployees = `
      SELECT BUID(emp.uuid) AS employee_uuid, emp.uuid AS employee_buid, emp.code, ind.grade_indice,
-       ind.function_indice, ind.created_at, emp.date_embauche, patient.display_name
+       ind.function_indice, ind.created_at, emp.hiring_date, patient.display_name
      FROM payroll_configuration AS pc
        JOIN config_employee AS ce ON ce.id = pc.config_employee_id
        JOIN config_employee_item AS cei ON cei.config_employee_id = ce.id

--- a/server/controllers/payroll/reports/payslipGenerator.handlebars
+++ b/server/controllers/payroll/reports/payslipGenerator.handlebars
@@ -21,7 +21,7 @@
           <div> <b>{{translate "FORM.LABELS.CODE"}} :</b> {{code}} </div>
           <div> <b>{{translate "FORM.LABELS.REFERENCE"}} :</b> {{hrreference}} </div>
           <div> <b>{{translate "FORM.LABELS.GRADE"}} :</b> {{text}} </div>
-          <div> <b>{{translate "FORM.LABELS.DATE_EMBAUCHE"}} :</b> {{date date_embauche}} </div>
+          <div> <b>{{translate "FORM.LABELS.DATE_EMBAUCHE"}} :</b> {{date hiring_date}} </div>
           <div> <b>{{translate "FORM.LABELS.NB_CHILD"}} :</b> {{nb_enfant}} </div>
         </div>
       </header>

--- a/server/controllers/payroll/reports/registrations.handlebars
+++ b/server/controllers/payroll/reports/registrations.handlebars
@@ -31,7 +31,7 @@
             <td>{{this.fonction_txt}}</td>
             <td>{{this.service_name}}</td>
             <td>{{this.cost_center}}</td>
-            <td>{{date this.date_embauche}}</td>
+            <td>{{date this.hiring_date}}</td>
           </tr>
         {{else}}
           <tr>

--- a/server/models/01-schema.sql
+++ b/server/models/01-schema.sql
@@ -515,7 +515,7 @@ DROP TABLE IF EXISTS `employee`;
 CREATE TABLE `employee` (
   `uuid`          BINARY(16) NOT NULL,
   `code`          VARCHAR(20) NOT NULL,
-  `date_embauche` DATETIME DEFAULT NULL,
+  `hiring_date`   DATETIME DEFAULT NULL,
   `grade_uuid`    BINARY(16) NOT NULL,
   `nb_spouse`     INT(2) DEFAULT 0,
   `nb_enfant`     INT(3) DEFAULT 0,

--- a/server/models/03-procedures.sql
+++ b/server/models/03-procedures.sql
@@ -3735,7 +3735,7 @@ DROP PROCEDURE IF EXISTS `UpdateStaffingIndices`$$
 CREATE PROCEDURE `UpdateStaffingIndices`(IN _dateFrom DATE, IN _dateTo DATE, IN _payroll_conf_id INT)
 BEGIN
   DECLARE _id mediumint(8) unsigned;
-  DECLARE _date_embauche DATE;
+  DECLARE _hiring_date DATE;
   DECLARE _employee_uuid, _grade_uuid, _current_staffing_indice_uuid, _last_staffing_indice_uuid BINARY(16);
   DECLARE _hiring_year, _fonction_id INT;
   DECLARE _grade_indice, _last_grade_indice, _function_indice, _grade_indice_rate DECIMAL(19,4);
@@ -3745,7 +3745,7 @@ BEGIN
   DECLARE curs1 CURSOR FOR
   -- The request should only return the employees affected by the pay period,
   -- just because two pay periods can have the same time range.
-  SELECT emp.uuid, emp.grade_uuid, emp.fonction_id, emp.date_embauche
+  SELECT emp.uuid, emp.grade_uuid, emp.fonction_id, emp.hiring_date
     FROM employee AS emp
     JOIN config_employee_item AS conf ON conf.employee_uuid = emp.uuid
     JOIN config_employee AS cemp ON cemp.id = conf.config_employee_id
@@ -3758,12 +3758,12 @@ BEGIN
 
     OPEN curs1;
         read_loop: LOOP
-        FETCH curs1 INTO _employee_uuid, _grade_uuid, _fonction_id, _date_embauche;
+        FETCH curs1 INTO _employee_uuid, _grade_uuid, _fonction_id, _hiring_date;
             IF done THEN
                 LEAVE read_loop;
             END IF;
             -- anciennette
-            SET _hiring_year = FLOOR(DATEDIFF(_dateTo, _date_embauche)/365);
+            SET _hiring_year = FLOOR(DATEDIFF(_dateTo, _hiring_date)/365);
             -- is there any staffing indice specified for the employee in this payroll config period interval ?
             -- _current_staffing_indice_uuid is the indice for this payroll config period interval
             SET _current_staffing_indice_uuid  = IFNULL((
@@ -3783,12 +3783,12 @@ BEGIN
 
             SET @shouldInsert = FALSE;
 
-            -- check if the date_embauche is in the current payroll config period interval
-            SET @hiring_date = DATE(CONCAT(YEAR(_dateTo), '-', MONTH(_date_embauche), '-', DAY(_date_embauche)));
-            SET @date_embauche_interval = (@hiring_date BETWEEN _dateFrom AND _dateTo);
+            -- check if the hiring_date is in the current payroll config period interval
+            SET @hiring_date = DATE(CONCAT(YEAR(_dateTo), '-', MONTH(_hiring_date), '-', DAY(_hiring_date)));
+            SET @hiring_date_interval = (@hiring_date BETWEEN _dateFrom AND _dateTo);
 
             -- should update staffing_indice and there's no previous staffing_indice for in this payroll config period interval
-            IF  ((@date_embauche_interval=1)  AND (_current_staffing_indice_uuid = HUID('0'))) THEN
+            IF  ((@hiring_date_interval=1)  AND (_current_staffing_indice_uuid = HUID('0'))) THEN
                 -- increase the _last_grade_indice if it exist
                 IF (_last_staffing_indice_uuid <> HUID('0')) THEN
                     SET _last_grade_indice = (SELECT grade_indice FROM staffing_indice WHERE uuid = _last_staffing_indice_uuid);
@@ -3802,7 +3802,7 @@ BEGIN
             -- no indice has been created for the employee previously(no record in the table for him)
             -- this is used when configuring for the first time
             ELSE
-                IF ((@date_embauche_interval = 0) && (_last_staffing_indice_uuid = HUID('0'))) THEN
+                IF ((@hiring_date_interval = 0) && (_last_staffing_indice_uuid = HUID('0'))) THEN
                     SET _grade_indice = (SELECT IFNULL(value, 0)  FROM staffing_grade_indice WHERE grade_uuid = _grade_uuid LIMIT 1);
                     SET _grade_indice = _grade_indice + (_grade_indice * _hiring_year * _grade_indice_rate);
                     SET @shouldInsert = TRUE;

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -1,3 +1,4 @@
+-- migrate/next.sql
 
 -- @jniles: modify the email fields to standarize the field length
 ALTER TABLE `patient` MODIFY `email` VARCHAR(150) DEFAULT NULL;
@@ -11,5 +12,12 @@ ALTER TABLE `user` MODIFY `email` VARCHAR(150) DEFAULT NULL;
  * @date: 2024-11-27
  * @description: Fix and Update Cashflow Report and Budget Report #7897
  */
-
 INSERT INTO `account_reference_type` (`id`, `label`, `fixed`) VALUES (8, 'FORM.LABELS.BUDGET_ANALYSIS', 1);
+
+
+/*
+ * @author: jniles
+ * @date: 2024-12-24
+ * Change the name of the "hiring_date" column to "date_embauche" in the "employee" table
+ */
+ALTER TABLE `employee` CHANGE COLUMN date_embauche hiring_date DATETIME DEFAULT NULL;

--- a/test/data.sql
+++ b/test/data.sql
@@ -504,7 +504,7 @@ INSERT INTO `reference` VALUES
   (3, 0, 'AC', 'Reference resultat 1', 1, NULL, 1),
   (4, 0, 'XX', 'Deletable reference 1', 1, NULL, NULL);
 
-INSERT INTO `employee` (`uuid`, `code`, `date_embauche`, `grade_uuid`, `nb_spouse`, `nb_enfant`, `individual_salary`, `bank`, `bank_account`, `fonction_id`, `service_uuid`, `creditor_uuid`, `locked`, `patient_uuid`) VALUES
+INSERT INTO `employee` (`uuid`, `code`, `hiring_date`, `grade_uuid`, `nb_spouse`, `nb_enfant`, `individual_salary`, `bank`, `bank_account`, `fonction_id`, `service_uuid`, `creditor_uuid`, `locked`, `patient_uuid`) VALUES
   (HUID('75e09694-65f2-45a1-a8a2-8b025003d793'),'E1','2016-02-02 00:00:00',HUID('71e9f21c-d9b1-11e5-8ab7-78eb2f2a46e0'),1,3,500,'TMB','1201-3456-5423-03', 1, @medicineInterneService, HUID('42d3756a-7770-4bb8-a899-7953cd859892'), 0, HUID('274c51ae-efcc-4238-98c6-f402bfb39866')),
   (HUID('75e69409-562f-a2a8-45a1-3d7938b02500'), 'WWEFCB', '2016-01-01 01:00:00', HUID('9ee06e4a7b5948e6812cc0f8a00cf7d3'), 0, 0, 0, 'BCOL', '00-99-88-77', 1, @testService, HUID('18dcada5-f149-4eea-8267-19c346c2744f'), 0, HUID('d1d7f856-d414-4400-8b94-8ba9445a2bc0'));
 
@@ -1223,8 +1223,8 @@ INSERT INTO `patient` (`uuid`, `project_id`, `reference`, `debtor_uuid`, `displa
 INSERT INTO `creditor` (`uuid`, `group_uuid`, `text`) VALUES (0x75ED6B1141764BF7821D34BA638B0647, 0xB0FA5ED204F94CB392F761D6404696E7, 'Crediteur [Employee indice 1]');
 INSERT INTO `creditor` (`uuid`, `group_uuid`, `text`) VALUES (0x6150E9B14D214DC28E845BFAAB40DD5E, 0xB0FA5ED204F94CB392F761D6404696E7, 'Crediteur [Employee indice 2]');
 
-INSERT INTO `employee` (`uuid`, `code`, `date_embauche`, `grade_uuid`, `nb_spouse`, `nb_enfant`, `individual_salary`, `bank`, `bank_account`, `fonction_id`, `service_uuid`, `creditor_uuid`, `locked`, `patient_uuid`, `reference`) VALUES (0x10F64A41DA594962AA9A90CF0D42257C, 'IMA-ASSR-1', DATE_ADD(CURRENT_DATE, INTERVAL -25 MONTH)   , 0x71E9F21CD9B111E58AB778EB2F2A46E0, 0, 0, 0, NULL, NULL, 2, 0xB1816006555845F993A0C222B5EFA6CB, 0x75ED6B1141764BF7821D34BA638B0647, 0 , 0x4B23E6B9187F4CE69696542F798B5F32, 3);
-INSERT INTO `employee` (`uuid`, `code`, `date_embauche`, `grade_uuid`, `nb_spouse`, `nb_enfant`, `individual_salary`, `bank`, `bank_account`, `fonction_id`, `service_uuid`, `creditor_uuid`, `locked`, `patient_uuid`, `reference`) VALUES (0xD321099D01CD41029686B87CB70B9311, 'IMA-ASSP-2', DATE_ADD(CURRENT_DATE, INTERVAL -2 YEAR), 0x61E9F21CD9B111E48AB678EB2F2A46E0, 0, 2, 0, NULL, NULL, 1, 0xE3988489EF6641DF88FA8B8ED6AA03AC, 0x6150E9B14D214DC28E845BFAAB40DD5E, 0, 0xA6643C4F310145BA961B54FD83D71E7C, 4);
+INSERT INTO `employee` (`uuid`, `code`, `hiring_date`, `grade_uuid`, `nb_spouse`, `nb_enfant`, `individual_salary`, `bank`, `bank_account`, `fonction_id`, `service_uuid`, `creditor_uuid`, `locked`, `patient_uuid`, `reference`) VALUES (0x10F64A41DA594962AA9A90CF0D42257C, 'IMA-ASSR-1', DATE_ADD(CURRENT_DATE, INTERVAL -25 MONTH)   , 0x71E9F21CD9B111E58AB778EB2F2A46E0, 0, 0, 0, NULL, NULL, 2, 0xB1816006555845F993A0C222B5EFA6CB, 0x75ED6B1141764BF7821D34BA638B0647, 0 , 0x4B23E6B9187F4CE69696542F798B5F32, 3);
+INSERT INTO `employee` (`uuid`, `code`, `hiring_date`, `grade_uuid`, `nb_spouse`, `nb_enfant`, `individual_salary`, `bank`, `bank_account`, `fonction_id`, `service_uuid`, `creditor_uuid`, `locked`, `patient_uuid`, `reference`) VALUES (0xD321099D01CD41029686B87CB70B9311, 'IMA-ASSP-2', DATE_ADD(CURRENT_DATE, INTERVAL -2 YEAR), 0x61E9F21CD9B111E48AB678EB2F2A46E0, 0, 2, 0, NULL, NULL, 1, 0xE3988489EF6641DF88FA8B8ED6AA03AC, 0x6150E9B14D214DC28E845BFAAB40DD5E, 0, 0xA6643C4F310145BA961B54FD83D71E7C, 4);
 
 INSERT INTO `config_employee_item` (`id`, `config_employee_id`, `employee_uuid`) VALUES
   (3, 2, 0x10F64A41DA594962AA9A90CF0D42257C),

--- a/test/end-to-end/employees/registration.page.js
+++ b/test/end-to-end/employees/registration.page.js
@@ -43,7 +43,7 @@ class RegistrationPage {
 
   // set hiring date
   setHiringDate(hiringDate) {
-    return TU.input('EmployeeCtrl.employee.date_embauche', hiringDate);
+    return TU.input('EmployeeCtrl.employee.hiring_date', hiringDate);
   }
 
   // set the employee code

--- a/test/end-to-end/employees/registration.spec.js
+++ b/test/end-to-end/employees/registration.spec.js
@@ -20,7 +20,7 @@ test.describe('Employees', () => {
     display_name  : 'Dedrick Kitamuka',
     sex          : 'M',
     dob           : '30/06/1960',
-    date_embauche : '17/05/1997',
+    hiring_date : '17/05/1997',
     nb_enfant     : 2,
     bank          : 'BIAC',
     bank_account  : '00-99-88-77',
@@ -32,7 +32,7 @@ test.describe('Employees', () => {
   const patient = {
     code           : 'HBB2018',
     display_name   : 'Test 1 Patient',
-    date_embauche  : '24/11/1965',
+    hiring_date  : '24/11/1965',
     nb_spouse      : 5,
     nb_enfant      : 3,
     bank           : 'BCDC_1909',
@@ -69,7 +69,7 @@ test.describe('Employees', () => {
     await registrationPage.setDebtorGroup('NGO IMA World Health');
     await registrationPage.setOriginLocation(helpers.data.locations);
     await registrationPage.setCurrentLocation(helpers.data.locations);
-    await registrationPage.setHiringDate(employee.date_embauche);
+    await registrationPage.setHiringDate(employee.hiring_date);
     await registrationPage.setNumberChild(employee.nb_enfant);
     await registrationPage.setService('Administration');
     await registrationPage.setFunction('Infirmier');
@@ -98,7 +98,7 @@ test.describe('Employees', () => {
     await registrationPage.setGrade('A1');
     await registrationPage.setCreditorGroup(patient.creditor_group);
     await registrationPage.setDebtorGroup(patient.debtor_group);
-    await registrationPage.setHiringDate(patient.date_embauche);
+    await registrationPage.setHiringDate(patient.hiring_date);
     await registrationPage.setNumberChild(patient.nb_enfant);
     await registrationPage.setService('Administration');
     await registrationPage.setFunction('Infirmier');

--- a/test/integration/employee.js
+++ b/test/integration/employee.js
@@ -23,7 +23,7 @@ describe('test/integration/employees the employees API', () => {
     display_name : 'Magnus Carolus Charlemagne',
     sex : 'M',
     dob : dob1,
-    date_embauche : embaucheDate,
+    hiring_date : embaucheDate,
     nb_spouse : 0,
     nb_enfant : 0,
     grade_uuid : '9EE06E4A-7B59-48E6-812C-C0F8A00CF7D3',
@@ -49,7 +49,7 @@ describe('test/integration/employees the employees API', () => {
     display_name : 'Charle Magne De France',
     sex : 'M',
     dob : dob2,
-    date_embauche : embaucheDate,
+    hiring_date : embaucheDate,
     nb_spouse : 0,
     nb_enfant : 0,
     hospital_no : 'HBB 2017',
@@ -70,7 +70,7 @@ describe('test/integration/employees the employees API', () => {
     display_name : 'Test 1 Patient',
     patient_uuid : '81AF634F321A40DEBC6FCEB1167A9F65',
     debtor_uuid : 'A11E6B7FFBBB432EAC2A5312A66DCCF4',
-    date_embauche : embaucheDate,
+    hiring_date : embaucheDate,
     nb_spouse : 0,
     nb_enfant : 0,
     grade_uuid : '9EE06E4A7B5948E6812CC0F8A00CF7D3',
@@ -278,7 +278,7 @@ describe('test/integration/employees the employees API', () => {
   function checkValidUpdate(person, update) {
     // eslint-disable-next-line
     for (const i in update) {
-      if (i === 'dob' || i === 'date_embauche') {
+      if (i === 'dob' || i === 'hiring_date') {
         expect(new Date(person[i])).to.equalDate(new Date(update[i]));
       } else {
         expect(person[i]).to.equal(update[i]);

--- a/test/integration/payroll.js
+++ b/test/integration/payroll.js
@@ -20,7 +20,7 @@ describe('test/integration/payroll the Multiple Payroll API', () => {
   const employees = [{
     employee_uuid : '6b4642a7-4577-4768-b6ae-1b3d38f0bbef',
     code : 'x500',
-    date_embauche : '2016-01-01T00:00:00.000Z',
+    hiring_date : '2016-01-01T00:00:00.000Z',
     nb_enfant : 0,
     individual_salary : null,
     account_id : 179,
@@ -47,7 +47,7 @@ describe('test/integration/payroll the Multiple Payroll API', () => {
   }, {
     employee_uuid : '75e69409-562f-a2a8-45a1-3d7938b02500',
     code : 'WWEFCB',
-    date_embauche : '2016-01-01T00:00:00.000Z',
+    hiring_date : '2016-01-01T00:00:00.000Z',
     nb_enfant : 0,
     individual_salary : 0,
     account_id : 179,
@@ -96,7 +96,7 @@ describe('test/integration/payroll the Multiple Payroll API', () => {
        display_name : 'Employee Test 1',
        sex : 'F',
        dob : '1960-06-29T22:00:00.000Z',
-       date_embauche : '2016-01-01T00:00:00.000Z',
+       hiring_date : '2016-01-01T00:00:00.000Z',
        service_uuid : 1,
        nb_spouse : 0,
        nb_enfant : 0,


### PR DESCRIPTION
This PR does some minor UI tweaks to the employee registration page.  It adds a labels above the "Rubrics" section to clearly identify that they are rubrics, and moves the rubrics section to the bottom of the optional information in the form.

Additionally, I added an optional flag to the `bhCurrencyInput` to support `form-horizontal` cases.  It is fixed a `col-md-3` since that is what is used on this page.  I'm conflicted about if having the `form-horizontal` is even a good idea here, but we'll keep it until there is more data than just my own personal feeling.

Major code changes are the updates to the Currency Service to bring it in line with modern ECMAScript.

Here is what it looks like using the test database:

![image](https://github.com/user-attachments/assets/785d8de2-7ef7-4095-bc10-fc15433da91e)
