### PR TITLE
fix(reports): inventory changes misc fixes

### DIFF
--- a/client/src/i18n/en/stock.json
+++ b/client/src/i18n/en/stock.json
@@ -126,7 +126,7 @@
     "INCLUDE_ARTICLES_NOT_IN_STOCK_HELP" : "Shows inventory articles not in stock (with quantity equal to zero)",
     "INCLUDE_EMPTY_LOTS" : "Include empty lots",
     "INCLUDE_EMPTY_OR_NEGATIVE_LOTS" : "Include exhausted or negative lots",
-    "INCLUDE_PENDING_TRANSFERT": "Include Pending Transfert",
+    "INCLUDE_PENDING_TRANSFERT": "Include Pending Transfers",
     "INCREASE"        : "Increase",
     "INCREASE_HELP"   : "Adjust stock by increasing the quantity of lots of products in stock",
     "INVENTORY"       : "Inventory",

--- a/client/src/modules/stock/lots/modals/duplicates.modal.html
+++ b/client/src/modules/stock/lots/modals/duplicates.modal.html
@@ -13,7 +13,7 @@
 
   <div class="modal-body">
     <div style="margin-bottom: 0.5em">
-      <span class="text-bold">{{$ctrl.selectedLot.inventory_code}} - {{$ctrl.selectedLot.inventory_text}}</span>
+      <span class="text-bold">{{$ctrl.selectedLot.inventory_code}} - {{$ctrl.selectedLot.inventory_name}}</span>
     </div>
     <div ng-if="$ctrl.lots.length === 1">
       <span translate>LOTS.NO_LOTS_FOUND</span>

--- a/server/controllers/inventory/inventory/core.js
+++ b/server/controllers/inventory/inventory/core.js
@@ -66,6 +66,7 @@ exports.errorHandler = errorHandler;
 exports.remove = remove;
 exports.inventoryLog = inventoryLog;
 exports.inventoryColsMap = inventoryColsMap;
+
 /**
 * Create inventory metadata in the database
 *

--- a/server/controllers/inventory/reports/changes.handlebars
+++ b/server/controllers/inventory/reports/changes.handlebars
@@ -1,7 +1,6 @@
 {{> head }}
 
 <body>
-  <!-- header  -->
  {{> header}}
 
   <table class="table table-report table-condensed">

--- a/server/controllers/inventory/reports/changes.js
+++ b/server/controllers/inventory/reports/changes.js
@@ -24,7 +24,11 @@ const TEMPLATE = './server/controllers/inventory/reports/changes.handlebars';
  */
 function transformChangeLogRecords(records) {
   return records.flatMap((record) => {
-    const { last, current } = JSON.parse(record.changes);
+    const changes = typeof record.changes === 'string'
+      ? JSON.parse(record.changes)
+      : record.changes;
+
+    const { last, current } = changes;
     const prev = formatKeys(last);
     const next = formatKeys(current);
 

--- a/server/controllers/inventory/reports/changes.js
+++ b/server/controllers/inventory/reports/changes.js
@@ -4,12 +4,11 @@
  * @description
  * This report shows all the changes made to inventory items by different users.
  *
- * @requires lodash
  * @requires ReportManager
- * @requires inventorycore
+ * @requires inventory/core
+ * @requires lib/db
  */
 
-const _ = require('lodash');
 const ReportManager = require('../../../lib/ReportManager');
 const db = require('../../../lib/db');
 const core = require('../inventory/core');
@@ -18,142 +17,178 @@ module.exports = inventoryChanges;
 
 const TEMPLATE = './server/controllers/inventory/reports/changes.handlebars';
 
-function processChangeLog(records) {
-  return _.flatMap(records, (record) => {
-    record.changes = JSON.parse(record.changes);
-    const prev = formatKeys(record.changes.last);
-    const next = formatKeys(record.changes.current);
+/**
+ * Parses and transforms raw change log records into a structured format for the report.
+ * @param {Array<Object>} records - The raw log records from the database.
+ * @returns {Array<Object>} A flat array of change objects.
+ */
+function transformChangeLogRecords(records) {
+  return records.flatMap((record) => {
+    const { last, current } = JSON.parse(record.changes);
+    const prev = formatKeys(last);
+    const next = formatKeys(current);
 
-    const keys = Object.keys(next);
-
-    // loop through updated columns and create rows for them.
-    return keys.map((key) => {
-      return ({
-        uuid : record.uuid,
-        col : core.inventoryColsMap[key],
-        value : getValue(prev, next, key),
-        date : record.log_timestamp,
-        userName : record.user_name,
-        update : true,
-      });
-    });
+    return Object.keys(next).map((key) => ({
+      key,
+      uuid : record.uuid,
+      col : core.inventoryColsMap[key],
+      value : getValue(prev, next, key),
+      date : record.log_timestamp,
+      userName : record.user_name,
+      update : true,
+    }));
   });
 }
 
-async function inventoryChanges(req, res, next) {
-  const metadata = _.clone(req.session);
-  const params = _.clone(req.query);
-  _.extend(params, { filename : 'REPORT.INVENTORY_CHANGE.TITLE' });
+// groups an array by a key.
+function groupBy(array, key) {
+  return array.reduce((accumulator, row) => {
+
+    // ensure that the accumulator has an entry for the key
+    if (!accumulator[row[key]]) {
+      accumulator[row[key]] = [];
+    }
+
+    // push the matching row to the entry
+    accumulator[row[key]].push(row);
+    return accumulator;
+  }, {});
+
+}
+
+async function inventoryChanges(req, res) {
+  const metadata = { ...req.session };
+  const params = { ...req.query };
+  Object.assign(params, { filename : 'REPORT.INVENTORY_CHANGE.TITLE' });
 
   const currencyId = req.session.enterprise.currency_id;
 
-  try {
-    const report = new ReportManager(TEMPLATE, metadata, params);
-    const { dateFrom, dateTo } = params;
+  const report = new ReportManager(TEMPLATE, metadata, params);
+  const { dateFrom, dateTo } = params;
 
-    const inventorySql = `
-      SELECT BUID(iv.uuid) AS uuid, iv.code, iv.text AS label, iv.created_at,
-      iv.updated_at, ivt.text AS type,
-      IF(ISNULL(ivu.token), ivu.text, CONCAT("INVENTORY.UNITS.",ivu.token,".TEXT")) AS unit_type,
-      ivg.name AS group_name
-      FROM inventory iv
-        JOIN inventory_type ivt ON iv.type_id = ivt.id
-        JOIN inventory_group ivg ON iv.group_uuid = ivg.uuid
-        JOIN inventory_unit ivu ON iv.unit_id = ivu.id
-      WHERE iv.uuid IN (
-        SELECT inventory_log.inventory_uuid FROM inventory_log
-        WHERE inventory_log.log_timestamp BETWEEN DATE(?) AND DATE(?)
-      )
-      ORDER BY ivg.name, iv.text;
-    `;
+  const inventorySql = `
+    SELECT BUID(iv.uuid) AS uuid, iv.code, iv.text AS label, iv.created_at,
+    iv.updated_at, ivt.text AS type,
+    IF(ISNULL(ivu.token), ivu.text, CONCAT("INVENTORY.UNITS.",ivu.token,".TEXT")) AS unit_type,
+    ivg.name AS group_name
+    FROM inventory iv
+      JOIN inventory_type ivt ON iv.type_id = ivt.id
+      JOIN inventory_group ivg ON iv.group_uuid = ivg.uuid
+      JOIN inventory_unit ivu ON iv.unit_id = ivu.id
+    WHERE iv.uuid IN (
+      SELECT inventory_log.inventory_uuid FROM inventory_log
+      WHERE inventory_log.log_timestamp BETWEEN DATE(?) AND DATE(?)
+    )
+    ORDER BY ivg.name, iv.text;
+  `;
 
-    const logsSql = `
-      SELECT BUID(ivl.inventory_uuid) AS uuid, ivl.text AS changes, u.display_name as user_name,
-        ivl.log_timestamp
-      FROM inventory_log ivl
-        JOIN user u ON u.id = ivl.user_id
-      WHERE ivl.log_timestamp BETWEEN DATE(?) AND DATE(?)
-        AND ivl.text->"$.action" = "UPDATE"
-      ORDER BY ivl.log_timestamp DESC;
-    `;
-    const inventories = await db.exec(inventorySql, [dateFrom, dateTo]);
-    const logs = await db.exec(logsSql, [dateFrom, dateTo]);
+  const logsSql = `
+    SELECT BUID(ivl.inventory_uuid) AS uuid, ivl.text AS changes, u.display_name as user_name,
+      ivl.log_timestamp
+    FROM inventory_log ivl
+      JOIN user u ON u.id = ivl.user_id
+    WHERE ivl.log_timestamp BETWEEN DATE(?) AND DATE(?)
+      AND ivl.text->"$.action" = "UPDATE"
+    ORDER BY ivl.log_timestamp DESC;
+  `;
 
-    // parse the changes to avoid doing that later
-    const changelog = processChangeLog(logs);
+  const [inventories, logs] = await Promise.all([
+    db.exec(inventorySql, [dateFrom, dateTo]),
+    db.exec(logsSql, [dateFrom, dateTo]),
+  ]);
 
-    // group changelog by the inventory uuid
-    const changeMap = _.groupBy(changelog, 'uuid');
+  // parse the changes to avoid doing that later
+  let changelog = transformChangeLogRecords(logs);
 
-    // attach logs to each inventory item
-    inventories.forEach(inventory => {
-      inventory.logs = changeMap[inventory.uuid];
-      // Note whether the item is a unit price so we can format it in the handlebars file
-      if (inventory.logs) {
-        inventory.logs.forEach(log => {
-          if (log.col === 'FORM.LABELS.UNIT_PRICE' && typeof log.value.to === 'number') {
-            log.is_unit_price = true;
-          }
-          if (log.col === 'FORM.LABELS.UNIT_PRICE' && typeof log.value.from === 'number') {
-            log.is_unit_price = true;
-          }
-        });
+  // TODO(@jniles): we have several changelog records where both the "to"
+  // and "from" values are null.  This is because we have things like "updated_by" that are
+  // not being filtered out, and some columns such as "manufacturer_brand" that seems to cause
+  // the inventory_changes table to fill up with null values.
+  // The fix currently is to filter this out of the view, but we should make sure
+  // to sync up our inventory columns table with the text.
+  changelog = changelog
+    .filter(row => (row.value.to !== null && row.value.from !== null))
+    .filter(row => row.key !== 'updated_by');
+
+  // group changelog by the inventory uuid
+  const changeMap = groupBy(changelog, 'uuid');
+
+  inventories.forEach(inventory => {
+    inventory.logs = changeMap[inventory.uuid] || [];
+    inventory.logs.forEach(log => {
+      if (log.col === 'FORM.LABELS.UNIT_PRICE'
+        && (typeof log.value.to === 'number' || typeof log.value.from === 'number')) {
+        log.is_unit_price = true;
       }
     });
+  });
 
-    // calculate the number of changes by user.
-    const userChanges = _.chain(changelog)
-      .groupBy('userName')
-      .mapValues('length')
-      .map((value, key) => ({ user : key, numberOfChanges : value }))
-      .sortBy(row => -1 * row.numberOfChanges) // sort DESC
-      .value();
+  // only show inventory items that have at least one change.
+  const inventoriesWithChanges = inventories.filter(inventory => inventory.logs.length > 0);
 
-    const renderResult = await report.render({
-      inventories, dateFrom, dateTo, userChanges, currencyId,
-    });
-    res.set(renderResult.headers).send(renderResult.report);
-  } catch (e) {
-    next(e);
-  }
+  const userChanges = Object.entries(
+    changelog.reduce((acc, log) => {
+      acc[log.userName] = (acc[log.userName] || 0) + 1;
+      return acc;
+    }, {}),
+  )
+    .map(([user, numberOfChanges]) => ({ user, numberOfChanges }))
+    .sort((a, b) => b.numberOfChanges - a.numberOfChanges);
+
+  const renderResult = await report.render({
+    inventories : inventoriesWithChanges,
+    dateFrom,
+    dateTo,
+    userChanges,
+    currencyId,
+  });
+  res.set(renderResult.headers).send(renderResult.report);
 }
 
+/**
+ * Prepares a record for comparison by aliasing 'text' to 'label' and removing internal keys.
+ * @param {Object} record - The record to format.
+ * @returns {Object} The formatted record.
+ */
 function formatKeys(record) {
-  record.label = record.text;
-  if (!record.label) { delete record.label; }
-  return _.omit(record, ['group_uuid', 'type_id', 'unit_id', 'text']);
+  const {
+    group_uuid, type_id, unit_id, text, ...rest // eslint-disable-line
+  } = record;
+  const newRecord = { ...rest };
+  if (text) { newRecord.label = text; }
+  return newRecord;
 }
 
+/**
+ * Extracts the 'from' and 'to' values for a specific changed key.
+ * @param {Object} last - The previous state of the record.
+ * @param {Object} current - The new state of the record.
+ * @param {string} key - The key that was changed.
+ * @returns {{from: *, to: *}} An object containing the old and new values.
+ */
 function getValue(last, current, key) {
   const result = {};
 
-  if (key === 'tags') {
-    const lastTags = last.tags.map(tag => `"${tag.name}"`).join(',  ');
-    result.from = `[${lastTags}]`;
-    const newTags = current.tags.map(tag => `"${tag.name}"`).join(',  ');
-    result.to = `[${newTags}]`;
-    return result;
-  }
-
-  if (key === 'inventoryGroup') {
+  switch (key) {
+  case 'tags':
+    result.from = `[${last.tags.map(tag => `"${tag.name}"`).join(',  ')}]`;
+    result.to = `[${current.tags.map(tag => `"${tag.name}"`).join(',  ')}]`;
+    break;
+  case 'inventoryGroup':
     result.from = last.groupName || '';
     result.to = current.inventoryGroup.name || '';
-    return result;
-  }
-
-  if (key === 'inventoryType') {
+    break;
+  case 'inventoryType':
     result.from = last.type;
     result.to = current.inventoryType.text;
-    return result;
-  }
-
-  if (key === 'inventoryUnit') {
+    break;
+  case 'inventoryUnit':
     result.from = last.unit;
     result.to = current.inventoryUnit.text;
-    return result;
+    break;
+  default:
+    result.from = last[key];
+    result.to = current[key];
   }
-
-  result.from = last[key];
-  result.to = current[key];
   return result;
 }

--- a/server/controllers/inventory/reports/changes.js
+++ b/server/controllers/inventory/reports/changes.js
@@ -44,7 +44,7 @@ function transformChangeLogRecords(records) {
 function groupBy(array, key) {
   return array.reduce((accumulator, row) => {
 
-    // ensure that the accumulator has an entry for the key
+    // ensure that the accumulator has an entry for the group key
     if (!accumulator[row[key]]) {
       accumulator[row[key]] = [];
     }
@@ -107,7 +107,7 @@ async function inventoryChanges(req, res) {
   // The fix currently is to filter this out of the view, but we should make sure
   // to sync up our inventory columns table with the text.
   changelog = changelog
-    .filter(row => (row.value.to !== null && row.value.from !== null))
+    .filter(row => row.value.to !== null && row.value.from !== null)
     .filter(row => row.key !== 'updated_by');
 
   // group changelog by the inventory uuid
@@ -152,7 +152,7 @@ async function inventoryChanges(req, res) {
  */
 function formatKeys(record) {
   const {
-    group_uuid, type_id, unit_id, text, ...rest // eslint-disable-line
+    group_uuid, type_id, unit_id, text, ...rest // eslint-disable-line camelcase
   } = record;
   const newRecord = { ...rest };
   if (text) { newRecord.label = text; }


### PR DESCRIPTION
This commit updates the inventory change report:
 1. Removes empty rows from the report that doesn't make sense to show to users.
 2. Removes `lodash` from the report, replacing with native JS functions.
 3. Adds documentation comments.
 4. Prunes the empty inventory items from the report.