### PR TITLE
feature(payroll): add zero balance payment status and filtering

### DIFF
--- a/client/src/i18n/en/payroll.json
+++ b/client/src/i18n/en/payroll.json
@@ -4,7 +4,8 @@
     "PAID": "Paid",
     "PARTIALLY_PAID": "Partially paid",
     "WAITING_FOR_CONFIGURATION": "Waiting for configuration",
-    "WAITING_FOR_PAYMENT": "Waiting for payment"
+    "WAITING_FOR_PAYMENT": "Waiting for payment",
+    "ZERO_BALANCE": "Zero Balance"
   },
   "PAYROLL_RUBRIC": {
     "ADD_PAYROLL_RUBRIC": "Add a Payroll Rubric",

--- a/client/src/i18n/fr/payroll.json
+++ b/client/src/i18n/fr/payroll.json
@@ -4,7 +4,8 @@
     "PAID": "Payé",
     "PARTIALLY_PAID": "Payé partiellement",
     "WAITING_FOR_CONFIGURATION": "En attente de configuration",
-    "WAITING_FOR_PAYMENT": "En attente de paiement"
+    "WAITING_FOR_PAYMENT": "En attente de paiement",
+    "ZERO_BALANCE": "Solde nul"
   },
   "PAYROLL_RUBRIC": {
     "ADD_PAYROLL_RUBRIC": "Ajouter une rubrique de paie",

--- a/client/src/modules/multiple_payroll/templates/cellStatus.tmpl.html
+++ b/client/src/modules/multiple_payroll/templates/cellStatus.tmpl.html
@@ -4,4 +4,5 @@
   <span ng-if="row.entity.status_id == 3" class="label label-primary" translate> PAYROLL_STATUS.WAITING_FOR_PAYMENT </span>  
   <span ng-if="row.entity.status_id == 4" class="label label-warning" translate> PAYROLL_STATUS.PARTIALLY_PAID</span>
   <span ng-if="row.entity.status_id == 5" class="label label-success" translate> PAYROLL_STATUS.PAID </span>
+  <span ng-if="row.entity.status_id == 6" class="label label-danger" translate> PAYROLL_STATUS.ZERO_BALANCE </span>
 </div>

--- a/client/src/modules/vouchers/toolkit/payment_employee/payment_employee.js
+++ b/client/src/modules/vouchers/toolkit/payment_employee/payment_employee.js
@@ -80,11 +80,13 @@ function PaymentEmployeeKitController(
 
       MultiplePayroll.read(null, params)
         .then((payments) => {
+          // filter out employees with zero balance
+          const filteredEmployees = payments.filter(payment => payment.balance !== 0);
 
           // total amount
-          const totals = payments.reduce(aggregate, 0);
+          const totals = filteredEmployees.reduce(aggregate, 0);
 
-          vm.gridOptions.data = payments || [];
+          vm.gridOptions.data = filteredEmployees || [];
 
           // make sure we are always within precision
           vm.totalNetSalary = Number.parseFloat(totals.toFixed(MAX_DECIMAL_PRECISION));

--- a/server/controllers/payroll/multiplePayroll/commitmentByEmployee.js
+++ b/server/controllers/payroll/multiplePayroll/commitmentByEmployee.js
@@ -62,9 +62,11 @@ function commitmentByEmployee(employees, rubrics, configuration, exchangeRates) 
     // transaction.  It's linked to the payment period.  It should be instead moved to somewhere that
     // deals with the payment periods, not the employees.
     // EDIT(@jniles) - It actually might be employee related. Leave this in until we get better clarity.
+    const paymentStatus = employee.balance === 0 ? 6 : 3; // 6 = ZERO_BALANCE, 3 = WAITING_FOR_PAYMENT
+
     transactions.push({
-      query : 'UPDATE payment SET status_id = 3 WHERE uuid = ?',
-      params : [paymentUuid],
+      query : 'UPDATE payment SET status_id = ? WHERE uuid = ?',
+      params : [paymentStatus, paymentUuid],
     });
 
     // helper object to hold shared metadata for each voucher

--- a/server/controllers/payroll/multiplePayroll/commitmentByEmployee.js
+++ b/server/controllers/payroll/multiplePayroll/commitmentByEmployee.js
@@ -62,7 +62,8 @@ function commitmentByEmployee(employees, rubrics, configuration, exchangeRates) 
     // transaction.  It's linked to the payment period.  It should be instead moved to somewhere that
     // deals with the payment periods, not the employees.
     // EDIT(@jniles) - It actually might be employee related. Leave this in until we get better clarity.
-    const paymentStatus = employee.balance === 0 ? 6 : 3; // 6 = ZERO_BALANCE, 3 = WAITING_FOR_PAYMENT
+    // 6 = ZERO_BALANCE, 3 = WAITING_FOR_PAYMENT
+    const paymentStatus = employee.balance === 0 ? 6 : 3;
 
     transactions.push({
       query : 'UPDATE payment SET status_id = ? WHERE uuid = ?',

--- a/server/controllers/payroll/multiplePayroll/commitmentFunction.js
+++ b/server/controllers/payroll/multiplePayroll/commitmentFunction.js
@@ -63,7 +63,9 @@ function dataCommitment(employees, rubrics, exchangeRates, identificationCommitm
     // FIXME(@jniles) - this gets executed for every employee, even though it is not an employee-specific
     // transaction.  It's linked to the payment period.  It should be instead moved to somewhere that
     // deals with the payment periods, not the employees.
-    const paymentStatus = employee.balance === 0 ? 6 : 3; // 6 = ZERO_BALANCE, 3 = WAITING_FOR_PAYMENT
+    // 6 = ZERO_BALANCE, 3 = WAITING_FOR_PAYMENT
+
+    const paymentStatus = employee.balance === 0 ? 6 : 3;
     transactions.push({
       query : 'UPDATE payment SET status_id = ? WHERE uuid = ?',
       params : [paymentStatus, paymentUuid],

--- a/server/controllers/payroll/multiplePayroll/commitmentFunction.js
+++ b/server/controllers/payroll/multiplePayroll/commitmentFunction.js
@@ -63,9 +63,10 @@ function dataCommitment(employees, rubrics, exchangeRates, identificationCommitm
     // FIXME(@jniles) - this gets executed for every employee, even though it is not an employee-specific
     // transaction.  It's linked to the payment period.  It should be instead moved to somewhere that
     // deals with the payment periods, not the employees.
+    const paymentStatus = employee.balance === 0 ? 6 : 3; // 6 = ZERO_BALANCE, 3 = WAITING_FOR_PAYMENT
     transactions.push({
-      query : 'UPDATE payment set status_id = 3 WHERE uuid = ?',
-      params : [paymentUuid],
+      query : 'UPDATE payment SET status_id = ? WHERE uuid = ?',
+      params : [paymentStatus, paymentUuid],
     });
 
     // exchange rate if the employee.currency is equal enterprise currency

--- a/server/models/06-bhima.sql
+++ b/server/models/06-bhima.sql
@@ -394,7 +394,8 @@ INSERT IGNORE INTO payment_status (id, text) VALUES
 (2, 'PAYROLL_STATUS.CONFIGURED'),
 (3, 'PAYROLL_STATUS.WAITING_FOR_PAYMENT'),
 (4, 'PAYROLL_STATUS.PARTIALLY_PAID'),
-(5, 'PAYROLL_STATUS.PAID');
+(5, 'PAYROLL_STATUS.PAID'),
+(6, 'PAYROLL_STATUS.ZERO_BALANCE');
 
 -- locations (default enterprise location only)
 INSERT IGNORE INTO country VALUES (HUID('dbe330b6-5cde-4830-8c30-dc00eccd1a5f'), 'République Démocratique du Congo');

--- a/server/models/migrations/next/migrate.sql
+++ b/server/models/migrations/next/migrate.sql
@@ -67,3 +67,8 @@ CREATE TABLE `uuid_map` (
 -- author: jniles
 -- update UUID mappings.  This will take  along time!
 CALL zRecomputeUuidMapping();
+
+-- author: lomamech
+-- add new payment status for payroll with zero balance
+INSERT IGNORE INTO payment_status (id, text) VALUES
+(6, 'PAYROLL_STATUS.ZERO_BALANCE');


### PR DESCRIPTION
- Add ZERO_BALANCE payment status with ID 6
- Set payment status to ZERO_BALANCE when the employee balance is zero
- Keep employees with a remaining balance in WAITING_FOR_PAYMENT status
- Exclude employees with zero balance from the employee payment list
- Exclude zero-balance employees from the total net salary calculation
- Display the ZERO_BALANCE status in the payroll interface
- Add a database migration to register the new payment status