### PR TITLE
Standardize default report currency

### DIFF
--- a/client/src/modules/reports/generate/account_report/account_report.config.js
+++ b/client/src/modules/reports/generate/account_report/account_report.config.js
@@ -95,8 +95,11 @@ function AccountReportConfigController(
   }
 
   function checkCachedConfiguration() {
-    if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
+
+    // Set the defaults
+    if (!angular.isDefined(vm.reportDetails.currency_id)) {
+      vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
   }
 }

--- a/client/src/modules/reports/generate/account_report/account_report.config.js
+++ b/client/src/modules/reports/generate/account_report/account_report.config.js
@@ -17,7 +17,6 @@ function AccountReportConfigController(
   vm.previewGenerated = false;
 
   vm.reportDetails = {
-    currency_id : Session.enterprise.currency_id,
     includeUnpostedValues : 0,
   };
 
@@ -95,7 +94,7 @@ function AccountReportConfigController(
   }
 
   function checkCachedConfiguration() {
-    vm.reportDetails = angular.copy(cache.reportDetails || {});
+    vm.reportDetails = angular.merge(cache.reportDetails || {}, vm.reportDetails);
 
     // Set the defaults
     if (!angular.isDefined(vm.reportDetails.currency_id)) {

--- a/client/src/modules/reports/generate/account_report_multiple/account_report_multiple.config.js
+++ b/client/src/modules/reports/generate/account_report_multiple/account_report_multiple.config.js
@@ -110,7 +110,7 @@ function AccountReportMultipleConfigController(
   }
 
   function checkCachedConfiguration() {
-    vm.reportDetails = angular.copy(cache.reportDetails || {});
+    vm.reportDetails = angular.merge(cache.reportDetails || {}, vm.reportDetails);
 
     // Set the defaults
     if (!angular.isDefined(vm.reportDetails.currency_id)) {

--- a/client/src/modules/reports/generate/account_report_multiple/account_report_multiple.config.js
+++ b/client/src/modules/reports/generate/account_report_multiple/account_report_multiple.config.js
@@ -13,13 +13,14 @@ function AccountReportMultipleConfigController(
   const vm = this;
   const cache = new AppCache('configure_account_report_multiple');
   const reportUrl = 'reports/finance/account_report_multiple';
-  vm.previewGenerated = false;
 
+  vm.previewGenerated = false;
   vm.reportDetails = {
-    currency_id : Session.enterprise.currency_id,
     accountIds : [],
     includeUnpostedValues : 0,
   };
+
+  checkCachedConfiguration();
 
   function handleStateParameters() {
     const { data } = reportData.params;
@@ -30,8 +31,6 @@ function AccountReportMultipleConfigController(
   }
 
   vm.dateInterval = 1;
-
-  checkCachedConfiguration();
 
   vm.selectAccount = function selectAccount(account) {
     vm.reportDetails.accountIds.push(account.id);
@@ -111,8 +110,11 @@ function AccountReportMultipleConfigController(
   }
 
   function checkCachedConfiguration() {
-    if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
+
+    // Set the defaults
+    if (!angular.isDefined(vm.reportDetails.currency_id)) {
+      vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
   }
 

--- a/client/src/modules/reports/generate/aged_creditors/aged_creditors.config.js
+++ b/client/src/modules/reports/generate/aged_creditors/aged_creditors.config.js
@@ -61,12 +61,10 @@ function AgedCreditorsConfigController($sce, Notify, SavedReports, AppCache, rep
   };
 
   function checkCachedConfiguration() {
-    if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
-    }
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
 
     // Set the defaults
-    if (!angular.isDefined(vm.reportDetails.currencyId)) {
+    if (!angular.isDefined(vm.reportDetails.currency_id)) {
       vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
   }

--- a/client/src/modules/reports/generate/aged_debtors/aged_debtors.config.js
+++ b/client/src/modules/reports/generate/aged_debtors/aged_debtors.config.js
@@ -65,7 +65,7 @@ function AgedDebtorsConfigController($sce, Notify, SavedReports, AppCache, repor
     vm.reportDetails = angular.copy(cache.reportDetails || {});
 
     // Set the defaults
-    if (!angular.isDefined(vm.reportDetails.currencyId)) {
+    if (!angular.isDefined(vm.reportDetails.currency_id)) {
       vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
   }

--- a/client/src/modules/reports/generate/aged_debtors/aged_debtors.config.js
+++ b/client/src/modules/reports/generate/aged_debtors/aged_debtors.config.js
@@ -62,9 +62,7 @@ function AgedDebtorsConfigController($sce, Notify, SavedReports, AppCache, repor
   };
 
   function checkCachedConfiguration() {
-    if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
-    }
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
 
     // Set the defaults
     if (!angular.isDefined(vm.reportDetails.currencyId)) {

--- a/client/src/modules/reports/generate/annual_clients_report/annual_clients_report.html
+++ b/client/src/modules/reports/generate/annual_clients_report/annual_clients_report.html
@@ -120,7 +120,7 @@
 
   <div class="col-md-6">
     <bh-cron-email-report
-      report-id="17"
+      report-key="annual_clients_report"
       report-form="ConfigForm"
       report-details="ReportConfigCtrl.reportDetails"
       on-select-report="ReportConfigCtrl.onSelectCronReport(report)">

--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -19,6 +19,8 @@ function BalanceReportConfigController($sce, Notify, Session, SavedReports, AppC
   vm.previewGenerated = false;
   vm.reportDetails = {};
 
+  checkCachedConfiguration();
+
   vm.setCurrency = function setCurrency(currency) {
     vm.reportDetails.currency_id = currency.id;
   };
@@ -92,17 +94,14 @@ function BalanceReportConfigController($sce, Notify, Session, SavedReports, AppC
       .catch(Notify.handleError);
   };
 
-  checkCachedConfiguration();
-
   function checkCachedConfiguration() {
-    if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
-    }
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
 
     // Set the defaults
-    if (!angular.isDefined(vm.reportDetails.currencyId)) {
+    if (!angular.isDefined(vm.reportDetails.currency_id)) {
       vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
+
     if (!angular.isDefined(vm.reportDetails.includeClosingBalances)) {
       vm.reportDetails.includeClosingBalances = 0;
     }

--- a/client/src/modules/reports/generate/budget_report/budget_report.config.js
+++ b/client/src/modules/reports/generate/budget_report/budget_report.config.js
@@ -109,9 +109,11 @@ function BudgetReportController($sce, Notify, SavedReports, AppCache, reportData
   };
 
   function checkCachedConfiguration() {
-    if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
+
+    // Set the defaults
+    if (!angular.isDefined(vm.reportDetails.currency_id)) {
+      vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
-    vm.reportDetails.type = 1;
   }
 }

--- a/client/src/modules/reports/generate/cashflow/cashflow.html
+++ b/client/src/modules/reports/generate/cashflow/cashflow.html
@@ -36,86 +36,83 @@
               required="true">
             </bh-multiple-cashbox-select>
 
-            <div class="form-group">
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.is_transfer_as_revenue" ng-true-value="1" ng-false-value="0">
-                  <span translate>REPORT.CONSIDER_TRANSFER_MOVEMENTS_REVENUE</span>
-                </label>
-              </div>
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="ReportConfigCtrl.reportDetails.is_transfer_as_revenue" ng-true-value="1" ng-false-value="0">
+                <span translate>REPORT.CONSIDER_TRANSFER_MOVEMENTS_REVENUE</span>
+              </label>
             </div>
 
-            <div class="panel-body">
-              <div class="radio">
-                <label class="radio-inline">
-                  <input
-                    type="radio"
-                    name="modeReport"
-                    value="cash_accounts"
-                    ng-model="ReportConfigCtrl.reportDetails.modeReport"
-                    ng-click="ReportConfigCtrl.onSelectMode('cash_accounts')"
-                    required>
-                  <span translate>
-                    FORM.INFO.ANALYSIS_CASH_ACCOUNTS
-                  </span>
-                </label>
-              </div>
-              <div class="radio">
-                <label class="radio-inline">
-                  <input
-                    type="radio"
-                    name="modeReport"
-                    value="associated_account"
-                    ng-model="ReportConfigCtrl.reportDetails.modeReport"
-                    ng-click="ReportConfigCtrl.onSelectMode('associated_account')"
-                    required>
-                  <span translate>
-                    FORM.INFO.ANALYSIS_ASSOCIATED_ACCOUNTS
-                  </span>
-                </label>
-              </div>
-              <div class="radio">
-                <label class="radio-inline">
-                  <input
-                    type="radio"
-                    name="modeReport"
-                    value="transaction_type"
-                    ng-model="ReportConfigCtrl.reportDetails.modeReport"
-                    ng-click="ReportConfigCtrl.onSelectMode('transaction_type')"
-                    required>
-                  <span translate>
-                    FORM.INFO.ANALYSIS_TRANSACTION_TYPES
-                  </span>
-                </label>
-              </div>
-              <div class="radio">
-                <label class="radio-inline">
-                  <input
-                    type="radio"
-                    name="modeReport"
-                    value="global_analysis"
-                    ng-model="ReportConfigCtrl.reportDetails.modeReport"
-                    ng-click="ReportConfigCtrl.onSelectMode('global_analysis')"
-                    required>
-                  <span translate>
-                    FORM.INFO.GLOBAL_ANALYSIS_ACCOUNT_GROUPING
-                  </span>
-                </label>
-              </div>
-              <div class="radio">
-                <label class="radio-inline">
-                  <input
-                    type="radio"
-                    name="modeReport"
-                    value="synthetic_analysis"
-                    ng-model="ReportConfigCtrl.reportDetails.modeReport"
-                    ng-click="ReportConfigCtrl.onSelectMode('synthetic_analysis')"
-                    required>
-                  <span translate>
-                    FORM.INFO.SYNTHETIC_ANALYSIS_ACCOUNT_GROUPING
-                  </span>
-                </label>
-              </div>
+            <div class="radio">
+              <label>
+                <input
+                  type="radio"
+                  name="modeReport"
+                  value="cash_accounts"
+                  ng-model="ReportConfigCtrl.reportDetails.modeReport"
+                  ng-click="ReportConfigCtrl.onSelectMode('cash_accounts')"
+                  required>
+                <span translate>
+                  FORM.INFO.ANALYSIS_CASH_ACCOUNTS
+                </span>
+              </label>
+            </div>
+            <div class="radio">
+              <label>
+                <input
+                  type="radio"
+                  name="modeReport"
+                  value="associated_account"
+                  ng-model="ReportConfigCtrl.reportDetails.modeReport"
+                  ng-click="ReportConfigCtrl.onSelectMode('associated_account')"
+                  required>
+                <span translate>
+                  FORM.INFO.ANALYSIS_ASSOCIATED_ACCOUNTS
+                </span>
+              </label>
+            </div>
+            <div class="radio">
+              <label>
+                <input
+                  type="radio"
+                  name="modeReport"
+                  value="transaction_type"
+                  ng-model="ReportConfigCtrl.reportDetails.modeReport"
+                  ng-click="ReportConfigCtrl.onSelectMode('transaction_type')"
+                  required>
+                <span translate>
+                  FORM.INFO.ANALYSIS_TRANSACTION_TYPES
+                </span>
+              </label>
+            </div>
+            <div class="radio">
+              <label>
+                <input
+                  type="radio"
+                  name="modeReport"
+                  value="global_analysis"
+                  ng-model="ReportConfigCtrl.reportDetails.modeReport"
+                  ng-click="ReportConfigCtrl.onSelectMode('global_analysis')"
+                  required>
+                <span translate>
+                  FORM.INFO.GLOBAL_ANALYSIS_ACCOUNT_GROUPING
+                </span>
+              </label>
+            </div>
+            <div class="radio">
+              <label >
+                <input
+                  type="radio"
+                  name="modeReport"
+                  value="synthetic_analysis"
+                  ng-model="ReportConfigCtrl.reportDetails.modeReport"
+                  ng-click="ReportConfigCtrl.onSelectMode('synthetic_analysis')"
+                  required>
+                <span translate>
+                  FORM.INFO.SYNTHETIC_ANALYSIS_ACCOUNT_GROUPING
+                </span>
+              </label>
+
               <div ng-if="ReportConfigCtrl.reportDetails.modeReport === 'global_analysis' || ReportConfigCtrl.reportDetails.modeReport === 'synthetic_analysis'">
                 <bh-reference-account-multiple-select
                   label="FORM.SELECT.SELECT_REFERENCES_LOCAL_REVENUES"

--- a/client/src/modules/reports/generate/cost_center/cost_center.config.js
+++ b/client/src/modules/reports/generate/cost_center/cost_center.config.js
@@ -11,6 +11,7 @@ function CostCenterConfigController($sce, Notify, SavedReports, AppCache, report
   const vm = this;
   const cache = new AppCache('configure_cost_center');
   const reportUrl = 'reports/finance/cost_center';
+
   vm.reportDetails = {};
   vm.previewGenerated = false;
   checkCachedConfiguration();
@@ -67,9 +68,9 @@ function CostCenterConfigController($sce, Notify, SavedReports, AppCache, report
   };
 
   function checkCachedConfiguration() {
-    if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
-    }
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
+
+    // TODO(@jniles) - what is this?
     vm.reportDetails.type = 1;
   }
 }

--- a/client/src/modules/reports/generate/cost_center_accounts/cost_center_accounts.config.js
+++ b/client/src/modules/reports/generate/cost_center_accounts/cost_center_accounts.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('cost_center_accountsController', CostCenterAccountsReportConfigController);
 
 CostCenterAccountsReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
 /**
@@ -11,13 +11,17 @@ CostCenterAccountsReportConfigController.$inject = [
  * @description
  * This function renders the cost_center_accounts report.
  */
-function CostCenterAccountsReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function CostCenterAccountsReportConfigController(
+  $sce, Notify, SavedReports, AppCache, reportData, $state,
+  Session,
+) {
   const vm = this;
   const cache = new AppCache('CostCenterAccountsReport');
   const reportUrl = 'reports/finance/cost_center_accounts';
 
   vm.previewGenerated = false;
   vm.reportDetails = { include_revenue : false };
+  checkCachedConfiguration();
 
   vm.onSelectFiscalYear = (fiscalYear) => {
     vm.reportDetails.fiscal_id = fiscalYear.id;
@@ -79,11 +83,12 @@ function CostCenterAccountsReportConfigController($sce, Notify, SavedReports, Ap
       .catch(Notify.handleError);
   };
 
-  checkCachedConfiguration();
-
   function checkCachedConfiguration() {
-    if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
+
+    // Set the defaults
+    if (!angular.isDefined(vm.reportDetails.currency_id)) {
+      vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
   }
 }

--- a/client/src/modules/reports/generate/cost_center_income_and_expense/cost_center_income_and_expense.config.js
+++ b/client/src/modules/reports/generate/cost_center_income_and_expense/cost_center_income_and_expense.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('cost_center_income_and_expenseController', CostCenterIncomeAndExpenseReportConfigController);
 
 CostCenterIncomeAndExpenseReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
 /**
@@ -11,7 +11,9 @@ CostCenterIncomeAndExpenseReportConfigController.$inject = [
  * @description
  * This function renders the cost_center_income_and_expense report.
  */
-function CostCenterIncomeAndExpenseReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function CostCenterIncomeAndExpenseReportConfigController(
+  $sce, Notify, SavedReports, AppCache, reportData, $state, Session,
+) {
   const vm = this;
   const cache = new AppCache('CostCenterIncomeAndExpenseReport');
   const reportUrl = 'reports/finance/cost_center_income_and_expense';
@@ -74,8 +76,11 @@ function CostCenterIncomeAndExpenseReportConfigController($sce, Notify, SavedRep
   checkCachedConfiguration();
 
   function checkCachedConfiguration() {
-    if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
+
+    // Set the defaults
+    if (!angular.isDefined(vm.reportDetails.currency_id)) {
+      vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
   }
 }

--- a/client/src/modules/reports/generate/cost_center_step_down/cost_center_step_down.config.js
+++ b/client/src/modules/reports/generate/cost_center_step_down/cost_center_step_down.config.js
@@ -21,8 +21,9 @@ function CostCenterStepdownReportConfigController($sce, Notify, SavedReports, Ap
   vm.reportDetails = {
     include_revenue : false,
     show_allocations_table : true,
-    currency_id : Session.enterprise.currency_id,
   };
+
+  checkCachedConfiguration();
 
   vm.onSelectFiscalYear = (fiscalYear) => {
     vm.reportDetails.fiscal_id = fiscalYear.id;
@@ -87,8 +88,11 @@ function CostCenterStepdownReportConfigController($sce, Notify, SavedReports, Ap
   checkCachedConfiguration();
 
   function checkCachedConfiguration() {
-    if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
+
+    // Set the defaults
+    if (!angular.isDefined(vm.reportDetails.currency_id)) {
+      vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
   }
 }

--- a/client/src/modules/reports/generate/employee_standing/employee_standing.js
+++ b/client/src/modules/reports/generate/employee_standing/employee_standing.js
@@ -10,19 +10,15 @@ EmployeeStandingController.$inject = [
  * @function EmployeeStandingController
  *
  * @description
-
  */
 function EmployeeStandingController($state, $sce, Notify, AppCache, SavedReports, reportData, Session) {
-
   const vm = this;
   const cache = new AppCache('configure_employee_standing');
 
+  vm.previewGenerated = false;
   vm.reportDetails = {};
 
   checkCachedConfiguration();
-
-  vm.reportDetails.currency_id = vm.reportDetails?.currency_id || Session.enterprise.currency_id;
-
 
   // custom filter employee_uuid
   vm.onSelectEmployee = function onSelectEmployee(employee) {
@@ -84,8 +80,11 @@ function EmployeeStandingController($state, $sce, Notify, AppCache, SavedReports
   };
 
   function checkCachedConfiguration() {
-    if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
+
+    // Set the defaults
+    if (!angular.isDefined(vm.reportDetails.currency_id)) {
+      vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
 
     vm.reportDetails.modeReport = 'summary';

--- a/client/src/modules/reports/generate/operating/operating.config.js
+++ b/client/src/modules/reports/generate/operating/operating.config.js
@@ -10,11 +10,9 @@ function OperatingConfigController($sce, Notify, SavedReports, AppCache, reportD
   const cache = new AppCache('configure_operating');
   const reportUrl = 'reports/finance/operating';
 
-  vm.reportDetails = {
-    currency_id : Session.enterprise.currency_id,
-  };
-
   vm.previewGenerated = false;
+  vm.reportDetails = {};
+
   checkCachedConfiguration();
 
   vm.onSelectFiscal = function onSelectFiscal(fiscal) {
@@ -72,9 +70,11 @@ function OperatingConfigController($sce, Notify, SavedReports, AppCache, reportD
   };
 
   function checkCachedConfiguration() {
-    if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
+    vm.reportDetails = angular.copy(cache.reportDetails || {});
+
+    // Set the defaults
+    if (!angular.isDefined(vm.reportDetails.currency_id)) {
+      vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
-    vm.reportDetails.type = 1;
   }
 }

--- a/client/src/modules/reports/generate/stock_expiration_report/stock_expiration_report.config.js
+++ b/client/src/modules/reports/generate/stock_expiration_report/stock_expiration_report.config.js
@@ -97,7 +97,7 @@ function StockExpirationReportConfigCtrl($sce, Notify, SavedReports, AppCache, r
 
     // Set the defaults
     if (!angular.isDefined(vm.reportDetails.currencyId)) {
-      vm.reportDetails.currency_id = Session.enterprise.currency_id;
+      vm.reportDetails.currencyId = Session.enterprise.currency_id;
     }
   }
 }

--- a/client/src/modules/reports/generate/stock_value/stock_value.config.js
+++ b/client/src/modules/reports/generate/stock_value/stock_value.config.js
@@ -11,7 +11,6 @@ function StockValueConfigController(
   $sce, Notify, SavedReports,
   AppCache, reportData, $state, Languages, moment, Session,
 ) {
-
   const vm = this;
   const cache = new AppCache('configure_stock_value_report');
   const reportUrl = 'reports/stock/value';
@@ -90,8 +89,15 @@ function StockValueConfigController(
 
   function checkCachedConfiguration() {
     if (cache.reportDetails) {
-      vm.reportDetails = angular.copy(cache.reportDetails);
-      vm.dateTo = new Date(); // always default to today
+      vm.reportDetails = angular.copy(cache.reportDetails || {});
+    }
+
+    // always default to today
+    vm.dateTo = new Date();
+
+    // Use the enterprise currency by default.
+    if (!angular.isDefined(vm.reportDetails.currency_id)) {
+      vm.reportDetails.currency_id = Session.enterprise.currency_id;
     }
   }
 }

--- a/test/end-to-end/reports/accountReport/account_report.page.js
+++ b/test/end-to-end/reports/accountReport/account_report.page.js
@@ -1,7 +1,5 @@
 const TU = require('../../shared/TestUtils');
-
 const components = require('../../shared/components');
-
 const ReportPage = require('../page');
 
 class AccountReportPage {


### PR DESCRIPTION
This PR standardizes the way BHIMA loads the default currency for reports using the exact same type of function calls and ordering across the *.config.js report renders.  Previously, default currencies were handled slightly differently and some copy and paste blunders resulted in a bug being propagated through some reports.  This commit cleans all those up.

It additionally cleans up a few HTML and console errors I found along the way.

Closes https://github.com/third-culture-software/bhima/issues/8184.