### PR TITLE
Fix chromium report html preview

### DIFF
--- a/client/src/js/directives/bhReportSrcdoc.js
+++ b/client/src/js/directives/bhReportSrcdoc.js
@@ -1,0 +1,30 @@
+angular.module('bhima.directives')
+
+
+  /**
+   * This horrible directive exists because chrome somehow killed the rendering of angularjs in the srcdoc 
+   * attribute.
+   */
+
+  .directive('bhReportSrcdoc', ['$sce', '$timeout', function ($sce, $timeout) {
+    return {
+      restrict: 'A',
+      scope: { bhReportSrcdoc: '<' },
+      link: function (scope, element) {
+        let iframe = element[0];
+
+        scope.$watch('bhReportSrcdoc', function (value) {
+          if (!value) return;
+
+          const html = $sce.trustAsHtml(value);
+
+          iframe.removeAttribute('srcdoc');
+          iframe.src = 'about:blank';
+
+          $timeout(function () {
+            iframe.srcdoc = html; 
+          }, 0);
+        });
+      }
+    };
+  }]);

--- a/client/src/modules/reports/generate/account_reference/account_reference.config.js
+++ b/client/src/modules/reports/generate/account_reference/account_reference.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('account_referenceController', AccountReferenceReportConfigController);
 
 AccountReferenceReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+  'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
 ];
 
 /**
@@ -14,7 +14,7 @@ AccountReferenceReportConfigController.$inject = [
  * @param reportData
  * @param $state
  */
-function AccountReferenceReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function AccountReferenceReportConfigController(Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('AccountReferenceReport');
   const reportUrl = 'reports/finance/account_reference';
@@ -53,7 +53,7 @@ function AccountReferenceReportConfigController($sce, Notify, SavedReports, AppC
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/account_report/account_report.config.js
+++ b/client/src/modules/reports/generate/account_report/account_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('account_reportController', AccountReportConfigController);
 
 AccountReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData',
+  'NotifyService', 'BaseReportService', 'AppCache', 'reportData',
   '$state', 'moment', 'SessionService',
 ];
 
@@ -18,8 +18,7 @@ AccountReportConfigController.$inject = [
  * @param Session
  */
 function AccountReportConfigController(
-  $sce, Notify, SavedReports, AppCache, reportData, $state,
-  Moment, Session,
+  Notify, SavedReports, AppCache, reportData, $state, Moment, Session,
 ) {
   const vm = this;
   const cache = new AppCache('configure_account_report');
@@ -84,7 +83,7 @@ function AccountReportConfigController(
     return SavedReports.requestPreview(reportUrl, reportData.id, sendDetails)
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/account_report_multiple/account_report_multiple.config.js
+++ b/client/src/modules/reports/generate/account_report_multiple/account_report_multiple.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('account_report_multipleController', AccountReportMultipleConfigController);
 
 AccountReportMultipleConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData',
   '$state', 'moment', 'SessionService',
 ];
 
@@ -18,7 +18,7 @@ AccountReportMultipleConfigController.$inject = [
  * @param Session
  */
 function AccountReportMultipleConfigController(
-  $sce, Notify, SavedReports, AppCache, reportData, $state,
+  Notify, SavedReports, AppCache, reportData, $state,
   Moment, Session,
 ) {
   const vm = this;

--- a/client/src/modules/reports/generate/account_report_multiple/account_report_multiple.config.js
+++ b/client/src/modules/reports/generate/account_report_multiple/account_report_multiple.config.js
@@ -103,7 +103,7 @@ function AccountReportMultipleConfigController(
     return SavedReports.requestPreview(reportUrl, reportData.id, sendDetails)
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/aged_creditors/aged_creditors.config.js
+++ b/client/src/modules/reports/generate/aged_creditors/aged_creditors.config.js
@@ -65,7 +65,7 @@ function AgedCreditorsConfigController($sce, Notify, SavedReports, AppCache, rep
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/aged_creditors/aged_creditors.config.js
+++ b/client/src/modules/reports/generate/aged_creditors/aged_creditors.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('aged_creditorsController', AgedCreditorsConfigController);
 
 AgedCreditorsConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
 /**
@@ -15,7 +15,7 @@ AgedCreditorsConfigController.$inject = [
  * @param $state
  * @param Session
  */
-function AgedCreditorsConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Session) {
+function AgedCreditorsConfigController(Notify, SavedReports, AppCache, reportData, $state, Session) {
   const vm = this;
   const cache = new AppCache('configure_aged_creditors');
   const reportUrl = 'reports/finance/creditors/aged';

--- a/client/src/modules/reports/generate/aged_debtors/aged_debtors.config.js
+++ b/client/src/modules/reports/generate/aged_debtors/aged_debtors.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('aged_debtorsController', AgedDebtorsConfigController);
 
 AgedDebtorsConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
 /**
@@ -15,7 +15,7 @@ AgedDebtorsConfigController.$inject = [
  * @param $state
  * @param Session
  */
-function AgedDebtorsConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Session) {
+function AgedDebtorsConfigController(Notify, SavedReports, AppCache, reportData, $state, Session) {
   const vm = this;
   const cache = new AppCache('configure_aged_debtors');
   const reportUrl = 'reports/finance/debtors/aged';

--- a/client/src/modules/reports/generate/aged_debtors/aged_debtors.config.js
+++ b/client/src/modules/reports/generate/aged_debtors/aged_debtors.config.js
@@ -66,7 +66,7 @@ function AgedDebtorsConfigController($sce, Notify, SavedReports, AppCache, repor
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/analysis_auxiliary_cashboxes/analysis_auxiliary_cashboxes.config.js
+++ b/client/src/modules/reports/generate/analysis_auxiliary_cashboxes/analysis_auxiliary_cashboxes.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('analysis_auxiliary_cashboxesController', analysisAuxiliaryCashboxesController);
 
 analysisAuxiliaryCashboxesController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache',
+   'NotifyService', 'BaseReportService', 'AppCache',
   'reportData', '$state',
 ];
 
@@ -15,7 +15,7 @@ analysisAuxiliaryCashboxesController.$inject = [
  * @param reportData
  * @param $state
  */
-function analysisAuxiliaryCashboxesController($sce, Notify, SavedReports, AppCache,
+function analysisAuxiliaryCashboxesController(Notify, SavedReports, AppCache,
   reportData, $state) {
   const vm = this;
 

--- a/client/src/modules/reports/generate/analysis_auxiliary_cashboxes/analysis_auxiliary_cashboxes.config.js
+++ b/client/src/modules/reports/generate/analysis_auxiliary_cashboxes/analysis_auxiliary_cashboxes.config.js
@@ -66,7 +66,7 @@ function analysisAuxiliaryCashboxesController($sce, Notify, SavedReports, AppCac
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -81,7 +81,7 @@ function BalanceReportConfigController($sce, Notify, Session, SavedReports, AppC
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/balance_report/balance_report.config.js
+++ b/client/src/modules/reports/generate/balance_report/balance_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('balance_reportController', BalanceReportConfigController);
 
 BalanceReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'SessionService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'SessionService', 'BaseReportService', 'AppCache', 'reportData', '$state',
 ];
 
 /**
@@ -17,7 +17,7 @@ BalanceReportConfigController.$inject = [
  * @description
  * This function renders the balance report.
  */
-function BalanceReportConfigController($sce, Notify, Session, SavedReports, AppCache, reportData, $state) {
+function BalanceReportConfigController(Notify, Session, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('BalanceReport');
   const reportUrl = 'reports/finance/balance';

--- a/client/src/modules/reports/generate/balance_sheet_report/balance_sheet_report.config.js
+++ b/client/src/modules/reports/generate/balance_sheet_report/balance_sheet_report.config.js
@@ -61,7 +61,7 @@ function BalanceSheetReportConfigController($sce, Notify, SavedReports, AppCache
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/balance_sheet_report/balance_sheet_report.config.js
+++ b/client/src/modules/reports/generate/balance_sheet_report/balance_sheet_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('balance_sheet_reportController', BalanceSheetReportConfigController);
 
 BalanceSheetReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache',
+   'NotifyService', 'BaseReportService', 'AppCache',
   'reportData', '$state', 'LanguageService',
 ];
 
@@ -16,7 +16,7 @@ BalanceSheetReportConfigController.$inject = [
  * @param $state
  * @param Languages
  */
-function BalanceSheetReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Languages) {
+function BalanceSheetReportConfigController(Notify, SavedReports, AppCache, reportData, $state, Languages) {
   const vm = this;
   const cache = new AppCache('configure_balance_sheet_report');
   const reportUrl = 'reports/finance/balance_sheet';

--- a/client/src/modules/reports/generate/budget_report/budget_report.config.js
+++ b/client/src/modules/reports/generate/budget_report/budget_report.config.js
@@ -83,7 +83,7 @@ function BudgetReportController($sce, Notify, SavedReports, AppCache, reportData
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/budget_report/budget_report.config.js
+++ b/client/src/modules/reports/generate/budget_report/budget_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('budget_reportController', BudgetReportController);
 
 BudgetReportController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
 /**
@@ -15,7 +15,7 @@ BudgetReportController.$inject = [
  * @param $state
  * @param Session
  */
-function BudgetReportController($sce, Notify, SavedReports, AppCache, reportData, $state, Session) {
+function BudgetReportController(Notify, SavedReports, AppCache, reportData, $state, Session) {
   const vm = this;
   const cache = new AppCache('configure_budget_report');
   const reportUrl = 'reports/finance/budget_report';

--- a/client/src/modules/reports/generate/cash_report/cash_report.config.js
+++ b/client/src/modules/reports/generate/cash_report/cash_report.config.js
@@ -52,7 +52,7 @@ function CashReportConfigController($sce, Notify, SavedReports, AppCache, report
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(err => {
         if (err.data.code && err.data.code === 'TOO_MANY_CASHBOXES_PER_ACCOUNT') {

--- a/client/src/modules/reports/generate/cash_report/cash_report.config.js
+++ b/client/src/modules/reports/generate/cash_report/cash_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('cash_reportController', CashReportConfigController);
 
 CashReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', '$translate',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', '$translate',
 ];
 
 /**
@@ -15,7 +15,7 @@ CashReportConfigController.$inject = [
  * @param $state
  * @param $translate
  */
-function CashReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, $translate) {
+function CashReportConfigController(Notify, SavedReports, AppCache, reportData, $state, $translate) {
   const vm = this;
   const cache = new AppCache('configure_cash_report');
   const reportUrl = 'reports/finance/cash_report';

--- a/client/src/modules/reports/generate/cashflow/cashflow.config.js
+++ b/client/src/modules/reports/generate/cashflow/cashflow.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('cashflowController', CashFlowConfigController);
 
 CashFlowConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'bhConstants',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'bhConstants',
 ];
 
 /**
@@ -15,7 +15,7 @@ CashFlowConfigController.$inject = [
  * @param $state
  * @param bhConstants
  */
-function CashFlowConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, bhConstants) {
+function CashFlowConfigController(Notify, SavedReports, AppCache, reportData, $state, bhConstants) {
   const vm = this;
   const cache = new AppCache('configure_cashflow');
   const reportUrl = 'reports/finance/cashflow/';

--- a/client/src/modules/reports/generate/cashflow/cashflow.config.js
+++ b/client/src/modules/reports/generate/cashflow/cashflow.config.js
@@ -71,7 +71,7 @@ function CashFlowConfigController($sce, Notify, SavedReports, AppCache, reportDa
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/cashflow_by_service/cashflow_by_service.config.js
+++ b/client/src/modules/reports/generate/cashflow_by_service/cashflow_by_service.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('cashflow_by_serviceController', cashflowByServiceController);
 
 cashflowByServiceController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
 ];
 
 /**
@@ -14,7 +14,7 @@ cashflowByServiceController.$inject = [
  * @param reportData
  * @param $state
  */
-function cashflowByServiceController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function cashflowByServiceController(Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('configure_cashflow_by_service');
   const reportUrl = 'reports/finance/cashflow/services';

--- a/client/src/modules/reports/generate/cashflow_by_service/cashflow_by_service.config.js
+++ b/client/src/modules/reports/generate/cashflow_by_service/cashflow_by_service.config.js
@@ -60,7 +60,7 @@ function cashflowByServiceController($sce, Notify, SavedReports, AppCache, repor
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/client_debts/client_debts.config.js
+++ b/client/src/modules/reports/generate/client_debts/client_debts.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('client_debtsController', clientDebtsController);
 
 clientDebtsController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService',
+   'NotifyService', 'BaseReportService',
   'AppCache', 'reportData', '$state',
 ];
 
@@ -15,7 +15,7 @@ clientDebtsController.$inject = [
  * @param reportData
  * @param $state
  */
-function clientDebtsController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function clientDebtsController(Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('client_debts');
   const reportUrl = 'reports/finance/client_debts';

--- a/client/src/modules/reports/generate/client_debts/client_debts.config.js
+++ b/client/src/modules/reports/generate/client_debts/client_debts.config.js
@@ -50,7 +50,7 @@ function clientDebtsController($sce, Notify, SavedReports, AppCache, reportData,
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/client_support/client_support.config.js
+++ b/client/src/modules/reports/generate/client_support/client_support.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('client_supportController', clientSupportController);
 
 clientSupportController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService',
+   'NotifyService', 'BaseReportService',
   'AppCache', 'reportData', '$state',
 ];
 
@@ -15,7 +15,7 @@ clientSupportController.$inject = [
  * @param reportData
  * @param $state
  */
-function clientSupportController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function clientSupportController(Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('client_support');
   const reportUrl = 'reports/finance/client_support';

--- a/client/src/modules/reports/generate/client_support/client_support.config.js
+++ b/client/src/modules/reports/generate/client_support/client_support.config.js
@@ -52,7 +52,7 @@ function clientSupportController($sce, Notify, SavedReports, AppCache, reportDat
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/configurable_analysis_report/configurable_analysis_report.config.js
+++ b/client/src/modules/reports/generate/configurable_analysis_report/configurable_analysis_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('configurable_analysis_reportController', ConfigurableAnalysisReportController);
 
 ConfigurableAnalysisReportController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'ConfigurationAnalysisToolsService',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'ConfigurationAnalysisToolsService',
 ];
 
 /**
@@ -15,7 +15,7 @@ ConfigurableAnalysisReportController.$inject = [
  * @param $state
  * @param ConfigurationAnalysisTools
  */
-function ConfigurableAnalysisReportController($sce, Notify, SavedReports, AppCache,
+function ConfigurableAnalysisReportController(Notify, SavedReports, AppCache,
   reportData, $state, ConfigurationAnalysisTools) {
   const vm = this;
   const cache = new AppCache('configurable_analysis_report');

--- a/client/src/modules/reports/generate/configurable_analysis_report/configurable_analysis_report.config.js
+++ b/client/src/modules/reports/generate/configurable_analysis_report/configurable_analysis_report.config.js
@@ -79,7 +79,7 @@ function ConfigurableAnalysisReportController($sce, Notify, SavedReports, AppCac
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/cost_center/cost_center.config.js
+++ b/client/src/modules/reports/generate/cost_center/cost_center.config.js
@@ -52,7 +52,7 @@ function CostCenterConfigController($sce, Notify, SavedReports, AppCache, report
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/cost_center/cost_center.config.js
+++ b/client/src/modules/reports/generate/cost_center/cost_center.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('cost_centerController', CostCenterConfigController);
 
 CostCenterConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
 // TODO(@jniles) - this name is remarkably close to the cost center controller.  Let's name
@@ -17,7 +17,7 @@ CostCenterConfigController.$inject = [
  * @param $state
  * @param Session
  */
-function CostCenterConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Session) {
+function CostCenterConfigController(Notify, SavedReports, AppCache, reportData, $state, Session) {
   const vm = this;
   const cache = new AppCache('configure_cost_center');
   const reportUrl = 'reports/finance/cost_center';

--- a/client/src/modules/reports/generate/cost_center_accounts/cost_center_accounts.config.js
+++ b/client/src/modules/reports/generate/cost_center_accounts/cost_center_accounts.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('cost_center_accountsController', CostCenterAccountsReportConfigController);
 
 CostCenterAccountsReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
 /**
@@ -18,7 +18,7 @@ CostCenterAccountsReportConfigController.$inject = [
  * This function renders the cost_center_accounts report.
  */
 function CostCenterAccountsReportConfigController(
-  $sce, Notify, SavedReports, AppCache, reportData, $state,
+  Notify, SavedReports, AppCache, reportData, $state,
   Session,
 ) {
   const vm = this;

--- a/client/src/modules/reports/generate/cost_center_accounts/cost_center_accounts.config.js
+++ b/client/src/modules/reports/generate/cost_center_accounts/cost_center_accounts.config.js
@@ -70,7 +70,7 @@ function CostCenterAccountsReportConfigController(
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/cost_center_income_and_expense/cost_center_income_and_expense.config.js
+++ b/client/src/modules/reports/generate/cost_center_income_and_expense/cost_center_income_and_expense.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('cost_center_income_and_expenseController', CostCenterIncomeAndExpenseReportConfigController);
 
 CostCenterIncomeAndExpenseReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
 /**
@@ -18,7 +18,7 @@ CostCenterIncomeAndExpenseReportConfigController.$inject = [
  * This function renders the cost_center_income_and_expense report.
  */
 function CostCenterIncomeAndExpenseReportConfigController(
-  $sce, Notify, SavedReports, AppCache, reportData, $state, Session,
+  Notify, SavedReports, AppCache, reportData, $state, Session,
 ) {
   const vm = this;
   const cache = new AppCache('CostCenterIncomeAndExpenseReport');

--- a/client/src/modules/reports/generate/cost_center_income_and_expense/cost_center_income_and_expense.config.js
+++ b/client/src/modules/reports/generate/cost_center_income_and_expense/cost_center_income_and_expense.config.js
@@ -60,7 +60,7 @@ function CostCenterIncomeAndExpenseReportConfigController(
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/cost_center_step_down/cost_center_step_down.config.js
+++ b/client/src/modules/reports/generate/cost_center_step_down/cost_center_step_down.config.js
@@ -72,7 +72,7 @@ function CostCenterStepdownReportConfigController($sce, Notify, SavedReports, Ap
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/cost_center_step_down/cost_center_step_down.config.js
+++ b/client/src/modules/reports/generate/cost_center_step_down/cost_center_step_down.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('cost_center_step_downController', CostCenterStepdownReportConfigController);
 
 CostCenterStepdownReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
   'SessionService',
 ];
 
@@ -18,7 +18,7 @@ CostCenterStepdownReportConfigController.$inject = [
  * @description
  * This function renders the cost_center_step_down report.
  */
-function CostCenterStepdownReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Session) {
+function CostCenterStepdownReportConfigController(Notify, SavedReports, AppCache, reportData, $state, Session) {
   const vm = this;
   const cache = new AppCache('CostCenterStepdownReport');
   const reportUrl = 'reports/finance/cost_center_step_down';

--- a/client/src/modules/reports/generate/data_kit/data_kit.config.js
+++ b/client/src/modules/reports/generate/data_kit/data_kit.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('data_kitController', dataKitController);
 
 dataKitController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SurveyFormService',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SurveyFormService',
   'ChoicesListManagementService',
 ];
 
@@ -17,7 +17,7 @@ dataKitController.$inject = [
  * @param SurveyForm
  * @param ChoicesList
  */
-function dataKitController($sce, Notify, SavedReports, AppCache, reportData, $state, SurveyForm,
+function dataKitController(Notify, SavedReports, AppCache, reportData, $state, SurveyForm,
   ChoicesList) {
   const vm = this;
   const cache = new AppCache('data_kit');

--- a/client/src/modules/reports/generate/data_kit/data_kit.config.js
+++ b/client/src/modules/reports/generate/data_kit/data_kit.config.js
@@ -108,7 +108,7 @@ function dataKitController($sce, Notify, SavedReports, AppCache, reportData, $st
     SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/debtor_summary/debtor_summary.config.js
+++ b/client/src/modules/reports/generate/debtor_summary/debtor_summary.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('debtor_summaryController', debtorSummaryController);
 
 debtorSummaryController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService',
+   'NotifyService', 'BaseReportService',
   'AppCache', 'reportData', '$state',
 ];
 
@@ -15,7 +15,7 @@ debtorSummaryController.$inject = [
  * @param reportData
  * @param $state
  */
-function debtorSummaryController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function debtorSummaryController(Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('debtor_summary');
   const reportUrl = 'reports/finance/debtor_summary';

--- a/client/src/modules/reports/generate/debtor_summary/debtor_summary.config.js
+++ b/client/src/modules/reports/generate/debtor_summary/debtor_summary.config.js
@@ -44,7 +44,7 @@ function debtorSummaryController($sce, Notify, SavedReports, AppCache, reportDat
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/indicators_report/indicators_report.config.js
+++ b/client/src/modules/reports/generate/indicators_report/indicators_report.config.js
@@ -46,7 +46,7 @@ function indicatorsReportController($sce, Notify, SavedReports, AppCache, report
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/indicators_report/indicators_report.config.js
+++ b/client/src/modules/reports/generate/indicators_report/indicators_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('indicators_reportController', indicatorsReportController);
 
 indicatorsReportController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
 ];
 
 /**
@@ -14,7 +14,7 @@ indicatorsReportController.$inject = [
  * @param reportData
  * @param $state
  */
-function indicatorsReportController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function indicatorsReportController(Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('indicators_report');
   const reportUrl = '/reports/indicators_report';

--- a/client/src/modules/reports/generate/inventory_changes/inventory_changes.config.js
+++ b/client/src/modules/reports/generate/inventory_changes/inventory_changes.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('inventory_changesController', inventoryChangesController);
 
 inventoryChangesController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache',
+   'NotifyService', 'BaseReportService', 'AppCache',
   'reportData', '$state', 'SessionService',
 ];
 
@@ -16,7 +16,7 @@ inventoryChangesController.$inject = [
  * @param $state
  * @param Session
  */
-function inventoryChangesController($sce, Notify, SavedReports, AppCache, reportData, $state, Session) {
+function inventoryChangesController(Notify, SavedReports, AppCache, reportData, $state, Session) {
   const vm = this;
   const cache = new AppCache('inventory_changes_report');
   const reportUrl = 'reports/inventory/changes/';

--- a/client/src/modules/reports/generate/inventory_changes/inventory_changes.config.js
+++ b/client/src/modules/reports/generate/inventory_changes/inventory_changes.config.js
@@ -43,7 +43,7 @@ function inventoryChangesController($sce, Notify, SavedReports, AppCache, report
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/inventory_report/inventory_report.config.js
+++ b/client/src/modules/reports/generate/inventory_report/inventory_report.config.js
@@ -84,7 +84,7 @@ function InventoryReportConfigController(
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/inventory_report/inventory_report.config.js
+++ b/client/src/modules/reports/generate/inventory_report/inventory_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('inventory_reportController', InventoryReportConfigController);
 
 InventoryReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
   'LanguageService', 'moment',
 ];
 
@@ -18,7 +18,7 @@ InventoryReportConfigController.$inject = [
  * @param moment
  */
 function InventoryReportConfigController(
-  $sce, Notify, SavedReports, AppCache, reportData, $state,
+  Notify, SavedReports, AppCache, reportData, $state,
   Languages, moment,
 ) {
   const vm = this;

--- a/client/src/modules/reports/generate/monthly_balance/monthly_balance.config.js
+++ b/client/src/modules/reports/generate/monthly_balance/monthly_balance.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('monthly_balanceController', monthlyBalanceController);
 
 monthlyBalanceController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
 /**
@@ -15,7 +15,7 @@ monthlyBalanceController.$inject = [
  * @param $state
  * @param Session
  */
-function monthlyBalanceController($sce, Notify, SavedReports, AppCache, reportData, $state, Session) {
+function monthlyBalanceController(Notify, SavedReports, AppCache, reportData, $state, Session) {
   const vm = this;
   const cache = new AppCache('monthly_balance');
   const reportUrl = 'reports/finance/monthly_balance';

--- a/client/src/modules/reports/generate/monthly_balance/monthly_balance.config.js
+++ b/client/src/modules/reports/generate/monthly_balance/monthly_balance.config.js
@@ -71,7 +71,7 @@ function monthlyBalanceController($sce, Notify, SavedReports, AppCache, reportDa
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/monthly_consumption_report/monthly_consumption_report.config.js
+++ b/client/src/modules/reports/generate/monthly_consumption_report/monthly_consumption_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('monthly_consumption_reportController', monthlyConsumptionReportController);
 
 monthlyConsumptionReportController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
   'LanguageService',
 ];
 
@@ -16,7 +16,7 @@ monthlyConsumptionReportController.$inject = [
  * @param $state
  * @param Languages
  */
-function monthlyConsumptionReportController($sce, Notify, SavedReports, AppCache, reportData, $state, Languages) {
+function monthlyConsumptionReportController(Notify, SavedReports, AppCache, reportData, $state, Languages) {
   const vm = this;
   const cache = new AppCache('monthly_consumption');
   const reportUrl = 'reports/stock/monthly_consumption';

--- a/client/src/modules/reports/generate/monthly_consumption_report/monthly_consumption_report.config.js
+++ b/client/src/modules/reports/generate/monthly_consumption_report/monthly_consumption_report.config.js
@@ -70,7 +70,7 @@ function monthlyConsumptionReportController($sce, Notify, SavedReports, AppCache
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/ohada_balance_sheet_report/ohada_balance_sheet_report.config.js
+++ b/client/src/modules/reports/generate/ohada_balance_sheet_report/ohada_balance_sheet_report.config.js
@@ -45,7 +45,7 @@ function OhadaBalanceSheetReportConfigController($sce, Notify, SavedReports, App
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/ohada_balance_sheet_report/ohada_balance_sheet_report.config.js
+++ b/client/src/modules/reports/generate/ohada_balance_sheet_report/ohada_balance_sheet_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('ohada_balance_sheet_reportController', OhadaBalanceSheetReportConfigController);
 
 OhadaBalanceSheetReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache',
+   'NotifyService', 'BaseReportService', 'AppCache',
   'reportData', '$state', 'LanguageService',
 ];
 
@@ -15,7 +15,7 @@ OhadaBalanceSheetReportConfigController.$inject = [
  * @param reportData
  * @param $state
  */
-function OhadaBalanceSheetReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function OhadaBalanceSheetReportConfigController(Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('configure_ohada_balance_sheet_report');
   const reportUrl = 'reports/finance/ohada_balance_sheet';

--- a/client/src/modules/reports/generate/ohada_profit_loss/ohada_profit_loss_report.config.js
+++ b/client/src/modules/reports/generate/ohada_profit_loss/ohada_profit_loss_report.config.js
@@ -45,7 +45,7 @@ function OhadaProfitLossReportConfigController($sce, Notify, SavedReports, AppCa
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/ohada_profit_loss/ohada_profit_loss_report.config.js
+++ b/client/src/modules/reports/generate/ohada_profit_loss/ohada_profit_loss_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('ohada_profit_lossController', OhadaProfitLossReportConfigController);
 
 OhadaProfitLossReportConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache',
+   'NotifyService', 'BaseReportService', 'AppCache',
   'reportData', '$state', 'LanguageService',
 ];
 
@@ -15,7 +15,7 @@ OhadaProfitLossReportConfigController.$inject = [
  * @param reportData
  * @param $state
  */
-function OhadaProfitLossReportConfigController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function OhadaProfitLossReportConfigController(Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('configure_ohada_profit_loss_report');
   const reportUrl = 'reports/finance/ohada_profit_loss';

--- a/client/src/modules/reports/generate/open_debtors/open_debtors.config.js
+++ b/client/src/modules/reports/generate/open_debtors/open_debtors.config.js
@@ -86,7 +86,7 @@ function OpenDebtorsConfigController(
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
 
         // reset form validation
         form.$setPristine();

--- a/client/src/modules/reports/generate/open_debtors/open_debtors.config.js
+++ b/client/src/modules/reports/generate/open_debtors/open_debtors.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('open_debtorsController', OpenDebtorsConfigController);
 
 OpenDebtorsConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'SessionService', 'reportData',
+   'NotifyService', 'BaseReportService', 'AppCache', 'SessionService', 'reportData',
   '$state', 'OpenDebtorsReportService', 'bhConstants',
 ];
 
@@ -22,7 +22,7 @@ OpenDebtorsConfigController.$inject = [
  * to see debtors with unpaid debts.
  */
 function OpenDebtorsConfigController(
-  $sce, Notify, SavedReports, AppCache, Session, reportData,
+  Notify, SavedReports, AppCache, Session, reportData,
   $state, OpenDebtorsReports, bhConstants,
 ) {
   const vm = this;

--- a/client/src/modules/reports/generate/operating/operating.config.js
+++ b/client/src/modules/reports/generate/operating/operating.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('operatingController', OperatingConfigController);
 
 OperatingConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
 /**
@@ -15,7 +15,7 @@ OperatingConfigController.$inject = [
  * @param $state
  * @param Session
  */
-function OperatingConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Session) {
+function OperatingConfigController(Notify, SavedReports, AppCache, reportData, $state, Session) {
   const vm = this;
   const cache = new AppCache('configure_operating');
   const reportUrl = 'reports/finance/operating';

--- a/client/src/modules/reports/generate/operating/operating.config.js
+++ b/client/src/modules/reports/generate/operating/operating.config.js
@@ -54,7 +54,7 @@ function OperatingConfigController($sce, Notify, SavedReports, AppCache, reportD
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/purchase_order_analysis/purchase_order_analysis.config.js
+++ b/client/src/modules/reports/generate/purchase_order_analysis/purchase_order_analysis.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('purchase_order_analysisController', purchaseOrderAnalysisController);
 
 purchaseOrderAnalysisController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache',
+   'NotifyService', 'BaseReportService', 'AppCache',
   'reportData', '$state',
 ];
 
@@ -15,7 +15,7 @@ purchaseOrderAnalysisController.$inject = [
  * @param reportData
  * @param $state
  */
-function purchaseOrderAnalysisController($sce, Notify, SavedReports, AppCache,
+function purchaseOrderAnalysisController(Notify, SavedReports, AppCache,
   reportData, $state) {
   const vm = this;
   const cache = new AppCache('purchase_order_analysis');

--- a/client/src/modules/reports/generate/purchase_order_analysis/purchase_order_analysis.config.js
+++ b/client/src/modules/reports/generate/purchase_order_analysis/purchase_order_analysis.config.js
@@ -45,7 +45,7 @@ function purchaseOrderAnalysisController($sce, Notify, SavedReports, AppCache,
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/purchase_prices/purchase_prices.config.js
+++ b/client/src/modules/reports/generate/purchase_prices/purchase_prices.config.js
@@ -45,7 +45,7 @@ function purchasePricesController($sce, Notify, SavedReports, AppCache,
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/purchase_prices/purchase_prices.config.js
+++ b/client/src/modules/reports/generate/purchase_prices/purchase_prices.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('purchase_pricesController', purchasePricesController);
 
 purchasePricesController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache',
+   'NotifyService', 'BaseReportService', 'AppCache',
   'reportData', '$state', 'AccountService', 'FormatTreeDataService',
 ];
 
@@ -15,7 +15,7 @@ purchasePricesController.$inject = [
  * @param reportData
  * @param $state
  */
-function purchasePricesController($sce, Notify, SavedReports, AppCache,
+function purchasePricesController(Notify, SavedReports, AppCache,
   reportData, $state) {
   const vm = this;
   const cache = new AppCache('purchase_prices');

--- a/client/src/modules/reports/generate/realized_profit/realized_profit.config.js
+++ b/client/src/modules/reports/generate/realized_profit/realized_profit.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('realized_profitController', realizedProfitController);
 
 realizedProfitController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService',
+   'NotifyService', 'BaseReportService',
   'AppCache', 'reportData', '$state',
 ];
 
@@ -15,7 +15,7 @@ realizedProfitController.$inject = [
  * @param reportData
  * @param $state
  */
-function realizedProfitController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function realizedProfitController(Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('realized_profit');
   const reportUrl = 'reports/finance/realized_profit';

--- a/client/src/modules/reports/generate/realized_profit/realized_profit.config.js
+++ b/client/src/modules/reports/generate/realized_profit/realized_profit.config.js
@@ -56,7 +56,7 @@ function realizedProfitController($sce, Notify, SavedReports, AppCache, reportDa
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/recovery_capacity/recovery_capacity.config.js
+++ b/client/src/modules/reports/generate/recovery_capacity/recovery_capacity.config.js
@@ -49,7 +49,7 @@ function recoveryCapacityController($sce, Notify, SavedReports, AppCache, report
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/recovery_capacity/recovery_capacity.config.js
+++ b/client/src/modules/reports/generate/recovery_capacity/recovery_capacity.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('recovery_capacityController', recoveryCapacityController);
 
 recoveryCapacityController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService',
+   'NotifyService', 'BaseReportService',
   'AppCache', 'reportData', '$state', 'SessionService',
 ];
 
@@ -16,7 +16,7 @@ recoveryCapacityController.$inject = [
  * @param $state
  * @param Session
  */
-function recoveryCapacityController($sce, Notify, SavedReports, AppCache, reportData, $state, Session) {
+function recoveryCapacityController(Notify, SavedReports, AppCache, reportData, $state, Session) {
   const vm = this;
   const cache = new AppCache('recovery_capacity');
   const reportUrl = 'reports/finance/recovery_capacity';

--- a/client/src/modules/reports/generate/rumer_report/rumer_report.config.js
+++ b/client/src/modules/reports/generate/rumer_report/rumer_report.config.js
@@ -74,7 +74,7 @@ function rumerReportController($sce, Notify, SavedReports, AppCache, reportData,
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/rumer_report/rumer_report.config.js
+++ b/client/src/modules/reports/generate/rumer_report/rumer_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('rumer_reportController', rumerReportController);
 
 rumerReportController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
   'LanguageService',
 ];
 
@@ -16,7 +16,7 @@ rumerReportController.$inject = [
  * @param $state
  * @param Languages
  */
-function rumerReportController($sce, Notify, SavedReports, AppCache, reportData, $state, Languages) {
+function rumerReportController(Notify, SavedReports, AppCache, reportData, $state, Languages) {
   const vm = this;
   const cache = new AppCache('rumer_report');
   const reportUrl = 'reports/stock/rumer_report';

--- a/client/src/modules/reports/generate/satisfaction_rate_report/satisfaction_rate_report.config.js
+++ b/client/src/modules/reports/generate/satisfaction_rate_report/satisfaction_rate_report.config.js
@@ -34,7 +34,7 @@ function SatisfactionRateReportController($sce, Notify, SavedReports, AppCache, 
     SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
         vm.loading = false;
       })
       .catch(handleError);

--- a/client/src/modules/reports/generate/satisfaction_rate_report/satisfaction_rate_report.config.js
+++ b/client/src/modules/reports/generate/satisfaction_rate_report/satisfaction_rate_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('satisfaction_rate_reportController', SatisfactionRateReportController);
 
 SatisfactionRateReportController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
 ];
 
 /**
@@ -14,7 +14,7 @@ SatisfactionRateReportController.$inject = [
  * @param reportData
  * @param $state
  */
-function SatisfactionRateReportController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function SatisfactionRateReportController(Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('satisfaction_rate_report');
   const reportUrl = '/reports/stock/satisfaction_rate_report';

--- a/client/src/modules/reports/generate/stock_entry/stock_entry.config.js
+++ b/client/src/modules/reports/generate/stock_entry/stock_entry.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('stock_entryController', StockEntryConfigController);
 
 StockEntryConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
   'LanguageService', 'SessionService',
 ];
 
@@ -17,7 +17,7 @@ StockEntryConfigController.$inject = [
  * @param Languages
  * @param Session
  */
-function StockEntryConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Languages, Session) {
+function StockEntryConfigController(Notify, SavedReports, AppCache, reportData, $state, Languages, Session) {
   const vm = this;
   const cache = new AppCache('configure_stock_entry_report');
   const reportUrl = 'reports/stock/entry';

--- a/client/src/modules/reports/generate/stock_entry/stock_entry.config.js
+++ b/client/src/modules/reports/generate/stock_entry/stock_entry.config.js
@@ -74,7 +74,7 @@ function StockEntryConfigController($sce, Notify, SavedReports, AppCache, report
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/stock_exit/stock_exit.config.js
+++ b/client/src/modules/reports/generate/stock_exit/stock_exit.config.js
@@ -85,7 +85,7 @@ function StockExitConfigController($sce, Notify, SavedReports, AppCache, reportD
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/stock_exit/stock_exit.config.js
+++ b/client/src/modules/reports/generate/stock_exit/stock_exit.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('stock_exitController', StockExitConfigController);
 
 StockExitConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
   'LanguageService', 'SessionService',
 ];
 
@@ -17,7 +17,7 @@ StockExitConfigController.$inject = [
  * @param Languages
  * @param Session
  */
-function StockExitConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Languages, Session) {
+function StockExitConfigController(Notify, SavedReports, AppCache, reportData, $state, Languages, Session) {
   const vm = this;
   const cache = new AppCache('configure_stock_exit_report');
   const reportUrl = 'reports/stock/exit';

--- a/client/src/modules/reports/generate/stock_expiration_report/stock_expiration_report.config.js
+++ b/client/src/modules/reports/generate/stock_expiration_report/stock_expiration_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('stock_expiration_reportController', StockExpirationReportConfigCtrl);
 
 StockExpirationReportConfigCtrl.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
   'LanguageService', 'SessionService',
 ];
 
@@ -17,7 +17,7 @@ StockExpirationReportConfigCtrl.$inject = [
  * @param Languages
  * @param Session
  */
-function StockExpirationReportConfigCtrl($sce, Notify, SavedReports, AppCache, reportData, $state, Languages, Session) {
+function StockExpirationReportConfigCtrl(Notify, SavedReports, AppCache, reportData, $state, Languages, Session) {
   const vm = this;
   const cache = new AppCache('stock_expiration_report');
   const reportUrl = 'reports/stock/expiration_report';

--- a/client/src/modules/reports/generate/stock_expiration_report/stock_expiration_report.config.js
+++ b/client/src/modules/reports/generate/stock_expiration_report/stock_expiration_report.config.js
@@ -88,7 +88,7 @@ function StockExpirationReportConfigCtrl($sce, Notify, SavedReports, AppCache, r
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/stock_movement_report/stock_movement_report.config.js
+++ b/client/src/modules/reports/generate/stock_movement_report/stock_movement_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('stock_movement_reportController', StockMovementReportCtrl);
 
 StockMovementReportCtrl.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
   'LanguageService',
 ];
 
@@ -16,7 +16,7 @@ StockMovementReportCtrl.$inject = [
  * @param $state
  * @param Languages
  */
-function StockMovementReportCtrl($sce, Notify, SavedReports, AppCache, reportData, $state, Languages) {
+function StockMovementReportCtrl(Notify, SavedReports, AppCache, reportData, $state, Languages) {
   const vm = this;
   const cache = new AppCache('stock_movement_report');
   const reportUrl = 'reports/stock/movement_report';

--- a/client/src/modules/reports/generate/stock_movement_report/stock_movement_report.config.js
+++ b/client/src/modules/reports/generate/stock_movement_report/stock_movement_report.config.js
@@ -60,7 +60,7 @@ function StockMovementReportCtrl($sce, Notify, SavedReports, AppCache, reportDat
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/stock_sheet/stock_sheet.config.js
+++ b/client/src/modules/reports/generate/stock_sheet/stock_sheet.config.js
@@ -90,7 +90,7 @@ function StockSheetConfigController(
     return SavedReports.requestPreview(reportUrl, reportData.id, options)
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/stock_sheet/stock_sheet.config.js
+++ b/client/src/modules/reports/generate/stock_sheet/stock_sheet.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('stock_sheetController', StockSheetConfigController);
 
 StockSheetConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
   'LanguageService', 'moment', 'SessionService',
 ];
 
@@ -19,7 +19,7 @@ StockSheetConfigController.$inject = [
  * @param Session
  */
 function StockSheetConfigController(
-  $sce, Notify, SavedReports, AppCache, reportData, $state, Languages, moment, Session,
+  Notify, SavedReports, AppCache, reportData, $state, Languages, moment, Session,
 ) {
   const vm = this;
   const cache = new AppCache('configure_stock_sheet_report');

--- a/client/src/modules/reports/generate/stock_value/stock_value.config.js
+++ b/client/src/modules/reports/generate/stock_value/stock_value.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('stock_valueController', StockValueConfigController);
 
 StockValueConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService',
+   'NotifyService', 'BaseReportService',
   'AppCache', 'reportData', '$state',
   'LanguageService', 'moment', 'SessionService',
 ];
@@ -20,7 +20,7 @@ StockValueConfigController.$inject = [
  * @param Session
  */
 function StockValueConfigController(
-  $sce, Notify, SavedReports,
+  Notify, SavedReports,
   AppCache, reportData, $state, Languages, moment, Session,
 ) {
   const vm = this;

--- a/client/src/modules/reports/generate/stock_value/stock_value.config.js
+++ b/client/src/modules/reports/generate/stock_value/stock_value.config.js
@@ -80,7 +80,7 @@ function StockValueConfigController(
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(options))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/system_usage_stat/system_usage_stat.config.js
+++ b/client/src/modules/reports/generate/system_usage_stat/system_usage_stat.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('system_usage_statController', systemUsageStatController);
 
 systemUsageStatController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService',
+   'NotifyService', 'BaseReportService',
   'AppCache', 'reportData', '$state',
 ];
 
@@ -15,7 +15,7 @@ systemUsageStatController.$inject = [
  * @param reportData
  * @param $state
  */
-function systemUsageStatController($sce, Notify, SavedReports, AppCache, reportData, $state) {
+function systemUsageStatController(Notify, SavedReports, AppCache, reportData, $state) {
   const vm = this;
   const cache = new AppCache('system_usage_stat');
   const reportUrl = 'reports/finance/system_usage_stat';

--- a/client/src/modules/reports/generate/system_usage_stat/system_usage_stat.config.js
+++ b/client/src/modules/reports/generate/system_usage_stat/system_usage_stat.config.js
@@ -52,7 +52,7 @@ function systemUsageStatController($sce, Notify, SavedReports, AppCache, reportD
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then(result => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/unpaid_invoice_payments/unpaid_invoice_payments.config.js
+++ b/client/src/modules/reports/generate/unpaid_invoice_payments/unpaid_invoice_payments.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('unpaid_invoice_paymentsController', UnbalancedInvoicePaymentsConfigController);
 
 UnbalancedInvoicePaymentsConfigController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
   'SessionService',
 ];
 
@@ -16,7 +16,7 @@ UnbalancedInvoicePaymentsConfigController.$inject = [
  * @param $state
  * @param Session
  */
-function UnbalancedInvoicePaymentsConfigController($sce, Notify, SavedReports, AppCache, reportData, $state, Session) {
+function UnbalancedInvoicePaymentsConfigController(Notify, SavedReports, AppCache, reportData, $state, Session) {
   const vm = this;
   const cache = new AppCache('configure_unpaid_invoice_payments');
   const reportUrl = 'reports/finance/unpaid_invoice_payments';

--- a/client/src/modules/reports/generate/unpaid_invoice_payments/unpaid_invoice_payments.config.js
+++ b/client/src/modules/reports/generate/unpaid_invoice_payments/unpaid_invoice_payments.config.js
@@ -85,7 +85,7 @@ function UnbalancedInvoicePaymentsConfigController($sce, Notify, SavedReports, A
 
         // update cached configuration
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/reports/generate/visit_report/visit_report.config.js
+++ b/client/src/modules/reports/generate/visit_report/visit_report.config.js
@@ -2,7 +2,7 @@ angular.module('bhima.controllers')
   .controller('visit_reportController', VisitReportController);
 
 VisitReportController.$inject = [
-  '$sce', 'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
+   'NotifyService', 'BaseReportService', 'AppCache', 'reportData', '$state',
 ];
 
 /**
@@ -15,7 +15,7 @@ VisitReportController.$inject = [
  * @param $state
  */
 function VisitReportController(
-  $sce, Notify, SavedReports, AppCache,
+  Notify, SavedReports, AppCache,
   reportData, $state,
 ) {
   const vm = this;

--- a/client/src/modules/reports/generate/visit_report/visit_report.config.js
+++ b/client/src/modules/reports/generate/visit_report/visit_report.config.js
@@ -47,7 +47,7 @@ function VisitReportController(
     return SavedReports.requestPreview(reportUrl, reportData.id, angular.copy(vm.reportDetails))
       .then((result) => {
         vm.previewGenerated = true;
-        vm.previewResult = $sce.trustAsHtml(result);
+        vm.previewResult = result;
       })
       .catch(Notify.handleError);
   };

--- a/client/src/modules/templates/bhReportPreview.tmpl.html
+++ b/client/src/modules/templates/bhReportPreview.tmpl.html
@@ -15,7 +15,7 @@
         <div class="panel-body" style="padding : 5px;">
           <!-- HTML rendered report presented in `iframe`, this ensures that -->
           <!-- the classes within the document do not clash with the page -->
-          <iframe id="report" name="report" style="border : none; width : 100%; height : 80vh;" srcdoc="{{$ctrl.sourceDocument}}"></iframe>
+          <iframe id="report" name="report" style="border : none; width : 100%; height : 80vh;" sandbox="allow-same-origin" bh-report-srcdoc="$ctrl.sourceDocument"></iframe>
         </div>
       </div>
     </div>

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -49,6 +49,7 @@ exports.configure = function configure(app) {
       useDefaults : false,
       directives : {
         defaultSrc : ['\'self\'', '\'unsafe-inline\'', 'blob:'],
+        scriptSrc: ['\'self\'', '\'unsafe-inline\'', '\'unsafe-eval\'',  'blob:'],
         fontSrc : ['\'self\'', 'https://fonts.gstatic.com'],
         imgSrc : ['\'self\'', 'blob:', 'data:'],
       },

--- a/server/controllers/finance/accounts/transactions.js
+++ b/server/controllers/finance/accounts/transactions.js
@@ -1,13 +1,11 @@
 /**
- * @overview AccountTransactions
- *
+ * @file AccountTransactions
  * @description
  * This file provides a common tool for reading the transations associated with an account.
  * It provides a re-usable interface to access this information, and supports:
  *  1. Inclusion of non-posted records
  *  2. Exchange Rate Calculation
  *  3. Running Balance Calculation
- *
  */
 
 const debug = require('debug')('bhima:accounts:transactions');
@@ -17,8 +15,9 @@ const Exchange = require('../exchange');
 const Accounts = require('.');
 
 /**
+ * @param options
+ * @param tableName
  * @function getTableSubquery
- *
  * @description
  * This function creates the subquery for each table (posting_journal and general_ledger)
  * depending on which table is passed in.
@@ -47,8 +46,8 @@ function getTableSubquery(options, tableName) {
 }
 
 /**
+ * @param options
  * @function getSubquery
- *
  * @description
  * This function constructs the underlying base tables for posted/unposted values from the general_ledger or
  * a UNION of the posting_journal and general_ledger.
@@ -70,6 +69,10 @@ function getSubquery(options) {
 
 // @TODO define standards for displaying and rounding totals, unless numbers are rounded
 //       uniformly they may be displayed differently from what is recorded
+/**
+ *
+ * @param options
+ */
 function getTotalsSQL(options) {
   const currencyId = options.currency_id || options.enterprise_currency_id;
 
@@ -92,8 +95,9 @@ function getTotalsSQL(options) {
 }
 
 /**
+ * @param options
+ * @param openingBalance
  * @function getAccountTransactions
- *
  * @description
  * This function returns all the transactions for an account,
  */
@@ -109,8 +113,8 @@ async function getAccountTransactions(options, openingBalance = 0) {
     db.one(totalsQuery, totalsParameters),
   ]);
 
-  debug(`The account number is ${account.account_number} with a total of ${transactions.length} transactions.`);
-  debug(`Opening Balance of ${account.account_number} is ${openingBalance}.`);
+  debug(`The account number is ${account.number } with a total of ${transactions.length} transactions.`);
+  debug(`Opening Balance of ${account.number } is ${openingBalance}.`);
 
   // alias the unposted record flag for styling with italics
   let hasUnpostedRecords = false;
@@ -151,8 +155,9 @@ async function getAccountTransactions(options, openingBalance = 0) {
 }
 
 /**
+ * @param options
+ * @param openingBalance
  * @function buildLedgerSQL
- *
  * @description
  *
  * Used by the getAccountTransactions() function internally.  The internal SQL

--- a/test/integration/finance/entities.js
+++ b/test/integration/finance/entities.js
@@ -37,7 +37,6 @@ describe('/finance/entities ', () => {
     return agent.get('/finance/entities')
       .query({ text : validEmployeeIdentifier })
       .then(res => {
-        console.log(res.body);
         helpers.api.listed(res, 1);
       })
       .catch(helpers.handler);


### PR DESCRIPTION
This PR creates a new directive to allow rendering the srcdoc on
iframes on Chrome.  I am not sure where the security policy went wrong,
but Chrome stopped rendering `<iframe srcdoc="">` with angularjs.  This
creates a custom directive that removes and forcibly updates the srcdoc
whenever the content changes.  Tested in Firefox and Chrome to confirm
that it works.

Note that there is the opportunity to reduce a lot of our report cruft,
but this PR doesn't take advantage of that.