### PR TITLE
ci: deduplicate semaphore blocks, cache build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,9 +18,17 @@ blocks:
       - Update Dependencies
     task:
       prologue:
-        commands:
-          - sem-service start redis
+        commands: &shared_prologue
+          - checkout
+          - sem-service start redis 8
           - cache restore
+          - sem-service start mysql $MYSQL_VERSION
+          - mysql -h 127.0.0.1 -P 3306 -u root -e "CREATE USER $DB_USER@$DB_HOST IDENTIFIED BY '$DB_PASS';"
+          - mysql -h 127.0.0.1 -P 3306 -u root -e "GRANT ALL PRIVILEGES ON *.* TO $DB_USER@$DB_HOST WITH GRANT OPTION;"
+          - mysql -h 127.0.0.1 -P 3306 -u root -e "FLUSH PRIVILEGES;"
+          - 'mysql -h 127.0.0.1 -P 3306 -u root -e "SET @@global.sql_mode=''STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION'';"'
+          - echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+          - nvm install $NODEJS_VERSION
       env_vars:
         - name: DB_USER
           value: bhima
@@ -49,17 +57,10 @@ blocks:
       jobs:
         - name: Run Test Matrix
           commands:
-            - sem-service start mysql $MYSQL_VERSION
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "CREATE USER $DB_USER@$DB_HOST IDENTIFIED BY '$DB_PASS';"
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "GRANT ALL PRIVILEGES ON *.* TO $DB_USER@$DB_HOST WITH GRANT OPTION;"
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "FLUSH PRIVILEGES;"
-            - 'mysql -h 127.0.0.1 -P 3306 -u root -e "SET @@global.sql_mode=''STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION'';"'
-            - echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-            - nvm install $NODEJS_VERSION
             - 'echo "$(which google-chrome)"'
-            - checkout
             - 'echo "Testing node:$NODEJS_VERSION on mysql:$MYSQL_VERSION"'
             - npm ci
+            - cache store
             - npx playwright install --with-deps --no-shell chromium
             - 'npm run build:db'
             - npm run build
@@ -73,18 +74,21 @@ blocks:
             - env_var: MYSQL_VERSION
               values:
                 - '8.4'
+                - '9'
             - env_var: NODEJS_VERSION
               values:
                 - '24'
                 - node
+      epilogue:
+        always:
+          commands:
+            - artifact push job results --destination test-results-$MYSQL_VERSION-$NODEJS_VERSION
   - name: Install Testing Matrix
     dependencies:
       - Update Dependencies
     task:
       prologue:
-        commands:
-          - sem-service start redis
-          - cache restore
+        commands: *shared_prologue
       env_vars:
         - name: DB_USER
           value: bhima
@@ -109,22 +113,16 @@ blocks:
       jobs:
         - name: Run Test Matrix
           commands:
-            - sem-service start mysql $MYSQL_VERSION
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "CREATE USER $DB_USER@$DB_HOST IDENTIFIED BY '$DB_PASS';"
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "GRANT ALL PRIVILEGES ON *.* TO $DB_USER@$DB_HOST WITH GRANT OPTION;"
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "FLUSH PRIVILEGES;"
-            - 'mysql -h 127.0.0.1 -P 3306 -u root -e "SET @@global.sql_mode=''STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION'';"'
-            - echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-            - nvm install $NODEJS_VERSION
-            - checkout
             - 'echo "[Installation] Testing node:$NODEJS_VERSION on mysql:$MYSQL_VERSION"'
             - npm ci
+            - cache store
             - npm run build
             - bash ./sh/install-tests.sh
           matrix:
             - env_var: MYSQL_VERSION
               values:
                 - '8.4'
+                - '9'
             - env_var: NODEJS_VERSION
               values:
                 - '24'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,9 +18,17 @@ blocks:
       - Update Dependencies
     task:
       prologue:
-        commands:
-          - sem-service start redis
+        commands: &shared_prologue
+          - checkout
+          - sem-service start redis 8
           - cache restore
+          - sem-service start mysql $MYSQL_VERSION
+          - mysql -h 127.0.0.1 -P 3306 -u root -e "CREATE USER $DB_USER@$DB_HOST IDENTIFIED BY '$DB_PASS';"
+          - mysql -h 127.0.0.1 -P 3306 -u root -e "GRANT ALL PRIVILEGES ON *.* TO $DB_USER@$DB_HOST WITH GRANT OPTION;"
+          - mysql -h 127.0.0.1 -P 3306 -u root -e "FLUSH PRIVILEGES;"
+          - 'mysql -h 127.0.0.1 -P 3306 -u root -e "SET @@global.sql_mode=''STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION'';"'
+          - echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+          - nvm install $NODEJS_VERSION
       env_vars:
         - name: DB_USER
           value: bhima
@@ -49,17 +57,10 @@ blocks:
       jobs:
         - name: Run Test Matrix
           commands:
-            - sem-service start mysql $MYSQL_VERSION
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "CREATE USER $DB_USER@$DB_HOST IDENTIFIED BY '$DB_PASS';"
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "GRANT ALL PRIVILEGES ON *.* TO $DB_USER@$DB_HOST WITH GRANT OPTION;"
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "FLUSH PRIVILEGES;"
-            - 'mysql -h 127.0.0.1 -P 3306 -u root -e "SET @@global.sql_mode=''STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION'';"'
-            - echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-            - nvm install $NODEJS_VERSION
             - 'echo "$(which google-chrome)"'
-            - checkout
             - 'echo "Testing node:$NODEJS_VERSION on mysql:$MYSQL_VERSION"'
             - npm ci
+            - cache store
             - npx playwright install --with-deps --no-shell chromium
             - "npm run build:db"
             - npm run build
@@ -77,14 +78,16 @@ blocks:
               values:
                 - "24"
                 - node
+      epilogue:
+        always:
+          commands:
+            - artifact push job results --destination test-results-$MYSQL_VERSION-$NODEJS_VERSION
   - name: Install Testing Matrix
     dependencies:
       - Update Dependencies
     task:
       prologue:
-        commands:
-          - sem-service start redis
-          - cache restore
+        commands: *shared_prologue
       env_vars:
         - name: DB_USER
           value: bhima
@@ -109,16 +112,9 @@ blocks:
       jobs:
         - name: Run Test Matrix
           commands:
-            - sem-service start mysql $MYSQL_VERSION
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "CREATE USER $DB_USER@$DB_HOST IDENTIFIED BY '$DB_PASS';"
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "GRANT ALL PRIVILEGES ON *.* TO $DB_USER@$DB_HOST WITH GRANT OPTION;"
-            - mysql -h 127.0.0.1 -P 3306 -u root -e "FLUSH PRIVILEGES;"
-            - 'mysql -h 127.0.0.1 -P 3306 -u root -e "SET @@global.sql_mode=''STRICT_ALL_TABLES,NO_UNSIGNED_SUBTRACTION'';"'
-            - echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-            - nvm install $NODEJS_VERSION
-            - checkout
             - 'echo "[Installation] Testing node:$NODEJS_VERSION on mysql:$MYSQL_VERSION"'
             - npm ci
+            - cache store
             - npm run build
             - bash ./sh/install-tests.sh
           matrix:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -45,7 +45,7 @@ blocks:
         - name: SESS_SECRET
           value: 1a3184a126e42fa0d9466cf14841f8a218cd92e961f5677b30
         - name: DEBUG
-          value: "app,bhima:errors,app:uploader"
+          value: "app,bhima:errors,bhima:app:uploader,http"
         - name: BHIMA_DATA_DIR
           value: bhima-data/
         - name: BUILD_TIMEOUT
@@ -53,6 +53,8 @@ blocks:
         - name: CI
           value: "1"
         - name: PUPPETEER_EXECUTABLE_PATH
+          value: "/usr/bin/google-chrome"
+        - name: CHROME_BIN
           value: "/usr/bin/google-chrome"
       jobs:
         - name: Run Test Matrix

--- a/test/integration/allocationCostCenters.js
+++ b/test/integration/allocationCostCenters.js
@@ -174,7 +174,7 @@ describe('test/integration/allocationCostCenters Cost Centers REST API', () => {
       .catch(helpers.handler);
   });
 
-  it('POST /allocation_cost_center/proceed throws BadRequest if dataToDistribute.length is 0', () => {
+  it('POST /allocation_cost_center/proceed throws and error if dataToDistribute.length is 0', () => {
     return agent.post('/allocation_cost_center/proceed')
       .send(proceedInternalServerError)
       .then((res) => {


### PR DESCRIPTION
This commit does several things:
 1. Deduplicates the semaphore blocks so that we only set the password and machine parameters in a single yaml block.
 2. Updates redis to the latest supported redis on semaphore.
 3. Set `CHROME_BIN`.