### PR TITLE
deps: remove uuid library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,6 @@
         "typeface-open-sans": "^1.1.13",
         "ui-select": "0.17.1",
         "use-strict": "^1.0.1",
-        "uuid": "^11.1.0",
         "uuid-parse": "^1.1.0",
         "webcam": "^3.2.1"
       },
@@ -15244,19 +15243,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/uuid-parse": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
     "typeface-open-sans": "^1.1.13",
     "ui-select": "0.17.1",
     "use-strict": "^1.0.1",
-    "uuid": "^11.1.0",
     "uuid-parse": "^1.1.0",
     "webcam": "^3.2.1"
   },

--- a/server/controllers/finance/transactions.js
+++ b/server/controllers/finance/transactions.js
@@ -10,8 +10,8 @@
  * @requires controllers/finance/vouchers
  * @requires controllers/finance/patientInvoice
  */
+
 const debug = require('debug')('bhima:controller:transactions');
-const luuid = require('uuid');
 const shared = require('./shared');
 const db = require('../../lib/db');
 const Unauthorized = require('../../lib/errors/Unauthorized');
@@ -36,6 +36,12 @@ const safeDeletionMethods = {
 exports.deleteRoute = deleteRoute;
 exports.deleteTransaction = deleteTransaction;
 exports.commentTransactions = commentTransactions;
+
+// expects a buffer and makes it into a nicely formatted UUID
+function formatUuid(uuid) {
+  const str = uuid.toString('hex');
+  return `${str.slice(0, 8)}-${str.slice(8, 12)}-${str.slice(12, 16)}-${str.slice(16, 20)}-${str.slice(20)}`;
+}
 
 /**
  * @function parseDocumentMapString
@@ -97,12 +103,16 @@ function deleteRoute(req, res, next) {
 function formatTransactionRecord(txnRecord) {
   return txnRecord.map(row => {
     const parsed = { ...row };
-    parsed.uuid = luuid.stringify(row.uuid);
-    parsed.record_uuid = luuid.stringify(row.record_uuid);
+    parsed.uuid = formatUuid(row.uuid);
+    parsed.record_uuid = formatUuid(row.record_uuid);
+
     if (row.reference_uuid && row.reference_uuid !== null) {
-      parsed.reference_uuid = luuid.stringify(row.reference_uuid);
+      parsed.reference_uuid = formatUuid(row.reference_uuid);
     }
-    if (row.entity_uuid && row.entity_uuid !== null) { parsed.entity_uuid = luuid.stringify(row.entity_uuid); }
+
+    if (row.entity_uuid && row.entity_uuid !== null) {
+      parsed.entity_uuid = formatUuid(row.entity_uuid);
+    }
     return parsed;
   });
 }

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -22,7 +22,7 @@ const debug = require('debug')('util');
 const csvtojson = require('csvtojson');
 const fs = require('fs');
 
-const { randomUUID } = require('crypto');
+const { randomUUID } = require('node:crypto');
 
 exports.take = take;
 exports.loadModuleIfExists = requireModuleIfExists;

--- a/test/integration-stock/helpers.js
+++ b/test/integration-stock/helpers.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-unused-expressions */
 
 // import plugins
-const uuid = require('uuid');
 const { expect } = require('chai');
+const crypto = require('node:crypto');
 
 /**
  * Clones the object and removes the field, to test if the field is required
@@ -224,6 +224,6 @@ exports.data = {
   },
 };
 
-exports.uuid = () => uuid.v4().toUpperCase().replace(/-/g, '');
+exports.uuid = () => crypto.randomUUID().toUpperCase().replace(/-/g, '');
 
 exports.uuidize = (uuidWithDashes) => uuidWithDashes.toUpperCase().replace(/-/g, '');

--- a/test/integration-stock/helpers.js
+++ b/test/integration-stock/helpers.js
@@ -2,7 +2,7 @@
 
 // import plugins
 const { expect } = require('chai');
-const crypto = require('node:crypto');
+const { randomUUID } = require('node:crypto');
 
 /**
  * Clones the object and removes the field, to test if the field is required
@@ -224,6 +224,6 @@ exports.data = {
   },
 };
 
-exports.uuid = () => crypto.randomUUID().toUpperCase().replace(/-/g, '');
+exports.uuid = () => randomUUID().toUpperCase().replace(/-/g, '');
 
 exports.uuidize = (uuidWithDashes) => uuidWithDashes.toUpperCase().replace(/-/g, '');

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 
 // import plugins
-const crypto = require('node:crypto');
+const { randomUUID } = require('node:crypto');
 const { expect } = require('chai');
 
 /**
@@ -229,4 +229,4 @@ exports.data = {
   },
 };
 
-exports.uuid = () => crypto.randomUUID().toUpperCase().replace(/-/g, '');
+exports.uuid = () => randomUUID().toUpperCase().replace(/-/g, '');

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 
 // import plugins
-const uuid = require('uuid');
+const crypto = require('node:crypto');
 const { expect } = require('chai');
 
 /**
@@ -229,4 +229,4 @@ exports.data = {
   },
 };
 
-exports.uuid = () => uuid.v4().toUpperCase().replace(/-/g, '');
+exports.uuid = () => crypto.randomUUID().toUpperCase().replace(/-/g, '');

--- a/test/integration/inventory/shared.js
+++ b/test/integration/inventory/shared.js
@@ -2,12 +2,11 @@
  * This file contains shared information between all inventory
  * elements (metadata, groups, types, unit, ...)
  */
-const uuid = require('uuid');
 
-const genuuid = () => uuid.v4().toUpperCase().replace(/-/g, '');
+const helpers = require('../helpers');
 
 const inventoryGroup = {
-  uuid : genuuid(),
+  uuid : helpers.uuid(),
   code : '99',
   name : 'Test Inventory Group 2',
   stock_account : 162, // 31110010 - 'Medicaments en comprimes *'

--- a/test/integration/mergeLots.js
+++ b/test/integration/mergeLots.js
@@ -1,13 +1,8 @@
 /* global expect, agent */
 
 const moment = require('moment');
-const UUID = require('uuid').v4;
 const helpers = require('./helpers');
 const db = require('../../server/lib/db');
-
-function uuid() {
-  return UUID().toUpperCase().replace(/-/g, '');
-}
 
 const preTestInfo = [
   { table : 'lot', count : 0 },
@@ -25,11 +20,11 @@ const depotUuid = 'F9CAEB16168443C5A6C447DBAC1DF296';
 const vitamineUuid = 'F6556E729D0547998CBD0A03B1810185';
 
 // Define needed UUIDs and labels
-const lot1Uuid = uuid();
-const lot2Uuid = uuid();
-const lot3Uuid = uuid();
-const lot4Uuid = uuid();
-const lot5Uuid = uuid();
+const lot1Uuid = helpers.uuid();
+const lot2Uuid = helpers.uuid();
+const lot3Uuid = helpers.uuid();
+const lot4Uuid = helpers.uuid();
+const lot5Uuid = helpers.uuid();
 
 const lot1Label = 'Test lot 1';
 const lot2Label = 'Test lot 2';
@@ -46,21 +41,21 @@ const mockLots = [
   [lot5Uuid, lot5Label, vitamineUuid], // This is another dupe of the first lot
 ];
 
-const tag3Uuid = uuid();
-const tag4Uuid = uuid();
-const tag5Uuid = uuid();
+const tag3Uuid = helpers.uuid();
+const tag4Uuid = helpers.uuid();
+const tag5Uuid = helpers.uuid();
 
 const mockTags = [
   // uuid, lot uuid, tag text
-  [uuid(), lot1Uuid, 'XYZ Brand'],
-  [uuid(), lot1Uuid, 'Vitamin'],
-  [uuid(), lot2Uuid, 'Partial'],
+  [helpers.uuid(), lot1Uuid, 'XYZ Brand'],
+  [helpers.uuid(), lot1Uuid, 'Vitamin'],
+  [helpers.uuid(), lot2Uuid, 'Partial'],
   [tag3Uuid, lot3Uuid, 'Vitamin2'],
   [tag4Uuid, lot4Uuid, 'Vitamin3'],
   [tag5Uuid, lot5Uuid, 'Vitamin4'],
 ];
 
-const stockMovement1Uuid = uuid();
+const stockMovement1Uuid = helpers.uuid();
 
 const mockStockMovements = [
   // stockMovementUuid, lotUuid, quantity, unit_cost, is_exit, user_id, created_at, period_id
@@ -95,7 +90,7 @@ function addStockMovementSQL(params) {
   const [smUuid, lotUuid, quantity, unitCost, isExit, userId, createdAt, periodId] = params;
   return 'INSERT INTO stock_movement (uuid, document_uuid, depot_uuid, lot_uuid, quantity, unit_cost, '
     + '  date, is_exit, user_id, flux_id, created_at, period_id) '
-    + `VALUES (0x${smUuid}, 0x${uuid()}, 0x${depotUuid}, 0x${lotUuid}, ${quantity}, ${unitCost}, `
+    + `VALUES (0x${smUuid}, 0x${helpers.uuid()}, 0x${depotUuid}, 0x${lotUuid}, ${quantity}, ${unitCost}, `
     + `  '${createdAt}', ${isExit}, ${userId}, 9, '${createdAt}', '${periodId}');`;
 }
 

--- a/test/integration/patientInvoice.js
+++ b/test/integration/patientInvoice.js
@@ -1,10 +1,7 @@
 /* eslint no-unused-expressions:"off" */
 /* global expect, agent */
 
-const uuid = require('uuid');
 const helpers = require('./helpers');
-
-const genuuid = () => uuid.v4().toUpperCase().replace(/-/g, '');
 
 /**
  * @todo passing the date as an object causes the invoice request object to
@@ -157,7 +154,7 @@ function InvoicingFeeScenario() {
    *  5) The 'user_id' should be ignored, and default to the logged in user.
    */
 
-  const SIMPLE_UUID = genuuid();
+  const SIMPLE_UUID = helpers.uuid();
   const simpleInvoice = {
     date : new Date(),
     cost : 35.14, // this cost should be calculated by the server (see test).

--- a/test/integration/patientMatches.js
+++ b/test/integration/patientMatches.js
@@ -2,15 +2,8 @@
 
 // eslint-disable no-unused-expressions
 
-const UUID = require('uuid').v4;
-
 const helpers = require('./helpers');
-
 const db = require('../../server/lib/db');
-
-function uuid() {
-  return UUID().toUpperCase().replace(/-/g, '');
-}
 
 // Reuse the same location/project uuids for all mock patients
 const groupUuid = '4DE0FE47177F4D30B95FCFF8166400B4';
@@ -33,15 +26,15 @@ function addPatientSQL(pinfo) {
 
 const mockPatients = [
   // uuid, display_name, sex, dob, dob_unknown_date, debtorUuid
-  [uuid(), 'John Smith', 'M', '1993-08-01', 'FALSE', uuid()],
-  [uuid(), 'Jon Smith', 'M', '1995-06-01', 'TRUE', uuid()],
+  [helpers.uuid(), 'John Smith', 'M', '1993-08-01', 'FALSE', helpers.uuid()],
+  [helpers.uuid(), 'Jon Smith', 'M', '1995-06-01', 'TRUE', helpers.uuid()],
 
-  [uuid(), 'John Jones Mitchum', 'M', '1980-06-01', 'TRUE', uuid()],
-  [uuid(), 'John Janes Mitchum', 'M', '1981-04-21', 'FALSE', uuid()],
-  [uuid(), 'John Jenes Matchim', 'M', '1984-06-01', 'TRUE', uuid()],
+  [helpers.uuid(), 'John Jones Mitchum', 'M', '1980-06-01', 'TRUE', helpers.uuid()],
+  [helpers.uuid(), 'John Janes Mitchum', 'M', '1981-04-21', 'FALSE', helpers.uuid()],
+  [helpers.uuid(), 'John Jenes Matchim', 'M', '1984-06-01', 'TRUE', helpers.uuid()],
 
-  [uuid(), 'Lynn H. Black', 'M', '1970-08-01', 'FALSE', uuid()],
-  [uuid(), 'Lynn Black', 'F', '1981-06-01', 'TRUE', uuid()],
+  [helpers.uuid(), 'Lynn H. Black', 'M', '1970-08-01', 'FALSE', helpers.uuid()],
+  [helpers.uuid(), 'Lynn Black', 'F', '1981-06-01', 'TRUE', helpers.uuid()],
 ];
 
 describe('test/integration/patientMatches Find matching patients', () => {
@@ -279,5 +272,4 @@ describe('test/integration/patientMatches Find matching patients', () => {
         .then(() => db.exec(`DELETE FROM patient WHERE uuid=0x${p[0]};`));
     }, Promise.resolve());
   });
-
 });

--- a/test/integration/vouchers.js
+++ b/test/integration/vouchers.js
@@ -1,15 +1,12 @@
 /* global expect, agent */
 /* eslint-disable no-unused-expressions */
 
-const uuid = require('uuid');
 const helpers = require('./helpers');
-
-const genuuid = () => uuid.v4().toUpperCase().replace(/-/g, '');
 
 /*
  * The /vouchers API
  *
- * This test suit is about the vouchers table
+ * This test suite for the vouchers table
  */
 describe('test/integration/vouchers The vouchers HTTP endpoint', () => {
   const date = new Date();
@@ -31,11 +28,11 @@ describe('test/integration/vouchers The vouchers HTTP endpoint', () => {
     description : 'Voucher Transaction to BCDC',
     user_id     : 1,
     items       : [{
-      uuid          : genuuid(),
+      uuid          : helpers.uuid(),
       account_id    : 184,
       debit         : 10,
       credit        : 0,
-      document_uuid : genuuid(),
+      document_uuid : helpers.uuid(),
       voucher_uuid  : vUuid,
     }, {
       account_id   : 217,
@@ -71,13 +68,13 @@ describe('test/integration/vouchers The vouchers HTTP endpoint', () => {
   // only one item - bad transaction
   const badVoucher = {
     date,
-    uuid        : genuuid(),
+    uuid        : helpers.uuid(),
     project_id  : 1,
     currency_id : helpers.data.USD,
     amount      : 10,
     description : 'Voucher Transaction',
     items       : [{
-      uuid       : genuuid(),
+      uuid       : helpers.uuid(),
       account_id : 177,
       debit      : 10,
       credit     : 0,
@@ -86,7 +83,7 @@ describe('test/integration/vouchers The vouchers HTTP endpoint', () => {
 
   // this voucher will not have an exchange rate
   const predatedVoucher = {
-    uuid        : genuuid(),
+    uuid        : helpers.uuid(),
     date        : new Date('2000-01-01'),
     project_id  : 1,
     currency_id : helpers.data.FC,
@@ -95,12 +92,12 @@ describe('test/integration/vouchers The vouchers HTTP endpoint', () => {
     description : 'Voucher Transaction',
     user_id     : 1,
     items       : [{
-      uuid       : genuuid(),
+      uuid       : helpers.uuid(),
       account_id : 179,
       debit      : 10,
       credit     : 0,
     }, {
-      uuid       : genuuid(),
+      uuid       : helpers.uuid(),
       account_id : 191,
       debit      : 0,
       credit     : 10,
@@ -119,11 +116,11 @@ describe('test/integration/vouchers The vouchers HTTP endpoint', () => {
     description : 'Partial Paiement Salary [ 02 - 2018]',
     user_id     : 1,
     items       : [{
-      uuid          : genuuid(),
+      uuid          : helpers.uuid(),
       account_id    : 187,
       debit         : 0,
       credit        : 14.07,
-      document_uuid : genuuid(),
+      document_uuid : helpers.uuid(),
       voucher_uuid  : pUuid,
     }, {
       account_id   : 179,
@@ -183,7 +180,7 @@ describe('test/integration/vouchers The vouchers HTTP endpoint', () => {
   });
 
   it('POST /vouchers doesn\'t register when missing data', () => {
-    const uid = genuuid();
+    const uid = helpers.uuid();
     mockVoucher = {
       date,
       uuid          : uid,
@@ -191,7 +188,7 @@ describe('test/integration/vouchers The vouchers HTTP endpoint', () => {
       currency_id   : 1,
       amount        : 10,
       description   : 'Bad Voucher Transaction',
-      document_uuid : genuuid(), // technically, this should reference something..
+      document_uuid : helpers.uuid(), // technically, this should reference something..
       user_id       : 1,
       items         : [{
         account_id   : 3631,
@@ -212,7 +209,7 @@ describe('test/integration/vouchers The vouchers HTTP endpoint', () => {
   it('POST /vouchers will reject a voucher will less than two records', () => {
     // attempt 1 - missing items completely + bad voucher
     return agent.post('/vouchers')
-      .send({ voucher : { uuid : genuuid() } })
+      .send({ voucher : { uuid : helpers.uuid() } })
       .then((res) => {
         helpers.api.errored(res, 400);
 

--- a/test/server-unit/purchases/purchases.spec.js
+++ b/test/server-unit/purchases/purchases.spec.js
@@ -1,8 +1,8 @@
 /* eslint global-require:off */
 const { expect } = require('chai');
-const crypto = require('node:crypto');
+const { randomUUID } = require('node:crypto');
 
-const uuid = () => crypto.randomUUID().toUpperCase().replace(/-/g, '');
+const uuid = () => randomUUID().toUpperCase().replace(/-/g, '');
 
 describe('test/server-unit/purchases/purchases', () => {
 

--- a/test/server-unit/purchases/purchases.spec.js
+++ b/test/server-unit/purchases/purchases.spec.js
@@ -1,6 +1,8 @@
 /* eslint global-require:off */
 const { expect } = require('chai');
-const uuid = require('uuid').v4;
+const crypto = require('node:crypto');
+
+const uuid = () => crypto.randomUUID().toUpperCase().replace(/-/g, '');
 
 describe('test/server-unit/purchases/purchases', () => {
 


### PR DESCRIPTION
This commit removes the dependency on the `uuid` library and replaces it with `node:crypto` and `Buffer.toString()` methods.

Closes #8203.