### PR TITLE
fix(payroll): show service on the index grid

### DIFF
--- a/client/src/modules/multiple_payroll_indice/multiple_payroll_indice.js
+++ b/client/src/modules/multiple_payroll_indice/multiple_payroll_indice.js
@@ -119,7 +119,7 @@ function MultiplePayrollIndiceController(
 
   function renameGridHeaders(rubrics) {
     const actions = angular.copy(columnDefs[columnDefs.length - 1]);
-    const newColumns = columnDefs.slice(0, 2);
+    const newColumns = columnDefs.slice(0, 3);
 
     const header = {
       type : 'number',


### PR DESCRIPTION
This multiple payroll by indice grid so that both the service and employee references are shown in columns.  It was previously clobbered during our testing of the payroll modules.

Thanks to Vanga users for reporting this bug.