### PR TITLE
Fix: semaphore mysql testing

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -49,7 +49,7 @@ blocks:
         - name: Run Test Matrix
           commands:
             - sem-service start mysql $MYSQL_VERSION
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "CREATE USER $DB_USER@$DB_HOST IDENTIFIED WITH mysql_native_password BY '$DB_PASS';"
+            - mysql -h 127.0.0.1 -P 3306 -u root -e "CREATE USER $DB_USER@$DB_HOST IDENTIFIED BY '$DB_PASS';"
             - mysql -h 127.0.0.1 -P 3306 -u root -e "GRANT ALL PRIVILEGES ON *.* TO $DB_USER@$DB_HOST WITH GRANT OPTION;"
             - mysql -h 127.0.0.1 -P 3306 -u root -e "FLUSH PRIVILEGES;"
             - 'mysql -h 127.0.0.1 -P 3306 -u root -e "SET @@global.sql_mode=''STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION'';"'
@@ -69,7 +69,7 @@ blocks:
           matrix:
             - env_var: MYSQL_VERSION
               values:
-                - '8'
+                - '8.4'
             - env_var: NODEJS_VERSION
               values:
                 - '22'
@@ -107,7 +107,7 @@ blocks:
         - name: Run Test Matrix
           commands:
             - sem-service start mysql $MYSQL_VERSION
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "CREATE USER $DB_USER@$DB_HOST IDENTIFIED WITH mysql_native_password BY '$DB_PASS';"
+            - mysql -h 127.0.0.1 -P 3306 -u root -e "CREATE USER $DB_USER@$DB_HOST IDENTIFIED BY '$DB_PASS';"
             - mysql -h 127.0.0.1 -P 3306 -u root -e "GRANT ALL PRIVILEGES ON *.* TO $DB_USER@$DB_HOST WITH GRANT OPTION;"
             - mysql -h 127.0.0.1 -P 3306 -u root -e "FLUSH PRIVILEGES;"
             - 'mysql -h 127.0.0.1 -P 3306 -u root -e "SET @@global.sql_mode=''STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION'';"'
@@ -120,7 +120,7 @@ blocks:
           matrix:
             - env_var: MYSQL_VERSION
               values:
-                - '8'
+                - '8.4'
             - env_var: NODEJS_VERSION
               values:
                 - '22'

--- a/docs/en/for-developers/installing-bhima.md
+++ b/docs/en/for-developers/installing-bhima.md
@@ -12,7 +12,7 @@ This guide will get you up and running with bhima locally. Please note that bhim
 
 Before you begin the installation process, please make sure you have all the bhima dependencies installed locally. We only test on Linux, so your best bet is to use a Linux flavor you are familiar with. Please make sure you have recent version of:
 
-1. [MySQL 8](http://dev.mysql.com/downloads/)
+1. [MySQL 8.4 LTS](http://dev.mysql.com/downloads/)
 2. [Redis](https://redis.io)
 3. [curl](https://curl.haxx.se/)
 4. [NodeJS](https://nodejs.org/en/) \(Note that we only test on stable and edge\).
@@ -20,18 +20,18 @@ Before you begin the installation process, please make sure you have all the bhi
 
 ### Detailed dependency installation instructions for Ubuntu
 
-Some of the following instructions assume Ubuntu 22.04 and Node.js 20 LTS.  Update these versions as needed.
+Some of the following instructions assume Ubuntu 22.04 and Node.js 22 LTS.  Update these versions as needed.
 
 ```bash
 # Run the following command to update the package lists:
 sudo apt-get update
 
 # Run the following command to install git:
-sudo apt-get install git
+sudo apt-get install -y git
 
 # Install MySQL with the following command:
 # (On Debian 12, check [Installing MySQL on Debian](https://www.digitalocean.com/community/tutorials/how-to-install-the-latest-mysql-on-debian-10) )
-sudo apt-get install mysql-server
+sudo apt-get install -y mysql-server
 
 # Run the following commands to install Redis:
 sudo apt-get install redis-server
@@ -44,7 +44,7 @@ sudo apt-get install curl
 sudo apt-get install -y ca-certificates curl gnupg
 sudo mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-NODE_MAJOR=20
+NODE_MAJOR=22
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 sudo apt-get update
 sudo apt-get install nodejs
@@ -120,16 +120,12 @@ nano .env
 # Run the following commands to create the bhima user in MySQL, so that it can build the database (make sure the user and 'password' both match what you set in the .env file):
 
 sudo mysql -u root -p
-CREATE USER 'bhima'@'localhost' IDENTIFIED WITH 'mysql_native_password' BY 'password';
+CREATE USER 'bhima'@'localhost' IDENTIFIED BY 'password';
 GRANT ALL PRIVILEGES ON *.* TO 'bhima'@'localhost';
 FLUSH PRIVILEGES;
 # Use ctrl + z to get back to the main terminal prompt
 ```
 
-NOTE: Debian installs MariaDB by default and the `CREATE USER` statement should look like this:
-```bash
-CREATE USER 'bhima'@'localhost' IDENTIFIED BY 'password';
-```
 
 Then, build the app with:
 

--- a/docs/fr/for-developers/installing-bhima.md
+++ b/docs/fr/for-developers/installing-bhima.md
@@ -10,7 +10,7 @@ Ce guide vous permettra de vous familiariser avec bhima localement. Veuillez not
 
 Avant de commencer le processus d'installation, assurez-vous que toutes les dépendances bhima sont installées localement. Nous ne testons que sous Linux. Il est donc préférable d’utiliser une version de Linux que vous connaissez bien. Assurez-vous d'avoir la version récente de:
 
-1. [MySQL](http://dev.mysql.com/downloads/)
+1. [MySQL 8.4 LTS](http://dev.mysql.com/downloads/)
 2. [Redis](https://redis.io)
 3. [curl](https://curl.haxx.se/)
 4. [NodeJS](https://nodejs.org/en/) \(nous vous recommandons d’utiliser le [gestionnaire de version de node](https://github.com/creationix/nvm) sous Linux. Notez que nous ne testons que sur des versions stables. et bord \).
@@ -89,7 +89,7 @@ nano .env
 # Exécutez les commandes suivantes pour créer l'utilisateur bhima dans MySQL afin qu'il puisse construire la base de données (assurez-vous que l'utilisateur et #password correspondent tous les deux à ce que vous avez défini dans le fichier .env):
 
 sudo mysql -u root -p
-CREATE USER 'bhima'@'localhost' IDENTIFIED WITH 'mysql_native_password' BY 'mot de passe';
+CREATE USER 'bhima'@'localhost' IDENTIFIED BY 'mot de passe';
 Accordez tous les privilèges sur *. * TO 'bhima'@'localhost';
 #Utilisez ctrl + z pour revenir à l'invite du terminal principal
 ```


### PR DESCRIPTION
Bumps the MySQL version in the Semaphore matrix to 8.4 LTS (See: https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions/).  Updates the documentation to indicate minimum version support for LTS 8.4 as well.

