### PR TITLE
chore: refactor stored procedures

### DIFF
--- a/server/controllers/inventory/index.js
+++ b/server/controllers/inventory/index.js
@@ -117,7 +117,7 @@ async function getInventoryWac(req, res, next) {
 async function computeWac(inventoryUuid) {
   const binaryInventoryUuid = db.bid(inventoryUuid);
 
-  const queryRecompute = 'CALL RecomputeInventoryStockValue(?, ?);';
+  const queryRecompute = `CALL ComputeInventoryStockValue(?, COALESCE(?, CURRENT_DATE()));`;
 
   const querySelect = `
     SELECT

--- a/server/models/03-procedures.sql
+++ b/server/models/03-procedures.sql
@@ -2822,13 +2822,13 @@ BEGIN
       It uses modern SQL features like CTEs and window functions for improved readability and performance.
     */
 
-    -- Deletes records that will be recomputed to prevent duplicates.
+    -- Delete records that will be recomputed to prevent duplicates.
     DELETE sms
     FROM stock_movement_status AS sms
     JOIN stage_inventory_for_amc AS staged ON sms.inventory_uuid = staged.inventory_uuid
     WHERE sms.depot_uuid = _depot_uuid AND sms.date >= _start_date;
 
-    -- A single INSERT statement with CTEs to compute and insert the new statuses.
+    -- A single INSERT statement with CTEs to compute and insert new statuses.
     INSERT INTO stock_movement_status (
         depot_uuid, inventory_uuid, date,
         quantity_delta, in_quantity, out_quantity_exit, out_quantity_consumption,

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -1,5 +1,3 @@
-
-
 -- adds the preferred_language to the user table
 -- Close #7936.
 CALL add_column_if_missing('user', 'preferred_language', 'TEXT NULL');
@@ -7,8 +5,15 @@ CALL add_column_if_missing('user', 'preferred_language', 'TEXT NULL');
 -- removes the is_admin column from the user table
 ALTER TABLE `user` DROP COLUMN `is_admin`;
 
--- move all of asset management into Stock
+-- move all of asset management into stock
 UPDATE unit set `parent` = 160 WHERE `id` = 307;
 
+-- drop unused stored procedures and functions
 DROP PROCEDURE IF EXISTS `UnbalancedInvoicePayments`;
 DROP PROCEDURE IF EXISTS `UnbalancedInvoicePaymentsTable`;
+DROP PROCEDURE IF EXISTS RecomputeInventoryStockValue;
+DROP PROCEDURE IF EXISTS RecomputeAllInventoriesValue;
+DROP PROCEDURE IF EXISTS UpdateStaffingIndices;
+DROP PROCEDURE IF EXISTS addStagePaymentIndice;
+DROP FUNCTION IF EXISTS sumTotalIndex;
+DROP FUNCTION IF EXISTS getStagePaymentIndice;

--- a/test/integration-stock/depots.js
+++ b/test/integration-stock/depots.js
@@ -27,7 +27,7 @@ describe('test/integration-stock/depots The depots API ', () => {
    * The WAC (Weighted Avarage Cost) is :
    * (CURRENT_STOCK_VALUE + INCOMING_STOCK_VALUE) / FINAL_STOCK_QUANTITY
    * NOTA: From the 3rd decimal place after the decimal point,
-   *       the EXPECTED_WAC is different from what the procedure `RecomputeInventoryStockValue` compute
+   *       the EXPECTED_WAC is different from what the procedure `ComputeInventoryStockValue` compute
    */
   const EXPECTED_WAC = Number((CURRENT_STOCK_VALUE + INCOMING_STOCK_VALUE) / FINAL_STOCK_QUANTITY).toFixed(2);
 

--- a/test/integration/stock/stock.js
+++ b/test/integration/stock/stock.js
@@ -59,7 +59,8 @@ describe('test/integration/stock/stock The Stock API', () => {
 
   // list all movement relatives to 'Service Administration'
   it(
-    `GET /stock/lots/movements?service_uuid=${shared.serviceAdministrationUuid} returns movements for Service Uuid (1 OUT)`, // eslint-disable-line
+    `GET /stock/lots/movements?service_uuid=${shared.serviceAdministrationUuid} `
+    + `returns movements for Service Uuid (1 OUT)`,
     async () => {
       const res = await (agent.get(`/stock/lots/movements`)
         .query({ service_uuid : shared.serviceAdministrationUuid }));

--- a/test/integration/stock/stock.js
+++ b/test/integration/stock/stock.js
@@ -39,12 +39,11 @@ describe('test/integration/stock/stock The Stock API', () => {
   });
 
   // list all movement relatives to 'Depot Principal'
-  it(
-    `GET /stock/lots/movements?depot_uuid=...
-    returns movements for Depot Principal`,
+  it(`GET /stock/lots/movements?depot_uuid=${shared.depotPrincipalUuid} returns movements for Depot Principal`,
     async () => {
       const res = await (agent.get('/stock/lots/movements')
         .query({ depot_uuid : shared.depotPrincipalUuid }));
+
       helpers.api.listed(res, shared.depotPrincipalMvt + STOCK_IMPORTED_FROM_CSV_FILE);
     },
   );
@@ -60,8 +59,7 @@ describe('test/integration/stock/stock The Stock API', () => {
 
   // list all movement relatives to 'Service Administration'
   it(
-    `GET /stock/lots/movements?service_uuid=...
-    returns movements for Service Uuid (1 OUT)`,
+    `GET /stock/lots/movements?service_uuid=${shared.serviceAdministrationUuid} returns movements for Service Uuid (1 OUT)`, // eslint-disable-line
     async () => {
       const res = await (agent.get(`/stock/lots/movements`)
         .query({ service_uuid : shared.serviceAdministrationUuid }));


### PR DESCRIPTION
This commit refactors the stored procedures (SP) to remove redundant procedures (or unused SPs).  It also rewrite the `stock_movement_status` stored procedures to use common table expressions CTEs rather than the the temporary table mess that it used to be.  This should hopefully improve the performance of our stock movement tables a bit.

Just to note, when rebuilding the `stock_movement_status` table using these improvements, the time to completion falls from just over 8 minutes to just over 1 minute, and 87% increase in performance.