### PR TITLE
fix(db): change the order of setTimeout() parameters

### DIFF
--- a/server/lib/db/transaction.js
+++ b/server/lib/db/transaction.js
@@ -129,7 +129,7 @@ class Transaction {
 
         // restart transaction after a delay
         return setTimeout(TRANSACTION_DEADLOCK_RESTART_DELAY)
-          .then(() => { this.execute(); });
+          .then(() => { return this.execute(); });
       }
 
       // if we get here, all attempted restarts failed.  Report an error in case tables are permanently locked.

--- a/server/lib/db/transaction.js
+++ b/server/lib/db/transaction.js
@@ -128,9 +128,8 @@ class Transaction {
         debug(`#execute(): Reattempt transaction after ${TRANSACTION_DEADLOCK_RESTART_DELAY}ms.`);
 
         // restart transaction after a delay
-        return setTimeout(
-          () => { this.execute(); },
-          TRANSACTION_DEADLOCK_RESTART_DELAY);
+        return setTimeout(TRANSACTION_DEADLOCK_RESTART_DELAY)
+          .then(() => { this.execute(); });
       }
 
       // if we get here, all attempted restarts failed.  Report an error in case tables are permanently locked.


### PR DESCRIPTION
This is a critical bug.  Because the `setTimeout()` call returns a promise, the order of arguments changed.  This means that transactions are never restarted in the database when a transaction lock occurs.

I'm not sure how to cause a race condition in testing to create transaction locks, otherwise, I would right a unit test.  This is affecting our users in production at Vanga.