### PR TITLE
Improve component/directive tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = (config) => {
 
     // frameworks to use
     // available frameworks : https://npmjs.org/browse/keyword/karma-adapter
-    frameworks : ['mocha', 'chai-spies', 'chai-dom', 'chai', 'sinon'],
+    frameworks : ['mocha', 'chai-spies', 'chai-dom', 'chai'],
 
     // list of files / patterns to load in the browser
     files : [

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,6 @@
         "karma-junit-reporter": "^2.0.1",
         "karma-mocha": "^2.0.1",
         "karma-ng-html2js-preprocessor": "^1.0.0",
-        "karma-sinon": "^1.0.5",
         "merge-stream": "^2.0.0",
         "mocha": "^11.7.1",
         "mocha-multi-reporters": "^1.5.1",
@@ -9555,19 +9554,6 @@
       "license": "MIT",
       "peerDependencies": {
         "karma": ">=0.9"
-      }
-    },
-    "node_modules/karma-sinon": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/karma-sinon/-/karma-sinon-1.0.5.tgz",
-      "integrity": "sha512-wrkyAxJmJbn75Dqy17L/8aILJWFm7znd1CE8gkyxTBFnjMSOe2XTJ3P30T8SkxWZHmoHX0SCaUJTDBEoXs25Og==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10.0"
-      },
-      "peerDependencies": {
-        "karma": ">=0.10",
-        "sinon": "*"
       }
     },
     "node_modules/karma/node_modules/body-parser": {

--- a/package.json
+++ b/package.json
@@ -192,7 +192,6 @@
     "karma-junit-reporter": "^2.0.1",
     "karma-mocha": "^2.0.1",
     "karma-ng-html2js-preprocessor": "^1.0.0",
-    "karma-sinon": "^1.0.5",
     "merge-stream": "^2.0.0",
     "mocha": "^11.7.1",
     "mocha-multi-reporters": "^1.5.1",

--- a/test/client-unit/directives/bhHasPermission.spec.js
+++ b/test/client-unit/directives/bhHasPermission.spec.js
@@ -1,0 +1,193 @@
+/* global inject, expect, chai */
+describe('test/client-unit/directives/bhHasPermission directive', () => {
+  let $scope;
+  let $compile;
+  let element;
+  let SessionMock;
+
+  beforeEach(module('bhima.directives', ($provide) => {
+    // Create a mock SessionService with chai-chai.spy
+    SessionMock = { hasUserAction : (perm) => perm };
+
+    // Register the mock with Angular's dependency injection
+    $provide.value('SessionService', SessionMock);
+  }));
+
+  // $compile and $rootScope are injected using angular name-based dependency injection
+  beforeEach(inject((_$compile_, $rootScope) => {
+    $scope = $rootScope.$new();
+    $compile = _$compile_;
+  }));
+
+  function compileDirective(permissionValue, hasPermission) {
+    // Set the mock behavior for this test
+    chai.spy.on(SessionMock, 'hasUserAction', () => hasPermission);
+
+    // Set up the permission value in the scope
+    $scope.testPermission = permissionValue;
+
+    // Create the element with our directive
+    element = angular.element(`
+      <div id="parent">
+        <button id="testElement" bh-has-permission="testPermission">
+          Test Button
+        </button>
+      </div>
+    `);
+
+    // Compile the element with the scope
+    $compile(element)($scope);
+    $scope.$digest();
+
+    return element;
+  }
+
+  it('should keep the element when the user has the required permission', () => {
+    const permissionValue = 'VIEW_REPORTS';
+    const compiledElement = compileDirective(permissionValue, true);
+
+    // Verify the button is still in the DOM
+    const buttonElement = compiledElement.find('#testElement');
+
+    expect(buttonElement.length).to.equal(1);
+    expect(SessionMock.hasUserAction).to.have.been.called.with(permissionValue);
+  });
+
+  it('should remove the element when the user does not have the required permission', () => {
+    const permissionValue = 'EDIT_REPORTS';
+    const compiledElement = compileDirective(permissionValue, false);
+
+    // Verify the button has been removed from the DOM
+    const buttonElement = compiledElement.find('#testElement');
+
+    expect(buttonElement.length).to.equal(0);
+    expect(SessionMock.hasUserAction).to.have.been.called.with(permissionValue);
+  });
+
+  it('should handle multiple elements with different permissions', () => {
+    // Set up multiple permission values
+    $scope.allowedPermission = 'VIEW_PATIENTS';
+    $scope.deniedPermission = 'DELETE_PATIENTS';
+
+    // Configure spy to return true for VIEW_PATIENTS and false for DELETE_PATIENTS
+    chai.spy.on(SessionMock, 'hasUserAction', (permission) => (permission === 'VIEW_PATIENTS'));
+
+    // Create an element with multiple children using our directive
+    element = angular.element(`
+      <div id="parent">
+        <button id="allowedElement" bh-has-permission="allowedPermission">
+          Allowed Button
+        </button>
+        <button id="deniedElement" bh-has-permission="deniedPermission">
+          Denied Button
+        </button>
+      </div>
+    `);
+
+    // Compile the element with the scope
+    $compile(element)($scope);
+    $scope.$digest();
+
+    // Verify only the allowed element remains
+    const allowedElement = element.find('#allowedElement');
+    const deniedElement = element.find('#deniedElement');
+
+    expect(allowedElement.length).to.equal(1);
+    expect(deniedElement.length).to.equal(0);
+    expect(SessionMock.hasUserAction).to.have.been.called.with('VIEW_PATIENTS');
+    expect(SessionMock.hasUserAction).to.have.been.called.with('DELETE_PATIENTS');
+  });
+
+  it('should handle undefined permission values', () => {
+    // Test with undefined permission
+    $scope.undefinedPermission = undefined;
+
+    chai.spy.on(SessionMock, 'hasUserAction', () => false);
+
+    element = angular.element(`
+      <div id="parent">
+        <button id="testElement" bh-has-permission="undefinedPermission">
+          Test Button
+        </button>
+      </div>
+    `);
+
+    $compile(element)($scope);
+    $scope.$digest();
+
+    // Verify behavior with undefined permission
+    const buttonElement = element.find('#testElement');
+
+    expect(buttonElement.length).to.equal(0);
+    expect(SessionMock.hasUserAction).to.have.been.called.with(undefined);
+  });
+
+  it('should properly handle complex HTML structures', () => {
+    // Set up permission value
+    $scope.noAccess = 'RESTRICTED_AREA';
+
+    // Configure spy to return false
+    chai.spy.on(SessionMock, 'hasUserAction', () => false);
+
+    // Create an element with nested structure
+    element = angular.element(`
+      <div id="parent">
+        <div class="wrapper" bh-has-permission="noAccess">
+          <h1>Header</h1>
+          <p>Paragraph</p>
+          <button>Button</button>
+        </div>
+      </div>
+    `);
+
+    // Compile the element with the scope
+    $compile(element)($scope);
+    $scope.$digest();
+
+    // Verify the entire wrapper and its contents are removed
+    const wrapperElement = element.find('.wrapper');
+    const headerElement = element.find('h1');
+    const paragraphElement = element.find('p');
+    const buttonElement = element.find('button');
+
+    expect(wrapperElement.length).to.equal(0);
+    expect(headerElement.length).to.equal(0);
+    expect(paragraphElement.length).to.equal(0);
+    expect(buttonElement.length).to.equal(0);
+  });
+
+  it('should re-evaluate permissions when scope values change', () => {
+    // Set up initial permission
+    $scope.dynamicPermission = 'INITIAL_PERMISSION';
+
+    // First call returns true
+    chai.spy.on(SessionMock, 'hasUserAction', () => true);
+
+    element = angular.element(`
+      <div id="parent">
+        <button id="testElement" bh-has-permission="dynamicPermission">
+          Test Button
+        </button>
+      </div>
+    `);
+
+    $compile(element)($scope);
+    $scope.$digest();
+
+    // Verify button exists initially
+    let buttonElement = element.find('#testElement');
+    expect(buttonElement.length).to.equal(1);
+
+    // Now change the permission and make the spy return false
+    $scope.dynamicPermission = 'CHANGED_PERMISSION';
+    SessionMock.hasUserAction = chai.spy(() => false);
+
+    // Need to recompile since we're testing a one-time binding
+    element = $compile(element)($scope);
+    $scope.$digest();
+
+    // Now button should be removed
+    buttonElement = element.find('#testElement');
+    expect(buttonElement.length).to.equal(0);
+  });
+});

--- a/test/client-unit/directives/bhInteger.spec.js
+++ b/test/client-unit/directives/bhInteger.spec.js
@@ -5,8 +5,6 @@ describe('test/client-unit/directives/bhInteger directive', () => {
 
   beforeEach(module('bhima.directives'));
 
-  // $complile and $rootScope are injected using angular name based dependency
-  // injection
   beforeEach(inject(($compile, $rootScope) => {
     $scope = $rootScope;
 
@@ -16,19 +14,14 @@ describe('test/client-unit/directives/bhInteger directive', () => {
       </form>
     `);
 
-    // initialise models that will be used
-    $scope.models = {
-      intValue : null,
-    };
+    $scope.models = { intValue : null };
 
-    // compile angular element in with the context of $rootScope
     $compile(element)($scope);
 
-    // eslint-disable-next-line prefer-destructuring
     form = $scope.form;
   }));
 
-  it('validates an integer value', () => {
+  it('validates positive integer values', () => {
     const correctIntegerValue = 10;
 
     form.intValue.$setViewValue(correctIntegerValue);
@@ -38,17 +31,127 @@ describe('test/client-unit/directives/bhInteger directive', () => {
     expect(form.intValue.$valid).to.equal(true);
   });
 
-  it('blocks non integer values (string/decimal)', () => {
+  it('validates negative integer values', () => {
+    const negativeIntegerValue = -15;
+
+    form.intValue.$setViewValue(negativeIntegerValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(negativeIntegerValue);
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('validates zero as an integer', () => {
+    const zeroValue = 0;
+
+    form.intValue.$setViewValue(zeroValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(zeroValue);
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('validates integer strings', () => {
+    const stringIntegerValue = '42';
+
+    form.intValue.$setViewValue(stringIntegerValue);
+    $scope.$digest();
+
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('validates negative integer strings', () => {
+    const negativeStringIntegerValue = '-42';
+
+    form.intValue.$setViewValue(negativeStringIntegerValue);
+    $scope.$digest();
+
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('blocks decimal values', () => {
     const incorrectDecimalValue = 10.23;
-    const incorrectStringValue = 'value';
 
     form.intValue.$setViewValue(incorrectDecimalValue);
     $scope.$digest();
 
     expect($scope.models.intValue).to.equal(undefined);
     expect(form.intValue.$valid).to.equal(false);
+  });
+
+  it('blocks string decimal values', () => {
+    const stringDecimalValue = '10.23';
+
+    form.intValue.$setViewValue(stringDecimalValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(undefined);
+    expect(form.intValue.$valid).to.equal(false);
+  });
+
+  it('blocks non-numeric strings', () => {
+    const incorrectStringValue = 'value';
 
     form.intValue.$setViewValue(incorrectStringValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(undefined);
+    expect(form.intValue.$valid).to.equal(false);
+  });
+
+  it('blocks empty strings', () => {
+    const emptyStringValue = '';
+
+    form.intValue.$setViewValue(emptyStringValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(undefined);
+    expect(form.intValue.$valid).to.equal(false);
+  });
+
+  it('blocks null values', () => {
+    const nullValue = null;
+
+    form.intValue.$setViewValue(nullValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(undefined);
+    expect(form.intValue.$valid).to.equal(false);
+  });
+
+  it('blocks numbers with leading zeros', () => {
+    const leadingZeroValue = '007';
+
+    form.intValue.$setViewValue(leadingZeroValue);
+    $scope.$digest();
+
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('blocks mixed alphanumeric values', () => {
+    const mixedValue = '123abc';
+
+    form.intValue.$setViewValue(mixedValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(undefined);
+    expect(form.intValue.$valid).to.equal(false);
+  });
+
+  it('blocks values with scientific notation', () => {
+    const scientificValue = '1e10';
+
+    form.intValue.$setViewValue(scientificValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(undefined);
+    expect(form.intValue.$valid).to.equal(false);
+  });
+
+  it('blocks values with whitespace', () => {
+    const whitespaceValue = ' 123 ';
+
+    form.intValue.$setViewValue(whitespaceValue);
     $scope.$digest();
 
     expect($scope.models.intValue).to.equal(undefined);

--- a/test/client-unit/directives/bhMaxInteger.spec.js
+++ b/test/client-unit/directives/bhMaxInteger.spec.js
@@ -2,15 +2,13 @@
 describe('test/client-unit/directives/bhMaxInteger directive', () => {
   let $scope;
   let form;
-
-  const MAX_INT = 16777215;
+  let MAX_INTEGER;
 
   beforeEach(module('bhima.directives', 'bhima.constants'));
 
-  // $complile and $rootScope are injected using angular name based dependency
-  // injection
-  beforeEach(inject(($compile, $rootScope) => {
+  beforeEach(inject(($compile, $rootScope, bhConstants) => {
     $scope = $rootScope;
+    MAX_INTEGER = bhConstants.precision.MAX_INTEGER;
 
     const element = angular.element(`
       <form name="form">
@@ -18,19 +16,14 @@ describe('test/client-unit/directives/bhMaxInteger directive', () => {
       </form>
     `);
 
-    // initialise models that will be used
-    $scope.models = {
-      intValue : null,
-    };
+    $scope.models = { intValue : null };
 
-    // compile angular element in with the context of $rootScope
     $compile(element)($scope);
 
-    // eslint-disable-next-line prefer-destructuring
     form = $scope.form;
   }));
 
-  it('allows an integer value', () => {
+  it('allows small positive integer values', () => {
     const correctIntegerValue = 10;
 
     form.intValue.$setViewValue(correctIntegerValue);
@@ -40,16 +33,147 @@ describe('test/client-unit/directives/bhMaxInteger directive', () => {
     expect(form.intValue.$valid).to.equal(true);
   });
 
-  it('allows the MAX_INT value', () => {
-    form.intValue.$setViewValue(MAX_INT);
+  it('allows zero', () => {
+    form.intValue.$setViewValue(0);
     $scope.$digest();
 
-    expect($scope.models.intValue).to.equal(MAX_INT);
+    expect($scope.models.intValue).to.equal(0);
     expect(form.intValue.$valid).to.equal(true);
   });
 
-  it('blocks values that are larger than the MAX_INT value', () => {
-    form.intValue.$setViewValue(MAX_INT + 1);
+  it('allows negative values', () => {
+    const negativeValue = -1000;
+
+    form.intValue.$setViewValue(negativeValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(negativeValue);
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('allows the MAX_INTEGER value', () => {
+    form.intValue.$setViewValue(MAX_INTEGER);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(MAX_INTEGER);
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('allows values just below MAX_INTEGER', () => {
+    const belowMaxValue = MAX_INTEGER - 1;
+
+    form.intValue.$setViewValue(belowMaxValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(belowMaxValue);
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('blocks values that are larger than the MAX_INTEGER value', () => {
+    form.intValue.$setViewValue(MAX_INTEGER + 1);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(undefined);
+    expect(form.intValue.$valid).to.equal(false);
+  });
+
+  it('blocks values significantly larger than MAX_INTEGER', () => {
+    const largeValue = MAX_INTEGER * 2;
+
+    form.intValue.$setViewValue(largeValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(undefined);
+    expect(form.intValue.$valid).to.equal(false);
+  });
+
+  it('allows string representations of valid numbers', () => {
+    const stringValue = '1000';
+
+    form.intValue.$setViewValue(stringValue);
+    $scope.$digest();
+
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('allows string representations of MAX_INTEGER', () => {
+    const stringMaxValue = MAX_INTEGER.toString();
+
+    form.intValue.$setViewValue(stringMaxValue);
+    $scope.$digest();
+
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('blocks string representations of values over MAX_INTEGER', () => {
+    const stringOverMaxValue = (MAX_INTEGER + 1).toString();
+
+    form.intValue.$setViewValue(stringOverMaxValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(undefined);
+    expect(form.intValue.$valid).to.equal(false);
+  });
+
+  it('allows decimal values within range', () => {
+    const decimalValue = 1000.5;
+
+    form.intValue.$setViewValue(decimalValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(decimalValue);
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('blocks decimal values over MAX_INTEGER', () => {
+    const decimalOverMaxValue = MAX_INTEGER + 0.1;
+
+    form.intValue.$setViewValue(decimalOverMaxValue);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(undefined);
+    expect(form.intValue.$valid).to.equal(false);
+  });
+
+  it('handles non-numeric strings as invalid (NaN case)', () => {
+    const nonNumericString = 'not a number';
+
+    form.intValue.$setViewValue(nonNumericString);
+    $scope.$digest();
+
+    expect($scope.models.intValue).to.equal(undefined);
+    expect(form.intValue.$valid).to.equal(false);
+  });
+
+  it('handles empty strings as valid (converts to 0)', () => {
+    const emptyString = '';
+
+    form.intValue.$setViewValue(emptyString);
+    $scope.$digest();
+
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('handles null values as valid (converts to 0)', () => {
+    form.intValue.$setViewValue(null);
+    $scope.$digest();
+
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('handles scientific notation within range', () => {
+    const scientificValue = '1e3'; // 1000
+
+    form.intValue.$setViewValue(scientificValue);
+    $scope.$digest();
+
+    expect(form.intValue.$valid).to.equal(true);
+  });
+
+  it('blocks scientific notation over MAX_INTEGER', () => {
+    const largeSciValue = '1e10'; // 10,000,000,000
+
+    form.intValue.$setViewValue(largeSciValue);
     $scope.$digest();
 
     expect($scope.models.intValue).to.equal(undefined);

--- a/test/client-unit/directives/bhRequireEnterpriseSetting.spec.js
+++ b/test/client-unit/directives/bhRequireEnterpriseSetting.spec.js
@@ -1,0 +1,129 @@
+/* global inject, expect, chai */
+describe('test/client-unit/directives/bhRequireEnterpriseSetting directive', () => {
+  let $scope;
+  let $compile;
+  let element;
+  let SessionMock;
+
+  beforeEach(module('bhima.directives', ($provide) => {
+    SessionMock = { isSettingEnabled : chai.spy() };
+    $provide.value('SessionService', SessionMock);
+  }));
+
+  // $compile and $rootScope are injected using angular name-based dependency injection
+  beforeEach(inject((_$compile_, $rootScope) => {
+    $scope = $rootScope.$new();
+    $compile = _$compile_;
+  }));
+
+  function compileDirective(settingName, isEnabled) {
+    // Set the mock behavior for this test
+    SessionMock.isSettingEnabled = chai.spy(() => isEnabled);
+
+    // Create the element with our directive
+    element = angular.element(`
+      <div id="parent">
+        <button id="testElement" bh-require-enterprise-setting="${settingName}">
+          Test Button
+        </button>
+      </div>
+    `);
+
+    // Compile the element with the scope
+    $compile(element)($scope);
+    $scope.$digest();
+
+    return element;
+  }
+
+  it('should keep the element when the specified setting is enabled', () => {
+    const settingName = 'myEnabledSetting';
+    const compiledElement = compileDirective(settingName, true);
+
+    // Verify the button is still in the DOM
+    const buttonElement = compiledElement.find('#testElement');
+
+    expect(buttonElement.length).to.equal(1);
+    expect(SessionMock.isSettingEnabled).to.have.been.called.with(settingName);
+  });
+
+  it('should remove the element when the specified setting is disabled', () => {
+    const settingName = 'myDisabledSetting';
+    const compiledElement = compileDirective(settingName, false);
+
+    // Verify the button has been removed from the DOM
+    const buttonElement = compiledElement.find('#testElement');
+
+    expect(buttonElement.length).to.equal(0);
+    expect(SessionMock.isSettingEnabled).to.have.been.called.with(settingName);
+  });
+
+  it('should handle multiple elements with different settings', () => {
+    // Mock behavior for different settings
+    SessionMock.isSettingEnabled = chai.spy((setting) => setting === 'enabledSetting');
+
+    // Create an element with multiple children using our directive
+    element = angular.element(`
+      <div id="parent">
+        <button id="enabledElement" bh-require-enterprise-setting="enabledSetting">
+          Enabled Button
+        </button>
+        <button id="disabledElement" bh-require-enterprise-setting="disabledSetting">
+          Disabled Button
+        </button>
+      </div>
+    `);
+
+    // Compile the element with the scope
+    $compile(element)($scope);
+    $scope.$digest();
+
+    // Verify only the enabled element remains
+    const enabledElement = element.find('#enabledElement');
+    const disabledElement = element.find('#disabledElement');
+
+    expect(enabledElement.length).to.equal(1);
+    expect(disabledElement.length).to.equal(0);
+  });
+
+  it('should handle empty setting name', () => {
+    // Empty setting name behavior
+    const emptySettingName = '';
+    const compiledElement = compileDirective(emptySettingName, false);
+
+    // Verify behavior with empty setting name
+    const buttonElement = compiledElement.find('#testElement');
+
+    expect(buttonElement.length).to.equal(0);
+    expect(SessionMock.isSettingEnabled).to.have.been.called.with(emptySettingName);
+  });
+
+  it('should properly handle complex HTML structures', () => {
+    SessionMock.isSettingEnabled = chai.spy(() => false);
+
+    element = angular.element(`
+      <div id="parent">
+        <div class="wrapper" bh-require-enterprise-setting="complexSetting">
+          <h1>Header</h1>
+          <p>Paragraph</p>
+          <button>Button</button>
+        </div>
+      </div>
+    `);
+
+    // Compile the element with the scope
+    $compile(element)($scope);
+    $scope.$digest();
+
+    // Verify the entire wrapper and its contents are removed
+    const wrapperElement = element.find('.wrapper');
+    const headerElement = element.find('h1');
+    const paragraphElement = element.find('p');
+    const buttonElement = element.find('button');
+
+    expect(wrapperElement.length).to.equal(0);
+    expect(headerElement.length).to.equal(0);
+    expect(paragraphElement.length).to.equal(0);
+    expect(buttonElement.length).to.equal(0);
+  });
+});

--- a/test/client-unit/services/VoucherForm.spec.js
+++ b/test/client-unit/services/VoucherForm.spec.js
@@ -1,4 +1,4 @@
-/* global inject, expect, chai, sinon */
+/* global inject, expect, chai */
 /* eslint no-unused-expressions:off */
 describe('test/client-unit/services/VoucherForm', () => {
   let VoucherForm;
@@ -146,17 +146,14 @@ describe('test/client-unit/services/VoucherForm', () => {
   });
 
   it('#handleCurrencyChange updates currency_id and optionally converts values', () => {
-  // Setup: Add a row with known values
     form.store.data[0].debit = 100;
     form.details.currency_id = 1;
     const newCurrencyId = 2;
     const conversionRate = 2;
 
+    form.details = { currency_id : 1, date : new Date() };
+
     chai.spy.on(form, 'validate');
-
-    // Stub Exchange.getExchangeRate and Exchange.round for predictable conversion
-    sinon.stub(form, 'details').value({ currency_id : 1, date : new Date() });
-
     chai.spy.on(Exchange, 'getExchangeRate', () => conversionRate);
     chai.spy.on(Exchange, 'round', (val) => Math.round(val));
 
@@ -219,9 +216,9 @@ describe('test/client-unit/services/VoucherForm', () => {
   });
 
   it('#description sets details.description using $translate', () => {
-    sinon.stub($translate, 'instant').returns('translated string');
+    chai.spy.on($translate, 'instant', () => 'translated string');
+
     form.description('KEY');
     expect(form.details.description).to.equal('translated string');
-    $translate.instant.restore();
   });
 });


### PR DESCRIPTION
This commit adds more tests to the client-unit tests.  It also rewrites the previous tests that used `karma-sinon` to use `chai-spies` and removes the dependency on that module.

Since this issue is so old, I'm considering it closed for now.  We've added tests for a large number of our services since it was written.

Closes https://github.com/third-culture-software/bhima/issues/337