### PR TITLE
chore: use fine-grain token

### DIFF
--- a/.github/workflows/publish-containerfile.yml
+++ b/.github/workflows/publish-containerfile.yml
@@ -8,21 +8,17 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      # 1) Check out your repository code
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
-      # 2) Set up QEMU for multi-architecture builds (optional if you need multi-arch)
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: all
 
-      # 3) Set up Docker Buildx (for building multi-platform images or advanced features)
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
-      # 4) Log in to GitHub Container Registry
       - name: Log in to GHCR
         uses: docker/login-action@v2
         with:
@@ -30,9 +26,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # 5) Build and push the Docker image using the release tag (e.g., v1.0.0)
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .               
           file: ./Dockerfile        

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -40,19 +40,17 @@ jobs:
       # run the lint
       - name: reviewdog (eslint)
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEWDOG_TOKEN }}
         uses: reviewdog/action-eslint@v1.34.0
         with:
-          github_token :  ${{ secrets.GITHUB_TOKEN }}
+          github_token :  ${{ secrets.REVIEWDOG_TOKEN }}
           reporter: github-pr-review
           eslint_flags: ""
 
       - name: reviewdog (shellcheck)
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEWDOG_TOKEN }}
         uses: reviewdog/action-shellcheck@v1.32.1
         with:
-          github_token :  ${{ secrets.GITHUB_TOKEN }}
+          github_token : ${{ secrets.REVIEWDOG_TOKEN }}
           reporter: github-pr-review
-


### PR DESCRIPTION
An attempt to use finer-grained permissions for the reviewdog token to get comments to be published as a review.