### PR TITLE
Remove isAdmin column from the user table

### DIFF
--- a/client/src/modules/users/user.modal.html
+++ b/client/src/modules/users/user.modal.html
@@ -130,16 +130,6 @@
     </div>
 
     <div class="form-group">
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" name="is_admin" ng-true-value="1" ng-false-value="0"
-            ng-model="UserModalCtrl.user.is_admin">
-          <span translate>USERS.SUPER</span>
-        </label>
-      </div>
-    </div>
-
-    <div class="form-group">
       <label for="select-language" translate>FORM.LABELS.PREFERRED_LANGUAGE</label>
       <select
         id="select-language"

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -9,6 +9,7 @@
  * allowing for modules to subscribe to different levels of authority
  *
  * @requires uploader
+ * @requires debug
  */
 
 const debug = require('debug')('app');
@@ -597,11 +598,11 @@ exports.configure = function configure(app) {
 
   // users controller
   app.get('/users', users.list);
-  app.post('/users', users.isAdmin, users.create);
+  app.post('/users', users.create);
   app.get('/users/:id', users.detail);
-  app.get('/users/:username/exists', users.isAdmin, users.exists);
-  app.put('/users/:id', users.isAdmin, users.update);
-  app.delete('/users/:id', users.isAdmin, users.delete);
+  app.get('/users/:username/exists', users.exists);
+  app.put('/users/:id', users.update);
+  app.delete('/users/:id', users.delete);
   app.get('/users/:id/projects', users.projects.list);
   app.get('/users/:id/depots', users.depots.list);
   app.post('/users/:id/depots', users.depots.create);
@@ -613,15 +614,15 @@ exports.configure = function configure(app) {
   app.post('/users/:uuid/depotUsersManagment', users.depotUsersManagment);
   app.post('/users/:uuid/depotUsersSupervision', users.depotUsersSupervision);
 
-  app.put('/users/:id/password', users.isAdmin, users.password);
+  app.put('/users/:id/password', users.password);
   app.get('/users/:id/cashboxes', users.cashboxes.list);
   app.post('/users/:id/cashboxes', users.cashboxes.create);
 
   // projects controller
   app.get('/projects/:id', projects.detail);
-  app.put('/projects/:id', users.isAdmin, projects.update);
-  app.post('/projects', users.isAdmin, projects.create);
-  app.delete('/projects/:id', users.isAdmin, projects.delete);
+  app.put('/projects/:id', projects.update);
+  app.post('/projects', projects.create);
+  app.delete('/projects/:id', projects.delete);
 
   // cashbox controller
   app.get('/cashboxes', cashboxes.list);
@@ -667,9 +668,9 @@ exports.configure = function configure(app) {
   app.get('/enterprises', enterprises.list);
   app.get('/enterprises/:id', enterprises.detail);
   app.post('/enterprises', enterprises.create);
-  app.put('/enterprises/:id', users.isAdmin, enterprises.update);
+  app.put('/enterprises/:id', enterprises.update);
   app.get('/enterprises/:id/fiscal_start', fiscal.getEnterpriseFiscalStart);
-  app.post('/enterprises/:id/logo', users.isAdmin, upload.middleware('pics', 'logo'), enterprises.uploadLogo);
+  app.post('/enterprises/:id/logo', upload.middleware('pics', 'logo'), enterprises.uploadLogo);
   app.get('/helpdesk_info', helpdesk.read);
 
   // employees
@@ -978,13 +979,13 @@ exports.configure = function configure(app) {
   app.get('/roles/actions/:roleUuid', rolesCtrl.rolesAction);
   app.get('/roles/actions/user/:action_id', rolesCtrl.hasAction);
   app.get('/roles/user/:id', rolesCtrl.listForUser);
-  app.post('/roles', users.isAdmin, rolesCtrl.create);
-  app.put('/roles/:uuid', users.isAdmin, rolesCtrl.update);
-  app.delete('/roles/:uuid', users.isAdmin, rolesCtrl.remove);
+  app.post('/roles', rolesCtrl.create);
+  app.put('/roles/:uuid', rolesCtrl.update);
+  app.delete('/roles/:uuid', rolesCtrl.remove);
 
-  app.post('/roles/affectUnits', users.isAdmin, rolesCtrl.assignUnitsToRole);
-  app.post('/roles/assignTouser', users.isAdmin, rolesCtrl.assignRolesToUser);
-  app.post('/roles/actions', users.isAdmin, rolesCtrl.assignActionToRole);
+  app.post('/roles/affectUnits', rolesCtrl.assignUnitsToRole);
+  app.post('/roles/assignTouser', rolesCtrl.assignRolesToUser);
+  app.post('/roles/actions', rolesCtrl.assignActionToRole);
 
   // entities types API
   app.get('/entities/types', entities.types.list);

--- a/server/controllers/admin/users/index.js
+++ b/server/controllers/admin/users/index.js
@@ -12,7 +12,7 @@
 
 const db = require('../../../lib/db');
 const FilterParser = require('../../../lib/filter');
-const { NotFound, BadRequest, Forbidden } = require('../../../lib/errors');
+const { NotFound, BadRequest } = require('../../../lib/errors');
 
 // expose submodules
 exports.projects = require('./projects');
@@ -31,7 +31,6 @@ exports.update = update;
 exports.delete = remove;
 exports.password = password;
 exports.lookup = lookupUser;
-exports.isAdmin = isAdmin;
 exports.depotUsersManagment = depotUsersManagment;
 exports.depotUsersSupervision = depotUsersSupervision;
 
@@ -50,7 +49,7 @@ async function lookupUser(id) {
 
   let sql = `
     SELECT user.id, user.username, user.email, user.display_name,
-      user.active, user.last_login, user.deactivated, user.is_admin, user.enable_external_access,
+      user.active, user.last_login, user.deactivated, user.enable_external_access,
       user.preferred_language,
       GROUP_CONCAT(DISTINCT role.label ORDER BY role.label DESC SEPARATOR ', ') AS roles,
       GROUP_CONCAT(DISTINCT depot.text ORDER BY depot.text DESC SEPARATOR ', ') AS depots,
@@ -297,19 +296,6 @@ async function remove(req, res) {
   }
 
   res.sendStatus(204);
-}
-
-/**
- * Allow only request from BHIMA client for authenticated user
- */
-async function isAdmin(req, res, next) {
-  try {
-    const query = `SELECT username FROM user WHERE user.id = ? AND user.is_admin = 1`;
-    const user = await db.one(query, [req.session.user.id]);
-    if (user && user.username) { next(); } else { next(new Forbidden('ERRORS.ER_ACCESS_DENIED_ERROR')); }
-  } catch (error) {
-    next(new Forbidden('ERRORS.ER_ACCESS_DENIED_ERROR'));
-  }
 }
 
 /**

--- a/server/models/01-schema.sql
+++ b/server/models/01-schema.sql
@@ -1808,7 +1808,6 @@ CREATE TABLE `user` (
   `last_login`               TIMESTAMP NULL,
   `created_at`               TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at`               TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `is_admin`                 TINYINT(1) NOT NULL DEFAULT 0,
   `preferred_language`       TEXT NULL,
   `enable_external_access`   TINYINT(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),

--- a/server/models/03-procedures.sql
+++ b/server/models/03-procedures.sql
@@ -3750,8 +3750,6 @@ BEGIN
   INSERT INTO role_unit SELECT HUID(uuid()) as uuid,roleUUID, id FROM unit;
   INSERT INTO user_role(uuid, user_id, role_uuid) VALUES(HUID(uuid()), user_id, roleUUID);
   INSERT INTO role_actions(uuid, role_uuid, actions_id) SELECT HUID(uuid()) as uuid, roleUUID, id FROM actions;
-
-  UPDATE user SET is_admin = 1 WHERE id = user_id;
 END $$
 
 

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -3,3 +3,7 @@
 -- adds the preferred_language to the user table
 -- Close #7936.
 CALL add_column_if_missing('user', 'preferred_language', 'TEXT NULL');
+
+
+-- removes the is_admin column from the user table
+ALTER TABLE `user` DROP COLUMN `is_admin`;


### PR DESCRIPTION
Removes the `isAdmin` column from the user table.  

Must be merged after #8170.

This is a follow-on fix to https://github.com/third-culture-software/bhima/pull/7457 and https://github.com/third-culture-software/bhima/issues/7451.



