### PR TITLE
fix(barcode): ensure options is an object

### DIFF
--- a/client/src/js/services/BarcodeService.js
+++ b/client/src/js/services/BarcodeService.js
@@ -5,6 +5,7 @@ BarcodeService.$inject = ['$http', 'util', '$uibModal'];
 
 function BarcodeService($http, util, Modal) {
   const service = this;
+
   // TODO - barcode redirection
   service.redirect = angular.noop;
 
@@ -13,7 +14,7 @@ function BarcodeService($http, util, Modal) {
       .then(util.unwrapHttpResponse);
   };
 
-  service.modal = (options) => Modal.open({
+  service.modal = (options = {}) => Modal.open({
     controller  : 'BarcodeModalController as BarcodeModalCtrl',
     templateUrl : 'modules/templates/barcode-scanner-modal.html',
     size        : 'lg',


### PR DESCRIPTION
Fixes a typo in the barcode servicde that would omit the options object and crash the modal.  This has been corrected.

To test this, make sure the "enable barcodes throughout app" option is enabled on the enterprise settings page.  Then go to any registry (e.g. voucher, invoices, cash) and you'll find the "Scan Barcode" option in the registry's dropdown menu.  Click it, and a modal should appear.

Previously, the modal did not appear.

Closes #8212.