### PR TITLE
deps: remove use-strict in preparation for esm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
         "tempy": "^1.0.1",
         "typeface-open-sans": "^1.1.13",
         "ui-select": "0.17.1",
-        "use-strict": "^1.0.1",
         "uuid-parse": "^1.1.0",
         "webcam": "^3.2.1"
       },
@@ -13197,17 +13196,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-query-selector": {
@@ -13471,12 +13487,6 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
-    },
-    "node_modules/use-strict": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/use-strict/-/use-strict-1.0.1.tgz",
-      "integrity": "sha512-IeiWvvEXfW5ltKVMkxq6FvNf2LojMKvB2OCeja6+ct24S1XOmQw2dGr2JyndwACWAGJva9B7yPHwAmeA9QCqAQ==",
-      "license": "ISC"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,6 @@
     "tempy": "^1.0.1",
     "typeface-open-sans": "^1.1.13",
     "ui-select": "0.17.1",
-    "use-strict": "^1.0.1",
     "uuid-parse": "^1.1.0",
     "webcam": "^3.2.1"
   },

--- a/server/app.js
+++ b/server/app.js
@@ -18,7 +18,6 @@
  * @copyright IMA World Health 2016
  */
 
-require('use-strict');
 require('dotenv').config();
 
 const http = require('node:http');


### PR DESCRIPTION
All ESM runs in strict mode, so there isn't any point in having "use strict" in the code.