### PR TITLE
Refactor budget client cashflow report

### DIFF
--- a/client/src/modules/reports/generate/budget_report/budget_report.config.js
+++ b/client/src/modules/reports/generate/budget_report/budget_report.config.js
@@ -50,10 +50,10 @@ function BudgetReportController($sce, Notify, SavedReports, AppCache, reportData
     vm.reportDetails.transactionTypes = transactionTypes;
   };
 
-  // For Determining local revenues, operating subvention must be excluded, as these funds do not
+  // For Determining local revenues, operating subsidy must be excluded, as these funds do not
   // constitute local revenues.
-  vm.onTransactionTypesSubventionChange = function onTransactionTypesChange(transactionTypes) {
-    vm.reportDetails.transactionTypesSubventions = transactionTypes;
+  vm.onTransactionTypesSubsidyChange = function onTransactionTypesChange(transactionTypes) {
+    vm.reportDetails.transactionTypesSubsidies = transactionTypes;
   };
 
   vm.numberYears = [

--- a/client/src/modules/reports/generate/budget_report/budget_report.html
+++ b/client/src/modules/reports/generate/budget_report/budget_report.html
@@ -98,7 +98,7 @@
 
               <bh-transaction-type-select
                 label="REPORT.BUDGET_REPORT.TRANSACTIONS_TYPE_SUBVENTION"
-                on-change="ReportConfigCtrl.onTransactionTypesSubventionChange(transactionTypes)"
+                on-change="ReportConfigCtrl.onTransactionTypesSubsidyChange(transactionTypes)"
                 transaction-type-ids="ReportConfigCtrl.reportDetails.transaction_type_id">
               </bh-transaction-type-select>
             </div>

--- a/server/controllers/finance/reports/budget_analytical/index.js
+++ b/server/controllers/finance/reports/budget_analytical/index.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 
 const ReportManager = require('../../../../lib/ReportManager');
 const db = require('../../../../lib/db');
+const util = require('../../../../lib/util');
 const Budget = require('../../budget');
 const Fiscal = require('../../fiscal');
 const ReferencesCompute = require('../../accounts/references.compute');
@@ -42,9 +43,8 @@ async function report(req, res, next) {
   let localCashRevenues = 0;
 
   let cashLabelDetails;
-  let firstIncomeDescription;
-  let secondIncomeDescription;
-  let thirdIncomeDescription;
+  let operatingRevenueDescription;
+  let operatingFinancialRevenueDescription;
 
   let balanceOtherIncome = 0;
 
@@ -62,16 +62,25 @@ async function report(req, res, next) {
     let configurationReferences = [];
     let configurationReferencesException = [];
 
+    const ACCOUNT_REFERENCE_NUMBERS = 2;
+    const ACCOUNT_REFERENCE_EXCLUSIONS = 3;
+
+    const CONFIG_REF_OPERATING_REVENUE = 0;
+    const CONFIG_REF_OPERATING_FINANCIAL_REVENUE = 1;
+    const CONFIG_REF_OPERATING_SUBSIDIES = 2;
+    const CONFIG_REF_REVENUE_OTHER_SOURCES = 4;
+    const CONFIG_REF_LOCAL_REVENUES = 3;
+
     const fiscalYear = await Fiscal.lookupFiscalYear(fiscalYearId);
 
     if (includeSummarySection) {
       let cashboxesIds = [];
       let transactionTypes = [];
-      let transactionTypesSubventions = [];
+      let transactionTypesSubsidies = [];
 
       if (params.cashboxesIds) {
         // Selecting the cashbox to enable local revenue analysis
-        cashboxesIds = normalizeParam(params.cashboxesIds);
+        cashboxesIds = util.convertToNumericArray(params.cashboxesIds);
       }
 
       if (params.transactionTypes) {
@@ -79,17 +88,17 @@ async function report(req, res, next) {
          * Determination of transaction types to exclude for fund inflows
          * that are not considered as revenue
          */
-        transactionTypes = normalizeParam(params.transactionTypes);
+        transactionTypes = util.convertToNumericArray(params.transactionTypes);
 
       }
 
-      if (params.transactionTypesSubventions) {
+      if (params.transactionTypesSubsidies) {
         /**
          * Determination of transactions for operating subsidies,
          * subsidies are included in the calculation of overall revenue
          * but excluded when determining local revenue
          */
-        transactionTypesSubventions = normalizeParam(params.transactionTypesSubventions);
+        transactionTypesSubsidies = util.convertToNumericArray(params.transactionTypesSubsidies);
       }
 
       const query = `
@@ -135,6 +144,9 @@ async function report(req, res, next) {
         [BUDGET_ANALYSIS_REFERENCE_TYPE_ID],
       );
 
+      const accountNumbersByReference = accountsReferenceType[ACCOUNT_REFERENCE_NUMBERS];
+      const excludedAccounts = accountsReferenceType[ACCOUNT_REFERENCE_EXCLUSIONS];
+
       configurationReferences = await db.exec(sqlReferences, [BUDGET_ANALYSIS_REFERENCE_TYPE_ID]);
 
       /**
@@ -153,13 +165,15 @@ async function report(req, res, next) {
           .filter(num => Number.isInteger(num)),
       }));
 
-      let referencesTypeAccounts = accountsReferenceType[2].filter(
-        item => item.account_reference_id === configurationReferences[3].id,
+      const localRevenues = configurationReferences[CONFIG_REF_LOCAL_REVENUES];
+
+      let referencesTypeAccounts = accountNumbersByReference.filter(
+        item => item.account_reference_id === localRevenues.id,
       );
 
       referencesTypeAccounts.forEach(item => {
         item.exception = false;
-        accountsReferenceType[3].forEach(elt => {
+        excludedAccounts.forEach(elt => {
           if (item.acc_id === elt.acc_id) {
             item.exception = true;
           }
@@ -209,14 +223,14 @@ async function report(req, res, next) {
         filterExcludeTransactionType = ` AND gl.transaction_type_id NOT IN (${transactionTypes})`;
       }
 
-      let filterTransactionTypesSubventions = ``;
+      let filterTransactionTypesSubsidies = ``;
 
       /**
        * Here, clauses are formatted to be injected into SQL queries
        * to exclude transaction types corresponding to operating subsidies
        */
-      if (transactionTypesSubventions.length) {
-        filterTransactionTypesSubventions = ` AND gl.transaction_type_id NOT IN (${transactionTypesSubventions})`;
+      if (transactionTypesSubsidies.length) {
+        filterTransactionTypesSubsidies = ` AND gl.transaction_type_id NOT IN (${transactionTypesSubsidies})`;
       }
 
       const sqlCashflowIncome = `
@@ -280,8 +294,8 @@ async function report(req, res, next) {
        * Configuration with index 4 corresponds to the fifth account reference configuration
        * to capture revenue from other sources such as bank accounts
        */
-      if (configurationReferences[4]) {
-        const otherIncome = configurationReferences[4];
+      if (configurationReferences[CONFIG_REF_REVENUE_OTHER_SOURCES]) {
+        const otherIncome = configurationReferences[CONFIG_REF_REVENUE_OTHER_SOURCES];
 
         const sqlOtherIncome = `
           SELECT map.text AS referenceVoucher, gl.trans_id, gl.trans_date, a.id AS account_id,
@@ -296,7 +310,7 @@ async function report(req, res, next) {
           WHERE
           gl.fiscal_year_id = ?
           AND gl.account_id IN ? AND gl.debit > 0 AND v.reversed = 0
-          AND gl.transaction_type_id <> 10 ${filterTransactionTypesSubventions}
+          AND gl.transaction_type_id <> 10 ${filterTransactionTypesSubsidies}
           ${filterExcludeTransactionType}
           ORDER BY gl.trans_date ASC;
         `;
@@ -498,42 +512,40 @@ async function report(req, res, next) {
 
     /**
      * Here, we iterate through both arrays configurationReferences and configurationReferencesException
-     * in order to subtract the corresponding value from the exceptions array
+     * in order to subtract the corresponding value from the exceptions array:
      */
     configurationReferences.forEach(item => {
-      const getException = configurationReferencesException.filter(elt => elt.abbr === item.abbr);
-      if (getException.length) {
-        if (getException[0].value_account_number) {
-          item.value_account_number -= getException[0].value_account_number;
-        }
+      const getException = configurationReferencesException.find(elt => elt.abbr === item.abbr);
+      if (getException) {
+        item.value_account_number -= getException.value_account_number;
       }
     });
 
-    let firstIncomeConfigurationReferences = 0;
-    let secondIncomeConfigurationReferences = 0;
-    let thirdIncomeConfigurationReferences = 0;
+    const operatingRevenue = configurationReferences[CONFIG_REF_OPERATING_REVENUE];
+    const operatingFinancialRevenue = configurationReferences[CONFIG_REF_OPERATING_FINANCIAL_REVENUE];
+
+    let operatingSubsidiesReferences = 0;
 
     if (includeSummarySection) {
-      // Corresponds to net revenue
-      firstIncomeConfigurationReferences = configurationReferences[0].value_account_number;
-      firstIncomeDescription = configurationReferences[0].description;
+      // Corresponds to operating revenue
+      operatingRevenueDescription = operatingRevenue.description;
 
       // Corresponds to actual revenue generated without operating subsidies
-      secondIncomeConfigurationReferences = configurationReferences[1].value_account_number;
-      secondIncomeDescription = configurationReferences[1].description;
+      operatingFinancialRevenueDescription = operatingFinancialRevenue.description;
 
       // Corresponds to the value of operating subsidies received
-      thirdIncomeConfigurationReferences = configurationReferences[2].value_account_number;
+      operatingSubsidiesReferences = configurationReferences[CONFIG_REF_OPERATING_SUBSIDIES].value_account_number;
     }
 
     /**
      * Here, we calculate the result without the accounts, which would represent the result
-     * without subsidies and other revenues
+     * without subsidies and Financial revenues
      */
-    const realisationIncomeExpenseFirst = firstIncomeConfigurationReferences - totalRealisationExpense;
+    const realisationOperatingRevenue = (operatingRevenue.value_account_number || 0) - totalRealisationExpense;
 
     /** Here, we evaluate the result without operating subsidies */
-    const realisationIncomeExpenseSecond = secondIncomeConfigurationReferences - totalRealisationExpense;
+    const realisationOperatingFinancialRevenue = (operatingFinancialRevenue.value_account_number || 0)
+      - totalRealisationExpense;
 
     /** localCash corresponds to the revenue generated without operating subsidies */
     localCashRevenues += balanceOtherIncome;
@@ -541,7 +553,7 @@ async function report(req, res, next) {
     /**
      * Total Cash is the sum of local revenue + operating subsidies
      */
-    totalCash = localCashRevenues + thirdIncomeConfigurationReferences;
+    totalCash = localCashRevenues + operatingSubsidiesReferences;
     const soldeTotalFinancement = totalCash - totalRealisationExpense;
 
     const data = {
@@ -568,16 +580,14 @@ async function report(req, res, next) {
       includeSummarySection,
       totalCash,
       realisationIncomeExpense,
-      realisationIncomeExpenseFirst,
-      realisationIncomeExpenseSecond,
-      secondIncomeConfigurationReferences,
-      thirdIncomeConfigurationReferences,
+      realisationOperatingRevenue,
+      realisationOperatingFinancialRevenue,
+      operatingSubsidiesReferences,
       localCashRevenues,
       soldeTotalFinancement,
       cashLabelDetails,
-      firstIncomeDescription,
-      secondIncomeDescription,
-      thirdIncomeDescription,
+      operatingRevenueDescription,
+      operatingFinancialRevenueDescription,
     };
 
     const result = await reporting.render(data);
@@ -585,14 +595,4 @@ async function report(req, res, next) {
   } catch (e) {
     next(e);
   }
-}
-
-function normalizeParam(param) {
-  if (!param) return [];
-
-  if (Array.isArray(param)) {
-    return param.map(Number);
-  }
-
-  return [Number(param)];
 }

--- a/server/controllers/finance/reports/budget_analytical/report.handlebars
+++ b/server/controllers/finance/reports/budget_analytical/report.handlebars
@@ -141,13 +141,13 @@
             <td width="60%" colspan="2"></td>
           </tr>
           <tr>
-            <td class="text-uppercase" colspan="2"><strong>{{translate 'TABLE.COLUMNS.RESULT_WITHOUT_ACCOUNTS'}} {{ firstIncomeDescription }} </strong></td>
-            <td class="text-right" colspan="1"><strong>{{debcred realisationIncomeExpenseFirst currencyId}}</strong></td>
+            <td class="text-uppercase" colspan="2"><strong>{{translate 'TABLE.COLUMNS.RESULT_WITHOUT_ACCOUNTS'}} {{ operatingRevenueDescription }} </strong></td>
+            <td class="text-right" colspan="1"><strong>{{debcred realisationOperatingRevenue currencyId}}</strong></td>
             <td colspan="2"></td>
           </tr>
           <tr>
-            <td class="text-uppercase" colspan="2"><strong>{{translate 'TABLE.COLUMNS.RESULT_WITHOUT_ACCOUNTS'}} {{ secondIncomeDescription }} </strong></td>
-            <td class="text-right" colspan="1"><strong>{{debcred realisationIncomeExpenseSecond currencyId}}</strong></td>
+            <td class="text-uppercase" colspan="2"><strong>{{translate 'TABLE.COLUMNS.RESULT_WITHOUT_ACCOUNTS'}} {{ operatingFinancialRevenueDescription }} </strong></td>
+            <td class="text-right" colspan="1"><strong>{{debcred realisationOperatingFinancialRevenue currencyId}}</strong></td>
             <td colspan="2"></td>
           </tr>
           <tr>
@@ -160,8 +160,8 @@
             <td colspan="2"></td>
           </tr>
           <tr>
-            <td class="text-uppercase" colspan="2"><strong>{{translate 'TABLE.COLUMNS.TOTAL_SUBSIDIES'}}</strong></td>
-            <td class="text-right" colspan="1"><strong>{{debcred thirdIncomeConfigurationReferences currencyId}}</strong></td>
+            <td class="text-uppercase" colspan="2"><strong>{{translate 'TABLE.COLUMNS.TOTAL_SUBSIDIES'}} </strong></td>
+            <td class="text-right" colspan="1"><strong>{{debcred operatingSubsidiesReferences currencyId}}</strong></td>
             <td colspan="2"></td>
           </tr>
           <tr>

--- a/server/controllers/finance/reports/cashflow/cashflow.function.js
+++ b/server/controllers/finance/reports/cashflow/cashflow.function.js
@@ -6,16 +6,6 @@ const _ = require('lodash');
 const db = require('../../../../lib/db');
 const AccountsExtra = require('../../accounts/extra');
 
-function convertToNumericArray(param) {
-  if (!param) return [];
-
-  if (Array.isArray(param)) {
-    return param.map(Number);
-  }
-
-  return [Number(param)];
-}
-
 function totalOpening(accountIds, openingBalanceData, periods) {
   let sumOpening = 0;
   const tabFormated = {};
@@ -125,16 +115,20 @@ function aggregateData(data) {
 function aggregateTotalByTextKeys(data, source = {}) {
   const sourceTotalByTextKeys = {};
 
-  _.keys(source).forEach((index) => {
+  Object.keys(source).forEach((index) => {
     const currentTransactionText = source[index] || [];
     sourceTotalByTextKeys[index] = {
       sumAggregate : 0,
     };
 
-    // loop for each periods
+    // loop for each period
     data.periods.forEach(periodId => {
-      sourceTotalByTextKeys[index][periodId] = _.sumBy(currentTransactionText, periodId);
-      sourceTotalByTextKeys[index].sumAggregate += _.sumBy(currentTransactionText, periodId);
+      // Use _.sumBy safely, fallback to 0 if result is NaN or undefined
+      const sum = _.sumBy(currentTransactionText, periodId);
+      const safeSum = Number.isFinite(sum) ? sum : 0;
+
+      sourceTotalByTextKeys[index][periodId] = safeSum;
+      sourceTotalByTextKeys[index].sumAggregate += safeSum;
     });
   });
 
@@ -215,7 +209,6 @@ function sumTotalIncomes(data, incomeTotal, otherTotal, opening) {
   return sum;
 }
 
-exports.convertToNumericArray = convertToNumericArray;
 exports.totalOpening = totalOpening;
 exports.getOpeningBalanceData = getOpeningBalanceData;
 exports.getCashboxesDetails = getCashboxesDetails;

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -39,6 +39,7 @@ exports.createDirectory = createDirectory;
 exports.getRandomColor = getRandomColor;
 
 exports.median = median;
+exports.convertToNumericArray = convertToNumericArray;
 
 /**
  * @function take
@@ -295,3 +296,22 @@ exports.getPeriodIdForDate = (date) => {
   const periodId = `${date.getFullYear()}${monthStr}`;
   return periodId;
 };
+
+/**
+ * Converts a given input into an array of numbers.
+ * - If the input is falsy (e.g., null, undefined, ''), returns an empty array.
+ * - If the input is already an array, it converts each element to a number.
+ * - If the input is a single value, it converts it to a number and wraps it in an array.
+ *
+ * @param {*} param - The value or array of values to convert.
+ * @returns {number[]} An array of numbers.
+ */
+function convertToNumericArray(param) {
+  if (!param) return [];
+
+  if (Array.isArray(param)) {
+    return param.map(Number);
+  }
+
+  return [Number(param)];
+}

--- a/test/server-unit/cashflow/aggregateData.spec.js
+++ b/test/server-unit/cashflow/aggregateData.spec.js
@@ -1,0 +1,36 @@
+const { expect } = require('chai');
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('cashflowFunction.aggregateData', () => {
+  it('should correctly aggregate values by period and compute total sumAggregate', () => {
+    // Arrange - Input data
+    const inputData = {
+      'Clients and Other Debtor Groups' : {
+        202501 : 10,
+        202502 : 20,
+        202503 : 30,
+        202504 : 101.0752,
+        sumAggregate : 161.0752,
+      },
+      'Medical Activities' : {
+        202501 : 100,
+        202502 : 200,
+        202503 : 300,
+        202504 : 26012,
+        sumAggregate : 26612,
+      },
+    };
+
+    // Act - Call the function
+    const result = cashflowFunction.aggregateData(inputData);
+
+    // Assert - Expected result
+    expect(result).to.deep.equal({
+      202501 : 110,
+      202502 : 220,
+      202503 : 330,
+      202504 : 26113.0752,
+      sumAggregate : 26773.0752,
+    });
+  });
+});

--- a/test/server-unit/cashflow/aggregateTotal.spec.js
+++ b/test/server-unit/cashflow/aggregateTotal.spec.js
@@ -1,0 +1,39 @@
+const { expect } = require('chai');
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('cashflowFunction.aggregateTotal', () => {
+  it('should aggregate values from multiple items into a single total per period', () => {
+    // Arrange - Input data
+    const data = {
+      periods : [202501, 202502, 202503],
+    };
+
+    const source = {
+      item1 : {
+        202501 : 100,
+        202502 : 150,
+        202503 : 200,
+      },
+      item2 : {
+        202501 : 50,
+        202502 : 70,
+        202503 : 80,
+      },
+      item3 : {
+        202501 : 10,
+        202502 : 20,
+        202503 : 30,
+      },
+    };
+
+    // Act - Call the function
+    const result = cashflowFunction.aggregateTotal(data, source);
+
+    // Assert - Expected result
+    expect(result).to.deep.equal({
+      202501 : 160, // 100 + 50 + 10
+      202502 : 240, // 150 + 70 + 20
+      202503 : 310, // 200 + 80 + 30
+    });
+  });
+});

--- a/test/server-unit/cashflow/aggregateTotalByTextKeys.spec.js
+++ b/test/server-unit/cashflow/aggregateTotalByTextKeys.spec.js
@@ -1,0 +1,78 @@
+const { expect } = require('chai');
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('aggregateTotalByTextKeys Function', () => {
+
+  it('should aggregate totals by periods and calculate sumAggregate', () => {
+    const data = { periods : ['202501', '202502', '202503'] };
+    const source = {
+      key1 : [
+        { 202501 : 10, 202502 : 20, 202503 : 30 }, { 202501 : 5, 202502 : 10, 202503 : 15 },
+      ],
+      key2 : [
+        { 202501 : 7, 202502 : 14, 202503 : 21 }, { 202501 : 3, 202502 : 6, 202503 : 9 },
+      ],
+    };
+
+    const result = cashflowFunction.aggregateTotalByTextKeys(data, source);
+
+    expect(result.key1['202501']).to.equal(15);
+    expect(result.key1['202502']).to.equal(30);
+    expect(result.key1['202503']).to.equal(45);
+    expect(result.key1.sumAggregate).to.equal(90);
+
+    expect(result.key2['202501']).to.equal(10);
+    expect(result.key2['202502']).to.equal(20);
+    expect(result.key2['202503']).to.equal(30);
+    expect(result.key2.sumAggregate).to.equal(60);
+  });
+
+  it('should handle empty transactions correctly', () => {
+    const data = { periods : ['202501', '202502', '202503'] };
+    const source = {
+      key1 : [],
+      key2 : [],
+    };
+
+    const result = cashflowFunction.aggregateTotalByTextKeys(data, source);
+
+    expect(result.key1['202501']).to.equal(0);
+    expect(result.key1['202502']).to.equal(0);
+    expect(result.key1['202503']).to.equal(0);
+    expect(result.key1.sumAggregate).to.equal(0);
+
+    expect(result.key2['202501']).to.equal(0);
+    expect(result.key2['202502']).to.equal(0);
+    expect(result.key2['202503']).to.equal(0);
+    expect(result.key2.sumAggregate).to.equal(0);
+  });
+
+  it('should return 0 for missing periods in transactions', () => {
+    const data = { periods : ['202501', '202502', '202503'] };
+    const source = {
+      key1 : [{ 202501 : 10 }, { 202502 : 20 }],
+    };
+
+    const result = cashflowFunction.aggregateTotalByTextKeys(data, source);
+
+    expect(result.key1['202501']).to.equal(10);
+    expect(result.key1['202502']).to.equal(20);
+    expect(result.key1['202503']).to.equal(0);
+    expect(result.key1.sumAggregate).to.equal(30);
+  });
+
+  it('should handle extra periods in data without error', () => {
+    const data = { periods : ['202501', '202502', '202503', '202504'] };
+    const source = {
+      key1 : [{ 202501 : 10, 202502 : 20, 202503 : 30 }],
+    };
+
+    const result = cashflowFunction.aggregateTotalByTextKeys(data, source);
+
+    expect(result.key1['202501']).to.equal(10);
+    expect(result.key1['202502']).to.equal(20);
+    expect(result.key1['202503']).to.equal(30);
+    expect(result.key1['202504']).to.equal(0);
+    expect(result.key1.sumAggregate).to.equal(60);
+  });
+});

--- a/test/server-unit/cashflow/getCashboxesDetails.spec.js
+++ b/test/server-unit/cashflow/getCashboxesDetails.spec.js
@@ -1,0 +1,49 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+// Import the database module to mock it
+const db = require('../../../server/lib/db');
+
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('Cashflow Function - getCashboxesDetails', () => {
+  let dbExecStub;
+
+  // Setup a stub before each test
+  beforeEach(() => {
+    dbExecStub = sinon.stub(db, 'exec');
+  });
+
+  // Restore original behavior after each test
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return cashbox details for given cashbox IDs', async () => {
+    // Arrange
+    const cashboxesIds = ['1']; // Input parameter
+    const fakeResult = [
+      {
+        currency_id : 1,
+        account_id : 2,
+        id : 1,
+        label : 'Main Cashbox',
+        symbol : '$',
+        account_number : '1000',
+        account_label : 'Main Account',
+      },
+    ];
+
+    // Mock db.exec to return the fake result
+    dbExecStub.resolves(fakeResult);
+
+    // Act
+    const result = await cashflowFunction.getCashboxesDetails(cashboxesIds);
+
+    // Assert
+    // eslint-disable-next-line no-unused-expressions
+    expect(dbExecStub.calledOnce).to.be.true;
+    expect(dbExecStub.firstCall.args[0]).to.include('SELECT'); // Check if the query was sent
+    expect(result).to.deep.equal(fakeResult);
+  });
+});

--- a/test/server-unit/cashflow/getOpeningBalanceData.spec.js
+++ b/test/server-unit/cashflow/getOpeningBalanceData.spec.js
@@ -1,0 +1,41 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+const AccountsExtra = require('../../../server/controllers/finance/accounts/extra');
+
+describe('cashflowFunction.getOpeningBalanceData', () => {
+  it('should return specific balances for each account and period combination', async () => {
+    const cashAccountIds = [190, 187];
+    const periods = [
+      { id : 202501, number : 1, start_date : new Date('2024-12-31') },
+      { id : 202502, number : 2, start_date : new Date('2025-01-31') },
+      { id : 202503, number : 3, start_date : new Date('2025-02-28') },
+      { id : 202504, number : 4, start_date : new Date('2025-03-31') },
+    ];
+
+    // Stub of the external function with a dynamic result
+    const stub = sinon.stub(AccountsExtra, 'getOpeningBalanceForDate').callsFake((accountId, startDate) => {
+      const timestamp = new Date(startDate).getTime();
+      return Promise.resolve({
+        balance : accountId + (timestamp % 1000),
+        credit : (accountId % 100) + 50,
+        debit : (accountId % 50) + 25,
+        accountId,
+      });
+    });
+
+    const result = await cashflowFunction.getOpeningBalanceData(cashAccountIds, periods);
+
+    expect(stub.callCount).to.equal(cashAccountIds.length * periods.length);
+    expect(result).to.have.length(8);
+
+    result.forEach(entry => {
+      expect(entry).to.have.property('balance').that.is.a('number');
+      expect(entry).to.have.property('credit').that.is.a('number');
+      expect(entry).to.have.property('debit').that.is.a('number');
+      expect(entry).to.have.property('accountId').that.is.oneOf(cashAccountIds);
+    });
+
+    stub.restore();
+  });
+});

--- a/test/server-unit/cashflow/sumAggregateTotal.spec.js
+++ b/test/server-unit/cashflow/sumAggregateTotal.spec.js
@@ -1,0 +1,35 @@
+const { expect } = require('chai');
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('cashflowFunction.sumAggregateTotal', () => {
+  it('should aggregate values from multiple items into a single total per period', () => {
+    // Arrange - Input data
+    const data = {
+      periods : [202501, 202502, 202503],
+    };
+
+    const source = {
+      item1 : {
+        202501 : 100,
+        202502 : 150,
+        202503 : 200,
+      },
+      item2 : {
+        202501 : 50,
+        202502 : 70,
+        202503 : 80,
+      },
+      item3 : {
+        202501 : 10,
+        202502 : 20,
+        202503 : 30,
+      },
+    };
+
+    // Act - Call the function
+    const result = cashflowFunction.sumAggregateTotal(data, source);
+
+    // Assert - Expected result
+    expect(result).to.equal(710);
+  });
+});

--- a/test/server-unit/cashflow/sumIncomesPeriods.spec.js
+++ b/test/server-unit/cashflow/sumIncomesPeriods.spec.js
@@ -1,0 +1,101 @@
+const { expect } = require('chai');
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('sumIncomesPeriods Function', () => {
+
+  it('should calculate the global total of incomes and transfers across all periods', () => {
+    // Arrange - Input data
+    const data = {
+      periods : ['202501', '202502', '202503'],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    // Act - Call the function
+    const result = cashflowFunction.sumIncomesPeriods(data, incomeTotal, transferTotal);
+
+    // Assert - Global total: (100+25) + (150+35) + (200+45) = 555
+    expect(result).to.equal(555);
+  });
+
+  it('should return NaN for periods with missing data in income or transfer totals', () => {
+    // Arrange - Input data with missing data for some periods
+    const data = {
+      periods : ['202501', '202502', '202503', '202504'],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+    };
+
+    // Act - Call the function
+    const result = cashflowFunction.sumIncomesPeriods(data, incomeTotal, transferTotal);
+
+    // eslint-disable-next-line no-unused-expressions
+    expect(result).to.be.NaN;
+  });
+
+  it('should handle empty periods array', () => {
+    // Arrange - empty periods
+    const data = {
+      periods : [],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+    };
+
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+    };
+
+    // Act
+    const result = cashflowFunction.sumIncomesPeriods(data, incomeTotal, transferTotal);
+
+    // Assert
+    expect(result).to.equal(0);
+  });
+
+  it('should return NaN if any of the totals (income or transfer) is missing for a period', () => {
+    // Arrange - Input data with a missing total for a period
+    const data = {
+      periods : ['202501', '202502', '202503'],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+    };
+
+    // Act - Call the function
+    const result = cashflowFunction.sumIncomesPeriods(data, incomeTotal, transferTotal);
+    // Assert - Expected result : NaN for the missing period (202503) in transferTotal
+    // eslint-disable-next-line no-unused-expressions
+    expect(result).to.be.NaN;
+  });
+});

--- a/test/server-unit/cashflow/sumTotalBalances.spec.js
+++ b/test/server-unit/cashflow/sumTotalBalances.spec.js
@@ -1,0 +1,85 @@
+const { expect } = require('chai');
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('sumTotalBalances Function', () => {
+  it('should calculate the total balance by summing income and expense totals for each period', () => {
+    const data = {
+      periods : ['202501', '202502', '202503'],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const expenseTotal = {
+      202501 : 50,
+      202502 : 75,
+      202503 : 100,
+    };
+
+    const result = cashflowFunction.sumTotalBalances(data, incomeTotal, expenseTotal);
+
+    expect(result).to.equal(675);
+  });
+
+  it('should return 0 if there are no periods', () => {
+    const data = {
+      periods : [],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const expenseTotal = {
+      202501 : 50,
+      202502 : 75,
+      202503 : 100,
+    };
+
+    const result = cashflowFunction.sumTotalBalances(data, incomeTotal, expenseTotal);
+
+    expect(result).to.equal(0); // No periods, so the sum is 0
+  });
+
+  it('should handle periods with missing income or expense data', () => {
+    const data = {
+      periods : ['202501', '202502', '202503', '202504'],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const expenseTotal = {
+      202501 : 50,
+      202502 : 75,
+    };
+
+    const result = cashflowFunction.sumTotalBalances(data, incomeTotal, expenseTotal);
+
+    // eslint-disable-next-line no-unused-expressions
+    expect(result).to.be.NaN;
+  });
+
+  it('should return NaN if all periods have missing data', () => {
+    const data = {
+      periods : ['202501', '202502', '202503', '202504'],
+    };
+
+    const incomeTotal = {};
+    const expenseTotal = {};
+
+    const result = cashflowFunction.sumTotalBalances(data, incomeTotal, expenseTotal);
+
+    expect(result).to.be.a('number');
+    // eslint-disable-next-line no-unused-expressions
+    expect(Number.isNaN(result)).to.be.true;
+  });
+});

--- a/test/server-unit/cashflow/sumTotalIncomes.spec.js
+++ b/test/server-unit/cashflow/sumTotalIncomes.spec.js
@@ -1,0 +1,111 @@
+const { expect } = require('chai');
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('sumTotalIncomes Function', () => {
+  it('should calculate the total income for all periods based on income, other, and opening totals', () => {
+    // Sample data with periods
+    const data = {
+      periods : ['202501', '202502', '202503'],
+    };
+
+    // Sample income total values for each period
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    // Sample other total values for each period
+    const otherTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    // Sample opening total values for each period
+    const opening = {
+      202501 : 50,
+      202502 : 60,
+      202503 : 70,
+    };
+
+    // Call the sumTotalIncomes function with the test data
+    const result = cashflowFunction.sumTotalIncomes(data, incomeTotal, otherTotal, opening);
+
+    // Assertions : check that the total sum is correctly calculated
+    // Sum for period 202501 = 100 + 25 + 50 = 175
+    // Sum for period 202502 = 150 + 35 + 60 = 245
+    // Sum for period 202503 = 200 + 45 + 70 = 315
+    // Total = 175 + 245 + 315 = 735
+    expect(result).to.equal(735);
+  });
+
+  it('should handle missing data for periods in incomeTotal, otherTotal, or opening', () => {
+    // Input data with a missing period in one of the totals
+    const data = {
+      periods : ['202501', '202502', '202503', '202504'],
+    };
+
+    // Sample income total values for each period
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    // Sample other total values for each period
+    const otherTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    // Sample opening values for each period
+    const opening = {
+      202501 : 50,
+      202502 : 60,
+      // Missing period 202503 data for opening
+    };
+
+    // Call the sumTotalIncomes function with the test data
+    const result = cashflowFunction.sumTotalIncomes(data, incomeTotal, otherTotal, opening);
+
+    // Assertions : check that missing data results in NaN for the missing period
+    // eslint-disable-next-line no-unused-expressions
+    expect(result).to.be.NaN;
+  });
+
+  it('should return 0 if the periods array is empty', () => {
+    // Input data with an empty periods array
+    const data = {
+      periods : [],
+    };
+
+    // Sample income total values for each period
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    // Sample other total values for each period
+    const otherTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    // Sample opening values for each period
+    const opening = {
+      202501 : 50,
+      202502 : 60,
+      202503 : 70,
+    };
+
+    // Call the sumTotalIncomes function with the test data
+    const result = cashflowFunction.sumTotalIncomes(data, incomeTotal, otherTotal, opening);
+
+    // Assertions : check that the result is 0 for an empty periods array
+    expect(result).to.equal(0);
+  });
+});

--- a/test/server-unit/cashflow/totalBalances.spec.js
+++ b/test/server-unit/cashflow/totalBalances.spec.js
@@ -1,0 +1,101 @@
+const { expect } = require('chai');
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('totalBalances Function', () => {
+  it('should calculate the total for each period based on income and transfer totals', () => {
+    const data = {
+      periods : ['202501', '202502', '202503'],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    const result = cashflowFunction.totalBalances(data, incomeTotal, transferTotal);
+
+    expect(result['202501']).to.equal(125);
+    expect(result['202502']).to.equal(185);
+    expect(result['202503']).to.equal(245);
+  });
+
+  it('should return NaN for periods with missing data in income or transfer totals', () => {
+    const data = {
+      periods : ['202501', '202502', '202503', '202504'],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+    };
+
+    const result = cashflowFunction.totalBalances(data, incomeTotal, transferTotal);
+
+    expect(result).to.deep.equal({
+      202501  : 125,
+      202502  : 185,
+      202503  : NaN,
+      202504  : NaN,
+    });
+  });
+
+  it('should handle empty periods array', () => {
+    const data = {
+      periods : [],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    const result = cashflowFunction.totalBalances(data, incomeTotal, transferTotal);
+
+    expect(result).to.deep.equal({});
+  });
+
+  it('should return NaN if any of the totals (income or transfer) is missing for a period', () => {
+    const data = {
+      periods : ['202501', '202502', '202503'],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+    };
+
+    const result = cashflowFunction.totalBalances(data, incomeTotal, transferTotal);
+
+    expect(result).to.deep.equal({
+      202501  : 125,
+      202502  : 185,
+      202503  : NaN,
+    });
+  });
+});

--- a/test/server-unit/cashflow/totalIncomes.spec.js
+++ b/test/server-unit/cashflow/totalIncomes.spec.js
@@ -1,0 +1,113 @@
+const { expect } = require('chai');
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('totalIncomes Function', () => {
+  it('should calculate the total for each period based on income, other totals, and opening values', () => {
+    // Input data for the periods
+    const data = {
+      periods : ['202501', '202502', '202503'],
+    };
+
+    // Sample total income values for each period
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    // Sample other totals for each period
+    const otherTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    // Sample opening values for each period
+    const opening = {
+      202501 : 10,
+      202502 : 20,
+      202503 : 30,
+    };
+
+    // Call the totalIncomes function with the test data
+    const result = cashflowFunction.totalIncomes(data, incomeTotal, otherTotal, opening);
+
+    // Assertions : check that the calculated total is correct for each period
+    expect(result['202501']).to.equal(100 + 25 + 10); // 135
+    expect(result['202502']).to.equal(150 + 35 + 20); // 205
+    expect(result['202503']).to.equal(200 + 45 + 30); // 275
+  });
+
+  it('should return NaN for periods with missing data in income, other total, or opening', () => {
+    // Input data with a missing period
+    const data = {
+      periods : ['202501', '202502', '202503', '202504'],
+    };
+
+    // Sample total income values for each period
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    // Sample other totals for each period
+    const otherTotal = {
+      202501 : 25,
+      202502 : 35,
+    };
+
+    // Sample opening values for each period
+    const opening = {
+      202501 : 10,
+      202502 : 20,
+      202503 : 30,
+    };
+
+    // Call the totalIncomes function with the test data
+    const result = cashflowFunction.totalIncomes(data, incomeTotal, otherTotal, opening);
+
+    expect(result['202501']).to.equal(135);
+    expect(result['202502']).to.equal(205);
+
+    // eslint-disable-next-line no-unused-expressions
+    expect(result['202503']).to.be.NaN;
+
+    // eslint-disable-next-line no-unused-expressions
+    expect(result['202504']).to.be.NaN;
+  });
+
+  it('should handle empty periods array', () => {
+    // Input data with an empty periods array
+    const data = {
+      periods : [],
+    };
+
+    // Sample total income values for each period
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    // Sample other totals for each period
+    const otherTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    // Sample opening values for each period
+    const opening = {
+      202501 : 10,
+      202502 : 20,
+      202503 : 30,
+    };
+
+    // Call the totalIncomes function with the test data
+    const result = cashflowFunction.totalIncomes(data, incomeTotal, otherTotal, opening);
+
+    // Assertions : check that the result is an empty object for an empty periods array
+    expect(result).to.deep.equal({});
+  });
+});

--- a/test/server-unit/cashflow/totalIncomesPeriods.spec.js
+++ b/test/server-unit/cashflow/totalIncomesPeriods.spec.js
@@ -1,0 +1,91 @@
+const { expect } = require('chai');
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('totalIncomesPeriods Function', () => {
+  it('should calculate the total for each period based on income and transfer totals', () => {
+    // Input data for the periods
+    const data = {
+      periods : ['202501', '202502', '202503'],
+    };
+
+    // Sample income total values for each period
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    // Sample transfer total values for each period
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    // Call the totalIncomesPeriods function with the test data
+    const result = cashflowFunction.totalIncomesPeriods(data, incomeTotal, transferTotal);
+
+    // Assertions : check that the calculated total is correct for each period
+    expect(result['202501']).to.equal(100 + 25); // 125
+    expect(result['202502']).to.equal(150 + 35); // 185
+    expect(result['202503']).to.equal(200 + 45); // 245
+  });
+
+  it('should return NaN for periods with missing data in income or transfer totals', () => {
+    // Input data with a missing period
+    const data = {
+      periods : ['202501', '202502', '202503', '202504'],
+    };
+
+    // Sample income total values for each period
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    // Sample transfer total values for each period
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+    };
+
+    // Call the totalIncomesPeriods function with the test data
+    const result = cashflowFunction.totalIncomesPeriods(data, incomeTotal, transferTotal);
+
+    // Assertions : check that missing data results in NaN for missing periods
+    expect(result['202501']).to.equal(100 + 25); // 125
+    expect(result['202502']).to.equal(150 + 35); // 185
+    // eslint-disable-next-line no-unused-expressions
+    expect(result['202503']).to.be.NaN; // Missing period should result in NaN
+    // eslint-disable-next-line no-unused-expressions
+    expect(result['202504']).to.be.NaN; // Missing period should result in NaN
+  });
+
+  it('should handle empty periods array', () => {
+    // Input data with an empty periods array
+    const data = {
+      periods : [],
+    };
+
+    // Sample income total values for each period
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    // Sample transfer total values for each period
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    // Call the totalIncomesPeriods function with the test data
+    const result = cashflowFunction.totalIncomesPeriods(data, incomeTotal, transferTotal);
+
+    // Assertions : check that the result is an empty object for an empty periods array
+    expect(result).to.deep.equal({});
+  });
+});

--- a/test/server-unit/cashflow/totalOpening.spec.js
+++ b/test/server-unit/cashflow/totalOpening.spec.js
@@ -1,0 +1,94 @@
+const { expect } = require('chai');
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('cashflowFunction.totalOpening', () => {
+  it('should correctly calculate total opening balances using provided balance values', () => {
+    // Arrange - Input data
+    const accountIds = [
+      {
+        currency_id : 1,
+        account_id : 190,
+        id : 1,
+        label : 'Caisse Principale',
+        symbol : 'Fc',
+        account_number : 57120010,
+        account_label : 'Caisse Principale USD',
+      },
+      {
+        currency_id : 2,
+        account_id : 187,
+        id : 1,
+        label : 'Caisse Principale',
+        symbol : '$',
+        account_number : 57110010,
+        account_label : 'Caisse Principale CDF',
+      },
+    ];
+
+    const openingBalanceData = [
+      {
+        debit : '100.00', credit : '50.00', balance : '50.0000', accountId : 190,
+      },
+      {
+        debit : '200.00', credit : '100.00', balance : '100.0000', accountId : 190,
+      },
+      {
+        debit : '300.00', credit : '150.00', balance : '150.0000', accountId : 190,
+      },
+      {
+        debit : '400.00', credit : '200.00', balance : '200.0000', accountId : 190,
+      },
+      {
+        debit : '500.00', credit : '250.00', balance : '250.0000', accountId : 187,
+      },
+      {
+        debit : '600.00', credit : '300.00', balance : '300.0000', accountId : 187,
+      },
+      {
+        debit : '700.00', credit : '350.00', balance : '350.0000', accountId : 187,
+      },
+      {
+        debit : '800.00', credit : '400.00', balance : '400.0000', accountId : 187,
+      },
+    ];
+
+    const periods = [202501, 202502, 202503, 202504];
+
+    // Act - Call the function
+    const result = cashflowFunction.totalOpening(accountIds, openingBalanceData, periods);
+
+    // Assert - Check returned structure
+    expect(result).to.have.keys(['tabFormated', 'tabAccountsFormated', 'sumOpening']);
+
+    // Assert - Check tabFormated result
+    expect(result.tabFormated).to.deep.equal({
+      202501 : 300,
+      202502 : 400,
+      202503 : 500,
+      202504 : 600,
+    });
+
+    // Assert - Check tabAccountsFormated result
+    expect(result.tabAccountsFormated).to.deep.equal([
+      {
+        202501 : '50.0000',
+        202502 : '100.0000',
+        202503 : '150.0000',
+        202504 : '200.0000',
+        account_label : 'Caisse Principale USD',
+        sumOpeningByAccount : 500,
+      },
+      {
+        202501 : '250.0000',
+        202502 : '300.0000',
+        202503 : '350.0000',
+        202504 : '400.0000',
+        account_label : 'Caisse Principale CDF',
+        sumOpeningByAccount : 1300,
+      },
+    ]);
+
+    // Assert - Check sumOpening result
+    expect(result.sumOpening).to.equal(1800);
+  });
+});

--- a/test/server-unit/cashflow/totalPeriods.spec.js
+++ b/test/server-unit/cashflow/totalPeriods.spec.js
@@ -1,0 +1,147 @@
+// server/controllers/finance/reports/cashflow/cashflow.test.js
+
+const { expect } = require('chai');
+
+// Import the function to be tested
+const cashflowFunction = require('../../../server/controllers/finance/reports/cashflow/cashflow.function');
+
+describe('cashflowFunction.totalPeriods', () => {
+  it('should calculate the total for each period based on income, expense, and transfer totals', () => {
+    // Arrange - Input data
+    const data = {
+      periods : ['202501', '202502', '202503'],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const expenseTotal = {
+      202501 : 50,
+      202502 : 70,
+      202503 : 80,
+    };
+
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    // Act - Call the function
+    const result = cashflowFunction.totalPeriods(data, incomeTotal, expenseTotal, transferTotal);
+
+    // Assert - Expected result for each period
+    // 202501: 100 + 50 + 25 = 175
+    // 202502: 150 + 70 + 35 = 255
+    // 202503: 200 + 80 + 45 = 325
+    expect(result).to.deep.equal({
+      202501 : 175,
+      202502 : 255,
+      202503 : 325,
+    });
+  });
+
+  it('should return NaN for periods with missing data in income, expense, or transfer totals', () => {
+    // Arrange - Input data with missing data for some periods
+    const data = {
+      periods : ['202501', '202502', '202503', '202504'],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const expenseTotal = {
+      202501 : 50,
+      202502 : 70,
+      202503 : 80,
+    };
+
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+    };
+
+    // Act - Call the function
+    const result = cashflowFunction.totalPeriods(data, incomeTotal, expenseTotal, transferTotal);
+
+    // Assert - Expected result with missing period (202504)
+    expect(result).to.deep.equal({
+      202501 : 175,
+      202502 : 255,
+      202503 : NaN, // For 202503, the transfer is missing, so the total is NaN
+      202504 : NaN, // Non-existent period in incomeTotal, so NaN
+    });
+  });
+
+  it('should handle empty periods array', () => {
+    // Arrange - Empty periods array
+    const data = {
+      periods : [],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const expenseTotal = {
+      202501 : 50,
+      202502 : 70,
+      202503 : 80,
+    };
+
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    // Act - Call the function
+    const result = cashflowFunction.totalPeriods(data, incomeTotal, expenseTotal, transferTotal);
+
+    // Assert - The result should be an empty object as there are no periods
+    expect(result).to.deep.equal({});
+  });
+
+  it('should return NaN if any of the totals (income, expense, or transfer) is missing for a period', () => {
+    // Arrange - Input data with a missing total for a period
+    const data = {
+      periods : ['202501', '202502', '202503'],
+    };
+
+    const incomeTotal = {
+      202501 : 100,
+      202502 : 150,
+      202503 : 200,
+    };
+
+    const expenseTotal = {
+      202501 : 50,
+      // 202502 missing
+      202503 : 80,
+    };
+
+    const transferTotal = {
+      202501 : 25,
+      202502 : 35,
+      202503 : 45,
+    };
+
+    // Act - Call the function
+    const result = cashflowFunction.totalPeriods(data, incomeTotal, expenseTotal, transferTotal);
+
+    // Assert - Expected result: NaN for the missing period (202502) in expenseTotal
+    expect(result).to.deep.equal({
+      202501 : 175,
+      202502 : NaN, // Period 202502 with a missing total for expenses
+      202503 : 325,
+    });
+  });
+});

--- a/test/server-unit/util.spec.js
+++ b/test/server-unit/util.spec.js
@@ -133,4 +133,45 @@ describe('test/server-unit/util', () => {
     const med4 = util.median(array4);
     expect(med4).to.equal(array4[0]);
   });
+
+  it('#convertToNumericArray() should correctly convert various inputs', () => {
+    // Normal array of integers
+    const normalArray = [1, 2, 3, 4];
+    const normalResult = util.convertToNumericArray(normalArray);
+    expect(normalResult).to.deep.equal([1, 2, 3, 4]);
+
+    // Array with missing values (sparse array)
+    const sparseArray = [1, undefined, undefined, undefined, undefined, 3];
+    const sparseResult = util.convertToNumericArray(sparseArray);
+    expect(sparseResult.length).to.equal(6);
+    expect(sparseResult[0]).to.equal(1);
+    expect(Number.isNaN(sparseResult[1])).to.equal(true);
+    expect(Number.isNaN(sparseResult[2])).to.equal(true);
+    expect(Number.isNaN(sparseResult[3])).to.equal(true);
+    expect(Number.isNaN(sparseResult[4])).to.equal(true);
+    expect(sparseResult[5]).to.equal(3);
+
+    // Array with string numbers
+    const stringArray = ['1', '2', '3', '5', '4'];
+    const stringResult = util.convertToNumericArray(stringArray);
+    expect(stringResult).to.deep.equal([1, 2, 3, 5, 4]);
+
+    // Array with non-integer values
+    const floatArray = [1.3, 2.5];
+    const floatResult = util.convertToNumericArray(floatArray);
+    expect(floatResult).to.deep.equal([1.3, 2.5]);
+
+    // Empty array
+    const emptyArray = [];
+    const emptyResult = util.convertToNumericArray(emptyArray);
+    expect(emptyResult).to.deep.equal([]);
+
+    // Mixed types
+    const mixedArray = [1, '2.3', ''];
+    const mixedResult = util.convertToNumericArray(mixedArray);
+    expect(mixedResult[0]).to.equal(1);
+    expect(mixedResult[1]).to.equal(2.3);
+    expect(mixedResult[2]).to.equal(0); // '' converted to 0
+  });
+
 });


### PR DESCRIPTION
Rename income description variables for clarity and consistency
- `firstIncomeDescription` → `operatingRevenueDescription`
- `secondIncomeDescription` → `operatingFinancialRevenueDescription`

Replace normalizeParam with convertToNumericArray for cashboxesIds
- Replaced the use of `normalizeParam` with `util.convertToNumericArray` for handling `cashboxesIds`.
- This change ensures that the parameter is explicitly converted into a numeric array, providing better type safety and avoiding potential issues with string-to-number conversions.

Improve readability by extracting configuration reference before filtering
- Extracted `configurationReferences[3]` into a named constant `localRevenues` for better readability and semantic clarity.
- Also updated the source array from `accountsReferenceType[2]` to `accountNumbersByReference` to align with updated data flow and improve maintainability.


Replace accountsReferenceType[3] with excludedAccounts for clarity
- Replaced usage of `accountsReferenceType[3]` with a more explicit and semantically meaningful variable name: `excludedAccounts`.
- This enhances code readability and makes the purpose of the iteration clearer.

Simplify exception lookup with find() instead of filter()
- Replaced the use of `filter()[0]` with `find()` to directly retrieve the matching exception from `configurationReferencesException`.
- This change simplifies the logic, improves performance slightly, and enhances code readability by eliminating unnecessary array handling.

Rename and restructure income configuration references for clarity
- `operatingRevenue` ← `configurationReferences[0]`
- `operatingFinancialRevenue` ← `configurationReferences[1]`
- Initialized `operatingSubsidiesReferences` to replace the former third income category.

Update variable naming for operating revenue description
- Renamed `firstIncomeDescription` to `operatingRevenueDescription` and updated the assignment to use the new `operatingRevenue` variable instead of accessing `configurationReferences[0]` directly.

Rename thirdIncomeConfigurationReferences to operatingSubsidiesReferences
- Renamed `thirdIncomeConfigurationReferences` to `operatingSubsidiesReferences` for improved semantic clarity.
- This change clarifies that the variable specifically refers to subsidies within the operating revenue structure, rather than using a generic ordinal-based name.

Renamed the following variables to reflect the updated revenue terminology:
- `realisationIncomeExpenseFirst` → `realisationOperatingRevenue`
- `realisationIncomeExpenseSecond` → `realisationOperatingFinancialRevenue`

Simplify exclusion logic in cashflow account configuration filtering
- Replaced nested `forEach` loops and manual exclusion counter with a cleaner `filter().some()` pattern.
- The new logic directly filters out accounts from `configAccountsCashflow` if they are present in `configAccountsExcludeCashflow`, improving code readability, reducing complexity, and enhancing performance.

Improve comment for report table column definition
- Updated the comment to provide more context on the behavior of the table columns in the cashflow report.
- The new comment clarifies that, in `global_analysis` or `synthetic_analysis` mode, a new column is added at the end of the report to display the total for each row, improving the understanding of this feature.


Implemented unit tests for the following functions to ensure accurate behavior and improve code reliability:
- `totalOpening`
- `getOpeningBalanceData`
- `getCashboxesDetails`
- `aggregateData`
- `aggregateTotalByTextKeys`
- `aggregateTotal`
- `sumAggregateTotal`
- `totalPeriods`
- `sumIncomesPeriods`
- `totalBalances`
- `sumTotalBalances`
- `totalIncomes`
- `totalIncomesPeriods`
- `sumTotalIncomes`