### PR TITLE
fix: update contact information from IMA to TCS.

### DIFF
--- a/docs/en/bhima-stock/private-policy/index.md
+++ b/docs/en/bhima-stock/private-policy/index.md
@@ -20,9 +20,9 @@ Your data cannot be shared with third parties, as we do not collect any personal
 We implement advanced security measures to protect your personal data against unauthorized access.
 
 ### 6. Users' rights
-In accordance with the GDPR and the CCPA, you have the right to access, modify or delete your data. To exercise your rights, contact us at <developers@imaworldhealth.org>
+In accordance with the GDPR and the CCPA, you have the right to access, modify or delete your data. To exercise your rights, contact us at <developers@thirdculturesoftware.com>
 
 ### 7. Contact
-If you have any questions about this privacy policy, please contact us at <developers@imaworldhealth.org>.
+If you have any questions about this privacy policy, please contact us at <developers@thirdculturesoftware.com>.
 
 Last updated: 10 Sept. 2024.

--- a/docs/en/for-developers/installing-bhima.md
+++ b/docs/en/for-developers/installing-bhima.md
@@ -6,7 +6,7 @@ The BHIMA software can be complex to install.  We only officially support Linux,
 
 Note: if you are running on the x64 architecture, you may consider [installing BHIMA using Docker](./installing-bhima-with-docker.md).
 
-This guide will get you up and running with bhima locally. Please note that bhima is under active development and tends to move fast and break things. If you are interested in development progress, shoot us a line at [developers@imaworldhealth.org](mailto:developers@imaworldhealth.org).
+This guide will get you up and running with bhima locally. Please note that bhima is under active development and tends to move fast and break things. If you are interested in development progress, shoot us a line at [developers@thirdculturesoftware.com](mailto:developers@thirdculturesoftware.com).
 
 ### Dependencies
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -21,7 +21,7 @@ This manual is split into chapters:
 
 BHIMA is free software, released under the GPL-2.0 license.  As such, it is distributed AS IS with no assumed warrantee, though we strive to create the best product possible.  You may use the application at your own risk, without any liability assumed of IMA World Health, the principle sponsor of BHIMA development.
 
-> This is a living document written by the authors of BHIMA and the material can sometimes be dense and unclear.  If anything doesn't make sense to you, please tell us about it!  You can leave a comment right on this site or you can send us an email at [developers@imaworldhealth.org](mailto:developers@imaworldhealth.org).  Thanks!
+> This is a living document written by the authors of BHIMA and the material can sometimes be dense and unclear.  If anything doesn't make sense to you, please tell us about it!  You can leave a comment right on this site or you can send us an email at [developers@thirdculturesoftware.com](mailto:developers@thirdculturesoftware.com).  Thanks!
 
 ## Contributing
 
@@ -39,7 +39,7 @@ If you are a hospital administrator please provide feedback on how the system is
 
 If you are a developer, we appreciate code contributions - a good place to start is our [First Time Contributor](https://github.com/Third-Culture-Software/bhima/wiki/Getting-Started:-Contributing-on-Github) tags on GitHub.
 
-You can usually reach our team for questions via the [developers@imaworldhealth.org](mailto:developers@imaworldhealth.org) email address.
+You can usually reach our team for questions via the [developers@thirdculturesoftware.com](mailto:developers@thirdculturesoftware.com) email address.
 
 Think you found a bug?  Let us know by [filing an issue](https://github.com/Third-Culture-Software/bhima/issues/new) and we'll fix it as soon as possible!
 

--- a/docs/fr/bhima-stock/private-policy/index.md
+++ b/docs/fr/bhima-stock/private-policy/index.md
@@ -20,9 +20,9 @@ Vos données ne peuvent pas être partagées avec des tiers, étant donné que n
 Nous mettons en œuvre des mesures de sécurité avancées pour protéger vos données personnelles contre tout accès non autorisé.
 
 ### 6. Droits des utilisateurs
-Conformément au RGPD et à la CCPA, vous avez le droit d’accéder à vos données, de les modifier ou de les supprimer. Pour exercer vos droits, contactez-nous à <developers@imaworldhealth.org>
+Conformément au RGPD et à la CCPA, vous avez le droit d’accéder à vos données, de les modifier ou de les supprimer. Pour exercer vos droits, contactez-nous à <developers@thirdculturesoftware.com>
 
 ### 7. Contact
-Si vous avez des questions concernant cette politique de confidentialité, veuillez nous contacter à <developers@imaworldhealth.org>.
+Si vous avez des questions concernant cette politique de confidentialité, veuillez nous contacter à <developers@thirdculturesoftware.com>.
 
 Dernière mise à jour : 10 sept. 2024.

--- a/docs/fr/for-developers/installing-bhima.md
+++ b/docs/fr/for-developers/installing-bhima.md
@@ -4,7 +4,7 @@ NB: ce sont les instructions pour installer l'environnement de développement BH
 
 Le logiciel BHIMA peut être complexe à installer. Nous ne prenons officiellement en charge que Linux. Le guide suivant suppose donc que vous configurez BHIMA dans un environnement Linux basé sur Debian.
 
-Ce guide vous permettra de vous familiariser avec bhima localement. Veuillez noter que bhima est en développement actif et a tendance à aller vite et à casser des choses. Si vous êtes intéressé par les progrès du développement, envoyez-nous une ligne à [developers@imaworldhealth.org](mailto: <developers@imaworldhealth.org>).
+Ce guide vous permettra de vous familiariser avec bhima localement. Veuillez noter que bhima est en développement actif et a tendance à aller vite et à casser des choses. Si vous êtes intéressé par les progrès du développement, envoyez-nous une ligne à [developers@thirdculturesoftware.com](mailto: <developers@thirdculturesoftware.com>).
 
 ### Dépendances
 

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -20,7 +20,7 @@ Ce manuel est divisé en chapitres:
 
 BHIMA est un logiciel libre, publié sous la licence GPL-2.0. En tant que tel, il est distribué tel quel, sans aucune garantie, bien que nous nous efforcions de créer le meilleur produit possible. Vous pouvez utiliser l'application à vos risques et périls, sans aucune responsabilité assumée par IMA World Health, le principal sponsor du développement de BHIMA.
 
-> Ceci est un document vivant écrit par les auteurs de BHIMA et le matériel peut parfois être dense et flou. Si quelque chose ne vous dit rien, parlez-nous-en! Vous pouvez laisser un commentaire directement sur ce site ou nous envoyer un email à [developers@imaworldhealth.org](mailto:developers@imaworldhealth.org). Merci!
+> Ceci est un document vivant écrit par les auteurs de BHIMA et le matériel peut parfois être dense et flou. Si quelque chose ne vous dit rien, parlez-nous-en! Vous pouvez laisser un commentaire directement sur ce site ou nous envoyer un email à [developers@thirdculturesoftware.com](mailto:developers@thirdculturesoftware.com). Merci!
 
 ## Contributions
 
@@ -38,7 +38,7 @@ Si vous êtes un administrateur d’hôpital, veuillez donner votre avis sur le 
 
 Si vous êtes un développeur, nous apprécions les contributions de code - un bon endroit pour commencer est notre [Premier contributeur](https://github.com/Third-Culture-Software/bhima/wiki/Getting-Started) sur GitHub.
 
-Vous pouvez généralement contacter notre équipe pour toute question via l'adresse électronique [developers@imaworldhealth.org](mailto: <developers@imaworldhealth.org>).
+Vous pouvez généralement contacter notre équipe pour toute question via l'adresse électronique [developers@thirdculturesoftware.com](mailto: <developers@thirdculturesoftware.com>).
 
 Vous pensez avoir trouvé un bug? Faites-nous savoir en [déposant un problème](https://github.com/Third-Culture-Software/bhima/issues/new) et nous le corrigerons dès que possible!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,4 +7,4 @@ Please choose your language:
 1. [English](./en/index.md)
 2. [Français](./fr/index.md)
 
-> This is a living document written by the authors of BHIMA and the material can sometimes be dense and unclear.  If anything doesn't make sense to you, please tell us about it!  You can leave a comment right on this site or you can send us an email at [developers@imaworldhealth.org](mailto:developers@imaworldhealth.org).  Thanks!
+> This is a living document written by the authors of BHIMA and the material can sometimes be dense and unclear.  If anything doesn't make sense to you, please tell us about it!  You can leave a comment right on this site or you can send us an email at [developers@thirdculturesoftware.com](mailto:developers@thirdculturesoftware.com).  Thanks!

--- a/server/config/constants.js
+++ b/server/config/constants.js
@@ -45,7 +45,7 @@ module.exports = {
     { id : 9, label : 'ASSET.CONDITION.LOST' },
   ],
   settings : {
-    CONTACT_EMAIL : 'developers@imaworldhealth.org',
+    CONTACT_EMAIL : 'developers@thirdculturesoftware.com',
   },
   barcodes : {
     LENGTH : 10,

--- a/server/controllers/admin/cronEmailReport/index.js
+++ b/server/controllers/admin/cronEmailReport/index.js
@@ -18,7 +18,7 @@ const { addDynamicDatesOptions } = require('./utils');
 
 const CURRENT_JOBS = new Map();
 
-const DEVELOPER_ADDRESS = 'developers@imaworldhealth.org';
+const DEVELOPER_ADDRESS = 'developers@thirdculturesoftware.com';
 const DEFAULT_LANGUAGE = 'fr';
 const RETRY_COUNT = 5;
 
@@ -266,6 +266,9 @@ async function sendEmailReportDocument(record) {
     const addresses = contacts.map(addr => addr.trim());
 
      
+    /**
+     *
+     */
     function sendEmailToSubscribers() {
       return mailer.email(DEVELOPER_ADDRESS, record.label, body, { attachments, bcc : addresses });
     }


### PR DESCRIPTION
This PR fixes a bunch of dangling references to @imaworldhealth that should point to the @thirdculturesoftware org.

Pointed out by #8897.