### PR TITLE
fix(test): search before editing in posting_journal

### DIFF
--- a/test/end-to-end/journal/SearchModal.page.js
+++ b/test/end-to-end/journal/SearchModal.page.js
@@ -35,6 +35,10 @@ class JournalSearchModal extends SearchModal {
     return bhAccountSelect.set(account);
   }
 
+  async setTransaction(entity) {
+    return TU.input('ModalCtrl.searchQueries.trans_id', entity, this.element);
+  }
+
   async setEntity(entity) {
     return TU.input('ModalCtrl.searchQueries.hrEntity', entity, this.element);
   }

--- a/test/end-to-end/journal/SearchModal.tests.js
+++ b/test/end-to-end/journal/SearchModal.tests.js
@@ -77,6 +77,15 @@ function JournalSearchTests() {
     await modal.submit();
     await page.expectRowCount(NUM_REFERENCED_ROWS);
   });
+
+  const NUM_TRANS_ROWS = 2;
+  const TRANS_ID = 'TPB1';
+  test(`finds ${NUM_REFERENCED_ROWS} rows for transaction ${TRANS_ID}`, async () => {
+    await modal.setTransaction(TRANS_ID);
+    await modal.submit();
+    await page.expectRowCount(NUM_TRANS_ROWS);
+  });
+
 }
 
 module.exports = JournalSearchTests;


### PR DESCRIPTION
This commit fixes the end to end tests so that the posting journal filters on a given transaction before attempting to edit it.