### PR TITLE
fix: stock tests fiscal year issue

### DIFF
--- a/test/data.sql
+++ b/test/data.sql
@@ -26,7 +26,6 @@ SET @medicineInterneService = HUID('e3988489-ef66-41df-88fa-8b8ed6aa03ac');
 SET @newService =  HUID('029263E99A29436BB12EE9730A70C515');
 SET @newService2 =  HUID('63E9029299A26B43B21EE973051A70C5');
 
-
 -- Services
 INSERT INTO `service` (uuid, enterprise_id, project_id, name) VALUES
   (@testService, 1, 1, 'Test Service'),

--- a/test/data/core.sql
+++ b/test/data/core.sql
@@ -112,6 +112,9 @@ CALL CreateFiscalYear(1, @fiscalYear2022, @superUser, 'Fiscal Year 2023', 12, DA
 SET @fiscalYear2024 = 0;
 CALL CreateFiscalYear(1, @fiscalYear2023, @superUser, 'Fiscal Year 2024', 12, DATE('2024-01-01'), DATE('2024-12-31'), 'Notes for 2024', @fiscalYear2024);
 
+SET @fiscalYear2025 = 0;
+CALL CreateFiscalYear(1, @fiscalYear2025, @superUser, 'Fiscal Year 2025', 12, DATE('2025-01-01'), DATE('2025-12-31'), 'Notes for 2025', @fiscalYear2025);
+
 --
 -- Project permission
 --

--- a/test/data/service-stock.sql
+++ b/test/data/service-stock.sql
@@ -54,22 +54,22 @@ INSERT INTO depot_permission (user_id, depot_uuid) VALUES
 -- SET @two_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 2 MONTH), INTERVAL (3000*RAND()) SECOND);
 -- SET @one_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 1 MONTH), INTERVAL (3000*RAND()) SECOND);
 
--- Compute all these times based on 30.5 days per month (rounding up)
-SET @one_year_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 366 DAY), INTERVAL (3000*RAND()) SECOND);
-SET @eleven_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 336 DAY), INTERVAL (3000*RAND()) SECOND);
-SET @ten_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 305 DAY), INTERVAL (3000*RAND()) SECOND);
-SET @nine_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 275 DAY), INTERVAL (3000*RAND()) SECOND);
-SET @eight_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 244 DAY), INTERVAL (3000*RAND()) SECOND);
-SET @seven_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 214 DAY), INTERVAL (3000*RAND()) SECOND);
-SET @six_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 183 DAY), INTERVAL (3000*RAND()) SECOND);
-SET @five_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 153 DAY), INTERVAL (3000*RAND()) SECOND);
-SET @four_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 122 DAY), INTERVAL (3000*RAND()) SECOND);
-SET @three_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 92 DAY), INTERVAL (3000*RAND()) SECOND);
-SET @two_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 61 DAY), INTERVAL (3000*RAND()) SECOND);
-SET @one_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 31 DAY), INTERVAL (3000*RAND()) SECOND);
+-- Use true month intervals instead of day approximations
+SET @one_year_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 12 MONTH), INTERVAL FLOOR(3000 * RAND()) SECOND);
+SET @eleven_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 11 MONTH), INTERVAL FLOOR(3000 * RAND()) SECOND);
+SET @ten_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 10 MONTH), INTERVAL FLOOR(3000 * RAND()) SECOND);
+SET @nine_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 9 MONTH), INTERVAL FLOOR(3000 * RAND()) SECOND);
+SET @eight_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 8 MONTH), INTERVAL FLOOR(3000 * RAND()) SECOND);
+SET @seven_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 7 MONTH), INTERVAL FLOOR(3000 * RAND()) SECOND);
+SET @six_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 6 MONTH), INTERVAL FLOOR(3000 * RAND()) SECOND);
+SET @five_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 5 MONTH), INTERVAL FLOOR(3000 * RAND()) SECOND);
+SET @four_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 4 MONTH), INTERVAL FLOOR(3000 * RAND()) SECOND);
+SET @three_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 3 MONTH), INTERVAL FLOOR(3000 * RAND()) SECOND);
+SET @two_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 2 MONTH), INTERVAL FLOOR(3000 * RAND()) SECOND);
+SET @one_months_ago = DATE_ADD(DATE_SUB(NOW(), INTERVAL 1 MONTH), INTERVAL FLOOR(3000 * RAND()) SECOND);
 
 -- two years and some into the future
-SET @expiration_date = DATE_ADD(DATE_ADD(NOW(), INTERVAL 732 DAY), INTERVAL (100000 *RAND()) SECOND);
+SET @expiration_date = DATE_ADD(DATE_ADD(NOW(), INTERVAL 2 YEAR), INTERVAL (100000 *RAND()) SECOND);
 
 DELIMITER $$
 CREATE FUNCTION GetPeriodId(period_date DATETIME)
@@ -102,7 +102,9 @@ INSERT INTO `stock_movement` (`uuid`, `document_uuid`, `depot_uuid`, `lot_uuid`,
   (0x3138767AE6404C9D8BF536D64D11207F,0x60F74D25E1B94D8DACAAD51B3318216E,@depot_uuid,0x8E8D1F39D57348689800EB8EA707E813,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption of March.2020',10,@nine_months_ago,300,7.0600,1,1,4,NULL,NULL,GetPeriodId(@nine_months_ago), @nine_months_ago),
   (0x44D06FD1A86F4A32BA33CC9CA3ED7B79,0xAE2714926A714AE9B56C96A102B0D98F,@depot_uuid,0x3CAA76C5748041F5A55600D48B770B9D,0xB1816006555845F993A0C222B5EFA6CB,'Distribution to the service Administration from Depot Principal : Consumption of Jan 1',10,@eleven_months_ago,30,9.4000,1,1,2,NULL,NULL,GetPeriodId(@eleven_months_ago), @eleven_months_ago),
   (0x4DEA61312CEA466B956602AADEF50673,0xAE2714926A714AE9B56C96A102B0D98F,@depot_uuid,0x971F7AC3FF604A649773CE9539871A07,0xB1816006555845F993A0C222B5EFA6CB,'Distribution to the service Administration from Depot Principal : Consumption of Jan 1',10,@eleven_months_ago,20,9.4000,1,1,2,NULL,NULL,GetPeriodId(@eleven_months_ago), @eleven_months_ago),
-  (0x4E6E8DA908EA4C5D82F21925ADEDD6FC,0x5D1695E2AE4C42EE80DDA6D80DE9BF07,@depot_uuid,0x8E8D1F39D57348689800EB8EA707E813,0xB1816006555845F993A0C222B5EFA6CB,'Distribution to the service Administration from Depot Principal : Consumption for June 2020',10,@six_months_ago,90,7.0600,1,1,7,NULL,NULL,GetPeriodId(@six_months_ago), @six_months_ago),
+  (0x4E6E8DA908EA4C5D82F21925ADEDD6FC,0x5D1695E2AE4C42EE80DDA6D80DE9BF07,@depot_uuid,0x8E8D1F39D57348689800EB8EA707E813,0xB1816006555845F993A0C222B5EFA6CB,'Distribution to the service Administration from Depot Principal : Consumption for June 2020',10,@six_months_ago,90,7.0600,1,1,7,NULL,NULL,GetPeriodId(@six_months_ago), @six_months_ago);
+
+INSERT INTO `stock_movement` (`uuid`, `document_uuid`, `depot_uuid`, `lot_uuid`, `entity_uuid`, `description`, `flux_id`, `date`, `quantity`, `unit_cost`, `is_exit`, `user_id`, `reference`, `invoice_uuid`, `stock_requisition_uuid`, `period_id`, `created_at`) VALUES
   (0x4FD61D6DD31E406CB4F90AD76AF7FEF6,0xCC5446AF6CA44D29A955FC33AC75EAA3,@depot_uuid,0x6AA623AAA6EF4ECAB811E398D37C110D,NULL,'Initializing the inventory of the first depot.',13,@one_year_ago,60,3.1800,0,1,1,NULL,NULL,GetPeriodId(@eleven_months_ago), @eleven_months_ago),
   (0x568DB860F640468EA27D5088EE2ABC64,0xCC5446AF6CA44D29A955FC33AC75EAA3,@depot_uuid,0xC26BA248149D4FAB882C97A368072F2B,NULL,'Initializing the inventory of the first depot.',13,@one_year_ago,200,9.4000,0,1,1,NULL,NULL,GetPeriodId(@eleven_months_ago), @eleven_months_ago),
   (0x5D6539CF6D5A4AA4A5230669FC06BC77,0x0BF8E5AB353F4C0BA6BDD2E119C5C58E,@depot_uuid,0x8E8D1F39D57348689800EB8EA707E813,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption for April 2020',10,@eight_months_ago,60,7.0600,1,1,5,NULL,NULL,GetPeriodId(@eight_months_ago), @eight_months_ago),
@@ -111,14 +113,25 @@ INSERT INTO `stock_movement` (`uuid`, `document_uuid`, `depot_uuid`, `lot_uuid`,
   (0x65DC4EEC5F0249959A64E7B54C9F0F8E,0xCC5446AF6CA44D29A955FC33AC75EAA3,@depot_uuid,0x971F7AC3FF604A649773CE9539871A07,NULL,'Initializing the inventory of the first depot.',13,@one_year_ago,500,9.4000,0,1,1,NULL,NULL,GetPeriodId(@eleven_months_ago), @eleven_months_ago),
   (0x66B809243D054A44944445DCEF19A421,0x5CEDC2C76BDF44A38346BC869217DE30,@depot_uuid,0x8E8D1F39D57348689800EB8EA707E813,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption for July 2020',10,@four_months_ago,120,7.0600,1,1,8,NULL,NULL,GetPeriodId(@four_months_ago), @four_months_ago),
   (0x77A35840B74F49D5B47B3CE29840ABCD,0x5CEDC2C76BDF44A38346BC869217DE30,@depot_uuid,0xD5C6BC2825A24C218025817F8F00B8A7,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption for July 2020',10,@four_months_ago,80,9.4000,1,1,8,NULL,NULL,GetPeriodId(@four_months_ago), @four_months_ago),
-  (0x7B974EF9F33E4A7A97B5CE3DBE252EAD,0x52289678498B42AAB50115796C953B19,@depot_uuid,0x3CAA76C5748041F5A55600D48B770B9D,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption of February 2020',10,@ten_months_ago,50,9.4000,1,1,3,NULL,NULL,GetPeriodId(@ten_months_ago), @ten_months_ago),
-  (0x7E064AE1E81F404C911B2451D115F67F,0x414E2B0856C840B981AB4AB7E7711D51,@depot_uuid,0x8E8D1F39D57348689800EB8EA707E813,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Distribution to a service',10,@two_months_ago,45,7.0600,1,1,10,NULL,NULL,GetPeriodId(@two_months_ago), @two_months_ago),
-  (0x7E8CE78750304740BCC7A42B491C5EF8,0x60F74D25E1B94D8DACAAD51B3318216E,@depot_uuid,0x3CAA76C5748041F5A55600D48B770B9D,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption of March.2020',10,@nine_months_ago,20,9.4000,1,1,4,NULL,NULL,GetPeriodId(@nine_months_ago), @nine_months_ago),
-  (0x7F50D2C7C40B4D2D81AF430F4BDF33FE,0xCC5446AF6CA44D29A955FC33AC75EAA3,@depot_uuid,0x3CAA76C5748041F5A55600D48B770B9D,NULL,'Initializing the inventory of the first depot.',13,@one_year_ago,100,9.4000,0,1,1,NULL,NULL,GetPeriodId(@eleven_months_ago), @eleven_months_ago),
+  (0x7B974EF9F33E4A7A97B5CE3DBE252EAD,0x52289678498B42AAB50115796C953B19,@depot_uuid,0x3CAA76C5748041F5A55600D48B770B9D,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption of February 2020',10,@ten_months_ago,50,9.4000,1,1,3,NULL,NULL,GetPeriodId(@ten_months_ago), @ten_months_ago);
+
+INSERT INTO `stock_movement` (`uuid`, `document_uuid`, `depot_uuid`, `lot_uuid`, `entity_uuid`, `description`, `flux_id`, `date`, `quantity`, `unit_cost`, `is_exit`, `user_id`, `reference`, `invoice_uuid`, `stock_requisition_uuid`, `period_id`, `created_at`) VALUES
+  (0x7E064AE1E81F404C911B2451D115F67F,0x414E2B0856C840B981AB4AB7E7711D51,@depot_uuid,0x8E8D1F39D57348689800EB8EA707E813,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Distribution to a service',10,@two_months_ago,45,7.0600,1,1,10,NULL,NULL,GetPeriodId(@two_months_ago), @two_months_ago);
+
+INSERT INTO `stock_movement` (`uuid`, `document_uuid`, `depot_uuid`, `lot_uuid`, `entity_uuid`, `description`, `flux_id`, `date`, `quantity`, `unit_cost`, `is_exit`, `user_id`, `reference`, `invoice_uuid`, `stock_requisition_uuid`, `period_id`, `created_at`) VALUES
+  (0x7E8CE78750304740BCC7A42B491C5EF8,0x60F74D25E1B94D8DACAAD51B3318216E,@depot_uuid,0x3CAA76C5748041F5A55600D48B770B9D,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption of March.2020',10,@nine_months_ago,20,9.4000,1,1,4,NULL,NULL,GetPeriodId(@nine_months_ago), @nine_months_ago);
+
+INSERT INTO `stock_movement` (`uuid`, `document_uuid`, `depot_uuid`, `lot_uuid`, `entity_uuid`, `description`, `flux_id`, `date`, `quantity`, `unit_cost`, `is_exit`, `user_id`, `reference`, `invoice_uuid`, `stock_requisition_uuid`, `period_id`, `created_at`) VALUES
+  (0x7F50D2C7C40B4D2D81AF430F4BDF33FE,0xCC5446AF6CA44D29A955FC33AC75EAA3,@depot_uuid,0x3CAA76C5748041F5A55600D48B770B9D,NULL,'Initializing the inventory of the first depot.',13,@one_year_ago,100,9.4000,0,1,1,NULL,NULL,GetPeriodId(@eleven_months_ago), @eleven_months_ago);
+
+
+INSERT INTO `stock_movement` (`uuid`, `document_uuid`, `depot_uuid`, `lot_uuid`, `entity_uuid`, `description`, `flux_id`, `date`, `quantity`, `unit_cost`, `is_exit`, `user_id`, `reference`, `invoice_uuid`, `stock_requisition_uuid`, `period_id`, `created_at`) VALUES
   (0x82D8D6C347514C56BE0389240F04DA36,0x52289678498B42AAB50115796C953B19,@depot_uuid,0x8E8D1F39D57348689800EB8EA707E813,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption of February 2020',10,@ten_months_ago,25,7.0600,1,1,3,NULL,NULL,GetPeriodId(@ten_months_ago), @ten_months_ago),
   (0x85F8A8FA5C734D9E8A70A1E0045F60CF,0x52289678498B42AAB50115796C953B19,@depot_uuid,0x6E8A11992E8641758727F73A3648A1B8,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption of February 2020',10,@ten_months_ago,10,3.1800,1,1,3,NULL,NULL,GetPeriodId(@ten_months_ago), @ten_months_ago),
   (0x8CF662C80D4141E1B8C393CBBADC1D43,0x60F74D25E1B94D8DACAAD51B3318216E,@depot_uuid,0xC26BA248149D4FAB882C97A368072F2B,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption of March.2020',10,@nine_months_ago,40,9.4000,1,1,4,NULL,NULL,GetPeriodId(@nine_months_ago), @nine_months_ago),
-  (0x91048BFFCB274D63960D4DC91C15587D,0x52289678498B42AAB50115796C953B19,@depot_uuid,0x6AA623AAA6EF4ECAB811E398D37C110D,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption of February 2020',10,@ten_months_ago,20,3.1800,1,1,3,NULL,NULL,GetPeriodId(@ten_months_ago), @seven_months_ago),
+  (0x91048BFFCB274D63960D4DC91C15587D,0x52289678498B42AAB50115796C953B19,@depot_uuid,0x6AA623AAA6EF4ECAB811E398D37C110D,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption of February 2020',10,@ten_months_ago,20,3.1800,1,1,3,NULL,NULL,GetPeriodId(@ten_months_ago), @seven_months_ago);
+
+INSERT INTO `stock_movement` (`uuid`, `document_uuid`, `depot_uuid`, `lot_uuid`, `entity_uuid`, `description`, `flux_id`, `date`, `quantity`, `unit_cost`, `is_exit`, `user_id`, `reference`, `invoice_uuid`, `stock_requisition_uuid`, `period_id`, `created_at`) VALUES
   (0x938B11B7454D43C785D1AE8736530FDF,0x7FA5E0D14D7E436B89E4E7D0CDF0570F,@depot_uuid,0xD5C6BC2825A24C218025817F8F00B8A7,0xB1816006555845F993A0C222B5EFA6CB,'Distribution to the service Administration from Depot Principal : Consumption for Mai 2020',10,@seven_months_ago,20,9.4000,1,1,6,NULL,NULL,GetPeriodId(@seven_months_ago), @seven_months_ago),
   (0xA02C0EBF275A4F40BABDA6AF6EFB3554,0xBE5B30E5BBC2403AA49B7B58D019B7E8,@depot_uuid,0xA44C718A6A2D45DD9EE4BD85A9E99958,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption for August 2020',10,@three_months_ago,35,3.1800,1,1,9,NULL,NULL,GetPeriodId(@three_months_ago), @three_months_ago),
   (0xA376C333D663433687D9DB70B5411D88,0xAE2714926A714AE9B56C96A102B0D98F,@depot_uuid,0xC26BA248149D4FAB882C97A368072F2B,0xB1816006555845F993A0C222B5EFA6CB,'Distribution to the service Administration from Depot Principal : Consumption of Jan 1',10,@eleven_months_ago,10,9.4000,1,1,2,NULL,NULL,GetPeriodId(@eleven_months_ago), @eleven_months_ago),
@@ -132,7 +145,6 @@ INSERT INTO `stock_movement` (`uuid`, `document_uuid`, `depot_uuid`, `lot_uuid`,
   (0xDEB26BF75B934CFAB67220096825145F,0x60F74D25E1B94D8DACAAD51B3318216E,@depot_uuid,0x6AA623AAA6EF4ECAB811E398D37C110D,0xE3988489EF6641DF88FA8B8ED6AA03AC,'Distribution to the service Medecine Interne from Depot Principal : Consumption of March.2020',10,@nine_months_ago,30,3.1800,1,1,4,NULL,NULL,GetPeriodId(@nine_months_ago), @nine_months_ago),
   (0xDFA64BB33B064F32A61853D7921813EF,0xCC5446AF6CA44D29A955FC33AC75EAA3,@depot_uuid,0xD5C6BC2825A24C218025817F8F00B8A7,NULL,'Initializing the inventory of the first depot.',13,@one_year_ago,200,9.4000,0,1,1,NULL,NULL,GetPeriodId(@eleven_months_ago), @eleven_months_ago),
   (0xFF49CBF1A5A240E692859830840F2FC7,0xCC5446AF6CA44D29A955FC33AC75EAA3,@depot_uuid,0x6E8A11992E8641758727F73A3648A1B8,NULL,'Initializing the inventory of the first depot.',13,@one_year_ago,120,3.1800,0,1,1,NULL,NULL,GetPeriodId(@eleven_months_ago), @eleven_months_ago),
-  
   (0xDCAA9887DDF24D7B8B89770B9D88EAD4,0xCC5446AF6CA44D29A955FC33AC75EAA4,@depot_uuid,0x8E8D1F39D57348689800EB8EA707E814,NULL,'Second stock entry',13,@two_months_ago,5000,9.0000,0,1,1,NULL,NULL,GetPeriodId(@two_months_ago), @two_months_ago);
 
 --


### PR DESCRIPTION
The fiscal year breakage only catches up to us two months after the end of the fiscal year in the stock tests.  This adds in the new fiscal year to those stock tests to make them pass on `master`.

It should unbreak all the test breakages right now.